### PR TITLE
fix(local-dev): first-run paper cuts on Windows + tsx watch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,4 +58,4 @@ EXPOSE 3000 3001
 # Start both web and API. Use the locally-installed next binary (pnpm exec),
 # not `npx next start` — npx downloads a fresh next install to ~/.npm/_npx/
 # that lacks the Turbopack runtime files our build produced.
-CMD sh -c "cd /app/apps/api && node --import tsx src/index.ts & cd /app/apps/web && pnpm exec next start -p 3000"
+CMD sh -c "cd /app/apps/api && node --import tsx src/server.ts & cd /app/apps/web && pnpm exec next start -p 3000"

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -4,11 +4,11 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx watch src/index.ts",
-    "build": "tsx src/index.ts",
+    "dev": "tsx watch src/server.ts",
+    "build": "tsx src/server.ts",
     "typecheck": "tsc --noEmit",
     "test": "tsx --test --test-concurrency=1 test/*.test.ts",
-    "start": "node dist/index.js"
+    "start": "node dist/server.js"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.80.0",

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -3,9 +3,6 @@ import { Hono } from 'hono';
 import { cors } from 'hono/cors';
 import { logger } from 'hono/logger';
 import { secureHeaders } from 'hono/secure-headers';
-import { serve } from '@hono/node-server';
-import type { Server } from 'node:http';
-import { setupSocket } from './socket.js';
 import { authRoutes } from './routes/auth.js';
 import { spaceRoutes } from './routes/spaces.js';
 import { messageRoutes } from './routes/messages.js';
