### PR TITLE
fix(chat): show all members in group-DM header + enable huddles in DMs

### DIFF
--- a/apps/web/src/components/space-chat.tsx
+++ b/apps/web/src/components/space-chat.tsx
@@ -1096,7 +1096,10 @@ export function SpaceChat({
   const typingText = Array.from(typingUsers.values());
   const isDm = spaceType === 'dm' || spaceType === 'group_dm';
   const displayName = isDm
-    ? spaceName.split(',').map(n => n.trim()).find(n => n !== user?.name) || spaceName
+    ? (() => {
+        const others = spaceName.split(',').map((n) => n.trim()).filter((n) => n !== user?.name);
+        return others.length ? others.join(', ') : spaceName;
+      })()
     : spaceName;
 
   return (
@@ -1192,7 +1195,7 @@ export function SpaceChat({
             </button>
 
             {/* Huddle button */}
-            {!isDm && (() => {
+            {(() => {
               const inThisHuddle = huddleSpaceId === spaceId;
               const huddleHere = activeHuddles.get(spaceId);
               const othersInHuddle = !inThisHuddle && huddleHere && huddleHere.participants.length > 0;


### PR DESCRIPTION
## Summary

Two small UX bugs in `space-chat.tsx`, caught while testing the demo org as Maneek.

### 1. Group DM header + composer placeholder only showed one member

```ts
// before
const displayName = isDm
  ? spaceName.split(',').map(n => n.trim()).find(n => n !== user?.name) || spaceName
  : spaceName;
```

`find()` returns the *first* non-self name. For \"Maneek, Arjun, Priya\", Maneek saw \"Arjun\" in the header and the composer placeholder said \"Message Arjun\" — Priya was invisible until you opened the member panel.

Switched to `filter().join(', ')`. 1-on-1 DMs are unchanged (single name); group DMs now read \"Arjun, Priya\".

### 2. Huddle button was hidden in all DMs

The button was gated behind `{!isDm && (() => ...)()}`, so neither 1-on-1 nor group DMs got a huddle button.

The backend `huddle:create` socket handler in `apps/api/src/socket.ts` is already space-type-agnostic — it creates a room keyed on `space_id` and rings non-muted space members. So this was a pure UI hide; dropping the gate is enough.

## Test plan

- [ ] Open a group DM (e.g. \"Maneek, Arjun, Priya\") — header reads \"Arjun, Priya\", composer says \"Message Arjun, Priya\"
- [ ] Open a 1-on-1 DM (e.g. \"Maneek, Rahul\") — header still reads \"Rahul\" (no regression)
- [ ] Public channel — header still reads \"#general\" with the `#` icon (no regression)
- [ ] Huddle button appears in DMs and group DMs; click starts a huddle, other DM members get the ring

🤖 Generated with [Claude Code](https://claude.com/claude-code)