### PR TITLE
fix(alpha): unblock seed re-runs, audit auto-exec, scrub dead refs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -336,7 +336,7 @@ See plan: `docs/superpowers/plans/2026-04-28-phase9-simplify-agents.md` (this pr
 
 ## Known Limitations (deployment blockers)
 
-- **Drizzle `_journal.json` stale.** The Drizzle migration journal has been stale since migration 0017. Migrations 0025-0059 were applied manually and are not tracked in the journal. Production deploy must apply these manually via `drizzle-kit push` or direct SQL — `pnpm db:migrate` will not pick them up automatically. Any new migration must be tested against a DB that already has 0025-0059 applied.
+- **Use `pnpm db:push`, not `pnpm db:migrate`, for fresh installs.** The Drizzle `_journal.json` was rebuilt and is current through 0066. A couple of orphan migration files predating the rebuild remain on disk (`0002_subtasks_parent_task_id.sql`, `0020_wiki_search_vector.sql`) and aren't tracked, but their schema changes are folded into later migrations and the live schema. Fresh installs use `drizzle-kit push` which diffs the live schema against `schema.ts` — that's the supported path. Versioned `db:migrate` upgrades will be wired up post-alpha once orphan migration files are reconciled.
 
 ## What NOT To Do
 

--- a/apps/api/src/lib/agent-stream-loop.ts
+++ b/apps/api/src/lib/agent-stream-loop.ts
@@ -16,6 +16,7 @@ import { agentActions, messages, spaces } from '@deft/db/schema';
 import { eq } from 'drizzle-orm';
 import { env } from './env.js';
 import { executeToolCall } from './agent-context.js';
+import { executeActionDirect } from './agent-actions.js';
 import { getApprovalTier, shouldAutoExecute, type TrustLevel } from './agent-approval.js';
 import { resolveAnthropicApiKey } from './org-ai-config.js';
 
@@ -180,15 +181,21 @@ export async function runAgentStreamingLoop(p: StreamLoopParams): Promise<Stream
 
       if (isAction) {
         if (shouldAutoExecute(tool.name, p.trustLevel, tool.input)) {
-          try {
-            const { result, citations } = await executeToolCall(
-              tool.name, tool.input as any, p.orgId, p.userId, p.convoId, p.agentEmployeeId,
-            );
-            allCitations.push(...citations);
+          const approvalTier = getApprovalTier(tool.name);
+          const { success, result, error } = await executeActionDirect(
+            tool.name,
+            tool.input as any,
+            p.orgId,
+            p.userId,
+            p.convoId,
+            approvalTier,
+            { agentEmployeeId: p.agentEmployeeId, source: 'auto_execute' },
+          );
+          if (success) {
             await p.write({ type: 'tool_result', tool: tool.name, count: Array.isArray(result) ? result.length : 1 });
             toolResults.push({ type: 'tool_result', tool_use_id: tool.id, content: JSON.stringify(result) });
-          } catch (err) {
-            const errorMsg = err instanceof Error ? err.message : 'Tool execution failed';
+          } else {
+            const errorMsg = error ?? 'Tool execution failed';
             await p.write({ type: 'tool_result', tool: tool.name, error: errorMsg });
             toolResults.push({ type: 'tool_result', tool_use_id: tool.id, content: JSON.stringify({ error: errorMsg }), is_error: true });
           }

--- a/apps/api/src/scripts/seed-bundled-skills.ts
+++ b/apps/api/src/scripts/seed-bundled-skills.ts
@@ -4,10 +4,13 @@
  * Task 16: project-workflow skills (engineering, marketing-campaign,
  * sales-pipeline) retired — 6 bundled skills remain.
  *
- * Idempotent: uses the (source, COALESCE(org_id,''), slug) unique index
- * from migration 0035 as the conflict target. Re-running refreshes
- * name/description/version/config in place without breaking FKs held by
- * agent_employee_skills or project_skills.
+ * Idempotent: select-then-insert-or-update keyed on
+ * (source='bundled', org_id IS NULL, slug, is_deleted=false). We can't use
+ * ON CONFLICT against the partial unique index `skills_source_org_slug_idx`
+ * because its key uses `COALESCE(org_id,'')` and Postgres's
+ * infer_arbiter_indexes can't normalize the seeder's expression to match
+ * (plancat.c:920). Re-running refreshes name/description/version/config in
+ * place without breaking FKs held by agent_employee_skills.
  *
  * Run:
  *   pnpm --filter @deft/api exec tsx src/scripts/seed-bundled-skills.ts
@@ -31,34 +34,46 @@ export async function seedBundledSkills(
   log(`[seed-bundled-skills] Upserting ${BUNDLED_SKILLS.length} bundled skills`);
 
   for (const skill of BUNDLED_SKILLS) {
-    // Raw SQL: the declarative Drizzle unique index can't model
-    // COALESCE(org_id,''), so we target the partial unique index by name.
-    await db.execute(sql`
-      INSERT INTO skills (
-        id, org_id, source, slug, name, description, icon, version,
-        agent_config, is_deleted, usage_count
-      ) VALUES (
-        ${skill.id},
-        NULL,
-        'bundled',
-        ${skill.slug},
-        ${skill.name},
-        ${skill.description},
-        ${skill.icon},
-        ${skill.version},
-        ${JSON.stringify(skill.agent_config)}::jsonb,
-        false,
-        0
+    const [existing] = await db
+      .select({ id: skills.id })
+      .from(skills)
+      .where(
+        and(
+          eq(skills.source, 'bundled'),
+          isNull(skills.org_id),
+          eq(skills.slug, skill.slug),
+          eq(skills.is_deleted, false),
+        ),
       )
-      ON CONFLICT (source, (COALESCE(org_id,'')), slug) WHERE is_deleted = false
-      DO UPDATE SET
-        name = EXCLUDED.name,
-        description = EXCLUDED.description,
-        icon = EXCLUDED.icon,
-        version = EXCLUDED.version,
-        agent_config = EXCLUDED.agent_config,
-        updated_at = now()
-    `);
+      .limit(1);
+
+    if (existing) {
+      await db
+        .update(skills)
+        .set({
+          name: skill.name,
+          description: skill.description,
+          icon: skill.icon,
+          version: skill.version,
+          agent_config: skill.agent_config,
+          updated_at: sql`now()`,
+        })
+        .where(eq(skills.id, existing.id));
+    } else {
+      await db.insert(skills).values({
+        id: skill.id,
+        org_id: null,
+        source: 'bundled',
+        slug: skill.slug,
+        name: skill.name,
+        description: skill.description,
+        icon: skill.icon,
+        version: skill.version,
+        agent_config: skill.agent_config,
+        is_deleted: false,
+        usage_count: 0,
+      });
+    }
     log(`  upserted ${skill.slug}`);
   }
 

--- a/apps/api/src/scripts/seed-bundled-templates.ts
+++ b/apps/api/src/scripts/seed-bundled-templates.ts
@@ -1,12 +1,18 @@
 /**
- * Idempotent seeder for bundled task templates. Re-run on deploy; upserts
- * by (source, COALESCE(org_id,''), slug).
+ * Idempotent seeder for bundled task templates. Re-run on deploy; uses
+ * a select-then-insert-or-update keyed on
+ * (source='bundled', org_id IS NULL, slug, is_deleted=false). We can't use
+ * ON CONFLICT against the partial unique index
+ * `task_templates_source_org_slug_idx` because its key uses
+ * `COALESCE(org_id,'')` and Postgres's infer_arbiter_indexes can't normalize
+ * the seeder's expression to match (plancat.c:920).
  *
  *   pnpm tsx apps/api/src/scripts/seed-bundled-templates.ts
  */
 import { fileURLToPath } from 'node:url';
 import { db } from '../lib/db.js';
-import { sql } from 'drizzle-orm';
+import { and, eq, isNull, sql } from 'drizzle-orm';
+import { taskTemplates } from '@deft/db/schema';
 import { BUNDLED_TEMPLATES } from '../lib/bundled-templates.js';
 
 export async function seedBundledTemplates(
@@ -18,31 +24,46 @@ export async function seedBundledTemplates(
   log(`[seed-bundled-templates] Upserting ${BUNDLED_TEMPLATES.length} bundled templates`);
 
   for (const tpl of BUNDLED_TEMPLATES) {
-    await db.execute(sql`
-      INSERT INTO task_templates (
-        id, org_id, source, slug, name, description, icon, version, tasks, is_deleted, usage_count
-      ) VALUES (
-        ${tpl.id},
-        NULL,
-        'bundled',
-        ${tpl.slug},
-        ${tpl.name},
-        ${tpl.description},
-        ${tpl.icon},
-        ${tpl.version},
-        ${JSON.stringify(tpl.tasks)}::jsonb,
-        false,
-        0
+    const [existing] = await db
+      .select({ id: taskTemplates.id })
+      .from(taskTemplates)
+      .where(
+        and(
+          eq(taskTemplates.source, 'bundled'),
+          isNull(taskTemplates.org_id),
+          eq(taskTemplates.slug, tpl.slug),
+          eq(taskTemplates.is_deleted, false),
+        ),
       )
-      ON CONFLICT (source, (COALESCE(org_id,'')), slug) WHERE is_deleted = false
-      DO UPDATE SET
-        name = EXCLUDED.name,
-        description = EXCLUDED.description,
-        icon = EXCLUDED.icon,
-        version = EXCLUDED.version,
-        tasks = EXCLUDED.tasks,
-        updated_at = now()
-    `);
+      .limit(1);
+
+    if (existing) {
+      await db
+        .update(taskTemplates)
+        .set({
+          name: tpl.name,
+          description: tpl.description,
+          icon: tpl.icon,
+          version: tpl.version,
+          tasks: tpl.tasks,
+          updated_at: sql`now()`,
+        })
+        .where(eq(taskTemplates.id, existing.id));
+    } else {
+      await db.insert(taskTemplates).values({
+        id: tpl.id,
+        org_id: null,
+        source: 'bundled',
+        slug: tpl.slug,
+        name: tpl.name,
+        description: tpl.description,
+        icon: tpl.icon,
+        version: tpl.version,
+        tasks: tpl.tasks,
+        is_deleted: false,
+        usage_count: 0,
+      });
+    }
   }
   log(`[seed-bundled-templates] Done`);
   return BUNDLED_TEMPLATES.length;

--- a/apps/api/src/scripts/templates/devops/agents.md
+++ b/apps/api/src/scripts/templates/devops/agents.md
@@ -1,6 +1,6 @@
 # Working inside Deft
 
-Deft is your coordination surface. You read PR activity, track deploy tasks, maintain runbooks in the wiki, and drive the release process here. Actual infrastructure work happens via GitHub and the shell, but the memory and coordination live in Deft.
+Deft is your coordination surface. You read PR activity, track deploy tasks, maintain runbooks in the wiki, and drive the release process here. Actual infrastructure work happens via GitHub and a human operator at the shell, but the memory and coordination live in Deft.
 
 ## First rule: always start with platform_context
 
@@ -40,17 +40,17 @@ Use `memory_recall` to retrieve previously saved knowledge. The response include
 
 ### Remediation
 
-- `shell_exec(command)` — run shell commands on your runtime VPS. **Gated by approval at non-autonomous trust.** Draft the command and let a human approve it.
+You can't run shell commands yourself. When remediation requires one, draft the exact command (with rollback) in chat and ask a human to run it.
 
 ## Approval gating
 
 Write tools may return `{status: "queued_for_approval"}`. When this happens:
 
 1. Tell the user: "Drafted and queued for approval."
-2. **Do not retry.** Especially for shell commands — duplicate execution is dangerous.
+2. **Do not retry.** Duplicate writes are dangerous.
 3. Continue with the rest of the plan.
 
-Shell commands and `github_create_issue` (and any write to GitHub) **always** queue for approval unless the trust level is explicitly `autonomous`.
+`github_create_issue` (and any write to GitHub) **always** queues for approval unless the trust level is explicitly `autonomous`.
 
 ## Scope rules
 

--- a/apps/api/src/scripts/templates/devops/tools.md
+++ b/apps/api/src/scripts/templates/devops/tools.md
@@ -30,13 +30,9 @@
 - **`github_get_issue`** — fetch a specific issue.
 - **`github_create_issue`** — open an upstream issue (write; gated by approval).
 
-## Shell Exec (advanced — gated)
+## Shell commands
 
-> **Not yet available as a capability pack.** These tools require manual MCP server configuration.
-
-- **`shell_exec(command)`** — run a shell command on your runtime VPS. **Every shell command goes through approval** unless the trust level is `autonomous` and the command matches a pre-approved runbook entry.
-  _Example: draft `kubectl get pods -n prod` and let a human approve it before execution._
-- Never run destructive commands (`rm -rf`, `drop database`, `terraform destroy`, force push) without explicit human approval regardless of trust level.
+You don't have a shell-execution tool. When remediation needs one, draft the exact command (with rollback) in chat and ask a human to run it. Never propose destructive commands (`rm -rf`, `drop database`, `terraform destroy`, force push) without an explicit rollback plan.
 
 ## Rules of thumb
 

--- a/apps/api/src/scripts/templates/on-call/agents.md
+++ b/apps/api/src/scripts/templates/on-call/agents.md
@@ -1,6 +1,6 @@
 # Working inside Deft
 
-Deft is your incident coordination hub. You open incidents, track timeline, coordinate responders, and drive post-mortems here. External tools (GitHub, runbooks, shell) are for remediation; Deft is for memory and communication.
+Deft is your incident coordination hub. You open incidents, track timeline, coordinate responders, and drive post-mortems here. External tools (GitHub, runbooks) and human operators at the shell handle remediation; Deft is for memory and communication.
 
 ## First rule: always start with platform_context
 
@@ -38,9 +38,9 @@ Use `memory_recall` to retrieve previously saved knowledge. The response include
 - `memory_write({key, value, scope})` — record incident facts, root cause hypotheses, and remediation steps. Promote to org-wide after the post-mortem.
 - `delegation_self_report({target_employee_slug, reason})` — when the issue is clearly a devops infra problem, hand off with context.
 
-### Remediation (advanced)
+### Remediation
 
-- `shell_exec(...)` — **only if you are on `autonomous` trust** and the runbook explicitly authorises the command. Otherwise draft the command and ask a human to run it.
+You can't run shell commands yourself. Draft the exact remediation command (with rollback) from the runbook in chat and ask a human responder to run it.
 
 ## Approval gating
 
@@ -49,8 +49,6 @@ This is non-negotiable for on-call: most writes will queue for approval at `cons
 1. Say so clearly: "Queued for human approval — not yet executed."
 2. **Never retry.** Duplicate writes in an incident can make things worse.
 3. Continue coordinating — draft the next update, keep the timeline going.
-
-Shell commands ALWAYS queue for approval unless you're on `autonomous` trust AND the command matches a pre-approved runbook entry.
 
 ## Scope rules
 

--- a/apps/api/src/scripts/templates/on-call/tools.md
+++ b/apps/api/src/scripts/templates/on-call/tools.md
@@ -33,13 +33,9 @@
 - **`github_get_pr`** — read the PR description and diff for a suspected bad deploy.
 - **`github_create_issue`** — file an upstream issue (write; gated by approval).
 
-## Shell Exec (advanced — gated)
+## Shell commands
 
-> **Not yet available as a capability pack.** These tools require manual MCP server configuration.
-
-- **`shell_exec(command)`** — run a shell command on your runtime VPS. **Every shell command goes through approval** unless you're on `autonomous` trust AND the command matches a pre-approved runbook pattern.
-  _Example: draft `kubectl rollout undo deployment/payments -n prod` and ask the human to approve it._
-- Never run destructive commands (`rm`, `drop database`, `force push`) without explicit human approval, regardless of trust level.
+You don't have a shell-execution tool. When the runbook calls for one (e.g. `kubectl rollout undo deployment/payments -n prod`), draft the exact command in chat and ask a human responder to run it. Never propose destructive commands (`rm`, `drop database`, `force push`) without an explicit rollback plan.
 
 ## Rules of thumb
 

--- a/apps/api/test/bundled-skills-seed.test.ts
+++ b/apps/api/test/bundled-skills-seed.test.ts
@@ -1,10 +1,12 @@
 /**
  * Phase 4 Task 4.3 — Bundled skills seed verification.
  *
- * Asserts the 6 bundled skills (one per available capability pack) land
- * correctly and the seeder is idempotent. Coming-soon capability-pack
- * slugs must NOT appear. Project-workflow skills (engineering,
- * marketing-campaign, sales-pipeline) were retired in Task 16.
+ * Asserts the bundled skills (one per available capability pack, plus the
+ * deft-mcp-client on-ramp) land correctly and the seeder is idempotent.
+ * Coming-soon capability-pack slugs must NOT appear. Project-workflow
+ * skills (engineering, marketing-campaign, sales-pipeline) were retired
+ * in Task 16. `web-browsing` and `shell-exec` were OpenClaw Layer-2
+ * plugins removed in Phase 9 (2026-04-28).
  */
 import { test, before } from 'node:test';
 import assert from 'node:assert/strict';
@@ -17,13 +19,13 @@ const DATABASE_URL =
   process.env.DATABASE_URL || 'postgres://postgres:postgres@localhost:5432/deft';
 
 const EXPECTED_SLUGS = [
-  // 6 capability-pack skills (one per available pack)
+  // 4 available capability-pack skills (one per non-coming-soon pack)
   'deft-workspace',
-  'web-browsing',
   'tavily',
   'github',
   'google-calendar',
-  'shell-exec',
+  // BYOA on-ramp
+  'deft-mcp-client',
 ];
 
 async function withClient<T>(fn: (c: pg.Client) => Promise<T>): Promise<T> {
@@ -42,20 +44,20 @@ before(async () => {
   await seedBundledSkills({ silent: true });
 });
 
-test('BUNDLED_SKILLS has exactly 6 definitions matching expected slugs', () => {
-  assert.equal(BUNDLED_SKILLS.length, 6);
+test('BUNDLED_SKILLS matches expected slug set', () => {
+  assert.equal(BUNDLED_SKILLS.length, EXPECTED_SLUGS.length);
   const slugs = BUNDLED_SKILLS.map((s) => s.slug).sort();
   assert.deepEqual(slugs, [...EXPECTED_SLUGS].sort());
 });
 
-test('seed produces exactly 6 bundled rows', async () => {
+test('seed produces exactly one row per expected slug', async () => {
   await withClient(async (c) => {
     const res = await c.query<{ count: string }>(
       `SELECT count(*)::text FROM skills
        WHERE source = 'bundled' AND slug = ANY($1::text[]) AND is_deleted = false`,
       [EXPECTED_SLUGS],
     );
-    assert.equal(res.rows[0]!.count, '6');
+    assert.equal(res.rows[0]!.count, String(EXPECTED_SLUGS.length));
   });
 });
 


### PR DESCRIPTION
## Summary

Five fixes off the alpha punch-list. Code-only; no schema migrations.

- **Seed idempotency.** `seed-bundled-skills` + `seed-bundled-templates` were calling `ON CONFLICT (source, (COALESCE(org_id,'')), slug) WHERE is_deleted = false` to upsert against a partial unique index defined as `COALESCE(org_id,'')` (no parens). Postgres can't normalize the extra parens against the index expression, so every re-seed threw `infer_arbiter_indexes`. Switched both seeders to a typed Drizzle check-then-update pattern (same shape as `seed-templates.ts`). Re-runs are now no-ops.
- **Auto-exec audit row.** The agent stream loop's auto-execute branch was calling `executeToolCall` directly, so the approval inbox / dashboard never saw auto-executed actions. Routed it through `executeActionDirect` (mirroring `agent-runner.ts:438` and `agent-plans.ts:410`) so each auto-exec creates an `agent_actions` row with `approval_status='approved'`.
- **Dead `shell_exec` refs.** Phase 9 (2026-04-28) deleted OpenClaw and its Layer-2 plugins, including `shell_exec`. The DevOps and On-Call employee templates still prompted agents to use it. Replaced the relevant prose in both `agents.md` + `tools.md` files — agents now draft the command and hand it to a human.
- **Stale test.** `bundled-skills-seed.test.ts` still expected `web-browsing` and `shell-exec` in the bundled set and hardcoded `count = 6`. Updated `EXPECTED_SLUGS` (drop the two dead slugs, add `deft-mcp-client`) and made the count derive from the array.
- **Stale CLAUDE.md.** Replaced the "Drizzle journal stale since 0017" note — the journal was rebuilt and is current through `0066_drop_deprecated_tables`.

## Test plan

- [ ] `pnpm --filter @deft/api typecheck` — green locally
- [ ] `pnpm --filter @deft/api exec tsx src/scripts/seed-platform-bundles.ts` runs twice without `infer_arbiter_indexes`
- [ ] `pnpm --filter @deft/api test test/bundled-skills-seed.test.ts` passes after a fresh seed
- [ ] Trigger an auto-tier tool from chat (e.g. `list_my_tasks`) → row appears in `agent_actions` with `approval_status='approved'`
- [ ] Skim DevOps + On-Call employee personalities — no leftover `shell_exec` mentions

🤖 Generated with [Claude Code](https://claude.com/claude-code)