### PR TITLE
fix(ci): load built image into daemon for docker smoke-test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,7 @@ jobs:
         with:
           context: .
           push: false
+          load: true
           tags: deft:ci
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary
- `docker/build-push-action@v6` with `push: false` does not load the image into the runner's local docker daemon by default
- The next step (`docker run --rm --entrypoint sh deft:ci -c ...`) was failing every run with `Unable to find image 'deft:ci' locally` → exit 125
- Adding `load: true` makes the smoke step actually exercise the image we just built

## Test plan
- [ ] CI's "Docker Image Build" job goes green on this PR (Build production image + Smoke-test the image both succeed)
- [ ] Type Check still green
- [ ] (Test API will still be red — that's a separate schema-drift issue, not addressed here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)