### PR TITLE
fix(ci): make Test API job green (21 failing tests -> 0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,11 @@ jobs:
       REDIS_URL: redis://localhost:6379
       JWT_SECRET: ci-test-secret-not-for-prod
       JWT_REFRESH_SECRET: ci-test-refresh-secret-not-for-prod
+      # Fake, non-functional key. The memory-extract tests mock the Anthropic
+      # HTTP call, but the SDK throws at construction when no key is set, and
+      # the agent-reply dispatch is gated on the key being present. Setting a
+      # dummy unblocks both without ever making a real API call.
+      ANTHROPIC_API_KEY: sk-ant-ci-dummy-not-a-real-key
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -78,6 +83,12 @@ jobs:
         # suite as supported callers; without this step, login-based
         # tests get 401 and templates assertions fail.
         run: pnpm db:seed:demo
+      - name: Seed canonical test fixtures
+        # seed-demo uses random ids, but a chunk of the suite hardcodes fixed
+        # org/user/agent ids from the original dev-db snapshot. This adds
+        # exactly those fixed-id rows (idempotent, isolated). Without it ~13
+        # tests fail with FK violations / 0-row assertions.
+        run: pnpm --filter @deft/api exec tsx src/scripts/seed-test-fixtures.ts
       - name: Run tests
         run: pnpm --filter @deft/api test
 

--- a/apps/api/src/scripts/seed-test-fixtures.ts
+++ b/apps/api/src/scripts/seed-test-fixtures.ts
@@ -1,0 +1,108 @@
+/**
+ * Canonical test fixtures with FIXED ids.
+ *
+ * The apps/api/test suite hardcodes specific org / user / agent ids that
+ * match the original dev-database snapshot the tests were authored against
+ * (e.g. task-update-trust, reminder-fire, people-graph, agent-employee-schema,
+ * agent-tools-task-mutations). CI builds the DB fresh (`db:push-full` +
+ * `db:seed:demo`), and seed-demo uses RANDOM ids — so these fixed-id rows are
+ * absent and the dependent tests fail with FK violations or 0-row assertions.
+ *
+ * This script idempotently upserts exactly the fixed-id rows those tests
+ * require. Run it in CI AFTER `db:seed:demo` and BEFORE the test suite.
+ * Safe to run repeatedly: every insert is ON CONFLICT DO NOTHING and only
+ * touches its own fixed ids — it never mutates seed-demo or real data.
+ */
+import { config as loadEnv } from 'dotenv';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import pg from 'pg';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+// apps/api/src/scripts -> repo root is four levels up.
+loadEnv({ path: resolve(__dirname, '..', '..', '..', '..', '.env') });
+
+const DATABASE_URL = process.env.DATABASE_URL;
+if (!DATABASE_URL) {
+  console.error('[seed-test-fixtures] DATABASE_URL is required');
+  process.exit(1);
+}
+
+// ── Fixed ids referenced by the apps/api/test suite ──────────────────────────
+const ORG_A = '1d7d869a-5e68-48d5-832e-11d8f3bb1dd6'; // task-mutations, reminder-fire, people-graph, memory-extract
+const ORG_B = '760b7a2b-a4ce-4b75-897c-c86d8e5d8047'; // task-update-trust
+const USER_MANEEK = 'd4f985f6-6c37-4102-a7e8-32e22cfbe962'; // reminder-fire (reminder owner)
+const USER_ALEXPM = '329fe0f6-39b3-4f66-8e6d-539ad7f4906a'; // people-graph (citing author) + Alex PM shadow user
+const USER_PRIYA = '07308d0d-199a-479d-a2e3-fefdf7cdbac9'; // people-graph (cited author)
+const EMP_ALEXPM = '7e79b0a9-f88c-49f4-b79d-ab8a7c7f1633'; // agent-employee-schema "Alex PM seed row exists"
+
+async function main() {
+  const c = new pg.Client({ connectionString: DATABASE_URL });
+  await c.connect();
+  try {
+    await c.query(
+      `INSERT INTO orgs (id, name, slug) VALUES
+         ($1, 'Test Fixtures Org A', 'test-fixtures-org-a'),
+         ($2, 'Test Fixtures Org B', 'test-fixtures-org-b')
+       ON CONFLICT (id) DO NOTHING`,
+      [ORG_A, ORG_B],
+    );
+
+    await c.query(
+      `INSERT INTO users (id, name, email, kind, is_agent, email_verified) VALUES
+         ($1, 'Maneek (fixture)', 'maneek-fixture@test.local', 'human', false, true),
+         ($2, 'Alex PM (fixture)', 'alexpm-fixture@test.local', 'agent', true,  true),
+         ($3, 'Priya (fixture)',  'priya-fixture@test.local',  'human', false, true)
+       ON CONFLICT (id) DO NOTHING`,
+      [USER_MANEEK, USER_ALEXPM, USER_PRIYA],
+    );
+
+    await c.query(
+      `INSERT INTO org_members (id, org_id, user_id, role, is_active) VALUES
+         (gen_random_uuid()::text, $1, $2, 'owner',  true),
+         (gen_random_uuid()::text, $1, $3, 'member', true),
+         (gen_random_uuid()::text, $1, $4, 'member', true)
+       ON CONFLICT (org_id, user_id) DO NOTHING`,
+      [ORG_A, USER_MANEEK, USER_ALEXPM, USER_PRIYA],
+    );
+
+    await c.query(
+      `INSERT INTO agent_employees
+         (id, org_id, user_id, name, slug, role, system_prompt, trust_level, is_byoa, is_active, created_by)
+       VALUES
+         ($1, $2, $3, 'Alex PM', 'alex-pm-fixture', 'project_manager',
+          'Test fixture project-manager agent.', 'standard', true, true, $4)
+       ON CONFLICT (id) DO NOTHING`,
+      [EMP_ALEXPM, ORG_A, USER_ALEXPM, USER_MANEEK],
+    );
+
+    // people-graph's detectRelationships() early-returns when the org has zero
+    // people_interactions rows — before the wiki-citation knowledge_dependency
+    // logic the people-graph tests exercise. Seed one so it proceeds.
+    await c.query(
+      `INSERT INTO people_interactions (id, org_id, user_a_id, user_b_id, interaction_count, recency_weighted_score)
+       VALUES (gen_random_uuid()::text, $1, $2, $3, 1, 1)
+       ON CONFLICT DO NOTHING`,
+      [ORG_A, USER_ALEXPM, USER_PRIYA],
+    );
+
+    // task-update-trust reuses "the first project in the org"; with none it
+    // mints one led by its ephemeral user, then teardown deletes that user and
+    // trips projects_lead_id_users_id_fk. Give ORG_B a reusable project.
+    await c.query(
+      `INSERT INTO projects (id, org_id, name, prefix, lead_id)
+       VALUES ('fixture-project-org-b', $1, 'Test Fixtures Project B', 'TFB', $2)
+       ON CONFLICT (id) DO NOTHING`,
+      [ORG_B, USER_MANEEK],
+    );
+
+    console.log('[seed-test-fixtures] canonical fixed-id fixtures ensured (orgs, users, members, Alex PM, interaction, project)');
+  } finally {
+    await c.end();
+  }
+}
+
+main().catch((err) => {
+  console.error('[seed-test-fixtures] failed:', err);
+  process.exit(1);
+});

--- a/apps/api/test/people-graph-knowledge-dependency.test.ts
+++ b/apps/api/test/people-graph-knowledge-dependency.test.ts
@@ -61,8 +61,8 @@ async function seedWikiLink(
   suffix: string,
 ): Promise<string> {
   const r = await c.query(
-    `INSERT INTO wiki_links (org_id, source_page_id, target_page_id, context)
-     VALUES ($1, $2, $3, $4)
+    `INSERT INTO wiki_links (id, org_id, source_page_id, target_page_id, context)
+     VALUES (gen_random_uuid()::text, $1, $2, $3, $4)
      ON CONFLICT (source_page_id, target_page_id) DO UPDATE SET context = EXCLUDED.context
      RETURNING id`,
     [ORG_ID, sourcePageId, targetPageId, `test-kd-link-${suffix}`],

--- a/apps/web/src/components/sidebar.tsx
+++ b/apps/web/src/components/sidebar.tsx
@@ -35,11 +35,14 @@ import {
   Headphones,
   BookOpen,
   Smile,
+  Library,
+  Inbox,
 } from 'lucide-react';
 import { CreateSpaceModal } from './create-space-modal';
 import { CreateDmModal } from './create-dm-modal';
 import { SavedMessages } from './saved-messages';
 import { CreateProjectModal } from './create-project-modal';
+import { useInboxCount } from '@/hooks/use-inbox-count';
 
 type AgentEmployee = {
   id: string;
@@ -76,6 +79,8 @@ const navItems = [
   { name: 'Chat', href: '/chat', icon: MessageSquare },
   { name: 'Tasks', href: '/tasks', icon: CheckSquare },
   { name: 'Knowledge', href: '/knowledge', icon: BookOpen },
+  { name: 'Inbox', href: '/inbox', icon: Inbox },
+  { name: 'Library', href: '/library', icon: Library },
 ];
 
 // ── Chat sidebar content (Spaces + DMs) ──────────────────────────────
@@ -639,6 +644,9 @@ export function Sidebar({
   // Total unread across all spaces
   const totalUnread = Array.from(unreadCounts.values()).reduce((sum, c) => sum + c, 0);
 
+  // Inbox unread count (mentions, DMs, pending approvals)
+  const { count: inboxCount } = useInboxCount();
+
   const handleSpaceClick = (id: string) => {
     onSelectSpace(id);
     setMobileOpen(false);
@@ -729,6 +737,15 @@ export function Sidebar({
                   style={{ background: 'var(--primary-container)' }}
                 >
                   {totalUnread > 99 ? '99+' : totalUnread}
+                </div>
+              )}
+              {item.name === 'Inbox' && inboxCount > 0 && (
+                <div
+                  className="ml-auto min-w-[18px] h-[18px] rounded-full flex items-center justify-center text-[10px] font-bold text-white px-1"
+                  style={{ background: 'var(--danger, #ef4444)' }}
+                  title={`${inboxCount} unread item${inboxCount === 1 ? '' : 's'}`}
+                >
+                  {inboxCount > 99 ? '99+' : inboxCount}
                 </div>
               )}
             </Link>

--- a/packages/db/scripts/apply-extras.ts
+++ b/packages/db/scripts/apply-extras.ts
@@ -37,6 +37,17 @@ async function main() {
       await client.query(sql);
       console.log(`[apply-extras] applied ${file}`);
     }
+
+    // Expression-based unique indexes can't be declared in schema.ts, so
+    // `drizzle-kit push` silently drops them — migrate-built DBs have them,
+    // push-built DBs don't. Re-create the ones the app depends on so both
+    // paths behave identically. (migration 0051: org-scoped template slug
+    // uniqueness — COALESCE keeps first-party rows globally unique per slug.)
+    await client.query(
+      `CREATE UNIQUE INDEX IF NOT EXISTS agent_employee_templates_org_slug_uniq
+         ON agent_employee_templates (COALESCE(org_id, ''), slug)`,
+    );
+    console.log('[apply-extras] ensured agent_employee_templates_org_slug_uniq');
   } finally {
     await client.end();
   }


### PR DESCRIPTION
## What

The **Test API** CI job had been failing on every recent run — **21 of 479 tests** red, across `master` and every PR. This fixes all 21 with **zero regressions** (479/479 pass locally).

## Root causes — all environmental / `db:push`-vs-`db:migrate` schema drift, not product bugs

| Cluster | Tests | Cause | Fix |
|---|---|---|---|
| **A** | agent-mention-detection (3), memory-extract (4) | No `ANTHROPIC_API_KEY` in CI → Anthropic SDK throws at construction; agent-reply enqueue is gated on the key | Dummy key in the test job env (the HTTP call is mocked; no real request is made) |
| **B** | agent-employee-schema, agent-tools-task-mutations (6), reminder-fire, task-update-trust | Tests hardcode fixed org/user/agent ids from the original dev-db snapshot; `seed-demo` uses random ids | New idempotent `seed-test-fixtures.ts` + CI step after `db:seed:demo` |
| **C** | people-graph-knowledge-dependency (3) | Raw `wiki_links` insert omits `id`; the `id()` helper is an app-level `$defaultFn`, so `drizzle-kit push` creates no DB default | Supply an explicit `id` |
| **D** | clone-agent | COALESCE-keyed unique index (migration 0051) isn't reproduced by `push` → duplicate-slug save returned 201 not 409 | Recreate the index in `apply-extras.ts` (the push-vs-migrate bridge) |
| **E** | inbox-redirect | PR #21's sidebar refactor dropped the Inbox nav entry + `useInboxCount` badge (and Library) | Restore them (both routes still exist) |

## Verification

- Full `apps/api` suite **479/479 pass, 0 fail** against a fresh `push-full` + `seed:demo` + `seed-test-fixtures` DB with a dummy key
- `apps/web` `tsc --noEmit` clean

## Notes

Fix B's seed also adds one `people_interactions` row (so `detectRelationships` doesn't early-return before the citation logic) and an ORG_B project (so `task-update-trust`'s teardown doesn't trip `projects_lead_id_users_id_fk`) — both surfaced during verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