@@ -60,7 +57,11 @@ const app = new Hono();
 
 app.use('*', logger());
 app.use('*', cors({
-  origin: process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000',
+  origin: [
+    process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000',
+    'http://localhost:3000',
+    'http://127.0.0.1:3000',
+  ],
   credentials: true,
   allowHeaders: ['Content-Type', 'Authorization'],
   allowMethods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
@@ -187,54 +188,6 @@ app.get('/health/queue', async (c) => {
     return c.json({ error: 'Failed to query queue health', code: 'INTERNAL_ERROR' }, 500);
   }
 });
-
-// Prefer Railway/Fly's PORT env, then API_PORT, then local default.
-const port = parseInt(process.env.PORT || process.env.API_PORT || '3001');
-
-// Guard: only start the HTTP server when running as the main entry point,
-// not when imported by tests (avoids EADDRINUSE in test environments).
-// In ESM, there's no require.main; we use process.argv[1] vs import.meta.url.
-const isMain = process.argv[1]?.replace(/\\/g, '/').endsWith('/index.js') ||
-               process.argv[1]?.replace(/\\/g, '/').endsWith('/index.ts');
-
-let server: ReturnType<typeof serve> | null = null;
-if (isMain) {
-  server = serve({ fetch: app.fetch, port }, async (info) => {
-    console.log(`Deft API running on http://localhost:${info.port}`);
-
-    // Start background job workers — uses Postgres, no Redis needed
-    try {
-      const { startWorkers } = await import('./workers/index.js');
-      const { initScheduler } = await import('./lib/job-scheduler.js');
-      startWorkers();
-      await initScheduler();
-      console.log('[startup] Job workers and scheduler started');
-    } catch (err) {
-      console.warn('[startup] Job workers failed to start:', (err as Error).message);
-    }
-
-    // Self-hosted v1 — single-org hard-block. Warn the operator if the DB
-    // already holds more than one workspace; signup is blocked server-side
-    // but a legacy DB carried over from a pre-hard-block build can slip
-    // through. See apps/api/src/lib/single-org-guard.ts.
-    try {
-      const { countOrgs } = await import('./lib/single-org-guard.js');
-      const count = await countOrgs();
-      if (count > 1) {
-        console.warn(
-          `[startup] This Deft instance has ${count} orgs. Self-hosted ` +
-            'Deft is licensed for a single workspace per deployment ' +
-            '(BSL 1.1). Check LICENSE and consolidate before opening ' +
-            'signup to external users.',
-        );
-      }
-    } catch (err) {
-      console.warn('[startup] single-org check skipped:', (err as Error).message);
-    }
-  });
-
-  setupSocket(server as unknown as Server);
-}
 
 export { app };
 export default app;

--- a/apps/api/src/routes/messages.ts
+++ b/apps/api/src/routes/messages.ts
@@ -7,10 +7,10 @@ import { getIO, emitToUser } from '../socket.js';
 import { parseMentions } from '../lib/mentions.js';
 import { fetchLinkPreview, extractUrls, type LinkPreview } from '../lib/link-preview.js';
 import { enqueue, QUEUE_NAMES } from '../lib/queues.js';
-import { env } from '../lib/env.js';
 import { classifyMessage } from '../lib/classifier.js';
 import { requireSpaceMembership } from '../lib/space-membership.js';
 import { DEFTY_EMAIL, ensureDeftyMembership } from '../lib/ensure-defty-membership.js';
+import { resolveAnthropicApiKey } from '../lib/org-ai-config.js';
 
 export const messageRoutes = new Hono();
 
@@ -542,7 +542,9 @@ messageRoutes.post('/:spaceId', async (c) => {
       }
     }
 
-    if (agentMentioned && env.ANTHROPIC_API_KEY) {
+    const anthropicAvailable = Boolean(await resolveAnthropicApiKey(user.org_id));
+
+    if (agentMentioned && anthropicAvailable) {
       try {
         const [org] = await db.select({ name: orgs.name })
           .from(orgs)
@@ -566,7 +568,7 @@ messageRoutes.post('/:spaceId', async (c) => {
 
     // Detect agent-employee mentions → enqueue agent-employee-message per employee.
     // Also auto-trigger BYOA agents in DM/agent_conversation spaces — no mention required.
-    if (env.ANTHROPIC_API_KEY) {
+    if (anthropicAvailable) {
       try {
         const targetUserIds = new Set<string>(mentionedUserIds);
         const [spaceRow] = await db.select({ type: spaces.type })

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -1,0 +1,50 @@
+import 'dotenv/config';
+import { serve } from '@hono/node-server';
+import type { Server } from 'node:http';
+import { app } from './index.js';
+import { setupSocket } from './socket.js';
+
+// Prefer Railway/Fly's PORT env, then API_PORT, then local default.
+const port = parseInt(process.env.PORT || process.env.API_PORT || '3001');
+
+// index.ts only defines and exports the Hono app so tests can import it
+// without binding a port. This file is the actual entry point —
+// `pnpm dev`/`pnpm start` run it. The previous main-entry guard inside
+// index.ts (process.argv[1] string-endsWith check) silently disabled the
+// listen() under `tsx watch` because argv[1] became the tsx CLI script,
+// not our source file. Splitting removes the guard entirely.
+const server = serve({ fetch: app.fetch, port }, async (info) => {
+  console.log(`Deft API running on http://localhost:${info.port}`);
+
+  // Start background job workers — uses Postgres, no Redis needed
+  try {
+    const { startWorkers } = await import('./workers/index.js');
+    const { initScheduler } = await import('./lib/job-scheduler.js');
+    startWorkers();
+    await initScheduler();
+    console.log('[startup] Job workers and scheduler started');
+  } catch (err) {
+    console.warn('[startup] Job workers failed to start:', (err as Error).message);
+  }
+
+  // Self-hosted v1 — single-org hard-block. Warn the operator if the DB
+  // already holds more than one workspace; signup is blocked server-side
+  // but a legacy DB carried over from a pre-hard-block build can slip
+  // through. See apps/api/src/lib/single-org-guard.ts.
+  try {
+    const { countOrgs } = await import('./lib/single-org-guard.js');
+    const count = await countOrgs();
+    if (count > 1) {
+      console.warn(
+        `[startup] This Deft instance has ${count} orgs. Self-hosted ` +
+          'Deft is licensed for a single workspace per deployment ' +
+          '(BSL 1.1). Check LICENSE and consolidate before opening ' +
+          'signup to external users.',
+      );
+    }
+  } catch (err) {
+    console.warn('[startup] single-org check skipped:', (err as Error).message);
+  }
+});
+
+setupSocket(server as unknown as Server);

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -29,6 +29,7 @@ const apiOrigin = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
 
 const nextConfig: NextConfig = {
   transpilePackages: ['@deft/shared'],
+  allowedDevOrigins: ['localhost', '127.0.0.1'],
   // Hide the floating Next.js dev-tools indicator — it overlapped composer/FAB
   // on mobile audits. The badge is dev-only either way; this also hides the
   // build-activity spinner during dev.

--- a/packages/db/scripts/apply-extras.ts
+++ b/packages/db/scripts/apply-extras.ts
@@ -1,9 +1,18 @@
 import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { config as loadEnv } from 'dotenv';
 import pg from 'pg';
 
 const { Client } = pg;
+
+// drizzle.config.ts loads the repo-root .env, so `drizzle-kit push` sees
+// DATABASE_URL. apply-extras.ts runs as a separate `tsx` invocation in the
+// `db:push-full` chain and didn't — so a fresh-clone `pnpm db:push-full`
+// would push the schema, then die at the extras step. Load the same .env
+// here so both halves of push-full see the same env.
+const __filename = fileURLToPath(import.meta.url);
+loadEnv({ path: resolve(dirname(__filename), '..', '..', '..', '.env') });
 
 const DATABASE_URL = process.env.DATABASE_URL;
 if (!DATABASE_URL) {


### PR DESCRIPTION
## Summary

Five small fixes from the May 19 local deployment review — bugs that bite first-time clone-and-run on Windows / inherited-env shells. Findings sourced from `reports/deft-local-deployment-and-platform-review.pdf` and verified against current master.

- **API main-guard / `pnpm dev`** — `apps/api/src/index.ts` used `process.argv[1].endsWith('/index.ts')` to decide whether to call `serve()`. Under `tsx watch` (the actual `dev` invocation), argv[1] is the tsx CLI script, not our source, so the API silently never bound a port. Fixed by splitting the file: `index.ts` defines and exports `app` (tests keep importing from here without binding a port); new `server.ts` calls `serve()`. No guard needed. `dev` / `build` / `start` scripts and the Dockerfile CMD updated.
- **CORS allows `127.0.0.1`** — `apps/api/src/index.ts` accepted a single origin from `NEXT_PUBLIC_APP_URL`. Windows browsers sometimes default to `127.0.0.1:3000`, which failed preflight. Now accepts both `localhost` and `127.0.0.1` on the dev port alongside the env value.
- **Next dev origin** — `apps/web/next.config.ts` adds `allowedDevOrigins: ['localhost', '127.0.0.1']` for the matching Next-side check.
- **Org-stored Anthropic key now triggers Defty/BYOA replies** — `apps/api/src/routes/messages.ts` gated both the Defty enqueue and the BYOA `agent-employee-message` enqueue on `env.ANTHROPIC_API_KEY`. With the documented happy path (key saved through `/settings/ai`, env blank), no agent reply was ever queued. Both now use `resolveAnthropicApiKey(user.org_id)` — same resolver the streaming agent route already uses. Resolved once per request and reused.
- **`pnpm db:push-full` on a fresh clone** — `packages/db/scripts/apply-extras.ts` read `process.env.DATABASE_URL` with no dotenv load, so `drizzle-kit push` succeeded (loads .env through `drizzle.config.ts`) and then the extras step died. Both halves of `db:push-full` now see the same env.

## Out of scope (intentionally)

Report findings #2, #6, and #7 are bigger product calls and left for follow-ups:

- Docker compose Postgres port conflict — the current `127.0.0.1:5432:5432` binding has a deliberate security-comment defense (see `docker-compose.yml:39-47`); the better fix is a README override note, not changing the default.
- `DISABLE_ENV_AI_FALLBACK` flag — needs a UX call on whether to keep env fallbacks at all.
- `llm.ts` default model routes all-Anthropic — needs auto-routing or per-route warnings in `/settings/ai`.

## Test plan

- [x] `pnpm --filter @deft/api typecheck` passes.
- [x] `import('./src/index.ts')` returns `{ app, default }` without binding a port — tests can keep importing `app` from index.ts.
- [x] `pnpm --filter @deft/api dev` (tsx watch src/server.ts) binds `:3001` from a clean PowerShell on Windows. Workers + scheduler start. Verified against a clean port (Codex's `start-api-local.mjs` launcher killed first, then `pnpm dev` came up clean).
- [x] `OPTIONS /api/auth/me` preflight returns `access-control-allow-origin: http://127.0.0.1:3000` for that Origin, and `http://localhost:3000` for that Origin. Both pass.
- [x] `resolveAnthropicApiKey(user.org_id)` returns the org-stored Anthropic key (108-char string) for an org with a saved key — proving the messages.ts swap wires to a working resolver. End-to-end `@deft` DM smoke test still needs a logged-in session.
- [x] `env -u DATABASE_URL pnpm exec tsx scripts/apply-extras.ts` succeeds — dotenv loads the repo-root `.env` and both extras SQL files apply cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)