### PR TITLE
fix(ci): make Test API green — orphan SQL + stale test fixtures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Enable pgvector extension
         run: psql "$DATABASE_URL" -c "CREATE EXTENSION IF NOT EXISTS vector;"
       - name: Push schema
-        run: pnpm --filter @deft/db push --force
+        run: pnpm --filter @deft/db push-full
       - name: Run tests
         run: pnpm --filter @deft/api test
 

--- a/apps/api/test/agent-actions-routes.test.ts
+++ b/apps/api/test/agent-actions-routes.test.ts
@@ -78,8 +78,8 @@ async function seedFixtures() {
       TEST_PROJECT_ID = proj.rows[0].id;
     } else {
       const r = await c.query(
-        `INSERT INTO projects (org_id, name, prefix, lead_id, task_counter)
-         VALUES ($1, 'Actions Routes Test Project', 'ART', $2, 0)
+        `INSERT INTO projects (id, org_id, name, prefix, lead_id, task_counter)
+         VALUES (gen_random_uuid()::text, $1, 'Actions Routes Test Project', 'ART', $2, 0)
          RETURNING id`,
         [ORG_ID, SHADOW_USER_ID],
       );

--- a/apps/api/test/agent-approval-resolver.test.ts
+++ b/apps/api/test/agent-approval-resolver.test.ts
@@ -101,8 +101,8 @@ async function seedFixtures() {
       TEST_PROJECT_ID = proj.rows[0].id;
     } else {
       const r = await c.query(
-        `INSERT INTO projects (org_id, name, prefix, lead_id, task_counter)
-         VALUES ($1, 'Resolver Test Project', 'RSLV', $2, 0)
+        `INSERT INTO projects (id, org_id, name, prefix, lead_id, task_counter)
+         VALUES (gen_random_uuid()::text, $1, 'Resolver Test Project', 'RSLV', $2, 0)
          RETURNING id`,
         [ORG_ID, SHADOW_USER_ID],
       );

--- a/apps/api/test/burnout-detector.test.ts
+++ b/apps/api/test/burnout-detector.test.ts
@@ -55,8 +55,8 @@ async function seedWikiPage(
   const slug = `test-burnout-authorship-${suffix}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
   const r = await c.query(
     `INSERT INTO wiki_pages
-       (org_id, user_id, slug, title, content, type, scope, confidence, created_at)
-     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+       (id, org_id, user_id, slug, title, content, type, scope, confidence, created_at)
+     VALUES (gen_random_uuid()::text, $1, $2, $3, $4, $5, $6, $7, $8, $9)
      RETURNING id`,
     [
       ORG_ID,
@@ -87,8 +87,8 @@ async function seedCommitmentPage(
   const slug = `test-burnout-commitment-${suffix}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
   const r = await c.query(
     `INSERT INTO wiki_pages
-       (org_id, user_id, slug, title, content, type, scope, confidence, tags, referenced_user_ids, updated_at)
-     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, ARRAY['commitment']::text[], ARRAY[$9]::text[], $10)
+       (id, org_id, user_id, slug, title, content, type, scope, confidence, tags, referenced_user_ids, updated_at)
+     VALUES (gen_random_uuid()::text, $1, $2, $3, $4, $5, $6, $7, $8, ARRAY['commitment']::text[], ARRAY[$9]::text[], $10)
      RETURNING id`,
     [
       ORG_ID,

--- a/apps/api/test/dashboard-my-work.test.ts
+++ b/apps/api/test/dashboard-my-work.test.ts
@@ -70,8 +70,8 @@ async function seedFixtures() {
       projectId = proj.rows[0].id as string;
     } else {
       const r = await c.query(
-        `INSERT INTO projects (org_id, name, prefix, lead_id, task_counter)
-         VALUES ($1, 'My Work Test Project', 'MYW', $2, 0)
+        `INSERT INTO projects (id, org_id, name, prefix, lead_id, task_counter)
+         VALUES (gen_random_uuid()::text, $1, 'My Work Test Project', 'MYW', $2, 0)
          RETURNING id`,
         [ORG_ID, USER_A_ID],
       );

--- a/apps/api/test/embed-content.test.ts
+++ b/apps/api/test/embed-content.test.ts
@@ -62,8 +62,8 @@ test('1. writes a 1536-dim embedding to the target wiki page', async () => {
   const pageId = await withClient(async (c) => {
     const r = await c.query(
       `INSERT INTO wiki_pages
-        (org_id, slug, title, content, summary, type, scope, confidence)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+        (id, org_id, slug, title, content, summary, type, scope, confidence)
+       VALUES (gen_random_uuid()::text, $1, $2, $3, $4, $5, $6, $7, $8)
        RETURNING id`,
       [
         ORG_ID,
@@ -171,8 +171,8 @@ test('4. throws on non-OK OpenAI response so the queue retries', async () => {
     const pageId = await withClient(async (c) => {
       const r = await c.query(
         `INSERT INTO wiki_pages
-          (org_id, slug, title, content, type, scope, confidence)
-         VALUES ($1, $2, $3, $4, $5, $6, $7)
+          (id, org_id, slug, title, content, type, scope, confidence)
+         VALUES (gen_random_uuid()::text, $1, $2, $3, $4, $5, $6, $7)
          RETURNING id`,
         [ORG_ID, `test-embed-err-${Date.now()}`, 'Err page', 'content', 'decision', 'org', 1.0],
       );

--- a/apps/api/test/employee-trigger.test.ts
+++ b/apps/api/test/employee-trigger.test.ts
@@ -59,8 +59,8 @@ async function seedFixtures() {
       TEST_SPACE_ID = sp.rows[0].id;
     } else {
       const r = await c.query(
-        `INSERT INTO spaces (org_id, name, type, created_by)
-         VALUES ($1, 'phase9-trigger-test-space', 'public', $2)
+        `INSERT INTO spaces (id, org_id, name, type, created_by)
+         VALUES (gen_random_uuid()::text, $1, 'phase9-trigger-test-space', 'public', $2)
          RETURNING id`,
         [ORG_ID, TEST_USER_ID],
       );

--- a/apps/api/test/mcp-write-tools.test.ts
+++ b/apps/api/test/mcp-write-tools.test.ts
@@ -102,8 +102,8 @@ async function seedFixtures() {
       TEST_PROJECT_ID = proj.rows[0].id;
     } else {
       const r = await c.query(
-        `INSERT INTO projects (org_id, name, prefix, lead_id, task_counter)
-         VALUES ($1, 'MCP Phase4 Test Project', 'MCPP4', $2, 0)
+        `INSERT INTO projects (id, org_id, name, prefix, lead_id, task_counter)
+         VALUES (gen_random_uuid()::text, $1, 'MCP Phase4 Test Project', 'MCPP4', $2, 0)
          RETURNING id`,
         [ORG_ID, TEST_USER_ID]
       );
@@ -120,8 +120,8 @@ async function seedFixtures() {
       TEST_SPACE_ID = sp.rows[0].id;
     } else {
       const r = await c.query(
-        `INSERT INTO spaces (org_id, name, type, created_by)
-         VALUES ($1, 'mcp-phase4-test-space', 'public', $2)
+        `INSERT INTO spaces (id, org_id, name, type, created_by)
+         VALUES (gen_random_uuid()::text, $1, 'mcp-phase4-test-space', 'public', $2)
          RETURNING id`,
         [ORG_ID, TEST_USER_ID]
       );

--- a/apps/api/test/memory-extract-embed-enqueue.test.ts
+++ b/apps/api/test/memory-extract-embed-enqueue.test.ts
@@ -219,8 +219,8 @@ test('2. enqueue embed-content called after wiki page UPDATE', async () => {
   const slug = `test-existing-page-update-${Date.now()}`;
   const pageId: string = await withClient(async (c) => {
     const r = await c.query(
-      `INSERT INTO wiki_pages (org_id, slug, title, content, type, scope, confidence)
-       VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING id`,
+      `INSERT INTO wiki_pages (id, org_id, slug, title, content, type, scope, confidence)
+       VALUES (gen_random_uuid()::text, $1, $2, $3, $4, $5, $6, $7) RETURNING id`,
       [ORG_ID, slug, 'Existing Test Page', 'Original content.', 'fact', 'org', 0.9],
     );
     return r.rows[0].id;

--- a/apps/api/test/memory-extract-no-agent-memory.test.ts
+++ b/apps/api/test/memory-extract-no-agent-memory.test.ts
@@ -127,11 +127,26 @@ async function cleanupTest(slugPrefix: string) {
         );
       }
     }
-    // Clean up decisions rows
-    await c.query(
-      `DELETE FROM decisions WHERE org_id = $1 AND message_id = $2`,
+    // Clean up any decision-typed wiki_pages created from this message
+    // (legacy `decisions` table was retired 2026-05-12; decisions now live on
+    // wiki_pages where type='decision', linked to messages via wiki_citations).
+    const decisionPages = await c.query(
+      `SELECT wp.id
+         FROM wiki_pages wp
+         JOIN wiki_citations wc ON wc.page_id = wp.id
+        WHERE wp.org_id = $1
+          AND wp.type = 'decision'
+          AND wc.source_type = 'message'
+          AND wc.source_id = $2`,
       [ORG_ID, MESSAGE_ID],
     );
+    const decisionIds: string[] = decisionPages.rows.map((r: any) => r.id);
+    if (decisionIds.length) {
+      await c.query(`DELETE FROM wiki_citations WHERE page_id = ANY($1)`, [decisionIds]);
+      await c.query(`DELETE FROM wiki_links WHERE source_page_id = ANY($1) OR target_page_id = ANY($1)`, [decisionIds]);
+      await c.query(`DELETE FROM wiki_ops_log WHERE page_id = ANY($1)`, [decisionIds]);
+      await c.query(`DELETE FROM wiki_pages WHERE id = ANY($1)`, [decisionIds]);
+    }
     // Remove any stray agent_memory rows for the test user (should be zero, but clean anyway)
     await c.query(
       `DELETE FROM agent_memory WHERE org_id = $1 AND user_id = $2`,
@@ -230,9 +245,25 @@ test('handleMemoryExtract still writes to wiki_pages after removing dual-write',
   } finally {
     delete (globalThis as any).__mockAnthropicResponseNoAgMem;
     await cleanupTest('no-agent-mem-wiki-check-');
-    // Also clean up the wiki-check message decisions
-    await withClient((c) =>
-      c.query(`DELETE FROM decisions WHERE org_id = $1 AND message_id = $2`, [ORG_ID, `${MESSAGE_ID}-wiki-check`]),
-    );
+    // Also clean up any decision-typed wiki_pages cited from the wiki-check message
+    await withClient(async (c) => {
+      const r = await c.query(
+        `SELECT wp.id
+           FROM wiki_pages wp
+           JOIN wiki_citations wc ON wc.page_id = wp.id
+          WHERE wp.org_id = $1
+            AND wp.type = 'decision'
+            AND wc.source_type = 'message'
+            AND wc.source_id = $2`,
+        [ORG_ID, `${MESSAGE_ID}-wiki-check`],
+      );
+      const ids: string[] = r.rows.map((row: any) => row.id);
+      if (ids.length) {
+        await c.query(`DELETE FROM wiki_citations WHERE page_id = ANY($1)`, [ids]);
+        await c.query(`DELETE FROM wiki_links WHERE source_page_id = ANY($1) OR target_page_id = ANY($1)`, [ids]);
+        await c.query(`DELETE FROM wiki_ops_log WHERE page_id = ANY($1)`, [ids]);
+        await c.query(`DELETE FROM wiki_pages WHERE id = ANY($1)`, [ids]);
+      }
+    });
   }
 });

--- a/apps/api/test/oneone-prep-commitments.test.ts
+++ b/apps/api/test/oneone-prep-commitments.test.ts
@@ -111,8 +111,8 @@ test('generateOneOnePrep includes commitment from seeded wiki_page', async () =>
     const slug = `test-commitment-${Date.now()}`;
     const r = await c.query(
       `INSERT INTO wiki_pages
-         (org_id, slug, title, summary, content, type, scope, confidence, tags, referenced_user_ids)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9::text[], $10::text[])
+         (id, org_id, slug, title, summary, content, type, scope, confidence, tags, referenced_user_ids)
+       VALUES (gen_random_uuid()::text, $1, $2, $3, $4, $5, $6, $7, $8, $9::text[], $10::text[])
        RETURNING id`,
       [
         ORG_ID,

--- a/apps/api/test/people-graph-knowledge-dependency.test.ts
+++ b/apps/api/test/people-graph-knowledge-dependency.test.ts
@@ -45,8 +45,8 @@ async function seedWikiPage(
   const slug = `test-kd-${suffix}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
   const r = await c.query(
     `INSERT INTO wiki_pages
-       (org_id, user_id, slug, title, content, type, scope, confidence)
-     VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+       (id, org_id, user_id, slug, title, content, type, scope, confidence)
+     VALUES (gen_random_uuid()::text, $1, $2, $3, $4, $5, $6, $7, $8)
      RETURNING id`,
     [ORG_ID, userId, slug, `KD test page ${suffix}`, 'Test content.', 'decision', 'org', 0.9],
   );

--- a/apps/api/test/people-graph-relationships.test.ts
+++ b/apps/api/test/people-graph-relationships.test.ts
@@ -62,8 +62,8 @@ test('1. delegation_chain edge created when user-A assigns >=5 tasks to user-B w
     if (r.rows.length > 0) return r.rows[0].id as string;
     // Create a minimal project if none exists
     const ins = await c.query(
-      `INSERT INTO projects (org_id, name, slug, created_by)
-       VALUES ($1, 'Test Project (delegation)', 'test-delegation-proj', $2)
+      `INSERT INTO projects (id, org_id, name, prefix, lead_id, task_counter)
+       VALUES (gen_random_uuid()::text, $1, 'Test Project (delegation)', 'TDP', $2, 0)
        RETURNING id`,
       [ORG_ID, USER_A],
     );

--- a/apps/api/test/people-graph-task-completion.test.ts
+++ b/apps/api/test/people-graph-task-completion.test.ts
@@ -56,8 +56,8 @@ test('task completion with a label contributes +3 to assignee expertise on that 
     );
     if (r.rows.length > 0) return r.rows[0].id as string;
     const ins = await c.query(
-      `INSERT INTO projects (org_id, name, slug, created_by)
-       VALUES ($1, 'Test Project (task-completion)', 'test-task-completion-proj', $2)
+      `INSERT INTO projects (id, org_id, name, prefix, lead_id, task_counter)
+       VALUES (gen_random_uuid()::text, $1, 'Test Project (task-completion)', 'TTC', $2, 0)
        RETURNING id`,
       [ORG_ID, USER_A],
     );

--- a/apps/api/test/phase8-heartbeat-prompt.test.ts
+++ b/apps/api/test/phase8-heartbeat-prompt.test.ts
@@ -75,10 +75,10 @@ async function seedEmployee(opts: {
         const cfg = { heartbeat_checklist: opts.skillChecklists[i] };
         await c.query(
           `INSERT INTO skills (id, slug, name, description, version, source,
-                                author_user_id, agent_config)
+                                org_id, created_by, agent_config)
            VALUES ($1, $2, 'Phase 8 Prompt Skill', 'test skill', '0.1.0',
-                   'org', $3, $4::jsonb)`,
-          [skillId, `phase8-prompt-skill-${i}-${crypto.randomUUID()}`, userId, JSON.stringify(cfg)],
+                   'org', $3, $4, $5::jsonb)`,
+          [skillId, `phase8-prompt-skill-${i}-${crypto.randomUUID()}`, orgId, userId, JSON.stringify(cfg)],
         );
         skillIds.push(skillId);
 

--- a/apps/api/test/task-assignee-model.test.ts
+++ b/apps/api/test/task-assignee-model.test.ts
@@ -76,8 +76,8 @@ async function seedFixtures() {
       projectId = proj.rows[0].id as string;
     } else {
       const r = await c.query(
-        `INSERT INTO projects (org_id, name, prefix, lead_id, task_counter)
-         VALUES ($1, 'Assignee Model Test Project', 'AMT', $2, 0)
+        `INSERT INTO projects (id, org_id, name, prefix, lead_id, task_counter)
+         VALUES (gen_random_uuid()::text, $1, 'Assignee Model Test Project', 'AMT', $2, 0)
          RETURNING id`,
         [ORG_ID, MEMBER_USER_ID],
       );

--- a/apps/api/test/tasks-watchers-assignees-auth.test.ts
+++ b/apps/api/test/tasks-watchers-assignees-auth.test.ts
@@ -86,8 +86,8 @@ async function seedFixtures() {
       projectId = proj.rows[0].id as string;
     } else {
       const r = await c.query(
-        `INSERT INTO projects (org_id, name, prefix, lead_id, task_counter)
-         VALUES ($1, 'Watchers Auth Test Project', 'WAT', $2, 0)
+        `INSERT INTO projects (id, org_id, name, prefix, lead_id, task_counter)
+         VALUES (gen_random_uuid()::text, $1, 'Watchers Auth Test Project', 'WAT', $2, 0)
          RETURNING id`,
         [ORG_ID, MEMBER_USER_ID],
       );

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "generate": "drizzle-kit generate",
     "push": "drizzle-kit push",
+    "push-full": "drizzle-kit push --force && tsx scripts/apply-extras.ts",
     "migrate": "drizzle-kit migrate",
     "seed": "tsx seed.ts",
     "seed:demo": "tsx seed-demo.ts",

--- a/packages/db/scripts/apply-extras.ts
+++ b/packages/db/scripts/apply-extras.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import pg from 'pg';
+
+const { Client } = pg;
+
+const DATABASE_URL = process.env.DATABASE_URL;
+if (!DATABASE_URL) {
+  console.error('[apply-extras] DATABASE_URL is required');
+  process.exit(1);
+}
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const drizzleDir = resolve(__dirname, '..', 'drizzle');
+
+const files = [
+  '0020_wiki_search_vector.sql',
+  '0033_tasks_embedding.sql',
+];
+
+async function main() {
+  const client = new Client({ connectionString: DATABASE_URL });
+  await client.connect();
+  try {
+    for (const file of files) {
+      const sql = readFileSync(resolve(drizzleDir, file), 'utf8');
+      await client.query(sql);
+      console.log(`[apply-extras] applied ${file}`);
+    }
+  } finally {
+    await client.end();
+  }
+}
+
+main().catch((err) => {
+  console.error('[apply-extras] failed:', err);
+  process.exit(1);
+});

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -832,6 +832,7 @@ export const crossReferences = pgTable('cross_references', {
 }, (t) => [
   index('cross_ref_source_idx').on(t.source_type, t.source_id),
   index('cross_ref_target_idx').on(t.target_type, t.target_id),
+  uniqueIndex('cross_ref_unique_edge').on(t.source_type, t.source_id, t.target_type, t.target_id),
 ]);
 
 // ═══ DUPLICATE FLAGS ═══


### PR DESCRIPTION
## Summary
Two-commit fix to turn the long-red **Test API** CI job green. Bundled so the diff is reviewed as one story.

**Commit 1 — `fix(db)`:**
- `drizzle-kit push` only emits what's declared in `schema.ts`. Two orphan SQL files (`0020_wiki_search_vector`, `0033_tasks_embedding`) create FTS columns and indexes that runtime code references. Without them, every wiki/task search query errors with `column "search_vector" does not exist` — broken in CI **and on fresh self-hosts**.
- New `packages/db/scripts/apply-extras.ts` runs the orphans idempotently after push. New `pnpm db:push-full` chains them. CI calls `push-full`.
- Adds the missing unique constraint on `cross_references(source_type, source_id, target_type, target_id)` that runtime `ON CONFLICT` specs require.

**Commit 2 — `fix(test)`:**
- Stale raw-SQL fixtures across 16 test files. No runtime code touched.
- `DELETE FROM decisions` → `DELETE FROM wiki_pages WHERE type='decision' AND id IN (SELECT page_id FROM wiki_citations WHERE source_type='message' AND source_id=...)` (decisions table was dropped in migration 0066).
- `INSERT INTO projects (... slug, created_by)` → `INSERT INTO projects (id, org_id, name, prefix, lead_id, task_counter)`.
- `INSERT INTO skills (... author_user_id)` → drop that column.
- Raw inserts into `wiki_pages` / `projects` / `spaces` now supply `id = gen_random_uuid()::text` (cuid2 default lives in TS, not as a DB DEFAULT).

## Test plan
- [ ] CI's Test API job goes green
- [ ] CI's Docker Image Build still green (already passing post #14)
- [ ] CI's Type Check still green
- [ ] Once green, `pnpm db:push-full` becomes the documented self-host path (CLAUDE.md update — separate PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)