### PR TITLE
chore(deps): add Dependabot config (npm + github-actions, weekly)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,32 @@
+# Dependabot config — Deft monorepo.
+#
+# Scope: root package.json + GitHub Actions workflows. Workspace packages
+# (apps/api, apps/web, packages/*) get security alerts through Dependabot
+# Alerts (auto-enabled for public repos, separate from this config). For
+# routine version bumps inside workspace dirs, add per-directory `npm`
+# entries here as the project matures — keeping it narrow during alpha
+# to minimize PR noise.
+#
+# Grouping: patch + minor updates are batched into one PR per ecosystem
+# per week to reduce review overhead. Major bumps still open individual
+# PRs so each is reviewed in isolation.
+
+version: 2
+
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      patch-and-minor:
+        update-types:
+          - "patch"
+          - "minor"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## What

Adds `.github/dependabot.yml` covering two ecosystems on a weekly schedule:

- **`npm`** — root `package.json` only. Patch + minor batched into a single grouped PR per week; major bumps still open individually.
- **`github-actions`** — all workflow files under `.github/workflows/`.

Both capped at 5 open PRs to keep the PR list manageable.

## Why

- **Visibility**: weekly bumps surface ecosystem drift before it becomes a security CVE chase.
- **Low noise**: grouping + 5-PR cap means at most ~2 PRs/week landing for review.
- **Security alerts already covered separately**: Dependabot Alerts (auto-enabled for all public repos) does CVE scanning across every workspace `package.json` transitively, regardless of which directories are listed here.

## What's NOT in scope

Workspace packages (`apps/api`, `apps/web`, `packages/{db,mcp,shared}`) intentionally not listed yet. Reason: each per-directory entry generates its own weekly PRs, and during alpha the noise outweighs the benefit. Per-directory entries can be added post-alpha when the routine bump cadence is valuable enough to justify the review load.

## Companion work

Companion to the Phase 3 repo-metadata pass (no PR — applied via `gh repo edit`):
- Description: "Open-source AI-native workspace. Chat + tasks + Defty, an AI agent with direct SQL access to your data. BYOA via MCP. BSL 1.1."
- Homepage: `https://deft.ing`
- Topics: ai-agents, ai-workspace, open-source, self-hosted, mcp, byoa, chat, tasks, agent-platform, nextjs, typescript, drizzle-orm, postgres, pgvector, claude, hono

🤖 Generated with [Claude Code](https://claude.com/claude-code)