### PR TITLE
chore(release): prep v0.1.0-alpha — CHANGELOG + RELEASING + version field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,131 @@
+# Changelog
+
+All notable changes to Deft are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and during the pre-1.0 alpha phase the project uses a loose interpretation of
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html) — minor versions
+(`0.X.0`) may include breaking changes to schema, API contracts, or required
+env vars. Patch versions (`0.X.Y`) are non-breaking fixes only.
+
+## [Unreleased]
+
+## [0.1.0-alpha] — 2026-05-26
+
+First public alpha. Deft is an open-source AI-native workspace — native chat
++ tasks + an AI agent (Defty) with direct SQL access to your data, plus a
+Bring-Your-Own-Agent (BYOA) MCP surface for connecting external runtimes
+(Claude Code, Claude Desktop, Codex, Cursor, custom MCP).
+
+### Added — platform
+
+- Multi-tenant Postgres + Drizzle ORM workspace with `org_id` row-level
+  isolation on every table; soft-deletes throughout for agent history.
+- Native chat surface: TipTap composer, threads, group DMs, pins, mentions,
+  reactions, file uploads, presence + typing indicators over Socket.io
+  (Redis adapter).
+- Native tasks: 6-status engineering flow (`backlog → todo → in_progress →
+  in_review → done → cancelled`), p0–p3 priority, Board / List / Timeline /
+  Calendar / Pipeline views, labels, reactions, mentions in description +
+  comments, recurrence (daily / weekly / biweekly / monthly), inline
+  activity diff log, archive + soft-delete with 7-day recovery window.
+- Unified `events` table for connected tool data so the agent queries native
+  + Google Calendar / GitHub / Slack / Gmail in one breath.
+- Real-time over Socket.io with Redis adapter; background jobs via BullMQ.
+- Custom JWT + bcrypt auth (jsonwebtoken + bcryptjs); Google OAuth optional.
+- File storage via Cloudflare R2 or local disk with presigned uploads.
+
+### Added — agent
+
+- **Defty** — built-in platform agent. Runs in-process via Anthropic API
+  with direct SQL access, 42+ native tools, multi-step planning, persistent
+  memory (remember / recall), and streaming responses.
+- **Multi-provider Defty** — pluggable reasoning backend:
+  `anthropic` / `openai` (gpt-5.x and o-series via Responses API) /
+  `openrouter` / `ollama`. Falls back gracefully if a provider key is unset.
+- **BYOA employees** — every `agent_employees` row is an external runtime
+  connecting via MCP at `/api/mcp/v1`. Per-employee trust levels, daily
+  action caps, cost tracking ($100/day default), circuit breakers (3
+  consecutive errors → `unhealthy` flag blocks dispatch).
+- Three-tier approval flow: auto-execute / quick-approve / full-review.
+- Three trust levels per org: Conservative / Standard / Autonomous.
+- Workflow executor for the `task.status_changed` trigger with 4 actions
+  (`add_comment` / `assign_to` / `add_label` / `notify`).
+- GitHub `PR → task close`: parses `PREFIX-N` refs in PR title/body on the
+  `pr_merged` transition and closes each referenced task with an
+  attribution comment.
+- Heartbeat lifecycle with per-tick logging (`agent_heartbeat_turns`),
+  cost guardrails, idempotency via `prompt_sha`, and loop detection.
+- Unified `/inbox` queue: mentions + DM unread + task notifications +
+  agent approvals in one tab strip, with a single aggregated badge count.
+- Skills primitive with three tiers (bundled / marketplace / org); 14-entry
+  ClawHub allowlist bundled as a static fallback when the daily catalog
+  fetch fails.
+- Webhook-callable agents with HMAC-SHA256 signing (per-webhook key,
+  constant-time comparison; legacy raw-secret accepted with deprecation
+  warning).
+
+### Security
+
+- **Phase 7 hardening** — 10 vulnerabilities fixed:
+  - XSS prevention via DOMPurify on all `dangerouslySetInnerHTML` sites (6
+    components).
+  - IDOR fixes on workflow-run / agent-message / wiki-citation delete
+    endpoints (verify ownership before delete).
+  - Space-membership enforcement on every space / message / pin endpoint
+    and on the WebSocket `space:join` event.
+  - Upload path traversal fix (`path.basename` + `Content-Disposition:
+    attachment`).
+  - Daily-notes optimistic locking via CAS version check (409 on
+    conflict).
+- Webhook signing migrated from raw-secret comparison to HMAC-SHA256.
+
+### Changed — architecture
+
+- **Phase 9 simplification** (2026-04-28): collapsed 5 agent kinds
+  (`native`, `openclaw`, `claude_sdk`, `custom_mcp`, plus the unkinded
+  built-in) down to 2 roles — Defty (in-process, well-known
+  `deft-agent@system.local` system user) and BYOA (every
+  `agent_employees` row, MCP-only).
+- Removed the in-process gateway: `openclaw-gateway.ts`,
+  `openclaw-dispatch.ts`, `openclaw-client.ts`, `openclaw-chat-envelope.ts`,
+  the `gateway-ping.ts` worker, the `provider_instances` table, and 10
+  OpenClaw sidecar columns on `agent_employees`. All archived under
+  `docs/deprecated/openclaw/`.
+- Trigger system retained — `trigger_subscriptions` still routes webhooks,
+  `member.joined`, cron, and `task.status_changed` events into
+  `agent_actions` rows that BYOA clients pull via `poll_pending_work`.
+- **Phase 1–4 agent-chat unification** (2026-05-07): collapsed
+  `agent_conversations` + `agent_messages` tables into the unified
+  `spaces` + `messages` schema (each `/agent` conversation is a
+  `spaces` row of type `agent_conversation`; each agent turn carries
+  structured Anthropic content in `metadata.agent_blocks`). Deleted the
+  dedicated `/agent` route — chat is now the only agent-conversation
+  surface. Approval inbox promoted to a top-level `/approvals` page
+  (now `/inbox?tab=approvals` after Phase 5).
+
+### Known limitations
+
+- **`pnpm db:push-full`** is required for fresh installs — not
+  `db:push` or `db:migrate`. The `apply-extras.ts` script applies
+  schema features `drizzle-kit push` can't express (`tsvector` generated
+  columns + GIN indexes for wiki/task FTS; pgvector ivfflat indexes;
+  expression-based unique indexes).
+- **No transactional email** — invites and password recovery are
+  admin-generated one-time URLs (shared out-of-band by an admin).
+- **API can't deploy to Vercel** — WebSocket support required.
+  Use Railway, Fly.io, or any container host. The Next.js web app
+  deploys to Vercel fine.
+- **No Supabase support** — blocked in India.
+- Repo history still contains ~44 MB of audit screenshots (cleaned in
+  #26, not history-rewritten — history rewrite would break in-flight
+  forks/clones during alpha).
+
+### License
+
+[BSL 1.1](LICENSE) — free for any purpose except hosting as a service
+for third parties. Mandatory attribution in forks. Each release
+auto-converts to Apache 2.0 four years after its release date.
+
+[Unreleased]: https://github.com/Maneek21/Deft/compare/v0.1.0-alpha...HEAD
+[0.1.0-alpha]: https://github.com/Maneek21/Deft/releases/tag/v0.1.0-alpha

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,118 @@
+# Releasing Deft
+
+This document describes how to cut a new Deft release.
+
+## Versioning during alpha (0.x)
+
+Deft is pre-1.0. The project uses a loose interpretation of SemVer during
+alpha:
+
+- **Minor** (`0.X.0`) — may include breaking changes to schema, API
+  contracts, env vars, or wire formats. Read the CHANGELOG entry before
+  upgrading.
+- **Patch** (`0.X.Y`) — non-breaking fixes only. Safe to bump in place.
+
+Tag format: `vMAJOR.MINOR.PATCH[-channel]` where `channel` is one of
+`alpha` / `beta` / `rc`. Examples: `v0.1.0-alpha`, `v0.2.0-beta`,
+`v1.0.0-rc.1`. Once 1.0 ships, the channel suffix drops.
+
+## Cutting a release
+
+### 1. Pre-flight
+
+On `master`, verify the four required CI checks are green:
+
+```bash
+git checkout master
+git pull origin master
+gh pr checks --required  # or visit the most recent commit's checks page
+```
+
+If any required check is red, fix that first — releases must come off a
+green master.
+
+### 2. Open a release-prep PR
+
+Create a branch and update both the version and CHANGELOG in one PR:
+
+```bash
+git switch -c chore/release-vX.Y.Z-channel
+```
+
+Edit `package.json` (root) — bump the `version` field. Workspace
+`package.json`s under `apps/` and `packages/` intentionally do **not**
+carry independent versions; they all inherit the monorepo version.
+
+Edit `CHANGELOG.md`:
+- Move every item under `[Unreleased]` into a new section
+  `[X.Y.Z-channel] — YYYY-MM-DD` placed directly below `[Unreleased]`.
+- Leave a fresh empty `[Unreleased]` section at the top for next time.
+- Update the comparison links at the bottom of the file:
+  ```
+  [Unreleased]: https://github.com/Maneek21/Deft/compare/vX.Y.Z-channel...HEAD
+  [X.Y.Z-channel]: https://github.com/Maneek21/Deft/releases/tag/vX.Y.Z-channel
+  ```
+
+Commit, push, open a PR titled `chore(release): vX.Y.Z-channel`, get the
+required CI checks green, squash-merge.
+
+### 3. Tag the release
+
+After the prep PR lands on `master`:
+
+```bash
+git checkout master
+git pull origin master
+git tag -a vX.Y.Z-channel -m "Deft vX.Y.Z-channel"
+git push origin vX.Y.Z-channel
+```
+
+Use **annotated** tags (`-a`), never lightweight tags — the release page
+shows the annotation message and `git describe` works correctly.
+
+### 4. Create the GitHub Release
+
+Extract the `[X.Y.Z-channel]` section of `CHANGELOG.md` into a temp file
+`release-notes-X.Y.Z.md`, then:
+
+```bash
+gh release create vX.Y.Z-channel \
+  --title "vX.Y.Z-channel" \
+  --notes-file release-notes-X.Y.Z.md \
+  --prerelease   # omit once on 1.0+ stable
+```
+
+`--prerelease` flags the release as not-production-ready. Drop the flag
+on `1.0.0` and later stable releases.
+
+### 5. (Optional) Publish Docker image
+
+The `Docker Image Build` CI job builds the production `Dockerfile` on
+every PR but does not push to a registry. To publish a tagged image,
+build and push manually:
+
+```bash
+docker build -t ghcr.io/maneek21/deft:vX.Y.Z-channel .
+docker push ghcr.io/maneek21/deft:vX.Y.Z-channel
+```
+
+Or set up a `release.yml` workflow triggered on tag push that authenticates
+to GHCR / Docker Hub and pushes. Not wired up yet during alpha.
+
+## Hotfix releases
+
+For an urgent fix on a previously released minor version:
+
+1. Branch off the released tag: `git switch -c hotfix/vX.Y.Z+1 vX.Y.Z-channel`
+2. Cherry-pick or land the fix.
+3. Bump the patch number, update `CHANGELOG.md`, tag `vX.Y.Z+1-channel`.
+4. Push the tag and create the GitHub Release as above.
+5. Open a PR to merge the hotfix branch back into `master` so the fix
+   isn't lost when the next minor goes out.
+
+## License-date implications
+
+[BSL 1.1](LICENSE) auto-converts each release to Apache 2.0 four years
+after the release date. The release date is the tag date (the date of
+the annotated tag, not the prep-PR merge). Keep this in mind when
+back-dating tags is tempting — don't.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "deft",
+  "version": "0.1.0-alpha",
   "private": true,
   "scripts": {
     "audit:session1": "tsx docs/superpowers/audits/agent-ui-session-1.audit.ts",


### PR DESCRIPTION
## What

Final docs piece of the repo-health pass before tagging `v0.1.0-alpha`:

- **`CHANGELOG.md`** — Keep-a-Changelog format, with the initial `[0.1.0-alpha]` entry summarizing what alpha covers.
- **`RELEASING.md`** — describes pre-flight, prep-PR flow, tag creation, `gh release create`, hotfix branching, and the 4-year BSL→Apache auto-conversion semantics.
- **`package.json`** — root manifest gains `"version": "0.1.0-alpha"` so `RELEASING.md`'s bump-the-version step has a field to bump.

## CHANGELOG `[0.1.0-alpha]` sections

| Section | What it covers |
|---|---|
| Added — platform | multi-tenant Postgres + Drizzle, chat (TipTap, threads, pins, reactions), tasks (6-status, p0-p3, 5 views, recurrence, soft-delete), unified `events` table, Socket.io + Redis, BullMQ |
| Added — agent | Defty in-process (42+ tools), multi-provider reasoning (anthropic/openai/openrouter/ollama), BYOA via MCP, three-tier approval, three trust levels, workflow executor, GitHub PR→task close, heartbeat with cost guardrails, unified `/inbox`, skills primitive, HMAC webhooks |
| Security | Phase 7 hardening — 10 fixes (XSS via DOMPurify, IDOR fixes, space-membership enforcement, upload path traversal, optimistic locking) |
| Changed — architecture | Phase 9 — 5 agent kinds → 2 roles; in-process gateway + `provider_instances` table removed. Phase 1-4 agent-chat unification — collapsed `agent_conversations` / `agent_messages` into `spaces` / `messages` |
| Known limitations | `db:push-full` required; no transactional email; API can't deploy to Vercel; no Supabase; PNG audit history retained |
| License | BSL 1.1 (auto-converts to Apache 2.0 four years after release date) |

## What's NOT in this PR

- **CODEOWNERS** — deferred. With 1 contributor today, a `* @Maneek21` rule adds no review-protection signal. Easy 1-line PR to add when contributor #2 arrives.
- **Workspace-package version bumps** — workspace `package.json`s under `apps/` and `packages/` intentionally do not carry independent versions; they inherit the monorepo version. Bump only root for now.

## Next step after merge

Tag the release:

```bash
git checkout master && git pull
git tag -a v0.1.0-alpha -m "Deft v0.1.0-alpha — first public alpha"
git push origin v0.1.0-alpha
gh release create v0.1.0-alpha --title "v0.1.0-alpha" --prerelease --notes "<CHANGELOG [0.1.0-alpha] section>"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)