### PR TITLE
docs(readme): use db:push-full so fresh installs don't ship broken FTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,12 @@ Open `.env` and set three values:
 docker compose up -d
 
 # 3. Initialize the database (run once on first boot)
-pnpm db:push        # applies schema
+pnpm db:push-full   # applies schema + the two extras SQL files (FTS columns / triggers)
 pnpm db:seed        # seeds Defty + bundled skills/templates (prod-safe, idempotent)
 # pnpm db:seed:demo # ALSO inserts 5 test users for poking around — dev only, NEVER in prod
 ```
 
-> **Note:** Use `pnpm db:push`, not `pnpm db:migrate`. The migration journal is canonical as of v0.1 but `push` is the supported path for fresh installs — it diffs the live schema against `packages/db/src/schema.ts` and applies what's missing. `db:migrate` is for upgrade paths once we ship versioned releases.
+> **Note:** Use `pnpm db:push-full`, not `pnpm db:migrate`. The migration journal is canonical as of v0.1 but `push-full` is the supported path for fresh installs — it diffs the live schema against `packages/db/src/schema.ts`, then applies two orphan SQL files (`0020_wiki_search_vector.sql` and `0033_tasks_embedding.sql`) that create generated tsvector columns and GIN indexes Drizzle's pushed schema can't express. Plain `pnpm db:push` skips the orphans and leaves wiki/task FTS broken. `db:migrate` is for upgrade paths once we ship versioned releases.
 
 > **`pnpm db:seed` is prod-safe and idempotent** — re-running on a populated workspace is a no-op. It inserts only platform bundles (Defty system user, bundled skills, bundled task templates, first-party employee templates). It never inserts test accounts.
 
@@ -71,7 +71,7 @@ cp .env.example .env
 # Edit .env with your database URL
 
 # Set up database
-pnpm db:push
+pnpm db:push-full
 pnpm db:seed         # Platform bundle only (prod-safe)
 # pnpm db:seed:demo  # OR: wipe + populate with 5 test users + demo content (dev only)
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "db:generate": "pnpm --filter @deft/db generate",
     "db:migrate": "pnpm --filter @deft/db migrate",
     "db:push": "pnpm --filter @deft/db push",
+    "db:push-full": "pnpm --filter @deft/db push-full",
     "db:seed": "pnpm --filter @deft/db seed && pnpm --filter @deft/api exec tsx src/scripts/seed-platform-bundles.ts",
     "db:seed:demo": "pnpm --filter @deft/db seed:demo && pnpm --filter @deft/api exec tsx src/scripts/seed-platform-bundles.ts",
     "db:studio": "pnpm --filter @deft/db studio",


### PR DESCRIPTION
## Summary
Verified on a fresh Ubuntu 24.04 VPS today: following the README literally produces a broken schema.

\`drizzle-kit push\` only emits what's declared in \`schema.ts\`. Two orphan SQL files (\`0020_wiki_search_vector\`, \`0033_tasks_embedding\`) create generated tsvector columns + GIN indexes that the runtime wiki/task FTS queries against. Without them, every wiki/task search 500s with \`column "search_vector" does not exist\`.

PR #15 added \`pnpm --filter @deft/db push-full\` that chains schema-push + apply-orphans, but the README at line 46 still pointed at plain \`pnpm db:push\`. Anyone following the published instructions got a silently-broken FTS path.

## Changes
- Add root-level \`pnpm db:push-full\` alias matching the existing \`db:push\` shorthand pattern.
- Switch both README sections (self-host + local dev) to \`db:push-full\`.
- Expand the "use push not migrate" note to explain *why* push-full matters and what the orphans contain.

## Test plan
- [x] Verified on a fresh DigitalOcean droplet (Ubuntu 24.04, no pre-existing state):
  - \`pnpm db:push\` alone → \`wiki_pages.search_vector\` and \`tasks.search_vector\` MISSING; GIN indexes MISSING.
  - \`pnpm db:push-full\` (after this PR's alias lands) → both columns present, both \`*_search_idx\` GIN indexes present, \`cross_ref_unique_edge\` unique index present.
  - End-to-end signup → login → \`/api/spaces\` → \`/api/tasks/search?q=…\` all return 200; Defty DM auto-created (\`'VPS Tester, Defty'\`).
- [ ] CI Type Check + Docker Image Build stay green (README-only + one-line script alias).

🤖 Generated with [Claude Code](https://claude.com/claude-code)