### PR TITLE
docs: reconcile setup/install docs (db:push-full, first-boot env, BSL framing, security)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -21,7 +21,7 @@ body:
     attributes:
       label: Steps to reproduce
       placeholder: |
-        1. Run `pnpm db:push`
+        1. Run `pnpm db:push-full`
         2. Sign up at /signup
         3. ...
     validations:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,9 +17,9 @@ pnpm install
 cp .env.example .env
 # Edit .env with your database credentials
 
-# Create database and push schema
+# Create database and push schema (+ full-text-search extras)
 createdb deft
-pnpm db:push
+pnpm db:push-full
 
 # Seed demo data (5 test users + demo org + sample messages/tasks).
 # This wipes the DB — dev only, NEVER run in production.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Deft — The AI-Native Workspace
 
-> Chat, tasks, and an AI agent that actually understands your work. Open source.
+> Chat, tasks, and an AI agent that actually understands your work. Source-available.
 
 ## What is Deft?
 
@@ -11,6 +11,12 @@ Deft combines team chat, task management, and an AI agent into one workspace. Th
 - **AI Agent** — Ask questions, create tasks, summarize conversations, execute multi-step workflows with approval gates
 - **Dashboard** — Morning pulse briefing, task overview, activity feed, project progress
 
+> **License:** Source-available under the [Business Source License 1.1](./LICENSE). Use it for any purpose — including self-hosting — **except** offering Deft as a hosted or managed service to third parties. Forks must retain attribution. Converts to Apache License 2.0 four years from each release date.
+
+## Project status
+
+Deft is in **alpha** — usable and self-hostable today, but expect breaking changes and rough edges until a tagged `v0.1.0`. Designed for **one workspace per deployment**. Source-available under BSL 1.1.
+
 ## Quick Start
 
 Get to first login in under 5 minutes.
