### PR TITLE
fix(self-host): db:push/db:seed work out of the box

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,10 +14,13 @@
 POSTGRES_PASSWORD=
 
 # DATABASE_URL / REDIS_URL only matter when running Deft AGAINST an external
-# Postgres / Redis (not the bundled compose stack). The compose file overrides
-# DATABASE_URL using POSTGRES_PASSWORD automatically.
-DATABASE_URL=postgres://postgres:CHANGE_ME@localhost:5432/deft
-REDIS_URL=redis://localhost:6379
+# Postgres / Redis (not the bundled compose stack). With the compose stack:
+#   - Inside containers: docker-compose.yml builds DATABASE_URL from POSTGRES_PASSWORD.
+#   - Host-side (pnpm db:push, pnpm db:seed): the scripts do the same fallback
+#     when DATABASE_URL is unset or still carries the CHANGE_ME placeholder.
+# Uncomment and fill in only when pointing at an external DB / Redis.
+# DATABASE_URL=postgres://user:password@host:5432/deft
+# REDIS_URL=redis://host:6379
 
 # ── 2. Auth secrets ───────────────────────────────────
 # Both REQUIRED. Generate each with: openssl rand -hex 32

--- a/packages/db/drizzle.config.ts
+++ b/packages/db/drizzle.config.ts
@@ -1,11 +1,28 @@
-import 'dotenv/config';
+// `pnpm db:push` invokes this with cwd = packages/db, so the bare
+// `dotenv/config` import would miss the repo-root .env. Resolve it explicitly.
+import { config as loadEnv } from 'dotenv';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
 import { defineConfig } from 'drizzle-kit';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+loadEnv({ path: path.resolve(__dirname, '../../.env') });
+
+// Self-hosters fill in POSTGRES_PASSWORD and leave DATABASE_URL on the
+// .env.example default. Fall back to constructing the URL from POSTGRES_PASSWORD
+// when DATABASE_URL is unset or still carries the placeholder.
+function resolveDatabaseUrl(): string {
+  const explicit = process.env.DATABASE_URL;
+  if (explicit && !explicit.includes('CHANGE_ME')) return explicit;
+  const pw = process.env.POSTGRES_PASSWORD || 'postgres';
+  return `postgres://postgres:${pw}@localhost:5432/deft`;
+}
 
 export default defineConfig({
   out: './drizzle',
   schema: './src/schema.ts',
   dialect: 'postgresql',
   dbCredentials: {
-    url: process.env.DATABASE_URL!,
+    url: resolveDatabaseUrl(),
   },
 });

--- a/packages/db/seed.ts
+++ b/packages/db/seed.ts
@@ -27,7 +27,15 @@
  * Importable: `seedDeftyUser(db)` — used by `seed-demo.ts` to restore the
  * Defty user after the demo wipe.
  */
-import 'dotenv/config';
+// `pnpm db:seed` invokes this with cwd = packages/db, so the bare
+// `dotenv/config` import would miss the repo-root .env. Resolve it explicitly.
+import { config as loadEnv } from 'dotenv';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+loadEnv({ path: path.resolve(__dirname, '../../.env') });
+
 import pg from 'pg';
 import { drizzle } from 'drizzle-orm/node-postgres';
 import { sql } from 'drizzle-orm';
@@ -66,9 +74,19 @@ export async function seedDeftyUser(
   `);
 }
 
+function resolveDatabaseUrl(): string {
+  // Prefer explicit DATABASE_URL. If it's missing or still carries the .env.example
+  // placeholder, construct it from POSTGRES_PASSWORD — the same value docker-compose
+  // uses for the container. Self-hosters never have to touch DATABASE_URL.
+  const explicit = process.env.DATABASE_URL;
+  if (explicit && !explicit.includes('CHANGE_ME')) return explicit;
+  const pw = process.env.POSTGRES_PASSWORD || 'postgres';
+  return `postgres://postgres:${pw}@localhost:5432/deft`;
+}
+
 async function main(): Promise<void> {
   const pool = new Pool({
-    connectionString: process.env.DATABASE_URL || 'postgres://postgres:postgres@localhost:5432/deft',
+    connectionString: resolveDatabaseUrl(),
   });
   const db = drizzle(pool, { schema });
 


### PR DESCRIPTION
﻿## Summary

Surfaced during a clean redeploy on a freshly-reset DigitalOcean droplet. Docker built cleanly thanks to the new CI gate, but the host-side migration commands tripped on two issues a fresh self-hoster would hit immediately:

1. **`pnpm db:push` does not load the repo-root `.env`.** pnpm invokes the script with cwd=packages/db, and `dotenv/config` resolves `.env` relative to CWD — it misses the repo root entirely.
2. **`.env.example` `DATABASE_URL` ships with CHANGE_ME as the password.** Docs say "leave as-is, compose overrides automatically" — true inside the API container, but host-side `pnpm db:push` / `pnpm db:seed` hit `localhost:5432` directly and auth-fail against the random `POSTGRES_PASSWORD`.

## Changes

- `packages/db/drizzle.config.ts` + `packages/db/seed.ts` resolve `.env` from the repo root explicitly via `import.meta.url` + `path.resolve`.
- Both fall back to constructing `DATABASE_URL` from `POSTGRES_PASSWORD` when `DATABASE_URL` is unset or still carries the placeholder.
- `.env.example`: `DATABASE_URL` / `REDIS_URL` commented out by default with a clarifying note.

After the fix, a self-hoster only needs `POSTGRES_PASSWORD`, the two JWT secrets, and the three `NEXT_PUBLIC_*` URLs. `pnpm db:push && pnpm db:seed` runs clean.

## Test plan

- [x] Fresh Ubuntu 24.04 droplet, clean clone, `.env` from `.env.example` + only `POSTGRES_PASSWORD` / JWT secrets set → `pnpm db:push && pnpm db:seed` runs clean
- [x] `POST /api/auth/signup` returns HTTP 201 with JWT
- [x] CORS preflight returns 204 with correct `access-control-allow-origin`
- [x] Defty user seeded in `users` table

Generated with Claude Code
