### PR TITLE
docs(agents): reconcile CLAUDE.md + AGENTS.md with db:push-full

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -205,7 +205,7 @@ Migrations added: `0051_org_scoped_templates.sql`, `0052_agent_webhooks.sql`.
 
 ## Known Limitations (deployment blockers)
 
-- **Drizzle `_journal.json` stale.** The Drizzle migration journal has been stale since migration 0017. Migrations 0025-0052 were applied manually and are not tracked in the journal. Production deploy must apply these manually via `drizzle-kit push` or direct SQL — `pnpm db:migrate` will not pick them up automatically. Any new migration must be tested against a DB that already has 0025-0052 applied.
+- **Use `pnpm db:push-full` for fresh installs; `pnpm db:migrate` is not supported yet.** The Drizzle `_journal.json` was rebuilt and is current through 0066. Plain `drizzle-kit push` (`pnpm db:push`) can't express the generated tsvector/GIN full-text-search objects, so `push-full` runs `push` and then applies the orphan SQL files (`0020_wiki_search_vector.sql`, `0033_tasks_embedding.sql`) plus the expression-based unique index push drops — see `packages/db/scripts/apply-extras.ts`. `pnpm db:migrate` will not pick up the current schema; versioned migrate is post-alpha. (See the matching note in CLAUDE.md.)
 - **No live OpenClaw gateway in dev.** All `openclaw`-kind agent_employees rows currently have `connection_url IS NULL`. Block 1's live-gateway smoke tests run only once a gateway is provisioned; unit tests use MockTransport + `_setGatewayResolver` seams to exercise the forwarding code paths end-to-end.
 
 ## What NOT To Do

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -337,7 +337,7 @@ See plan: `docs/superpowers/plans/2026-04-28-phase9-simplify-agents.md` (this pr
 
 ## Known Limitations (deployment blockers)
 
-- **Use `pnpm db:push`, not `pnpm db:migrate`, for fresh installs.** The Drizzle `_journal.json` was rebuilt and is current through 0066. A couple of orphan migration files predating the rebuild remain on disk (`0002_subtasks_parent_task_id.sql`, `0020_wiki_search_vector.sql`) and aren't tracked, but their schema changes are folded into later migrations and the live schema. Fresh installs use `drizzle-kit push` which diffs the live schema against `schema.ts` — that's the supported path. Versioned `db:migrate` upgrades will be wired up post-alpha once orphan migration files are reconciled.
+- **Use `pnpm db:push-full`, not `pnpm db:push` or `pnpm db:migrate`, for fresh installs.** The Drizzle `_journal.json` was rebuilt and is current through 0066. Plain `drizzle-kit push` (`pnpm db:push`) can't express the generated tsvector columns + GIN indexes that wiki/task full-text search needs, so it leaves FTS broken. `push-full` runs `push` and then applies the two orphan SQL files (`0020_wiki_search_vector.sql`, `0033_tasks_embedding.sql`) plus the expression-based unique index push silently drops (`agent_employee_templates_org_slug_uniq`, migration 0051) — see `packages/db/scripts/apply-extras.ts`. That's the supported fresh-install path. Versioned `db:migrate` upgrades will be wired up post-alpha once the journal is reconciled — don't use `db:migrate` yet.
 
 ## What NOT To Do
 


### PR DESCRIPTION
Companion to #24 — that PR aligned the **public** setup docs (README, CONTRIBUTING, `docs/self-hosting.md`, bug template) on `pnpm db:push-full`. This PR aligns the **agent-config** files (CLAUDE.md, AGENTS.md) the same way so the in-repo agent guidance doesn't contradict the user-facing docs.

## What changes

Two single-paragraph swaps, four total line changes:

- **`CLAUDE.md`** *Known Limitations* — `pnpm db:push` → `pnpm db:push-full`, with the same FTS-extras rationale as the README.
- **`AGENTS.md`** *Known Limitations* — replaces a much older note ("journal stale since 0017, 0025-0052 applied manually") with the current state ("journal rebuilt and current through 0066, use push-full") to match CLAUDE.md.

## Why `db:push-full` is genuinely required

Plain `drizzle-kit push` can't express:

- Generated `tsvector` columns + GIN indexes (wiki/task full-text search — `0020_wiki_search_vector.sql`, `0033_tasks_embedding.sql`)
- The expression-based unique index drizzle-kit silently drops (`agent_employee_templates_org_slug_uniq`, migration 0051)

`db:push-full` = `drizzle-kit push --force && tsx packages/db/scripts/apply-extras.ts`. Confirmed by reading the two orphan SQL files + `apply-extras.ts`.

## Scope

- No code or schema changes
- No public-doc changes (those landed in #24)
- Agent-config-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)