### PR TITLE
fix(defty): drop stale "Agent panel" guidance from approval flow

### DIFF
--- a/apps/api/src/lib/agent-runner.ts
+++ b/apps/api/src/lib/agent-runner.ts
@@ -21,7 +21,7 @@ Rules:
 - Use search tools to find data before answering — don't guess
 - Cite your sources (the tools return source IDs)
 - Be concise and direct
-- For write actions (create_task, update_task_status, post_message), clearly explain what you'll do
+- For write actions (create_task, update_task_status, post_message), clearly explain what you'll do. When invoked from a chat mention, write actions are not executed immediately — they're queued for the user's approval, which appears as an Approve/Reject card on your reply and in the user's Inbox under the Approvals tab. Do NOT refer to an "Agent panel" or "Agent dashboard" — neither exists.
 - You are responding in a chat thread. Keep your reply as a single cohesive message.
 - Use markdown formatting (bold, lists, headers) for structure but keep it compact.
 - Do NOT narrate your tool usage. Do NOT say "I'll search for..." or "Let me look up..." — just use the tools silently and present your findings directly.
@@ -472,7 +472,7 @@ export async function runAgentQuery(params: {
               status: 'skipped',
               message: mode === 'background'
                 ? 'Action requires approval. Trust level does not permit auto-execution.'
-                : 'Write actions are not auto-executed from chat mentions. Suggest the user use the Agent panel for this action.',
+                : 'Write actions from chat mentions require user approval. The action has been queued — an Approve/Reject card will appear inline on this message, and it is also listed in the user\'s Inbox under the Approvals tab.',
             }),
           });
         }

--- a/apps/api/src/routes/agent.ts
+++ b/apps/api/src/routes/agent.ts
@@ -46,7 +46,7 @@ Rules:
 - Use search tools to find data before answering — don't guess
 - Cite your sources (the tools return source IDs)
 - Be concise and direct
-- For write actions (create_task, update_task_status, assign_task, post_message), clearly explain what you'll do
+- For write actions (create_task, update_task_status, assign_task, post_message), clearly explain what you'll do. Write actions that require approval are queued for the user — an Approve/Reject card appears inline on your reply, and pending actions are also listed in the user's Inbox under the Approvals tab. Do NOT refer to an "Agent panel" or "Agent dashboard" — neither exists.
 - Use the remember tool to store important facts about users and conversations for future reference
 - Use the recall tool to retrieve previously stored context when relevant
 - For "why" questions (why is X behind, why is X blocked), do a multi-step investigation:


### PR DESCRIPTION
## Summary

Defty was telling users to go to the **Agent panel** to approve write actions from chat. That panel was deleted two weeks ago — Phase 4 (2026-05-07) removed the `/agent` route + `AgentChat`, and Phase 5 folded the short-lived `/approvals` page into `/inbox`. The current surfaces are the inline Approve/Reject card on Defty's reply message and the **Approvals** tab in **/inbox**.

Repro (user screenshot): a "please add a task for Maya, launch is blocked" mention came back as

> I can help you create that task for Maya to review the AI setup. Since this involves creating a new task (a write action), you'll need to use the **Agent panel** to approve and execute this action.
> …
> Would you like me to proceed with creating this task through the Agent panel?

Root cause: `apps/api/src/lib/agent-runner.ts:475` — the `tool_result` string fed back to the model when a write action is skipped pending approval still names the removed surface. The model then paraphrases it verbatim in chat.

## Changes

- **`apps/api/src/lib/agent-runner.ts:475`** — replaces "Suggest the user use the Agent panel for this action" with a description of the real surfaces (inline card + Inbox > Approvals tab) and clarifies the action *has* been queued (it has — `pendingActions` is pushed just above).
- **`apps/api/src/lib/agent-runner.ts` SYSTEM_PROMPT** — extends the write-actions rule with the same approval-surface vocabulary, plus an explicit "do NOT refer to an Agent panel or Agent dashboard — neither exists" line so the model can't invent stale-named surfaces in adjacent phrasings.
- **`apps/api/src/routes/agent.ts` SYSTEM_PROMPT** — same line update on the streaming-route prompt, kept in sync.

No data/schema changes. No new dependencies. Typecheck passes.

## Test plan

- [x] `pnpm --filter @deft/api typecheck` passes.
- [ ] In a chat space, post a write-intent message like "Please add a task for Maya to review the AI setup tomorrow." Defty's reply should:
  - Describe the proposed task as before.
  - Refer to "the Approve/Reject card on this message" or "the Approvals tab in your Inbox", **not** "Agent panel" or "Agent dashboard".
  - Surface an inline `AgentActionCard` immediately under the reply (existing behavior, unchanged by this PR).
- [ ] Grep the model's reply text for "Agent panel" / "Agent dashboard" — should not appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)