### PR TITLE
fix(api): resolve .env from source path, not process.cwd()

### DIFF
--- a/apps/api/src/lib/env.ts
+++ b/apps/api/src/lib/env.ts
@@ -1,13 +1,28 @@
 import dotenv from 'dotenv';
-import { resolve } from 'node:path';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-// Load .env from project root (../../.env from apps/api/src/lib/)
-dotenv.config({ path: resolve(process.cwd(), '..', '..', '.env') });
-// Also try CWD
+// Resolve .env from the repo root via the source file's location, NOT
+// process.cwd() — when this module loads under tsx / pnpm --filter / docker /
+// a heartbeat worker, cwd is unpredictable. Anchor to the file path instead so
+// `pnpm db:seed`, `pnpm dev`, and the production runner all see the same .env.
+const __dirname = dirname(fileURLToPath(import.meta.url));
+dotenv.config({ path: resolve(__dirname, '..', '..', '..', '..', '.env') });
+// Fallback to CWD-relative .env (no-ops if absent).
 dotenv.config();
 
+// Same fallback the db package uses: if DATABASE_URL is unset or still carries
+// the .env.example placeholder, construct it from POSTGRES_PASSWORD — the value
+// docker-compose actually boots Postgres with.
+function resolveDatabaseUrl(): string {
+  const explicit = process.env.DATABASE_URL;
+  if (explicit && !explicit.includes('CHANGE_ME')) return explicit;
+  const pw = process.env.POSTGRES_PASSWORD || 'postgres';
+  return `postgres://postgres:${pw}@localhost:5432/deft`;
+}
+
 export const env = {
-  DATABASE_URL: process.env.DATABASE_URL || 'postgres://postgres:postgres@localhost:5432/deft',
+  DATABASE_URL: resolveDatabaseUrl(),
   REDIS_URL: process.env.REDIS_URL || 'redis://localhost:6379',
   JWT_SECRET: process.env.JWT_SECRET || 'dev-jwt-secret-change-me',
   JWT_REFRESH_SECRET: process.env.JWT_REFRESH_SECRET || 'dev-refresh-secret-change-me',


### PR DESCRIPTION
﻿## Summary

Found while testing PR #1 on a freshly-reset droplet. `pnpm db:seed` ran `pnpm --filter @deft/db seed` cleanly (PR #1 fix), but the second step — `pnpm --filter @deft/api exec tsx src/scripts/seed-platform-bundles.ts` — auth-failed against Postgres.

Root cause: `apps/api/src/lib/env.ts` loaded the repo-root `.env` via `resolve(process.cwd(), "..", "..", ".env")`. That only works when CWD happens to be `apps/api/`. Under tsx, `pnpm --filter`, heartbeat workers, or `docker exec`, CWD is unpredictable — the lookup misses repo root and env.ts falls back to its hardcoded `postgres://postgres:postgres@...` URL, which doesn't match the random `POSTGRES_PASSWORD` Postgres actually booted with.

## Changes

- `apps/api/src/lib/env.ts` anchors dotenv to `import.meta.url` instead of `process.cwd()` — same pattern as the PR #1 fix in `packages/db/`.
- `DATABASE_URL` default now constructs from `POSTGRES_PASSWORD` (with localhost) when DATABASE_URL is unset or still carries the `CHANGE_ME` placeholder, matching the db-package behaviour.

Inside the deft container, the compose file sets `DATABASE_URL=postgres://postgres:${POSTGRES_PASSWORD}@postgres:5432/deft` explicitly, so the fallback never kicks in there — it only matters for host-side scripts like `pnpm db:seed`.

## Test plan

After this lands, the deploy procedure on a fresh droplet should be:
1. `git clone ... && cd Deft`
2. `cp .env.example .env` + set POSTGRES_PASSWORD, JWT_SECRET, JWT_REFRESH_SECRET, three NEXT_PUBLIC_* URLs
3. `docker compose up -d --build`
4. `pnpm install && pnpm db:push && pnpm db:seed`
5. Visit http://<ip>:3000/signup

Will re-verify on the droplet after merge.

Generated with Claude Code
