### PR TITLE
feat(auth): redirect signup and login to /dashboard

### DIFF
--- a/apps/web/src/app/setup-ai/page.tsx
+++ b/apps/web/src/app/setup-ai/page.tsx
@@ -40,7 +40,7 @@ export default function SetupAIPage() {
       // Org-configured provider already exists — no reason to be here.
       const hasOrgKey = Object.values(data.api_keys ?? {}).some((k: any) => k?.configured);
       if (hasOrgKey) {
-        router.replace('/chat');
+        router.replace('/dashboard');
         return;
       }
       setHasEnvFallback(Boolean(data.has_provider));
@@ -65,7 +65,7 @@ export default function SetupAIPage() {
         const j = await r.json().catch(() => ({}));
         throw new Error(j.error || 'Save failed');
       }
-      router.push('/chat');
+      router.push('/dashboard');
     } catch (e: any) {
       setErr(e.message);
     } finally {
@@ -129,7 +129,7 @@ export default function SetupAIPage() {
           {hasEnvFallback ? (
             <div className="flex justify-end mt-2">
               <button
-                onClick={() => router.push('/chat')}
+                onClick={() => router.push('/dashboard')}
                 className="h-10 px-5 flex items-center gap-2 text-[0.875rem] font-semibold"
                 style={{ background: 'var(--primary-container)', color: '#FFFFFF', borderRadius: '0.5rem' }}
               >
@@ -216,7 +216,7 @@ export default function SetupAIPage() {
 
               <div className="flex justify-between items-center mt-2">
                 <Link
-                  href="/chat"
+                  href="/dashboard"
                   className="text-[0.8125rem]"
                   style={{ color: 'var(--on-surface-variant)' }}
                 >

--- a/apps/web/src/lib/auth-context.tsx
+++ b/apps/web/src/lib/auth-context.tsx
@@ -88,7 +88,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     const data = await res.json();
     api.setTokens(data.accessToken, data.refreshToken);
     await fetchMe();
-    router.push('/chat');
+    router.push('/dashboard');
   };
 
   const signup = async (name: string, email: string, password: string, orgName: string) => {


### PR DESCRIPTION
## Summary
- Signup now lands on `/setup-ai` → `/dashboard` (was `/chat`).
- Login lands on `/dashboard` (was `/chat`).
- `setup-ai` skip / continue / submit all push to `/dashboard`.

The dashboard is the actual entry surface — it shows what's on your plate today (overdue tasks, mentions, agent activity). Dropping users into `/chat` skipped the most useful page.

## Files
- `apps/web/src/lib/auth-context.tsx` — login `router.push('/dashboard')`
- `apps/web/src/app/setup-ai/page.tsx` — 4 sites changed `/chat` → `/dashboard`

## Test plan
- [ ] Fresh signup → lands on `/setup-ai`, then `/dashboard` after save / skip
- [ ] Existing user login → lands on `/dashboard`
- [ ] Setup-ai "Skip for now" link → `/dashboard`

🤖 Generated with [Claude Code](https://claude.com/claude-code)