### PR TITLE
fix(web): drop duplicate Library nav + add missing AI Providers settings link

### DIFF
--- a/apps/web/src/components/sidebar.tsx
+++ b/apps/web/src/components/sidebar.tsx
@@ -35,7 +35,6 @@ import {
   Headphones,
   BookOpen,
   Smile,
-  Library,
   Inbox,
 } from 'lucide-react';
 import { CreateSpaceModal } from './create-space-modal';
@@ -80,7 +79,6 @@ const navItems = [
   { name: 'Tasks', href: '/tasks', icon: CheckSquare },
   { name: 'Knowledge', href: '/knowledge', icon: BookOpen },
   { name: 'Inbox', href: '/inbox', icon: Inbox },
-  { name: 'Library', href: '/library', icon: Library },
 ];
 
 // ── Chat sidebar content (Spaces + DMs) ──────────────────────────────
@@ -526,6 +524,7 @@ function SettingsSidebarContent({ onNav }: { onNav?: () => void }) {
     { name: 'Projects', href: '/settings/projects' },
     { name: 'Tags', href: '/settings/tags' },
     { name: 'Integrations', href: '/settings/integrations' },
+    { name: 'AI Providers', href: '/settings/ai' },
     { name: 'Agent', href: '/settings/agent' },
     { name: 'Agent Employees', href: '/settings/agent-employees' },
     { name: 'API Access', href: '/settings/api-access' },


### PR DESCRIPTION
## What

Two small sidebar nav fixes (follow-up to #22):

1. **Remove the redundant top-level "Library" nav entry.** `/library` is only a redirect to `/settings/library`, so the main-nav link duplicated the existing **Settings → Library** entry. Removed it plus its now-unused `Library` lucide import. The Inbox entry restored in #22 stays.
2. **Add the missing "AI Providers" settings link.** `settings/ai` (multi-provider API keys + per-task model routing, from the multi-provider work) shipped with no settings-sidebar entry, so the page was unreachable from the UI. Added `AI Providers → /settings/ai`, placed after Integrations.

## Verify

- `apps/web` `tsc --noEmit` clean (no dangling `Library` reference)
- `inbox-redirect` test 9/9 pass

_Note: `settings/calendar` and `settings/workflows` pages also exist without nav entries — left untouched here; happy to add in a follow-up if wanted._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