@@ -18,7 +24,7 @@ Get to first login in under 5 minutes.
 ### Prerequisites
 
 - [Docker Desktop](https://www.docker.com/products/docker-desktop/) (includes Docker Compose)
-- A free [Anthropic API key](https://console.anthropic.com) — no other accounts required
+- (Optional) An [Anthropic API key](https://console.anthropic.com) for AI features — chat and tasks work without one
 
 ### Steps
 
@@ -30,13 +36,14 @@ cd deft
 cp .env.example .env
 ```
 
-Open `.env` and set three values:
+Open `.env` and set the three required values (plus the optional AI key if you want AI features):
 
-| Variable | How to get it |
-|---|---|
-| `ANTHROPIC_API_KEY` | https://console.anthropic.com — free tier works |
-| `JWT_SECRET` | Run `openssl rand -hex 32` |
-| `JWT_REFRESH_SECRET` | Run `openssl rand -hex 32` again |
+| Variable | Required? | How to get it |
+|---|---|---|
+| `POSTGRES_PASSWORD` | **Required** | Any strong string — `openssl rand -hex 32` |
+| `JWT_SECRET` | **Required** | `openssl rand -hex 32` |
+| `JWT_REFRESH_SECRET` | **Required** | `openssl rand -hex 32` (run it again) |
+| `ANTHROPIC_API_KEY` | Optional | [console.anthropic.com](https://console.anthropic.com) — only for AI features; can also be set per-org in Settings → AI |
 
 ```bash
 # 2. Start the stack (Postgres + Redis + Deft)
@@ -48,7 +55,7 @@ pnpm db:seed        # seeds Defty + bundled skills/templates (prod-safe, idempot
 # pnpm db:seed:demo # ALSO inserts 5 test users for poking around — dev only, NEVER in prod
 ```
 
-> **Note:** Use `pnpm db:push-full`, not `pnpm db:migrate`. The migration journal is canonical as of v0.1 but `push-full` is the supported path for fresh installs — it diffs the live schema against `packages/db/src/schema.ts`, then applies two orphan SQL files (`0020_wiki_search_vector.sql` and `0033_tasks_embedding.sql`) that create generated tsvector columns and GIN indexes Drizzle's pushed schema can't express. Plain `pnpm db:push` skips the orphans and leaves wiki/task FTS broken. `db:migrate` is for upgrade paths once we ship versioned releases.
+> **Note:** Use `pnpm db:push-full`, not `pnpm db:migrate`. `push-full` is the supported path for fresh installs — it diffs the live schema against `packages/db/src/schema.ts`, then applies two orphan SQL files (`0020_wiki_search_vector.sql` and `0033_tasks_embedding.sql`) that create generated tsvector columns and GIN indexes Drizzle's pushed schema can't express. Plain `pnpm db:push` skips the orphans and leaves wiki/task FTS broken. Versioned `db:migrate` upgrade paths are not yet supported and will arrive post-alpha.
 
 > **`pnpm db:seed` is prod-safe and idempotent** — re-running on a populated workspace is a no-op. It inserts only platform bundles (Defty system user, bundled skills, bundled task templates, first-party employee templates). It never inserts test accounts.
 
@@ -167,9 +174,11 @@ Every write action goes through an approval flow. The user sees what the agent w
 
 See `.env.example` for all configuration options with inline documentation. Three variables are required for first boot:
 
+- `POSTGRES_PASSWORD` — Database password (`openssl rand -hex 32`)
 - `JWT_SECRET` — Secret for JWT signing (`openssl rand -hex 32`)
 - `JWT_REFRESH_SECRET` — Secret for refresh tokens (`openssl rand -hex 32`)
-- `ANTHROPIC_API_KEY` — For AI agent features (app boots without it but AI is disabled)
+
+`ANTHROPIC_API_KEY` is optional — the app boots without it and AI features stay disabled until a key is configured (via env or per-org in Settings → AI).
 
 Full reference: [docs/self-hosting.md#environment-variables-reference](docs/self-hosting.md#environment-variables-reference)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,12 +2,12 @@
 
 ## Supported Versions
 
-Deft is in private alpha. We provide security updates for the latest tagged release only.
+Deft is in alpha. Security fixes land on the latest commit of the `master` branch. We don't yet publish tagged releases — versioned release support will begin when we cut `v0.1.0`.
 
 | Version | Supported |
 | ------- | --------- |
-| Latest `main` | ✅ |
-| Older tags    | ❌ |
+| `master` (latest commit) | ✅ |
+| Older commits / forks | ❌ |
 
 ## Reporting a Vulnerability
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -227,7 +227,7 @@ Schedule this with cron or any job scheduler. For production, consider streaming
 
 ## Upgrading
 
-Deft follows semantic versioning. Minor and patch releases are safe to roll forward; major releases may include breaking schema changes — check the release notes before upgrading.
+Deft is in alpha and does not publish tagged releases yet — roll forward by pulling the latest image and re-applying the schema (below). Semantic-versioning guarantees and release notes will apply once tagged releases begin; until then, expect occasional breaking schema changes between commits on `master`.
 
 ```bash
 # Pull the latest image and restart

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -15,8 +15,8 @@ Defty, the built-in native agent, is seeded automatically on first run. Think of
 | Requirement | Notes |
 |---|---|
 | Docker Desktop 4.x+ | Includes Docker Compose v2. [Download](https://www.docker.com/products/docker-desktop/) |
-| Anthropic API key | Free tier at [console.anthropic.com](https://console.anthropic.com). Required for AI features. |
 | `openssl` (any version) | For generating secrets. Ships with macOS, Linux, Git for Windows. |
+| Anthropic API key *(optional)* | Free tier at [console.anthropic.com](https://console.anthropic.com). Only needed for AI features — chat and tasks work without one. |
 
 **Alternative AI provider:** If you prefer not to use Anthropic, [Ollama](https://ollama.com) can serve a local model. You will need to update `ANTHROPIC_API_KEY` and the model references in Settings → Agent after first boot. Ollama support is community-maintained.
 
@@ -36,15 +36,17 @@ Open `.env` in your editor. You must set these three variables before starting:
 
 ```bash
 # Generate secrets — run each command separately
+openssl rand -hex 32   # paste result into POSTGRES_PASSWORD
 openssl rand -hex 32   # paste result into JWT_SECRET
 openssl rand -hex 32   # paste result into JWT_REFRESH_SECRET
 ```
 
 | Variable | Where to get it | Required |
 |---|---|---|
-| `JWT_SECRET` | `openssl rand -hex 32` | Yes |
-| `JWT_REFRESH_SECRET` | `openssl rand -hex 32` | Yes |
-| `ANTHROPIC_API_KEY` | https://console.anthropic.com | Yes for AI features |
+| `POSTGRES_PASSWORD` | `openssl rand -hex 32` | **Yes** |
+| `JWT_SECRET` | `openssl rand -hex 32` | **Yes** |
+| `JWT_REFRESH_SECRET` | `openssl rand -hex 32` | **Yes** |
+| `ANTHROPIC_API_KEY` | https://console.anthropic.com | Optional — only for AI features; can also be set per-org in Settings → AI |
 
 Everything else in `.env` is optional for a first boot. Leave the database and Redis URLs as-is — Docker Compose overrides them automatically.
 
@@ -81,14 +83,14 @@ All three services should show `healthy` or `running`.
 The container does not auto-migrate on startup. Run these from the repo root **once**, after the stack is up:
 
 ```bash
-# Apply the schema
-pnpm db:push
+# Apply the schema + full-text-search extras
+pnpm db:push-full
 
 # Seed Defty and starter data
 pnpm db:seed
 ```
 
-`pnpm db:push` talks to Postgres at `localhost:5432` (exposed by Docker Compose). `pnpm db:seed` seeds the Defty agent template, default skills, and starter prompts. Both commands are idempotent — safe to run again if something goes wrong.
+`pnpm db:push-full` syncs the schema to Postgres at `localhost:5432` (exposed by Docker Compose) and applies two extra SQL files that create the wiki/task full-text-search columns and indexes Drizzle's pushed schema can't express — plain `pnpm db:push` skips them and leaves search broken. `pnpm db:seed` seeds the Defty agent template, default skills, and starter prompts. Both commands are idempotent — safe to run again if something goes wrong.
 
 > **No pnpm locally?** Install it with `npm install -g pnpm`, then run the commands above. Node.js 18+ is required.
 
@@ -181,9 +183,10 @@ Defty is powered by the `defty` agent template. The template slug is `defty`. Yo
 |---|---|---|---|
 | `DATABASE_URL` | Yes (auto-set by Docker) | Postgres connection string | `postgres://postgres:postgres@localhost:5432/deft` |
 | `REDIS_URL` | Yes (auto-set by Docker) | Redis connection string | `redis://localhost:6379` |
+| `POSTGRES_PASSWORD` | **Yes** | Database password (Docker Compose auth) | none |
 | `JWT_SECRET` | **Yes** | Signs access tokens | none |
 | `JWT_REFRESH_SECRET` | **Yes** | Signs refresh tokens | none |
-| `ANTHROPIC_API_KEY` | Yes for AI | Anthropic Claude API key | none |
+| `ANTHROPIC_API_KEY` | Optional | Anthropic Claude API key — app boots without it; AI features disabled until set (env or per-org) | none |
 | `NEXT_PUBLIC_API_URL` | No | API base URL seen by browser | `http://localhost:3001` |
 | `NEXT_PUBLIC_WS_URL` | No | WebSocket URL seen by browser | `http://localhost:3001` |
 | `NEXT_PUBLIC_APP_URL` | No | App base URL (used in invite links) | `http://localhost:3000` |
@@ -231,11 +234,11 @@ Deft follows semantic versioning. Minor and patch releases are safe to roll forw
 docker compose pull
 docker compose up -d
 
-# Apply any new schema changes
-pnpm db:migrate   # uses Drizzle migrations (safer than db:push in production)
+# Apply any new schema changes (+ full-text-search extras)
+pnpm db:push-full
 ```
 
-`db:migrate` applies only pending migrations. `db:push` force-syncs the schema and is fine for development but should be avoided in production where you want a migration history.
+`pnpm db:push-full` diffs the live schema against `packages/db/src/schema.ts`, applies the full-text-search extras, and is idempotent — it is the supported path for both fresh installs and schema updates during the current alpha. Versioned `pnpm db:migrate` upgrade paths are **not yet supported** and will arrive post-alpha once the migration journal is wired for sequential upgrades. Do **not** use `pnpm db:migrate` — it is not a supported command at this stage.
 
 **Rollback:** Docker Compose does not keep the old image by default. Before upgrading, tag the current image or snapshot the `pgdata` volume so you have a restore point.
 


### PR DESCRIPTION
## What

**Phase 0** of the repo-health plan (`docs/superpowers/plans/2026-05-22-repo-health-maturity.md`): a focused **documentation-consistency** pass that fixes setup/install contradictions which could break a fresh self-host or mislead contributors. **No code changes.**

## Why

An external repo-health audit, cross-checked against `master`, found the public setup docs disagree with each other:

| Area | Before | After |
|---|---|---|
| **Install command** | README said `db:push-full`; CONTRIBUTING + self-hosting said plain `db:push`; self-hosting recommended the unsupported `db:migrate` | All standardized on `pnpm db:push-full` — plain `db:push` skips the wiki/task FTS SQL that `packages/db/scripts/apply-extras.ts` applies (`0020_wiki_search_vector.sql`, `0033_tasks_embedding.sql`: tsvector/GIN/ivfflat objects `drizzle-kit push` can't express) and **leaves search silently broken** |
| **First-boot env** | README quick-start required `ANTHROPIC_API_KEY` and omitted `POSTGRES_PASSWORD` → a literal first-boot failure (Postgres won't start) | README + self-hosting now match `.env.example`: `POSTGRES_PASSWORD` + the two JWT secrets required; AI key optional (env or per-org) |
| **License framing** | Tagline "Open source." | "Source-available" + one-line BSL 1.1 note; new **Project status** (alpha) section |
| **Security policy** | Said both "latest tagged release only" **and** "Latest `main`"; no tags exist; wrong branch | Latest commit on `master`; no phantom tagged-release claim |

## Files
`README.md` · `docs/self-hosting.md` · `CONTRIBUTING.md` · `SECURITY.md`

## Notes
- `CLAUDE.md` and `AGENTS.md` carry the same `db:push` → `db:push-full` staleness, but they're the **agent-config files** — intentionally kept out of this PR.
- Branch protection, repo curation, GitHub metadata, and release policy are later phases in the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)