### PR TITLE
feat(seed): replace Deft Labs demo with Testers Tomatoes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,4 @@ customer-website/
 screenshots/
 Logos/
 stitch-reference/
+.demo-private-keep/

--- a/DEMO-WALKTHROUGH.md
+++ b/DEMO-WALKTHROUGH.md
@@ -1,0 +1,189 @@
+# Demo Walkthrough — Testers Tomatoes
+
+When you run `pnpm db:seed:demo`, you get a fully lived-in workspace for a
+fictional family tomato farm. Six people, a busy week, real conflicts. Spend
+ten minutes inside and you'll see what makes Deft different from "Slack +
+Linear + Notion."
+
+---
+
+## How to seed
+
+From the repo root, with the dev stack running (`docker compose up -d` or
+`pnpm dev`):
+
+```bash
+# Without AI — workspace boots, agent stays disabled until a key is configured
+pnpm db:seed:demo
+
+# With OpenAI (recommended — the agent demo arc needs an LLM)
+SEED_OPENAI_KEY=sk-...your-key... pnpm db:seed:demo
+```
+
+The `db:seed:demo` proxy chains two scripts: this seed (wipes and re-creates
+the workspace) and then `seed-platform-bundles.ts` (re-installs bundled
+skills, task templates, employee templates).
+
+Anthropic, OpenRouter, and self-hosted Ollama work too — open Settings → AI
+in the workspace as Diego (owner) to switch providers per-org.
+
+---
+
+## Logins (password is **`tomato123`** for everyone)
+
+| Email | Role | Title |
+|---|---|---|
+| `diego@testers-tomatoes.com` | **owner** | Founder & Farm Manager — start here, sees everything |
+| `marigold@testers-tomatoes.com` | admin | Head Grower — runs the greenhouse |
+| `lina@testers-tomatoes.com` | member | Sales & Wholesale Lead — buyer pipeline |
+| `sage@testers-tomatoes.com` | member | QC & Food Safety — owns the GAP audit |
+| `cesar@testers-tomatoes.com` | member | Field Supervisor — outdoor crops + weather |
+| `tomas@testers-tomatoes.com` | member | Logistics & Distribution — trucks + cold storage |
+
+The fastest way to feel the product: log in as Diego in one browser, open an
+incognito window as Lina or Sage. You'll see how the same workspace looks
+completely different depending on who you are — and how the agent's answers
+shift to match. That contrast is the demo.
+
+---
+
+## The week you're walking into
+
+It's the third week of May, 2026. The farm is in the thick of spring
+harvest. Five things are on Diego's mind:
+
+1. **A storm's coming.** Cesar flagged hail risk for Tuesday–Wednesday. The Roma block in the south field is fruiting — losing it would cost ~$22k. Decision needed today.
+2. **Sunbelt wants a contract.** 1,200 lbs/week of slicers, six weeks, $1.85/lb. Diego has to confirm supply before Friday.
+3. **The greenhouse is too humid.** Marigold's overnight log shows 84% humidity in GH-2. If they don't fix it, the Cherokee Purples will catch early blight.
+4. **A new buyer is visiting Friday.** Asha Mehta from Field Co-op — second wholesale contract of the season, heritage varieties at a premium.
+5. **The food safety audit is in 4 weeks.** Sage just told Diego (in DM) that handwashing compliance is at 60%. That's audit-failing.
+
+Everything you'll see in chat, tasks, notes, and the wiki traces back to one
+of those five threads. In Slack the conversation floats away. In Linear the
+tasks have no context. In Notion the notes live in a different universe. In
+Deft, they're one substrate.
+
+---
+
+## What's in the seeded workspace
+
+- **10 spaces** — `#general`, `#greenhouse`, `#field-ops`, `#sales-and-buyers`, `#logistics`, `#harvest-room`, `#random`, plus 3 DMs from Diego (Marigold / Lina / Sage), plus 6 1:1 DMs between Defty and each human.
+- **79 chat messages** with reactions, 5 pinned messages, threaded replies.
+- **3 projects** — `HARV` (Spring 2026 Harvest), `WHL` (Wholesale Expansion), `GH3` (Greenhouse 3 Build-out).
+- **30 tasks** across every status (backlog → todo → in_progress → in_review → done), p0–p3 priorities, with overdue + this-week + next-week due dates. 14 task comments, 14 activity log entries, 7 labels.
+- **8 wiki pages** forming a knowledge graph (varieties, pest playbook, irrigation, cold chain, buyer directory, market pricing, climate setpoints, GAP audit checklist). Linked to each other internally.
+- **9 notes** — a mix of private strategy and shared org notes.
+- **12 cross-references** linking chat messages → tasks and tasks → tasks.
+- **29 entity-tags** weaving messages / tasks / notes through 8 tag families (`heritage`, `weather`, `audit`, `buyer`, `gh-3`, `cold-chain`, `pricing`, `urgent`).
+- **Defty** — built-in agent. His DM is pinned at the top of each user's DM list, with a personalized welcome message keyed off their role.
+
+---
+
+## Five things to do, in order
+
+### 1. Be Diego for two minutes
+Log in as Diego. The dashboard shows what's on his plate today: overdue
+tasks, unread mentions, today's priorities. Click into `#general` — the
+morning standup vibe gives you the feel of a real team. Skim `#field-ops`
+to see Cesar's hail warning (pinned).
+
+> **What to notice:** every channel has *stakes*. These are real decisions
+> getting made in chat that turn into work.
+
+### 2. Follow a real decision from chat into action
+
+Open `#field-ops` and find Cesar's hail warning. Diego replied *"Do it.
+Better insurance than insurance."* Now click over to **Tasks → HARV**. The
+first task — **HARV-1, "Install hail netting on south field"** — is in
+progress, p0, due tomorrow.
+
+Open the task. You'll see:
+- The conversation it came from (linked back to Cesar's chat message)
+- Comments from Cesar, Tomás, and Diego planning the install
+- Watchers (Diego is watching — he wants to know when it's done)
+- An activity log
+
+> **What to notice:** the task didn't appear by magic. A chat message
+> became a task without anyone copy-pasting. Six months from now, you'll
+> still know why this task exists.
+
+### 3. Ask the agent something hard *(needs SEED_OPENAI_KEY or BYOK)*
+
+Anywhere in chat, type `@deft` followed by:
+
+- `what's the status on the Sunbelt contract, and is there anything I should worry about?`
+- `what tasks are overdue or due this week?`
+- `summarize the GH-3 build status`
+- `why did we issue a credit memo to Green Leaf?`
+- `what's blocking us from committing to Whole Foods?`
+
+The agent pulls from chat, tasks, wiki pages, AND Diego's DMs (only the ones
+Diego can see). It synthesizes — with citations.
+
+> **What to notice:** the agent isn't just searching. It's reading the
+> *structured* state of the workspace and forming an answer. This is the
+> direct-SQL-access advantage. ChatGPT plugged into a Slack export cannot
+> do this.
+
+### 4. See how the same workspace looks to different people
+
+Open an incognito window. Log in as **Lina**.
+- Her dashboard shows *her* work. The Sunbelt contract is front and center.
+- She has a pinned private note: "Asha Mehta visit prep — Friday."
+- She has a DM with Diego about a *confidential* Whole Foods conversation. Members can't see that conversation. Even the agent respects it.
+
+Now log in as **Sage** in another incognito tab.
+- Her world is the food safety audit.
+- Her DM with Diego is *only* between them. As Sage, ask the agent `@deft what's our handwashing compliance rate?` — she gets a candid 60% answer. As Cesar, the agent doesn't have that information.
+
+> **What to notice:** Deft is multi-tenant by design AND permission-scoped
+> per user. The agent works for *you*, not the org — so it tells you what
+> you're allowed to know.
+
+### 5. Wander the knowledge graph
+
+Open the wiki. Eight pages, all linked to each other:
+
+- **Tomato Variety Guide** — the team's living reference for every variety
+- **Pest Management Playbook** — protocol, organic vs conventional
+- **Irrigation Schedules** — including the citric-acid emitter-flush trick
+- **Cold-Chain Protocol** — including the May 14 Green Leaf incident write-up
+- **Wholesale Buyer Directory** — Sunbelt, Green Leaf, Field Co-op, confidential Whole Foods exploration
+- **Farmers Market Pricing Strategy** — heat-day display adjustments
+- **Greenhouse Climate Setpoints** — the BTU/sqft rule for GH-3
+- **Food Safety Audit Checklist (USDA GAP)** — pre-audit checklist
+
+Each page links to the related pages. The wiki isn't a documentation
+graveyard — it's where the team puts the lessons that *should* outlive the
+chat thread that produced them.
+
+> **What to notice:** notes are personal. Wiki pages are institutional. The
+> agent reads both. The team gets smarter over time because nothing falls
+> into a Slack scrollback.
+
+---
+
+## What's intentionally NOT in the seed
+
+A few things you'll notice are bare. None of them are bugs — they're the
+choices we made to keep the seed self-contained:
+
+- **No integrations connected.** GitHub, Slack, Google Calendar, Gmail — the connector UI is wired and shows in Settings, but nothing is linked. Connect your own to see the events / calendar / PR features pull live data.
+- **No OAuth providers.** Email + password only. Google / GitHub sign-in won't work unless you set `GOOGLE_CLIENT_ID` / `GITHUB_CLIENT_ID` in `.env`.
+- **No file uploads or images in chat.** Same reason — would have needed real binary fixtures.
+- **AI is opt-in.** Without `SEED_OPENAI_KEY` (or BYOK in Settings → AI), the agent is dormant. The workspace works fully without it — chat + tasks + notes + wiki + reactions + threads all functional.
+
+---
+
+## Re-seeding
+
+The script is destructive — it `DELETE`s every row from every table before
+re-inserting. Re-running gives you the same workspace fresh. If you've added
+your own users or content while testing, back them up first.
+
+```bash
+pnpm db:seed:demo  # wipes everything, re-creates Testers Tomatoes
+```
+
+The seed script lives at `packages/db/seed-demo.ts` — open it if you want to
+add scenarios, change the cast, or fork the workspace for your own demo.

--- a/apps/api/src/scripts/seed-test-fixtures.ts
+++ b/apps/api/src/scripts/seed-test-fixtures.ts
@@ -16,6 +16,7 @@
 import { config as loadEnv } from 'dotenv';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import bcrypt from 'bcryptjs';
 import pg from 'pg';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -40,6 +41,11 @@ async function main() {
   const c = new pg.Client({ connectionString: DATABASE_URL });
   await c.connect();
   try {
+    // Tests in apps/api/test login as maneek@test.com / test1234 (the repo
+    // convention). Pre-hash here so the fixture is self-contained — neither
+    // the demo seed nor any other script needs to know about it.
+    const maneekHash = await bcrypt.hash('test1234', 12);
+
     await c.query(
       `INSERT INTO orgs (id, name, slug) VALUES
          ($1, 'Test Fixtures Org A', 'test-fixtures-org-a'),
@@ -49,12 +55,14 @@ async function main() {
     );
 
     await c.query(
-      `INSERT INTO users (id, name, email, kind, is_agent, email_verified) VALUES
-         ($1, 'Maneek (fixture)', 'maneek-fixture@test.local', 'human', false, true),
-         ($2, 'Alex PM (fixture)', 'alexpm-fixture@test.local', 'agent', true,  true),
-         ($3, 'Priya (fixture)',  'priya-fixture@test.local',  'human', false, true)
-       ON CONFLICT (id) DO NOTHING`,
-      [USER_MANEEK, USER_ALEXPM, USER_PRIYA],
+      `INSERT INTO users (id, name, email, password_hash, kind, is_agent, email_verified) VALUES
+         ($1, 'Maneek (fixture)', 'maneek@test.com',         $4,   'human', false, true),
+         ($2, 'Alex PM (fixture)', 'alexpm-fixture@test.local', NULL, 'agent', true,  true),
+         ($3, 'Priya (fixture)',  'priya-fixture@test.local',  NULL, 'human', false, true)
+       ON CONFLICT (id) DO UPDATE SET
+         email = EXCLUDED.email,
+         password_hash = COALESCE(EXCLUDED.password_hash, users.password_hash)`,
+      [USER_MANEEK, USER_ALEXPM, USER_PRIYA, maneekHash],
     );
 
     await c.query(

--- a/packages/db/seed-demo.ts
+++ b/packages/db/seed-demo.ts
@@ -1,38 +1,71 @@
 /**
- * Demo seeder — wipes the database and inserts 5 test users (maneek/rahul/priya/arjun/sara
- * with password test1234), demo orgs, spaces, messages, tasks. After repopulating, calls
- * `seedDeftyUser` to re-insert the Defty system user (the wipe removes him too).
+ * Demo seeder — wipes the database and inserts the "Testers Tomatoes" workspace
+ * (1 manager + 5 employees, rich chat/task history, notes, a wiki knowledge
+ * graph, cross-references, plus an encrypted per-org OpenAI key on orgs.ai_config
+ * when SEED_OPENAI_KEY is set).
  *
- * Bundled skills / task templates / employee templates live in `@deft/api` and are NOT
- * re-seeded here — run `pnpm --filter @deft/api exec tsx src/scripts/seed-platform-bundles.ts`
- * after this script to re-populate them. The root `db:seed:demo` proxy chains both.
+ * Credentials — password is tomato123 for every user:
+ *   diego@testers-tomatoes.com     (owner, Farm Manager)
+ *   marigold@testers-tomatoes.com  (admin, Head Grower)
+ *   cesar@testers-tomatoes.com     (member, Field Supervisor)
+ *   lina@testers-tomatoes.com      (member, Sales Lead)
+ *   tomas@testers-tomatoes.com     (member, Logistics)
+ *   sage@testers-tomatoes.com      (member, QC + Food Safety)
  *
- * DO NOT run this in production — it deletes EVERY user, org, message, and task. Reserved
- * for `pnpm dev` workflows, CI, audit harnesses, and the apps/api/test suite which depends
- * on the seeded credentials.
+ * DO NOT run this in production — it deletes EVERY user, org, message, and task.
+ * Reserved for `pnpm dev` workflows and demo deploys. CI tests use
+ * apps/api/src/scripts/seed-test-org.ts (separate fixture pipeline).
  *
- * For production-safe seeding (idempotent, platform-bundle only), use `pnpm db:seed`.
+ * Bundled skills / task templates / employee templates live in `@deft/api` and
+ * are NOT re-seeded here — `pnpm db:seed:demo` chains
+ * `pnpm --filter @deft/api exec tsx src/scripts/seed-platform-bundles.ts` after
+ * this script. Defty (the built-in agent user) is re-created inline below since
+ * we insert users via raw SQL rather than the signup API.
+ *
+ * Optional env:
+ *   SEED_OPENAI_KEY  — when set, encrypted via AES-256-GCM (keyed off
+ *                      ENCRYPTION_KEY) and stored on orgs.ai_config.api_keys.openai.
+ *                      All four LLM-task slots (classify/summarize/reason/extract)
+ *                      are routed to OpenAI when set.
  */
 import 'dotenv/config';
 import pg from 'pg';
 import { drizzle } from 'drizzle-orm/node-postgres';
 import { eq, and, asc } from 'drizzle-orm';
 import bcrypt from 'bcryptjs';
+import { createCipheriv, randomBytes, scryptSync } from 'node:crypto';
 import * as schema from './src/schema.js';
-import { seedDeftyUser } from './seed.js';
 
 const { Pool } = pg;
 
-const pool = new Pool({
-  connectionString: process.env.DATABASE_URL || 'postgres://postgres:postgres@localhost:5432/deft',
-});
+const OPENAI_KEY = process.env.SEED_OPENAI_KEY || '';
+const ENCRYPTION_KEY = process.env.ENCRYPTION_KEY || '';
 
+if (!OPENAI_KEY) console.log('[seed-demo] SEED_OPENAI_KEY not set — workspace will boot without OpenAI configured');
+if (OPENAI_KEY && !ENCRYPTION_KEY) throw new Error('ENCRYPTION_KEY env required to encrypt the OpenAI key');
+
+function encrypt(text: string): string {
+  const key = scryptSync(ENCRYPTION_KEY, 'deft-salt', 32);
+  const iv = randomBytes(16);
+  const cipher = createCipheriv('aes-256-gcm', key, iv);
+  let encrypted = cipher.update(text, 'utf8', 'hex');
+  encrypted += cipher.final('hex');
+  const tag = cipher.getAuthTag().toString('hex');
+  return iv.toString('hex') + ':' + tag + ':' + encrypted;
+}
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL || `postgres://postgres:${process.env.POSTGRES_PASSWORD ?? 'postgres'}@localhost:5432/deft`,
+});
 const db = drizzle(pool, { schema });
 
 async function seed() {
-  console.log('Seeding database...');
+  console.log('Seeding Testers Tomatoes demo workspace…');
 
-  // Clean existing data in reverse dependency order
+  // ── Wipe existing data in reverse dependency order ──
+  // The list mirrors the table relationships in schema.ts. Adding wipe entries
+  // here is required whenever a new seeded table is added below, otherwise a
+  // re-run hits a unique-constraint violation on the second pass.
   await db.delete(schema.burnoutAlerts);
   await db.delete(schema.oneonePreps);
   await db.delete(schema.teamHealthSnapshots);
@@ -56,6 +89,12 @@ async function seed() {
   await db.delete(schema.userGroups);
   await db.delete(schema.messageBookmarks);
   await db.delete(schema.canvases);
+  await db.delete(schema.wikiLinks);
+  await db.delete(schema.wikiPages);
+  await db.delete(schema.entityTags);
+  await db.delete(schema.tags);
+  await db.delete(schema.notes);
+  await db.delete(schema.taskWatchers);
   await db.delete(schema.taskActivity);
   await db.delete(schema.taskComments);
   await db.delete(schema.taskLabels);
@@ -78,835 +117,972 @@ async function seed() {
   await db.delete(schema.savedViews);
   await db.delete(schema.invites);
   await db.delete(schema.agentActions);
-  // agent_messages and agent_conversations dropped in migration 0065 (Phase 2 unification)
   await db.delete(schema.triggers);
   await db.delete(schema.skills);
   await db.delete(schema.tools);
-  await db.delete(schema.reminders);
   await db.delete(schema.labels);
   await db.delete(schema.events);
   await db.delete(schema.connectedAccounts);
   await db.delete(schema.orgs);
   await db.delete(schema.users);
 
-  console.log('Cleaned existing data.');
+  console.log('Wiped existing data');
 
-  // ── Users ──
-  const passwordHash = await bcrypt.hash('test1234', 12);
+  // ── Users (1 manager + 5 employees) — all share password tomato123 ──
+  const pw = await bcrypt.hash('tomato123', 12);
 
-  const [maneek] = await db.insert(schema.users).values({
-    name: 'Maneek',
-    email: 'maneek@test.com',
-    password_hash: passwordHash,
-    email_verified: true,
+  const [diego] = await db.insert(schema.users).values({
+    name: 'Diego Vargas', email: 'diego@testers-tomatoes.com',
+    password_hash: pw, email_verified: true,
+    title: 'Founder & Farm Manager', timezone: 'America/Los_Angeles',
+    status_emoji: '🍅', status_text: 'Walking the south field — pings will be slow',
   }).returning();
 
-  const [rahul] = await db.insert(schema.users).values({
-    name: 'Rahul',
-    email: 'rahul@test.com',
-    password_hash: passwordHash,
-    email_verified: true,
+  const [marigold] = await db.insert(schema.users).values({
+    name: 'Marigold Patel', email: 'marigold@testers-tomatoes.com',
+    password_hash: pw, email_verified: true,
+    title: 'Head Grower (Greenhouse)', timezone: 'America/Los_Angeles',
+    status_emoji: '🌱', status_text: 'In Greenhouse 2 — high humidity day',
   }).returning();
 
-  const [priya] = await db.insert(schema.users).values({
-    name: 'Priya',
-    email: 'priya@test.com',
-    password_hash: passwordHash,
-    email_verified: true,
+  const [cesar] = await db.insert(schema.users).values({
+    name: 'Cesar Okafor', email: 'cesar@testers-tomatoes.com',
+    password_hash: pw, email_verified: true,
+    title: 'Field Supervisor', timezone: 'America/Los_Angeles',
   }).returning();
 
-  const [arjun] = await db.insert(schema.users).values({
-    name: 'Arjun',
-    email: 'arjun@test.com',
-    password_hash: passwordHash,
-    email_verified: true,
+  const [lina] = await db.insert(schema.users).values({
+    name: 'Lina Bhattacharya', email: 'lina@testers-tomatoes.com',
+    password_hash: pw, email_verified: true,
+    title: 'Sales & Wholesale Lead', timezone: 'America/Los_Angeles',
+    status_emoji: '📞', status_text: 'On a call with Sunbelt Produce',
   }).returning();
 
-  const [sara] = await db.insert(schema.users).values({
-    name: 'Sara',
-    email: 'sara@test.com',
-    password_hash: passwordHash,
-    email_verified: true,
+  const [tomas] = await db.insert(schema.users).values({
+    name: 'Tomás Wakefield', email: 'tomas@testers-tomatoes.com',
+    password_hash: pw, email_verified: true,
+    title: 'Logistics & Distribution', timezone: 'America/Los_Angeles',
   }).returning();
 
-  console.log('Created users: Maneek, Rahul, Priya, Arjun, Sara');
+  const [sage] = await db.insert(schema.users).values({
+    name: 'Sage Nakamura', email: 'sage@testers-tomatoes.com',
+    password_hash: pw, email_verified: true,
+    title: 'QC & Food Safety', timezone: 'America/Los_Angeles',
+  }).returning();
 
-  // ── Org ──
+  console.log('Created 6 users');
+
+  // ── Org with optional OpenAI BYOK ──
+  const aiConfig: Record<string, unknown> = {};
+  if (OPENAI_KEY) {
+    aiConfig.api_keys = { openai: encrypt(OPENAI_KEY) };
+    aiConfig.ai_models = {
+      classify: { provider: 'openai', model: 'gpt-4o-mini' },
+      summarize: { provider: 'openai', model: 'gpt-4o-mini' },
+      reason: { provider: 'openai', model: 'gpt-4o' },
+      extract: { provider: 'openai', model: 'gpt-4o-mini' },
+    };
+  }
+
   const [org] = await db.insert(schema.orgs).values({
-    name: 'Deft Labs',
-    slug: 'deft-labs',
-    timezone: 'Asia/Kolkata',
-    trust_level: 'standard',
+    name: 'Testers Tomatoes', slug: 'testers-tomatoes',
+    timezone: 'America/Los_Angeles', trust_level: 'standard',
+    ai_config: aiConfig,
   }).returning();
 
   await db.insert(schema.orgMembers).values([
-    { org_id: org!.id, user_id: maneek!.id, role: 'owner' },
-    { org_id: org!.id, user_id: rahul!.id, role: 'member' },
-    { org_id: org!.id, user_id: priya!.id, role: 'member' },
-    { org_id: org!.id, user_id: arjun!.id, role: 'member' },
-    { org_id: org!.id, user_id: sara!.id, role: 'member' },
+    { org_id: org!.id, user_id: diego!.id, role: 'owner' },
+    { org_id: org!.id, user_id: marigold!.id, role: 'admin' },
+    { org_id: org!.id, user_id: cesar!.id, role: 'member' },
+    { org_id: org!.id, user_id: lina!.id, role: 'member' },
+    { org_id: org!.id, user_id: tomas!.id, role: 'member' },
+    { org_id: org!.id, user_id: sage!.id, role: 'member' },
   ]);
 
-  console.log('Created org: Deft Labs');
+  // ── Defty (built-in agent) ──
+  // Replicates apps/api/src/lib/ensure-defty-membership.ts: (1) ensure the
+  // Defty user row, (2) add him to org_members. The 1:1 DM spaces + welcome
+  // messages are created further below alongside the other DM spaces.
+  let [deftyUser] = await db.select({ id: schema.users.id })
+    .from(schema.users).where(eq(schema.users.email, 'deft-agent@system.local')).limit(1);
+  if (!deftyUser) {
+    [deftyUser] = await db.insert(schema.users).values({
+      email: 'deft-agent@system.local', name: 'Defty',
+      kind: 'agent', is_agent: true, email_verified: true,
+    }).returning({ id: schema.users.id });
+  }
+  await db.insert(schema.orgMembers).values({
+    org_id: org!.id, user_id: deftyUser!.id, role: 'member',
+  }).onConflictDoNothing();
 
-  // ── Onboarding ──
+  console.log('Created org: Testers Tomatoes');
+
+  // ── Onboarding state ──
   await db.insert(schema.onboardingState).values([
-    { user_id: maneek!.id, org_created: true, profile_set: true, first_space_created: true, first_message_sent: true, first_task_created: true, completed: true },
-    { user_id: rahul!.id, org_created: false, profile_set: true, first_message_sent: true, completed: false },
-    { user_id: priya!.id, org_created: false, profile_set: true, first_message_sent: true, completed: false },
-    { user_id: arjun!.id, org_created: false, profile_set: true, first_message_sent: false, completed: false },
-    { user_id: sara!.id, org_created: false, profile_set: true, first_message_sent: true, completed: false },
+    { user_id: diego!.id, org_created: true, profile_set: true, first_space_created: true, first_message_sent: true, first_task_created: true, completed: true },
+    { user_id: marigold!.id, profile_set: true, first_message_sent: true, completed: true },
+    { user_id: cesar!.id, profile_set: true, first_message_sent: true, completed: true },
+    { user_id: lina!.id, profile_set: true, first_message_sent: true, completed: true },
+    { user_id: tomas!.id, profile_set: true, first_message_sent: true, completed: false },
+    { user_id: sage!.id, profile_set: true, first_message_sent: true, completed: true },
   ]);
+
+  // ── Message helper (declared early so Defty welcomes can use baseTime too) ──
+  const baseTime = new Date('2026-05-04T07:30:00-07:00'); // 3 weeks ago, Pacific morning
+  let msgOffset = 0;
+  function msgTime(stepMin = 2): Date {
+    msgOffset += stepMin;
+    return new Date(baseTime.getTime() + msgOffset * 60_000);
+  }
 
   // ── Spaces ──
   const [general] = await db.insert(schema.spaces).values({
-    org_id: org!.id, name: 'general', description: 'Company-wide announcements and discussion', type: 'public', is_default: true, created_by: maneek!.id,
+    org_id: org!.id, name: 'general', description: 'Farm-wide announcements and daily checkins',
+    type: 'public', is_default: true, created_by: diego!.id,
   }).returning();
 
-  const [engineering] = await db.insert(schema.spaces).values({
-    org_id: org!.id, name: 'engineering', description: 'Engineering team discussions', type: 'public', created_by: maneek!.id,
+  const [greenhouse] = await db.insert(schema.spaces).values({
+    org_id: org!.id, name: 'greenhouse', description: 'Climate, irrigation, pest control — Greenhouses 1, 2, 3',
+    type: 'public', created_by: marigold!.id,
   }).returning();
 
-  const [design] = await db.insert(schema.spaces).values({
-    org_id: org!.id, name: 'design', description: 'Design reviews and feedback', type: 'public', created_by: maneek!.id,
+  const [fieldOps] = await db.insert(schema.spaces).values({
+    org_id: org!.id, name: 'field-ops', description: 'Outdoor crops, weather, soil',
+    type: 'public', created_by: cesar!.id,
+  }).returning();
+
+  const [sales] = await db.insert(schema.spaces).values({
+    org_id: org!.id, name: 'sales-and-buyers', description: 'Wholesale buyer pipeline, farmers market, pricing',
+    type: 'public', created_by: lina!.id,
+  }).returning();
+
+  const [logistics] = await db.insert(schema.spaces).values({
+    org_id: org!.id, name: 'logistics', description: 'Deliveries, refrigerated truck schedules, packing',
+    type: 'public', created_by: tomas!.id,
+  }).returning();
+
+  const [harvest] = await db.insert(schema.spaces).values({
+    org_id: org!.id, name: 'harvest-room', description: 'Picking schedules, sorting, packing crews',
+    type: 'public', created_by: cesar!.id,
   }).returning();
 
   const [random] = await db.insert(schema.spaces).values({
-    org_id: org!.id, name: 'random', description: 'Water cooler', type: 'public', created_by: rahul!.id,
+    org_id: org!.id, name: 'random', description: 'Water cooler — bring your own coffee',
+    type: 'public', created_by: diego!.id,
   }).returning();
 
-  const [dm] = await db.insert(schema.spaces).values({
-    org_id: org!.id, name: 'Maneek, Rahul', type: 'dm', created_by: maneek!.id,
+  // 1:1 DMs between Diego and his closest reports
+  const [dmDM] = await db.insert(schema.spaces).values({
+    org_id: org!.id, name: 'Diego, Marigold', type: 'dm', created_by: diego!.id,
+  }).returning();
+  const [dmDL] = await db.insert(schema.spaces).values({
+    org_id: org!.id, name: 'Diego, Lina', type: 'dm', created_by: diego!.id,
+  }).returning();
+  const [dmDS] = await db.insert(schema.spaces).values({
+    org_id: org!.id, name: 'Diego, Sage', type: 'dm', created_by: diego!.id,
   }).returning();
 
-  const [dmManeekPriya] = await db.insert(schema.spaces).values({
-    org_id: org!.id, name: 'Maneek, Priya', type: 'dm', created_by: maneek!.id,
-  }).returning();
+  // Memberships — everyone in the public spaces, DMs only their pair
+  const allHumans = [diego!, marigold!, cesar!, lina!, tomas!, sage!];
+  for (const space of [general!, greenhouse!, fieldOps!, sales!, logistics!, harvest!, random!]) {
+    await db.insert(schema.spaceMembers).values(
+      allHumans.map((u) => ({ space_id: space.id, user_id: u.id }))
+    );
+  }
+  await db.insert(schema.spaceMembers).values([
+    { space_id: dmDM!.id, user_id: diego!.id }, { space_id: dmDM!.id, user_id: marigold!.id },
+    { space_id: dmDL!.id, user_id: diego!.id }, { space_id: dmDL!.id, user_id: lina!.id },
+    { space_id: dmDS!.id, user_id: diego!.id }, { space_id: dmDS!.id, user_id: sage!.id },
+  ]);
 
-  const [dmManeekSara] = await db.insert(schema.spaces).values({
-    org_id: org!.id, name: 'Maneek, Sara', type: 'dm', created_by: maneek!.id,
-  }).returning();
-
-  // Add Maneek and Rahul to all original spaces
-  for (const space of [general!, engineering!, design!, random!, dm!]) {
+  // ── Defty DMs (1:1 with each human) + personalized welcome messages ──
+  // The sidebar (apps/web/src/components/sidebar.tsx) pins Defty's DM at the
+  // top of the Direct Messages section.
+  const deftyWelcomes: Record<string, string> = {
+    [diego!.id]: "Hey Diego, I'm Defty — your workspace agent. I can read the whole workspace (chat, tasks, notes, wiki, cross-references) and answer questions, draft updates, or kick off work. Some things to try:\n\n• Ask me 'what's on my plate this week?' for a personalized digest.\n• Ask 'summarize the GH-3 build' and I'll synthesize across chat, tasks, and Marigold's BOM notes.\n• @mention me (@deft) in any channel to pull me into a thread.\n\nI ask before I do anything irreversible. Trust level here is 'standard' so I'll auto-execute light things (creating tasks, posting summaries) and ask for approval on bigger writes.",
+    [marigold!.id]: "Hi Marigold — I'm Defty, the workspace agent. If you want quick answers across the greenhouse logs, the GH-3 plan, and the variety wiki without scrolling chat, ask me here.\n\nTry: 'what's the latest on the GH-2 humidity issue?' or 'what's still open on the GH-3 build?'",
+    [cesar!.id]: "Hey Cesar — I'm Defty. I can pull harvest schedules, weather-related tasks, and the audit checklist into one place when you need a quick read.\n\nTry: 'what's the hail prep status?' or 'list this week's harvest tasks ordered by day.'",
+    [lina!.id]: "Hi Lina — Defty here. Best use of me on your side: buyer-pipeline rollups, contract status, and pulling notes + chat history when you're prepping for a buyer call.\n\nTry: 'what's outstanding on the Sunbelt contract?' or 'pull everything we have on Asha Mehta / Field Co-op for Friday.'",
+    [tomas!.id]: "Hey Tomás — Defty. I can pull the delivery rotation, cold-chain incidents, and any open logistics tasks into a single view. Good for morning planning.\n\nTry: 'what's on the truck rotation this week?' or 'remind me of the cold-chain spec for Sunbelt.'",
+    [sage!.id]: "Hi Sage — Defty here. For the GAP audit, I can pull the checklist, recent compliance issues from chat, and the open audit tasks into one summary.\n\nTry: 'what's the audit dry-run agenda?' or 'find anything in chat about handwashing compliance from the last 30 days.'",
+  };
+  const welcomeTime = new Date(baseTime.getTime() - 2 * 86400_000);
+  for (const human of allHumans) {
+    const [dmSpace] = await db.insert(schema.spaces).values({
+      org_id: org!.id, name: `${human.name}, Defty`, type: 'dm', created_by: human.id,
+    }).returning();
     await db.insert(schema.spaceMembers).values([
-      { space_id: space.id, user_id: maneek!.id },
-      { space_id: space.id, user_id: rahul!.id },
+      { space_id: dmSpace!.id, user_id: human.id },
+      { space_id: dmSpace!.id, user_id: deftyUser!.id },
     ]);
+    await db.insert(schema.messages).values({
+      org_id: org!.id, space_id: dmSpace!.id, user_id: deftyUser!.id,
+      content: deftyWelcomes[human.id]!, created_at: welcomeTime,
+    });
   }
 
-  // Add new users to spaces
-  // All 3 new users to #general and #random
-  for (const space of [general!, random!]) {
-    await db.insert(schema.spaceMembers).values([
-      { space_id: space.id, user_id: priya!.id },
-      { space_id: space.id, user_id: arjun!.id },
-      { space_id: space.id, user_id: sara!.id },
-    ]);
-  }
-  // Priya, Arjun, Sara to #engineering
-  await db.insert(schema.spaceMembers).values([
-    { space_id: engineering!.id, user_id: priya!.id },
-    { space_id: engineering!.id, user_id: arjun!.id },
-    { space_id: engineering!.id, user_id: sara!.id },
-  ]);
-  // Arjun to #design
-  await db.insert(schema.spaceMembers).values([
-    { space_id: design!.id, user_id: arjun!.id },
-  ]);
+  console.log('Created 16 spaces (10 + 6 Defty DMs) with Defty welcome messages');
 
-  // DM members
-  await db.insert(schema.spaceMembers).values([
-    { space_id: dmManeekPriya!.id, user_id: maneek!.id },
-    { space_id: dmManeekPriya!.id, user_id: priya!.id },
-  ]);
-  await db.insert(schema.spaceMembers).values([
-    { space_id: dmManeekSara!.id, user_id: maneek!.id },
-    { space_id: dmManeekSara!.id, user_id: sara!.id },
-  ]);
-
-  console.log('Created 7 spaces');
-
-  // ── Helper to create messages with sequential timestamps ──
-  const baseTime = new Date('2026-03-28T09:00:00Z');
-  let msgOffset = 0;
-
-  function msgTime() {
-    msgOffset += 1;
-    return new Date(baseTime.getTime() + msgOffset * 90_000); // 1.5 min apart
-  }
-
-  async function msg(spaceId: string, userId: string, content: string) {
+  async function msg(spaceId: string, userId: string, content: string, opts: { parent_id?: string; stepMin?: number } = {}) {
     const [m] = await db.insert(schema.messages).values({
-      org_id: org!.id, space_id: spaceId, user_id: userId, content, created_at: msgTime(),
+      org_id: org!.id, space_id: spaceId, user_id: userId,
+      content, parent_id: opts.parent_id, created_at: msgTime(opts.stepMin ?? 2),
     }).returning();
     return m!;
   }
 
-  const M = maneek!.id;
-  const R = rahul!.id;
-  const P = priya!.id;
-  const A = arjun!.id;
-  const S = sara!.id;
+  const D = diego!.id, M = marigold!.id, C = cesar!.id, L = lina!.id, T = tomas!.id, Sg = sage!.id;
 
-  // ── #general — 10 messages about product launch ──
-  await msg(general!.id, M, "Alright team, we're targeting end of next week for the private beta launch. Let's make sure all the critical paths are solid.");
-  await msg(general!.id, R, "Sounds good. Auth flow is done, just need to wire up the email verification with Resend. Should be quick.");
-  await msg(general!.id, M, "Perfect. The biggest risk right now is the real-time chat — we need to make sure Socket.io reconnects gracefully when people switch between tabs.");
-  await msg(general!.id, R, "Yeah I noticed that too. I'll add exponential backoff on the client side. Also need to handle the case where the JWT expires mid-session.");
-  await msg(general!.id, M, "Good call. For the token refresh, let's intercept the 401 in the API client and silently refresh before retrying. Users shouldn't notice anything.");
-  await msg(general!.id, R, "Already set up that pattern in api.ts actually. It catches 401s, hits /auth/refresh, then replays the original request.");
-  await msg(general!.id, M, "Nice. One more thing — I want to get the agent observation pipeline stubbed out before launch. Even if it doesn't do anything yet, I want every message flowing through the classifier.");
-  await msg(general!.id, R, "Makes sense. We can use Haiku for classification — it's fast enough to not add noticeable latency. Want me to set up the BullMQ job for it?");
-  await msg(general!.id, M, "Yes please. Keep it simple — just queue every new message, classify intent and urgency, store the result in metadata. We'll build the action pipeline in week 2.");
-  await msg(general!.id, R, "On it. I'll have a PR up by tomorrow morning.");
+  // ── #general — daily standup vibes ──
+  const gen1 = await msg(general!.id, D, "Morning team. The Sun Gold trial in GH-2 is looking really strong — we're picking the first cluster Thursday. Cesar's crew is on the south field rotation today (Romas + San Marzanos). Lina, you've got the Sunbelt call at 11.");
+  await msg(general!.id, M, "Sun Gold trusses are heavier than last year by maybe 15%. Going to need extra clips before Thursday or they'll snap.");
+  await msg(general!.id, C, "South field is at 78°F by 8am, projecting 91°F peak. Heat-stress watch is on. I'm pushing the noon irrigation up by 90 min.");
+  await msg(general!.id, L, "Sunbelt wants to lock in a 6-week supply contract for slicers. Asking 1,200 lbs/week. Need to confirm we can hit that with the Beefsteak block before I commit.");
+  await msg(general!.id, D, "Marigold, can you walk Lina through the Beefsteak yield projection after she's off the call? Pretty sure we're at 1,400/wk peak but want to be honest with Sunbelt about ramp.");
+  await msg(general!.id, M, "Yep, I'll meet her in the office at noon. I have the truss counts from Monday.");
+  await msg(general!.id, Sg, "Reminder: USDA-GAP audit is on June 18th. I'm running the dry-run audit next Tuesday — please don't argue with me about washing logs, just sign them. 🙏");
+  await msg(general!.id, T, "Cold truck is back from servicing. Compressor was leaking — that explains why the Tuesday delivery to Green Leaf was warmer than spec. Logging it in the QC system.");
+  await msg(general!.id, D, "Good. We owe Green Leaf a credit note for that batch — Lina, can you handle it after Sunbelt?");
+  await msg(general!.id, L, "On it. I'll draft the credit memo this afternoon.");
 
-  // ── #engineering — 8 messages about API architecture ──
+  // ── #greenhouse — operational detail ──
+  msgOffset += 30;
+  const gh1 = await msg(greenhouse!.id, M, "GH-2 climate log overnight: humidity peaked at 84% at 4am. That's the third time this week. The dehumidifier on the north wall is undersized for the late-spring load.");
+  const gh2 = await msg(greenhouse!.id, M, "If we don't fix this before peak fruit set on the Cherokee Purples, we're going to see early blight. Saw a few suspicious leaves on Row 7 yesterday.");
+  await msg(greenhouse!.id, D, "Order a second unit. Pull from the GH-3 build budget if you have to — better to fight blight now than lose a block later.");
+  await msg(greenhouse!.id, M, "Already on Grainger. 18,000 BTU portable unit, $1,840, ships tomorrow.");
+  await msg(greenhouse!.id, Sg, "If we do get blight, the protocol is in the playbook — copper octanoate (OMRI listed) for the organic block, mancozeb for conventional. Don't mix them up.");
+  await msg(greenhouse!.id, M, "Got it. Marking Row 7 with a flag in the morning so the picking crew avoids it until I confirm.");
+  await msg(greenhouse!.id, M, "Side topic — Sun Gold drip emitters on Row 4 are clogging. Hard water deposits. Going to flush with citric acid this weekend.", { stepMin: 60 });
+  await msg(greenhouse!.id, C, "Want to share the flush procedure with the field team? Our T-tape lines have the same problem in late summer.");
+  const gh9 = await msg(greenhouse!.id, M, "Yeah, I'll write it up in the irrigation wiki. 1% citric solution, 30-min soak, flush with clean water. Works on emitters AND T-tape.");
+
+  // ── #field-ops ──
+  msgOffset += 25;
+  const fo1 = await msg(fieldOps!.id, C, "Weather alert: hail risk Tuesday-Wednesday next week per NOAA. 30% chance, 1/2 inch stones. The Romas in the south field are fruiting — we lose anything bigger than a marble if hail hits.");
+  await msg(fieldOps!.id, D, "What's the cost of putting hail netting on the south block?");
+  await msg(fieldOps!.id, C, "I called Eastern Ag last fall — about $4,800 per acre installed, leases for one season. South block is 1.8 acres so $8,640. We made $38k off that block last year so it's not crazy if we lose half the crop.");
+  await msg(fieldOps!.id, D, "Do it. Better insurance than insurance.");
+  await msg(fieldOps!.id, C, "Calling them now. Install needs to happen Monday, no later.");
+  await msg(fieldOps!.id, M, "While we're on weather — the hoop houses on the east edge are still vented for the heat. We should be ready to close them down fast if temps drop on Wednesday.");
+  await msg(fieldOps!.id, C, "Tomás, can you stage the side panels by the hoop houses Monday afternoon? Two people can close them in 30 min if we don't have to chase down materials.");
+  await msg(fieldOps!.id, T, "Done. I'll drop them off when I'm out there for the harvest pickup.");
+
+  // ── #sales-and-buyers ──
+  msgOffset += 40;
+  const s1 = await msg(sales!.id, L, "Sunbelt Produce call recap: They want 1,200 lbs/wk of Beefsteak slicers for 6 weeks starting May 26. Price: $1.85/lb FOB. They'll commit to a fixed quantity (not min/max). Decision needed by Friday.");
+  await msg(sales!.id, D, "How does $1.85 compare to last year's contract price?");
+  await msg(sales!.id, L, "Last year was $1.62. So 14% higher. They flinched but didn't push back hard. I think we could've held $2.00 but I didn't want to risk it on the first contract of the season.");
+  await msg(sales!.id, D, "Good read. Lock it in if Marigold confirms supply. The pricing-strategy doc I want to update — let's hold $2.00 as our anchor next year now that we've shown we can deliver.");
+  await msg(sales!.id, L, "Will do. I'll also send Sunbelt the cold-chain spec — they were asking about delivery temp range.");
+  await msg(sales!.id, T, "Our spec is 50-55°F. We pulp-temp every load before it leaves the cooler. Receipts in the QC log.");
+  await msg(sales!.id, L, "Switching topics — farmers market on Saturday is forecast 88°F. The Cherokee Purples don't hold up in heat. I'm shifting display to the Sun Golds, Romas, and slicers.");
+  await msg(sales!.id, L, "Also — the new buyer at Field Co-op (Asha Mehta) is coming to the farm Friday for a walk-through. I'd like the Cherokee Purple block to be at peak when she sees it. Marigold, what does your truss count say?");
+  await msg(sales!.id, M, "Cherokee Purple peak fruit-set is right now. She'll see the prettiest block we've had in 3 years if the dehumidifier issue doesn't trigger blight. Bring her at 10am — light is best then.");
+
+  // ── #logistics ──
+  msgOffset += 30;
+  const lg1 = await msg(logistics!.id, T, "Truck rotation for next week:\n- Mon 6am: harvest → cold storage (in-house)\n- Tue 4am: cold storage → Sunbelt DC (Fresno, 3.5hr)\n- Wed 4am: cold storage → Green Leaf (LA, 5hr)\n- Thu 5am: cold storage → Field Co-op trial run (2 pallets, sample order)\n- Sat 5am: farmers market load");
+  await msg(logistics!.id, T, "Need a second driver for Wed — Green Leaf wants the 5hr trip AND the return same day. Diego, you OK to drive the empty back if I take the load out?");
+  await msg(logistics!.id, D, "Yeah, I can do the return. Send me the pickup window.");
+  await msg(logistics!.id, T, "Loading window: 4am-5am. Departure target 5am sharp. Arrival 10am LA. Unload 10-11. I'll be home by 4pm.");
+  await msg(logistics!.id, Sg, "Pulp temps for the Tuesday Sunbelt load — make sure they're logged before AND after the trip. Sunbelt requires the printout. Last time we lost track and they took 30 min at the dock to verify.");
+  await msg(logistics!.id, T, "Already on it. New logger arrives Friday — it does both pre and post readings to one PDF.");
+
+  // ── #harvest-room ──
+  msgOffset += 25;
+  const hr1 = await msg(harvest!.id, C, "Harvest plan for the week:\n- Mon: Romas south field, full crew (6 people, 6am-12pm)\n- Tue: San Marzanos middle field, half crew (3 people)\n- Thu: Sun Gold first pull, GH-2, Marigold leads\n- Fri: Cherokee Purple selective pick for the Field Co-op visit");
+  await msg(harvest!.id, C, "Romas: target firmness is 'breaker-plus' for the Sunbelt load. Anything that's already red goes to the farmers market bin. Sage will spot-check.");
+  await msg(harvest!.id, Sg, "Reminder: nobody picks without washed hands and clean clippers. There's a sign at the entrance. I will absolutely walk you out and back if I see otherwise.");
+  await msg(harvest!.id, M, "Sun Gold pull on Thursday — single layer in the 25-lb totes, NOT the regular 40s. They bruise if they're stacked.");
+  await msg(harvest!.id, T, "I'll have 60 of the 25-lb totes washed and stacked at the harvest room by Wednesday EOD.");
+  await msg(harvest!.id, C, "Friday pick for Field Co-op visit: leave the prettiest Cherokee Purple cluster on Row 12 — that's the one we'll show Asha. DO NOT PICK ROW 12 UNTIL AFTER 11AM.");
+
+  // ── #random ──
+  msgOffset += 30;
+  await msg(random!.id, T, "Anyone else's farmers market table getting hit hard by the heat? I'm thinking we need a second pop-up for shade this weekend.");
+  await msg(random!.id, L, "Yes. Last Saturday I lost two flats of Cherokee Purples to sun damage by 11am. I'll order a second 10x10 — REI has them on sale.");
+  await msg(random!.id, M, "Random fact: the word 'tomato' comes from the Nahuatl 'tomatl' which literally means 'plump thing'. Just learned this from a podcast. 🍅");
+  await msg(random!.id, D, "Plump Thing Industries. Our new company name.");
+  await msg(random!.id, C, "Branding it.");
+  await msg(random!.id, Sg, "My audit checklist now reads 'Plump Thing storage protocol'. You're welcome.");
+  await msg(random!.id, T, "Lunch run to Manuel's tomorrow. Carne asada or al pastor? Going to do a batch order.");
+  await msg(random!.id, L, "Al pastor. Always al pastor.");
+  await msg(random!.id, M, "Vegetarian for me. Extra guacamole.");
+
+  // ── DM Diego ↔ Marigold ──
+  msgOffset += 30;
+  await msg(dmDM!.id, D, "Hey, I've been thinking about GH-3. We've been treating it like 'just another greenhouse' but if we set it up for the heritage varieties specifically, we could double our farmers market premium.");
+  await msg(dmDM!.id, M, "I agree. The Brandywines and Cherokee Purples sell for $6.50/lb retail vs $2.50 for the conventional slicers. If GH-3 is heritage-only we can run a tighter climate program (lower humidity, higher airflow) that's specifically what those varieties need.");
+  await msg(dmDM!.id, D, "Let's make GH-3 a heritage-only build. Update the GH-3 project plan when you have a chance — different climate sensors, different irrigation zoning.");
+  await msg(dmDM!.id, M, "Will do. Going to need a higher-capacity dehumidifier baseline (now that I'm thinking about it, the GH-2 issue is a foreshadowing) and a separate ferti-station because the heritages get a different feed schedule.");
+  await msg(dmDM!.id, D, "Budget's not infinite but I want this to be done right. Send me the revised BOM and we'll figure it out.");
+
+  // ── DM Diego ↔ Lina ──
+  msgOffset += 20;
+  await msg(dmDL!.id, D, "Confidential — I've been talking to Whole Foods Pacific Northwest about a regional supply slot. They want a year-round program, not seasonal. Means we'd need GH-3 producing by January 2027 at the latest.");
+  await msg(dmDL!.id, L, "Whoa. That's a big leap. What volume are they talking?");
+  await msg(dmDL!.id, D, "Initial: 800-1000 lbs/wk across 4 SKUs (Roma, Beefsteak, heritage mix, cherry mix). Could grow to 2,500/wk by year 2.");
+  await msg(dmDL!.id, L, "That would 4x our wholesale revenue. But it also means we can't lose them — one missed week is contract-killing with Whole Foods.");
+  await msg(dmDL!.id, D, "Exactly. I don't want to commit until GH-3 is online AND we've had a clean 6-month run with Sunbelt and Field Co-op. Let's plan to revisit in October.");
+  await msg(dmDL!.id, L, "Got it. Keeping this off the public channels for now. I'll start building the cost model — what wholesale margins look like with a national chain vs. our regional buyers.");
+
+  // ── DM Diego ↔ Sage ──
+  msgOffset += 20;
+  await msg(dmDS!.id, Sg, "About the GAP audit dry-run. I want to flag now — our handwashing log compliance has been spotty. Random spot-checks: 60% sign-in rate at the harvest room sink.");
+  await msg(dmDS!.id, D, "That's an audit-failure level. What's driving it?");
+  await msg(dmDS!.id, Sg, "Crews show up at 6am and want to start picking. Sign-in feels like friction. I think we need (1) a physical sign-in stand at the entrance with a clipboard literally blocking the path, and (2) Cesar enforcing it as part of the morning huddle.");
+  await msg(dmDS!.id, D, "Do both. I'll back you on this if there's friction. Failing GAP costs us Sunbelt AND Field Co-op — neither of them will buy without certification.");
+  await msg(dmDS!.id, Sg, "Thanks. I'll have the new station set up by Monday. Also — the audit covers more than handwashing. Pesticide application records, water testing, traceability. I'm building a checklist this weekend and would like an hour with you next week to walk through.");
+  await msg(dmDS!.id, D, "Tuesday 2pm. Block it on my calendar.");
+
+  console.log('Created messages across 10 spaces');
+
+  // ── Reactions ──
+  const reactions = [
+    [gen1.id, M, '🍅'], [gen1.id, L, '👍'], [gen1.id, C, '☀️'],
+    [gh1.id, D, '👀'], [gh1.id, Sg, '🚨'],
+    [gh2.id, D, '🚨'],
+    [gh9.id, C, '🙏'],
+    [fo1.id, D, '⚠️'], [fo1.id, M, '⚠️'], [fo1.id, T, '😬'],
+    [s1.id, D, '💰'], [s1.id, M, '🔥'],
+    [lg1.id, D, '👍'], [lg1.id, Sg, '📋'],
+    [hr1.id, M, '✅'], [hr1.id, L, '👍'],
+  ] as const;
+  for (const [mid, uid, emoji] of reactions) {
+    await db.insert(schema.reactions).values({ message_id: mid, user_id: uid, emoji }).catch(() => {});
+  }
+
+  // ── Pin key messages ──
+  await db.insert(schema.pinnedMessages).values([
+    { message_id: gh1.id, space_id: greenhouse!.id, pinned_by: M },
+    { message_id: fo1.id, space_id: fieldOps!.id, pinned_by: C },
+    { message_id: s1.id, space_id: sales!.id, pinned_by: L },
+    { message_id: lg1.id, space_id: logistics!.id, pinned_by: T },
+    { message_id: hr1.id, space_id: harvest!.id, pinned_by: C },
+  ]);
+
+  // ── Thread replies on a key message ──
   msgOffset += 5;
-  await msg(engineering!.id, R, "Quick question on the API structure — should we keep the message routes mounted under /api/messages/:spaceId or nest them under /api/spaces/:id/messages?");
-  await msg(engineering!.id, M, "I'd go with /api/spaces/:id/messages for the REST semantics. Messages belong to a space, the URL should reflect that hierarchy.");
-  await msg(engineering!.id, R, "Fair point. I'll refactor the routes. Also, I'm thinking about the cursor-based pagination — right now we're using created_at as the cursor, but if two messages have the same timestamp we could skip one.");
-  await msg(engineering!.id, M, "Good catch. Use a composite cursor — created_at + id. Sort by (created_at DESC, id DESC) and filter with (created_at, id) < (cursor_time, cursor_id).");
-  await msg(engineering!.id, R, "That's clean. I'll update the query. Also wanted to flag — the database migration for adding pgvector is going to be a bit involved. We need the extension enabled.");
-  await msg(engineering!.id, M, "Right, we'll need CREATE EXTENSION vector. Add it as a custom migration, not through Drizzle push. Don't want that running automatically in production.");
-  await msg(engineering!.id, R, "Agreed. I'll write a manual migration script. For the embedding column, thinking 1536 dimensions to match OpenAI's ada-002, or should we go with a smaller model?");
-  await msg(engineering!.id, M, "Let's use 1024 dims — we'll probably use Voyage or Cohere for embeddings, they're better for search. 1536 is overkill for our use case.");
+  await msg(greenhouse!.id, D, "Quick clarifying question — is Row 7 a Cherokee Purple block or a Brandywine block? Want to flag the right variety in the audit log.", { parent_id: gh2.id });
+  await msg(greenhouse!.id, M, "Cherokee Purple. Brandywines are in Row 11-13.", { parent_id: gh2.id });
+  await msg(greenhouse!.id, Sg, "Logging both rows for inspection just to be safe. Will visit tomorrow morning.", { parent_id: gh2.id });
 
-  // ── #design — 5 messages about dashboard mockups ──
-  msgOffset += 3;
-  await msg(design!.id, M, "Pushed the first dashboard mockups to Figma. The idea is three sections: Today's briefing (agent-generated), active tasks, and upcoming events from connected calendars.");
-  await msg(design!.id, R, "Just looked at them. Love the briefing card at the top. One thought — can we make the task section collapsible by project? When you have 20+ tasks it gets overwhelming.");
-  await msg(design!.id, M, "Yeah absolutely. I was thinking accordion-style with the project icon and a count badge. Click to expand and see the tasks grouped by status.");
-  await msg(design!.id, R, "That works. Also the dark mode palette is looking really good. The contrast ratios on the sidebar are much better than the last iteration.");
-  await msg(design!.id, M, "Thanks, spent way too long tweaking those CSS variables. Going to extract them into a proper theme system so we can support custom brand colors per org down the road.");
+  await msg(fieldOps!.id, M, "We've never had hail this late in May. Is the netting reusable for next year or single-season?", { parent_id: fo1.id });
+  await msg(fieldOps!.id, C, "Single season lease but Eastern Ag will swap it for next year if we commit early. I'll add a recurring task for January.", { parent_id: fo1.id });
 
-  // ── #random — 6 casual messages ──
-  msgOffset += 2;
-  await msg(random!.id, R, "Has anyone tried that new South Indian place on 12th Main? The filter coffee is unreal.");
-  await msg(random!.id, M, "Dosa Corner? Yes! Their ghee roast dosa is incredible. We should do a team lunch there.");
-  await msg(random!.id, R, "Let's do Thursday. Also, random thought — should we add emoji reactions to messages before launch? It feels like table stakes for a chat app.");
-  await msg(random!.id, M, "Agreed, reactions are essential. The schema already has a reactions table. Should be a quick frontend build — click emoji picker, POST to /api/reactions, broadcast via socket.");
-  await msg(random!.id, R, "I'll scope it out. Might use the native emoji picker on Mac/Windows to keep the bundle small. No need for a custom one yet.");
-  await msg(random!.id, M, "Smart. Ship the simple version first, we can always add a custom picker later if people want gif reactions or custom emoji.");
+  console.log('Added reactions, pins, threads');
 
-  // ── DM between Maneek and Rahul — 4 messages about a client meeting ──
-  msgOffset += 2;
-  await msg(dm!.id, M, "Hey, just got off a call with the Zephyr team. They want to pilot Deft for their 15-person eng team. Can you put together a quick demo environment by Wednesday?");
-  await msg(dm!.id, R, "Oh nice, that's exciting! Yeah I can spin up a demo instance on Railway. Should I pre-populate it with sample data so they can see the chat + tasks in action?");
-  await msg(dm!.id, M, "Exactly. Create a realistic workspace — a few spaces, some tasks across statuses, maybe mock a couple of agent suggestions. They specifically asked about the AI features.");
-  await msg(dm!.id, R, "Got it. I'll set up the demo with the agent doing a daily standup summary and auto-creating tasks from chat messages. Even if it's semi-hardcoded, it'll show the vision.");
-
-  // ── New messages in #general ──
-  msgOffset += 2;
-  await msg(general!.id, P, "Hey everyone! Just joined the team. Excited to work on the frontend.");
-  await msg(general!.id, A, "Welcome Priya! Let me know if you need the Figma access link.");
-  await msg(general!.id, S, "Welcome! I've added you to the sprint board. Let's sync tomorrow about priorities.");
-  await msg(general!.id, M, "Great to have the full team now. Let's aim for the beta demo by Friday.");
-
-  // ── New messages in #engineering ──
-  msgOffset += 2;
-  await msg(engineering!.id, P, "Found a hydration mismatch in the sidebar component. The useEffect for theme detection runs client-side but the server renders with the default theme.");
-  await msg(engineering!.id, A, "We had a similar issue with the avatar colors. The hash function gives different results on server vs client because of crypto.randomUUID timing.");
-  await msg(engineering!.id, S, "Can we track these in the project board? I want to make sure we don't ship the beta with hydration warnings.");
-  await msg(engineering!.id, R, "I'll create tickets for both. The theme one is a quick fix — we just need to suppress hydration warnings on the html element.");
-
-  // ── DM between Maneek and Priya — React hydration bug ──
-  msgOffset += 2;
-  await msg(dmManeekPriya!.id, M, "Hey Priya, saw your message about the hydration mismatch. Can you share the exact error from the console? I want to see if it's the same one I hit last week.");
-  await msg(dmManeekPriya!.id, P, "Sure! It's 'Warning: Text content did not match. Server: \"light\" Client: \"dark\"'. Happens because we read localStorage for the theme in useEffect but the server always renders light.");
-  await msg(dmManeekPriya!.id, M, "Yep, classic Next.js issue. The fix is to use suppressHydrationWarning on the html element and wrap the theme provider with a mounted check. I'll send you the pattern we used on a previous project.");
-
-  // ── DM between Maneek and Sara — sprint planning ──
-  msgOffset += 2;
-  await msg(dmManeekSara!.id, S, "Hey Maneek, wanted to chat about sprint planning for next week. I think we should focus on closing the auth flow and the real-time reconnection before adding new features.");
-  await msg(dmManeekSara!.id, M, "Agreed. Let's keep the sprint tight — auth, WebSocket reconnection, and cursor pagination. Everything else goes to backlog. Can you draft the sprint in the project board?");
-  await msg(dmManeekSara!.id, S, "On it. I'll also add estimates for each task so we can track velocity. Should have the draft ready by tomorrow morning.");
-
-  // ── #engineering — 50-message dense conversation between Rahul and Arjun ──
-  msgOffset += 3;
-  await msg(engineering!.id, R, "Arjun, you around? Need to figure out this WebSocket reconnection bug before the demo tomorrow.");
-  await msg(engineering!.id, A, "Yeah I'm here. What's happening exactly?");
-  await msg(engineering!.id, R, "When a user switches tabs for more than 30 seconds, the socket disconnects. On reconnect, it rejoins the room but misses every message that was sent while they were away.");
-  await msg(engineering!.id, A, "So the gap between disconnect and reconnect — those messages just vanish from their view?");
-  await msg(engineering!.id, R, "Exactly. They show up if you refresh the page because the initial load fetches from the DB, but the real-time layer drops them silently.");
-  await msg(engineering!.id, A, "We need to track the last received message timestamp on the client. When reconnecting, send that timestamp to the server and have it replay anything newer.");
-  await msg(engineering!.id, R, "That's what I was thinking. The server already stores everything in Postgres. On reconnect we can do a quick SELECT WHERE created_at > last_seen AND space_id = current_space.");
-  await msg(engineering!.id, A, "What about ordering? If two messages come in at the exact same millisecond during the gap, we might deliver them out of order.");
-  await msg(engineering!.id, R, "Good point. We should use the composite cursor — created_at + message id. Same pattern Maneek suggested for pagination.");
-  await msg(engineering!.id, A, "Makes sense. Want me to handle the server-side replay endpoint while you do the client reconnect logic?");
-  await msg(engineering!.id, R, "Yes please. The endpoint should be something like GET /api/spaces/:id/messages/since?after=<cursor>. Return max 200 messages to avoid blowing up the response.");
-  await msg(engineering!.id, A, "Got it. I'll add the route now. Also, should we emit them as regular socket events or as a batch?");
-  await msg(engineering!.id, R, "Batch. Emit a single 'messages:catchup' event with the array. Client processes them all at once, then resumes normal real-time flow.");
-  await msg(engineering!.id, A, "Smart. That avoids 200 individual DOM updates. The client can just concat and re-sort.");
-  await msg(engineering!.id, R, "Exactly. Alright, switching topics — did you see the Drizzle migration issue Sara flagged?");
-  await msg(engineering!.id, A, "The one where drizzle-kit generate creates a migration that tries to recreate existing indexes?");
-  await msg(engineering!.id, R, "Yeah. It's because we have custom SQL migrations alongside Drizzle-managed ones. The snapshot gets out of sync.");
-  await msg(engineering!.id, A, "We should probably stop using drizzle push in development and only use generate + migrate. That way the snapshot stays consistent.");
-  await msg(engineering!.id, R, "Agreed. I'll update the README. Also need to add the pgvector migration as a manual SQL file that runs before Drizzle migrations.");
-  await msg(engineering!.id, A, "I can handle that. CREATE EXTENSION IF NOT EXISTS vector; — simple enough. Where do we put manual migrations?");
-  await msg(engineering!.id, R, "Let's create a packages/db/manual/ folder. Number them 000_, 001_ etc. Run them in the seed script before Drizzle migrate.");
-  await msg(engineering!.id, A, "Makes sense. Quick question on something else — the file upload flow. Are we doing presigned URLs to R2 or proxying through our API?");
-  await msg(engineering!.id, R, "Presigned URLs. The flow is: client requests upload URL from our API, API generates presigned PUT to R2, client uploads directly. Avoids the API being a bottleneck for large files.");
-  await msg(engineering!.id, A, "What's the max file size we're allowing?");
-  await msg(engineering!.id, R, "50MB for now. We can bump it later. The presigned URL expires after 10 minutes. Once uploaded, client sends the file metadata (name, size, type, R2 key) back to our API to create the file record.");
-  await msg(engineering!.id, A, "And for images, are we generating thumbnails?");
-  await msg(engineering!.id, R, "Not yet. Phase 2. For now we just store the original and render it with width/height constraints in CSS. The browser handles the scaling.");
-  await msg(engineering!.id, A, "Fair enough. Hey, one more thing — the typing indicator is flickering. When someone types fast, it shows and hides rapidly.");
-  await msg(engineering!.id, R, "Yeah I noticed that. The issue is we emit 'typing:start' on every keystroke and 'typing:stop' after a 2-second timeout. But the timeout resets on each keystroke, causing the receiving end to see rapid start/stop events.");
-  await msg(engineering!.id, A, "We should debounce the start event too. Only emit typing:start if we haven't sent one in the last 3 seconds.");
-  await msg(engineering!.id, R, "Exactly. And on the receiving side, treat any 'typing:start' as 'this user is typing for the next 4 seconds'. Reset the timer on each new event. Only hide when the timer expires OR we get a 'typing:stop'.");
-  await msg(engineering!.id, A, "That's how Slack does it. I'll refactor the typing indicator component. Should be a quick fix.");
-  await msg(engineering!.id, R, "Thanks. Oh, also — have you looked at the notification system yet? Maneek wants it wired up before the demo.");
-  await msg(engineering!.id, A, "I started on it. The schema has a notifications table with type, content, read status. The question is — what triggers a notification?");
-  await msg(engineering!.id, R, "Three things for now: @mentions in chat, task assignments, and task status changes. DMs should always notify. Regular channel messages should NOT notify unless mentioned.");
-  await msg(engineering!.id, A, "That matches Slack's model. I'll hook into the message creation route — check for @mention regex, create notifications for mentioned users.");
-  await msg(engineering!.id, R, "For delivery, let's use socket first. Emit 'notification:new' to the user's personal room. We can add push notifications and email later.");
-  await msg(engineering!.id, A, "Sounds good. Each user auto-joins a room like user:<userId> on connect, right?");
-  await msg(engineering!.id, R, "Yep, that's already set up. The auth middleware on socket connection joins the user to their personal room and their org room.");
-  // ── Save this message as Maneek's "last read" anchor in #engineering ──
-  const engLastRead = await msg(engineering!.id, A, "Perfect. I'll have the notification flow done by tonight. Anything else blocking the demo?");
-  // ── The remaining 10 messages will be "unread" for Maneek ──
-  const engUnread1 = await msg(engineering!.id, R, "The task board drag-and-drop is janky. When you drag a card between columns, there's a 500ms delay before the status updates in the DB. Makes it feel laggy.");
-  const engUnread2 = await msg(engineering!.id, A, "Optimistic update. Change the UI immediately on drop, fire the PATCH in the background. If it fails, revert.");
-  const engUnread3 = await msg(engineering!.id, R, "Yeah, that's the pattern. The issue is dnd-kit fires onDragEnd with the new position, but our state update goes through React state → API call → re-render. We need to split that.");
-  await msg(engineering!.id, A, "Update local state in onDragEnd synchronously, then fire the API call. If the API returns an error, revert the state to the previous snapshot.");
-  await msg(engineering!.id, R, "I'll store a snapshot of the board state before each drag starts. On error, restore from snapshot. Simple undo.");
-  await msg(engineering!.id, A, "Clean. What about the sort order within a column? If I drag a task between two others, we need fractional ordering.");
-  await msg(engineering!.id, R, "I'm using integer sort_order right now. When inserting between two tasks, take the average. If the gap gets too small, rebalance the whole column.");
-  await msg(engineering!.id, A, "That works for now. At scale we'd want something like LexoRank but let's not over-engineer it for 5 beta users.");
-  await msg(engineering!.id, R, "Exactly. Ship it simple, optimize if it becomes a problem. Alright, I think we have a solid plan. Let me push what I have and you can pull and start on the replay endpoint.");
-  await msg(engineering!.id, A, "Sounds good. I'll branch off main. One last thing — are we doing PR reviews or just merging to main during this sprint?");
-  const engUnreadLast = await msg(engineering!.id, R, "Let's do quick PR reviews. Even a thumbs up is fine. Just want a second pair of eyes on things before they hit main. We can't afford broken builds right before the demo.");
-  await msg(engineering!.id, A, "Agreed. I'll have the replay endpoint and notification flow up as PRs by tonight. Ping me when your reconnect logic is ready for review.");
-
-  console.log('Created messages across all spaces');
-
-  // ── Set "last read" positions for Maneek ──
-  // Maneek has read #engineering up to the 40th message — last 12 are unread
-  await db.update(schema.spaceMembers).set({
-    last_read_message_id: engLastRead.id,
-    last_read_at: new Date(engLastRead.created_at),
-  }).where(
-    and(
-      eq(schema.spaceMembers.space_id, engineering!.id),
-      eq(schema.spaceMembers.user_id, maneek!.id),
-    )
-  );
-
-  // Maneek has read #general up to the 8th message — last 6 are unread
-  const generalMsgs = await db.select({ id: schema.messages.id, created_at: schema.messages.created_at })
-    .from(schema.messages)
-    .where(eq(schema.messages.space_id, general!.id))
-    .orderBy(asc(schema.messages.created_at));
-
-  if (generalMsgs.length > 8) {
-    const anchor = generalMsgs[7]!;
-    await db.update(schema.spaceMembers).set({
-      last_read_message_id: anchor.id,
-      last_read_at: new Date(anchor.created_at),
-    }).where(
-      and(
-        eq(schema.spaceMembers.space_id, general!.id),
-        eq(schema.spaceMembers.user_id, maneek!.id),
-      )
-    );
-  }
-
-  console.log('Set read positions for Maneek');
-
-  // ── Create notifications for Maneek from unread messages ──
-  const unreadNotifs = [
-    { from: 'Rahul', content: engUnread1.content, msgId: engUnread1.id, spaceId: engineering!.id, spaceName: 'engineering' },
-    { from: 'Arjun', content: engUnread2.content, msgId: engUnread2.id, spaceId: engineering!.id, spaceName: 'engineering' },
-    { from: 'Rahul', content: engUnread3.content, msgId: engUnread3.id, spaceId: engineering!.id, spaceName: 'engineering' },
-    { from: 'Rahul', content: engUnreadLast.content, msgId: engUnreadLast.id, spaceId: engineering!.id, spaceName: 'engineering' },
-  ];
-
-  for (const n of unreadNotifs) {
-    await db.insert(schema.notifications).values({
-      org_id: org!.id,
-      user_id: maneek!.id,
-      type: 'message',
-      title: `${n.from} in #${n.spaceName}`,
-      body: n.content.replace(/<[^>]+>/g, '').slice(0, 200),
-      link: `/chat?space=${n.spaceId}&message=${n.msgId}`,
-      is_read: false,
-    });
-  }
-
-  // Also create a couple task notifications
-  await db.insert(schema.notifications).values({
-    org_id: org!.id,
-    user_id: maneek!.id,
-    type: 'task_assigned',
-    title: 'Sara assigned you DEFT-8',
-    body: 'Build task board view',
-    link: '/tasks?task=DEFT-8',
-    is_read: false,
-  });
-
-  await db.insert(schema.notifications).values({
-    org_id: org!.id,
-    user_id: maneek!.id,
-    type: 'task_updated',
-    title: 'Rahul moved DEFT-10 to In Review',
-    body: 'Auth middleware and JWT refresh',
-    link: '/tasks?task=DEFT-10',
-    is_read: true,
-  });
-
-  console.log('Created notifications for Maneek');
-
-  // ── Project 1: Deft v1 ──
-  const [project1] = await db.insert(schema.projects).values({
-    org_id: org!.id, name: 'Deft v1', description: 'First release of the Deft workspace', prefix: 'DEFT', color: '#D4A853', lead_id: maneek!.id, task_counter: 15,
+  // ── Projects ──
+  const [projHarv] = await db.insert(schema.projects).values({
+    org_id: org!.id, name: 'Spring 2026 Harvest', description: 'Picking, packing, and delivery operations for the May-July harvest window.',
+    prefix: 'HARV', icon: '🍅', color: '#E03A2F', lead_id: cesar!.id, task_counter: 12,
   }).returning();
 
-  await db.insert(schema.projectSpaces).values({
-    project_id: project1!.id, space_id: engineering!.id,
-  });
-
-  // ── Project 2: Design System ──
-  const [project2] = await db.insert(schema.projects).values({
-    org_id: org!.id, name: 'Design System', description: 'Component library and design tokens', prefix: 'DS', color: '#8B5CF6', lead_id: arjun!.id, task_counter: 8,
+  const [projWhl] = await db.insert(schema.projects).values({
+    org_id: org!.id, name: 'Wholesale Expansion', description: 'New buyer pipeline, contracts, pricing strategy.',
+    prefix: 'WHL', icon: '🤝', color: '#3B82F6', lead_id: lina!.id, task_counter: 10,
   }).returning();
 
-  await db.insert(schema.projectSpaces).values({
-    project_id: project2!.id, space_id: design!.id,
-  });
+  const [projGh3] = await db.insert(schema.projects).values({
+    org_id: org!.id, name: 'Greenhouse 3 Build-out', description: 'New heritage-variety greenhouse — climate, irrigation, build schedule.',
+    prefix: 'GH3', icon: '🏗️', color: '#0EA5E9', lead_id: marigold!.id, task_counter: 8,
+  }).returning();
 
-  console.log('Created 2 projects');
-
-  // ── Deft v1 Tasks (15 tasks) ──
-  const deftTasks: { title: string; desc: string; status: 'backlog' | 'todo' | 'in_progress' | 'in_review' | 'done'; priority: 'p0' | 'p1' | 'p2' | 'p3'; assignee: string | null; num: number; creator?: string }[] = [
-    // Backlog (3)
-    { num: 1, title: 'Add message search filters', desc: 'Add search bar above the message list that filters messages by content, author, and date range.', status: 'backlog', priority: 'p2', assignee: null },
-    { num: 2, title: 'Implement message forwarding', desc: 'Forward a message to another space or DM. Include the original sender and timestamp.', status: 'backlog', priority: 'p3', assignee: null },
-    { num: 3, title: 'Add custom emoji support', desc: 'Allow orgs to upload custom emoji. Store in R2, surface in the emoji picker.', status: 'backlog', priority: 'p3', assignee: null },
-    // Todo (3)
-    { num: 4, title: 'Build notification preferences UI', desc: 'Settings page section where users can configure notification delivery: mentions only, all messages, muted per space.', status: 'todo', priority: 'p1', assignee: priya!.id, creator: sara!.id },
-    { num: 5, title: 'Set up CI/CD pipeline', desc: 'GitHub Actions workflow: lint, type-check, build, test. Deploy to Railway on main branch push.', status: 'todo', priority: 'p1', assignee: rahul!.id, creator: maneek!.id },
-    { num: 6, title: 'Design onboarding flow', desc: 'Multi-step onboarding for new users: profile setup, org creation or invite, first space, first message.', status: 'todo', priority: 'p2', assignee: arjun!.id, creator: sara!.id },
-    // In Progress (3)
-    { num: 7, title: 'Implement thread side panel', desc: 'Side panel that opens when clicking reply on a message. Shows parent message, thread replies, and a composer.', status: 'in_progress', priority: 'p0', assignee: rahul!.id },
-    { num: 8, title: 'Build task board view', desc: 'Kanban board with drag-and-drop. Columns: Backlog, Todo, In Progress, In Review, Done. Use dnd-kit.', status: 'in_progress', priority: 'p0', assignee: maneek!.id },
-    { num: 9, title: 'Design task detail panel', desc: 'Right side panel for task details: title, status, priority, assignee, description, comments, activity log.', status: 'in_progress', priority: 'p1', assignee: arjun!.id, creator: sara!.id },
-    // In Review (2)
-    { num: 10, title: 'Auth middleware and JWT refresh', desc: 'Hono middleware extracts JWT, validates, attaches user to context. Client-side interceptor auto-refreshes on 401.', status: 'in_review', priority: 'p1', assignee: rahul!.id },
-    { num: 11, title: 'Space member management', desc: 'Add/remove members from spaces. Private space member invite flow. Member list with role badges.', status: 'in_review', priority: 'p1', assignee: priya!.id },
-    // Done (4)
-    { num: 12, title: 'Set up monorepo scaffolding', desc: 'pnpm workspaces with apps/web, apps/api, packages/db, packages/shared, packages/ai. TypeScript strict mode.', status: 'done', priority: 'p1', assignee: maneek!.id },
-    { num: 13, title: 'Database schema design', desc: 'Drizzle ORM schema with 30 tables. Multi-tenant with org_id, soft deletes, timestamps, UUIDs.', status: 'done', priority: 'p0', assignee: maneek!.id },
-    { num: 14, title: 'Real-time chat messaging', desc: 'Socket.io with JWT auth, room-per-space. Events: message:new, message:edited, typing indicators, presence.', status: 'done', priority: 'p0', assignee: rahul!.id },
-    { num: 15, title: 'User signup and login flow', desc: 'Auth pages with email/password, JWT tokens, automatic org and #general space creation on signup.', status: 'done', priority: 'p1', assignee: priya!.id, creator: sara!.id },
-  ];
-
-  const createdTasks: Record<number, string> = {};
-
-  for (const t of deftTasks) {
-    const [task] = await db.insert(schema.tasks).values({
-      org_id: org!.id, project_id: project1!.id, number: t.num, title: t.title,
-      description: t.desc, status: t.status, priority: t.priority,
-      assignee_id: t.assignee, created_by: t.creator || maneek!.id, sort_order: t.num,
-    }).returning();
-    createdTasks[t.num] = task!.id;
-  }
-
-  // ── Design System Tasks (8 tasks) ──
-  const dsTasks: typeof deftTasks = [
-    { num: 1, title: 'Icon library selection', desc: 'Evaluate lucide, phosphor, heroicons. Need consistent stroke widths and comprehensive coverage.', status: 'backlog', priority: 'p2', assignee: null, creator: arjun!.id },
-    { num: 2, title: 'Animation guidelines', desc: 'Define timing, easing, and which interactions get animation. Max 150ms for micro-interactions.', status: 'backlog', priority: 'p3', assignee: null, creator: arjun!.id },
-    { num: 3, title: 'Color palette documentation', desc: 'Document the warm neutral palette with amber accent. Include WCAG contrast ratios for all pairings.', status: 'todo', priority: 'p1', assignee: arjun!.id, creator: arjun!.id },
-    { num: 4, title: 'Typography scale', desc: 'Plus Jakarta Sans for headings, DM Sans for body. Document sizes, weights, and letter-spacing.', status: 'todo', priority: 'p1', assignee: arjun!.id, creator: arjun!.id },
-    { num: 5, title: 'Component library setup', desc: 'Set up Storybook or similar for documenting reusable React components with their variants.', status: 'in_progress', priority: 'p0', assignee: arjun!.id, creator: arjun!.id },
-    { num: 6, title: 'Dark mode tokens', desc: 'CSS custom properties for dark mode. True black background, warm surfaces, correct contrast ratios.', status: 'in_progress', priority: 'p1', assignee: priya!.id, creator: arjun!.id },
-    { num: 7, title: 'Design audit of current UI', desc: 'Review all existing pages and components for consistency with the design system.', status: 'done', priority: 'p1', assignee: arjun!.id, creator: sara!.id },
-    { num: 8, title: 'Figma setup', desc: 'Create shared Figma project with component library, page templates, and design tokens.', status: 'done', priority: 'p2', assignee: arjun!.id, creator: arjun!.id },
-  ];
-
-  const dsTIds: Record<number, string> = {};
-  for (const t of dsTasks) {
-    const [task] = await db.insert(schema.tasks).values({
-      org_id: org!.id, project_id: project2!.id, number: t.num, title: t.title,
-      description: t.desc, status: t.status, priority: t.priority,
-      assignee_id: t.assignee, created_by: t.creator || arjun!.id, sort_order: t.num,
-    }).returning();
-    dsTIds[t.num] = task!.id;
-  }
-
-  console.log('Created 23 tasks across 2 projects');
-
-  // ── Task Comments ──
-  await db.insert(schema.taskComments).values([
-    { org_id: org!.id, task_id: createdTasks[7]!, user_id: rahul!.id, content: 'Started on this. The main challenge is handling socket reconnection when the parent message is scrolled out of view. Using IntersectionObserver.' },
-    { org_id: org!.id, task_id: createdTasks[7]!, user_id: maneek!.id, content: 'Good approach. Make sure to handle the case where the thread panel is already open when a new reply comes in via socket.' },
-    { org_id: org!.id, task_id: createdTasks[8]!, user_id: maneek!.id, content: 'Using @dnd-kit/core for drag-and-drop. The column layout is working, now need to wire up the PATCH /api/tasks/:id call on drop.' },
-    { org_id: org!.id, task_id: createdTasks[10]!, user_id: rahul!.id, content: 'Moved to review. The middleware handles both access token validation and automatic refresh via the API client interceptor. Edge case: refresh token expired while tab is in background — redirects to login.' },
-    { org_id: org!.id, task_id: createdTasks[12]!, user_id: maneek!.id, content: 'All good. Schema pushed cleanly to local Postgres. 30 tables, all indexes in place.' },
-    { org_id: org!.id, task_id: dsTIds[5]!, user_id: arjun!.id, content: 'Set up the initial structure. Using CSS custom properties for all tokens so they can be overridden per-org in the future.' },
+  await db.insert(schema.projectSpaces).values([
+    { project_id: projHarv!.id, space_id: harvest!.id },
+    { project_id: projHarv!.id, space_id: fieldOps!.id },
+    { project_id: projWhl!.id, space_id: sales!.id },
+    { project_id: projGh3!.id, space_id: greenhouse!.id },
   ]);
 
-  // ── Task Activity Log ──
-  await db.insert(schema.taskActivity).values([
-    { org_id: org!.id, task_id: createdTasks[7]!, user_id: rahul!.id, action: 'status_changed', field: 'status', old_value: 'todo', new_value: 'in_progress' },
-    { org_id: org!.id, task_id: createdTasks[8]!, user_id: maneek!.id, action: 'status_changed', field: 'status', old_value: 'todo', new_value: 'in_progress' },
-    { org_id: org!.id, task_id: createdTasks[10]!, user_id: rahul!.id, action: 'status_changed', field: 'status', old_value: 'in_progress', new_value: 'in_review' },
-    { org_id: org!.id, task_id: createdTasks[11]!, user_id: priya!.id, action: 'status_changed', field: 'status', old_value: 'in_progress', new_value: 'in_review' },
-    { org_id: org!.id, task_id: createdTasks[12]!, user_id: maneek!.id, action: 'status_changed', field: 'status', old_value: 'in_progress', new_value: 'done' },
-    { org_id: org!.id, task_id: createdTasks[13]!, user_id: maneek!.id, action: 'status_changed', field: 'status', old_value: 'in_review', new_value: 'done' },
-    { org_id: org!.id, task_id: createdTasks[14]!, user_id: rahul!.id, action: 'status_changed', field: 'status', old_value: 'in_review', new_value: 'done' },
-    { org_id: org!.id, task_id: createdTasks[15]!, user_id: priya!.id, action: 'status_changed', field: 'status', old_value: 'in_review', new_value: 'done' },
-    { org_id: org!.id, task_id: createdTasks[7]!, user_id: maneek!.id, action: 'assigned', field: 'assignee_id', old_value: null, new_value: rahul!.id },
-    { org_id: org!.id, task_id: dsTIds[5]!, user_id: arjun!.id, action: 'status_changed', field: 'status', old_value: 'todo', new_value: 'in_progress' },
-    { org_id: org!.id, task_id: dsTIds[7]!, user_id: arjun!.id, action: 'status_changed', field: 'status', old_value: 'in_review', new_value: 'done' },
-  ]);
+  console.log('Created 3 projects');
 
-  // ── Labels ──
-  const [bugLabel] = await db.insert(schema.labels).values({ org_id: org!.id, name: 'bug', color: '#ef4444' }).returning();
-  const [featureLabel] = await db.insert(schema.labels).values({ org_id: org!.id, name: 'feature', color: '#3b82f6' }).returning();
-  const [designLabel] = await db.insert(schema.labels).values({ org_id: org!.id, name: 'design', color: '#8b5cf6' }).returning();
+  // ── Tasks ──
+  type TaskDef = { num: number; title: string; desc: string; status: 'backlog' | 'todo' | 'in_progress' | 'in_review' | 'done' | 'cancelled'; priority: 'p0' | 'p1' | 'p2' | 'p3'; assignee: string | null; creator: string; due?: 'overdue' | 'tomorrow' | 'this_week' | 'next_week' | 'done' };
 
-  await db.insert(schema.taskLabels).values([
-    { task_id: createdTasks[7]!, label_id: featureLabel!.id },
-    { task_id: createdTasks[8]!, label_id: featureLabel!.id },
-    { task_id: createdTasks[9]!, label_id: designLabel!.id },
-    { task_id: createdTasks[1]!, label_id: featureLabel!.id },
-    { task_id: createdTasks[12]!, label_id: featureLabel!.id },
-    { task_id: dsTIds[3]!, label_id: designLabel!.id },
-    { task_id: dsTIds[4]!, label_id: designLabel!.id },
-    { task_id: dsTIds[5]!, label_id: designLabel!.id },
-    { task_id: dsTIds[7]!, label_id: designLabel!.id },
-  ]);
-
-  console.log('Created task data (comments, activity, labels)');
-
-  // ═══════════════════════════════════════════════════════════════
-  // LIFE — Make the workspace feel lived-in
-  // ═══════════════════════════════════════════════════════════════
-
-  // ── Reactions on existing messages ──
-  const allEngMsgs = await db.select({ id: schema.messages.id, user_id: schema.messages.user_id })
-    .from(schema.messages)
-    .where(eq(schema.messages.space_id, engineering!.id))
-    .orderBy(asc(schema.messages.created_at));
-
-  // Sprinkle reactions across engineering messages
-  const reactionPairs: [number, string, string][] = [
-    [2, R, '👍'], [2, A, '💯'], [5, M, '🔥'], [5, P, '👀'],
-    [8, R, '✅'], [10, A, '🚀'], [14, M, '💡'], [14, S, '💡'],
-    [18, R, '👍'], [20, A, '🎯'], [25, M, '💪'], [30, R, '👀'],
-    [35, A, '🙌'], [40, M, '🔥'], [40, P, '🔥'], [45, R, '✅'],
-    [48, A, '🚀'], [48, M, '🚀'], [50, R, '💯'], [50, A, '🎉'],
+  const harvTasks: TaskDef[] = [
+    { num: 1, title: 'Install hail netting on south field (Romas)', desc: 'Eastern Ag — 1.8 acres, $4,800/acre installed, lease for the season. Install Monday before NOAA hail window opens Tuesday.', status: 'in_progress', priority: 'p0', assignee: C, creator: D, due: 'tomorrow' },
+    { num: 2, title: 'Roma harvest — south field, breaker-plus firmness', desc: 'Mon 6am-12pm, full crew (6). Target: 1,400 lbs into the Sunbelt cooler bins. Anything already red goes to farmers market bins. Sage spot-checks firmness every hour.', status: 'todo', priority: 'p1', assignee: C, creator: D, due: 'this_week' },
+    { num: 3, title: 'San Marzano harvest — middle field', desc: 'Tue, half crew. These are going to the heritage box mix at the farmers market. Pick at full red, careful handling.', status: 'todo', priority: 'p1', assignee: C, creator: D, due: 'this_week' },
+    { num: 4, title: 'Sun Gold first pull — GH-2', desc: 'Thursday. Marigold leads. 25-lb totes only — they bruise in 40s. Target 80 lbs for the Saturday farmers market display.', status: 'todo', priority: 'p1', assignee: M, creator: D, due: 'this_week' },
+    { num: 5, title: 'Cherokee Purple selective pick — Field Co-op visit', desc: 'Friday afternoon. DO NOT pick Row 12 until after the 10am walkthrough with Asha Mehta. Then selective pick of mature clusters for the sample box.', status: 'todo', priority: 'p1', assignee: C, creator: L, due: 'this_week' },
+    { num: 6, title: 'Sunbelt Tuesday delivery — pulp temp protocol', desc: 'Pre- and post-trip pulp temps logged on the new dual-PDF logger. Drop at Sunbelt Fresno DC by 8am. Print the PDF for their receiving team.', status: 'todo', priority: 'p0', assignee: T, creator: D, due: 'this_week' },
+    { num: 7, title: 'Hand-washing sign-in station — harvest room entrance', desc: 'Physical clipboard stand that blocks the entrance path. Mandatory sign-in before any picking. Cesar enforces in the morning huddle. Drives the audit compliance from 60% to 100%.', status: 'in_progress', priority: 'p0', assignee: Sg, creator: D, due: 'tomorrow' },
+    { num: 8, title: 'Order 60 25-lb totes — washed and stacked at harvest room', desc: 'For the Sun Gold pull Thursday. Tomás handles. Stage by Wednesday EOD.', status: 'in_progress', priority: 'p2', assignee: T, creator: M, due: 'this_week' },
+    { num: 9, title: 'Credit memo — Green Leaf warm-batch from cold truck failure', desc: 'Compressor leak on the cold truck made the Tuesday Green Leaf delivery warmer than the 50-55°F spec. Draft the credit memo and send to their AP team.', status: 'todo', priority: 'p2', assignee: L, creator: D, due: 'tomorrow' },
+    { num: 10, title: 'Stage hoop house side panels for fast deployment', desc: 'Tomás drops panels by the east hoop houses Monday afternoon. Two-person closure in 30 min if Wednesday temps drop.', status: 'todo', priority: 'p2', assignee: T, creator: C, due: 'tomorrow' },
+    { num: 11, title: 'Saturday farmers market — heat-resilient variety shift', desc: 'Forecast 88°F. Display: Sun Golds, Romas, slicers. Skip the Cherokee Purples and Brandywines (heat-damaged by 11am). Order second 10x10 pop-up shade.', status: 'todo', priority: 'p2', assignee: L, creator: L, due: 'this_week' },
+    { num: 12, title: 'Cold storage protocol audit — pre-GAP dry-run', desc: 'Walk-through with Sage Tuesday 2pm. Pesticide records, water testing, traceability. Build the dry-run checklist this weekend.', status: 'in_progress', priority: 'p1', assignee: Sg, creator: D, due: 'this_week' },
   ];
-  for (const [idx, userId, emoji] of reactionPairs) {
-    if (allEngMsgs[idx]) {
-      await db.insert(schema.reactions).values({
-        message_id: allEngMsgs[idx]!.id, user_id: userId, emoji,
-      }).catch(() => {}); // ignore duplicates
+
+  const whlTasks: TaskDef[] = [
+    { num: 1, title: 'Sunbelt 6-week contract — sign and return', desc: 'Beefsteak slicers, 1,200 lbs/wk, $1.85/lb FOB, starts May 26. Confirm with Marigold on supply ramp. Decision needed by Friday.', status: 'in_review', priority: 'p0', assignee: L, creator: D, due: 'this_week' },
+    { num: 2, title: 'Field Co-op walk-through — Asha Mehta Friday 10am', desc: 'Tour: GH-2 Sun Gold, GH-2 Cherokee Purple, south field Roma block, harvest room. Sample box of heritage varieties + slicers. Pricing sheet for wholesale (heritage premium tier).', status: 'in_progress', priority: 'p1', assignee: L, creator: L, due: 'this_week' },
+    { num: 3, title: 'Update 2027 pricing anchor — $2.00/lb slicers', desc: 'Sunbelt accepted $1.85 with little pushback. Hold $2.00 as the anchor next year. Update wholesale pricing sheet wiki. Note in cell: "validated 2026 with Sunbelt at $1.85".', status: 'todo', priority: 'p2', assignee: L, creator: D, due: 'next_week' },
+    { num: 4, title: 'Whole Foods PNW — feasibility cost model (confidential)', desc: 'Year-round program, 800-1000 lbs/wk across 4 SKUs. Revisit in October once GH-3 status is clear and we have a clean 6-month run with regional buyers.', status: 'backlog', priority: 'p1', assignee: L, creator: D },
+    { num: 5, title: 'Set up Sunbelt cold-chain spec — formal handoff doc', desc: 'Document our pulp-temp logging procedure, refrigeration spec (50-55°F), and dock receiving protocol. Share with Sunbelt receiving team.', status: 'in_progress', priority: 'p2', assignee: T, creator: L, due: 'this_week' },
+    { num: 6, title: 'New buyer outreach — North Bay restaurant group', desc: 'A chef collective in Sonoma is looking for heritage tomatoes for a tasting menu. Lina to reach out, target 200 lbs/wk Cherokee Purples + Brandywines.', status: 'backlog', priority: 'p3', assignee: L, creator: L },
+    { num: 7, title: 'Farmers market — heritage education signage', desc: 'Customers are asking about the varieties. Print A4 cards with variety name, flavor notes, best-use suggestions. Display next to each crate.', status: 'todo', priority: 'p3', assignee: L, creator: L, due: 'next_week' },
+    { num: 8, title: 'Wholesale pricing sheet — heritage premium tier', desc: 'Document the +60% premium on Cherokee Purple, Brandywine, San Marzano vs slicers. Justify with retail comp ($6.50/lb vs $2.50/lb).', status: 'in_review', priority: 'p2', assignee: L, creator: D, due: 'this_week' },
+    { num: 9, title: 'Quarterly buyer report — Q1 2026 retrospective', desc: 'Pounds delivered, on-time rate, credit memos, buyer satisfaction. Share with Diego before May 30. Drives 2027 planning.', status: 'done', priority: 'p2', assignee: L, creator: D, due: 'done' },
+    { num: 10, title: 'CRM cleanup — buyer contacts current', desc: 'Old contact at Green Leaf left, new one is Mira Diaz (production planning). Update across all our sheets and the buyer directory wiki.', status: 'done', priority: 'p3', assignee: L, creator: L, due: 'done' },
+  ];
+
+  const gh3Tasks: TaskDef[] = [
+    { num: 1, title: 'GH-3 BOM revision — heritage-only build', desc: 'Pivot from "general" GH-3 to heritage-focused: tighter humidity control (separate dehumidifier from day 1), zoned irrigation, separate ferti-station. Marigold drafts revised BOM.', status: 'in_progress', priority: 'p0', assignee: M, creator: D, due: 'this_week' },
+    { num: 2, title: 'Climate control vendor RFQ — 3 quotes', desc: 'Wadsworth, AgriTomato, GreenTec. Spec: 40,000 sqft footprint, target 65-70%RH year-round, dual-zone temp. Want quotes by June 10.', status: 'todo', priority: 'p1', assignee: M, creator: M, due: 'next_week' },
+    { num: 3, title: 'Soil prep contractor — broadfork + compost amendment', desc: 'Heritage varieties want deeper soil structure than the conventional block. Looking at Madsen Farms — they do compost amendment passes for $1,200/quarter-acre.', status: 'todo', priority: 'p2', assignee: M, creator: M, due: 'next_week' },
+    { num: 4, title: 'GH-3 plumbing rough-in — schedule with Castro Bros', desc: 'Castro Bros has us tentatively in the calendar for July 8-15. Confirm by June 15 or they release the slot.', status: 'todo', priority: 'p1', assignee: M, creator: M, due: 'next_week' },
+    { num: 5, title: 'Seed selection — heritage starter list', desc: 'Brandywine (Sudduth strain), Cherokee Purple, Aunt Ruby\'s German Green, Black Krim, Mortgage Lifter, Green Zebra. Source from Baker Creek + Johnny\'s. Order by June 1 for August seeding.', status: 'in_progress', priority: 'p1', assignee: M, creator: M, due: 'this_week' },
+    { num: 6, title: 'Construction permit — county inspector follow-up', desc: 'Submitted April 1, expecting approval by mid-June. Have not heard back — call the inspector\'s office this week. Diego needs to be the point of contact (he\'s on the permit).', status: 'in_progress', priority: 'p1', assignee: D, creator: M, due: 'this_week' },
+    { num: 7, title: 'Dehumidifier upsize learnings — apply to GH-3 design', desc: 'GH-2 dehumidifier failure at peak load is informing the GH-3 spec. Document the BTU/sqft ratio we landed on and bake it into the GH-3 climate spec.', status: 'in_progress', priority: 'p2', assignee: M, creator: M, due: 'next_week' },
+    { num: 8, title: 'Initial GH-3 budget — submitted to Diego for approval', desc: 'Revised estimate after heritage-only pivot: $187,400 total (was $158,200). Diego to review and approve before BOM is locked.', status: 'done', priority: 'p1', assignee: M, creator: M, due: 'done' },
+  ];
+
+  const taskIds: Record<string, string> = {};
+  const now = new Date();
+  const dueMap = {
+    overdue: new Date(now.getTime() - 2 * 86400_000),
+    tomorrow: new Date(now.getTime() + 1 * 86400_000),
+    this_week: new Date(now.getTime() + 4 * 86400_000),
+    next_week: new Date(now.getTime() + 9 * 86400_000),
+    done: new Date(now.getTime() - 14 * 86400_000),
+  };
+
+  async function insertTasks(project: typeof projHarv, defs: TaskDef[], keyPrefix: string) {
+    for (const t of defs) {
+      const [task] = await db.insert(schema.tasks).values({
+        org_id: org!.id, project_id: project!.id, number: t.num, title: t.title, description: t.desc,
+        status: t.status, priority: t.priority, assignee_id: t.assignee, created_by: t.creator,
+        sort_order: t.num, due_date: t.due ? dueMap[t.due] : undefined,
+      }).returning();
+      taskIds[`${keyPrefix}${t.num}`] = task!.id;
     }
   }
+  await insertTasks(projHarv, harvTasks, 'HARV');
+  await insertTasks(projWhl, whlTasks, 'WHL');
+  await insertTasks(projGh3, gh3Tasks, 'GH3');
 
-  // Reactions in #general
-  const allGenMsgs = await db.select({ id: schema.messages.id })
-    .from(schema.messages)
-    .where(eq(schema.messages.space_id, general!.id))
-    .orderBy(asc(schema.messages.created_at));
-  if (allGenMsgs[0]) await db.insert(schema.reactions).values({ message_id: allGenMsgs[0]!.id, user_id: R, emoji: '🚀' }).catch(() => {});
-  if (allGenMsgs[0]) await db.insert(schema.reactions).values({ message_id: allGenMsgs[0]!.id, user_id: P, emoji: '🚀' }).catch(() => {});
-  if (allGenMsgs[0]) await db.insert(schema.reactions).values({ message_id: allGenMsgs[0]!.id, user_id: A, emoji: '💪' }).catch(() => {});
-  if (allGenMsgs[8]) await db.insert(schema.reactions).values({ message_id: allGenMsgs[8]!.id, user_id: M, emoji: '👋' }).catch(() => {});
-  if (allGenMsgs[8]) await db.insert(schema.reactions).values({ message_id: allGenMsgs[8]!.id, user_id: R, emoji: '👋' }).catch(() => {});
-  if (allGenMsgs[9]) await db.insert(schema.reactions).values({ message_id: allGenMsgs[9]!.id, user_id: M, emoji: '🙏' }).catch(() => {});
+  console.log('Created 30 tasks');
 
-  // Reactions in #random
-  const allRandMsgs = await db.select({ id: schema.messages.id })
-    .from(schema.messages)
-    .where(eq(schema.messages.space_id, random!.id))
-    .orderBy(asc(schema.messages.created_at));
-  if (allRandMsgs[0]) await db.insert(schema.reactions).values({ message_id: allRandMsgs[0]!.id, user_id: M, emoji: '☕' }).catch(() => {});
-  if (allRandMsgs[1]) await db.insert(schema.reactions).values({ message_id: allRandMsgs[1]!.id, user_id: R, emoji: '🤤' }).catch(() => {});
-  if (allRandMsgs[1]) await db.insert(schema.reactions).values({ message_id: allRandMsgs[1]!.id, user_id: P, emoji: '😋' }).catch(() => {});
-
-  console.log('Added reactions');
-
-  // ── Pin a key message in #engineering ──
-  if (allEngMsgs[10]) {
-    await db.insert(schema.pinnedMessages).values({
-      message_id: allEngMsgs[10]!.id, space_id: engineering!.id, pinned_by: R,
-    }).catch(() => {});
-  }
-  // Pin the launch announcement in #general
-  if (allGenMsgs[0]) {
-    await db.insert(schema.pinnedMessages).values({
-      message_id: allGenMsgs[0]!.id, space_id: general!.id, pinned_by: M,
-    }).catch(() => {});
-  }
-
-  console.log('Pinned key messages');
-
-  // ── Thread replies — make conversations deeper ──
-  // Thread on the WebSocket reconnection message in engineering
-  if (allEngMsgs[2]) {
-    msgOffset += 1;
-    await db.insert(schema.messages).values({
-      org_id: org!.id, space_id: engineering!.id, user_id: S,
-      content: "I ran into a similar issue at my last company. We ended up using a \"last event ID\" header on reconnect — the server replays everything after that ID. Much cleaner than timestamps.",
-      parent_id: allEngMsgs[2]!.id, created_at: msgTime(),
-    });
-    msgOffset += 1;
-    await db.insert(schema.messages).values({
-      org_id: org!.id, space_id: engineering!.id, user_id: P,
-      content: "That's the Server-Sent Events pattern, right? We could do the same with Socket.io — store a sequence number per space and replay on reconnect.",
-      parent_id: allEngMsgs[2]!.id, created_at: msgTime(),
-    });
-    msgOffset += 1;
-    await db.insert(schema.messages).values({
-      org_id: org!.id, space_id: engineering!.id, user_id: R,
-      content: "Good ideas from both of you. I'll combine the approaches — sequence ID for ordering, timestamp for the initial catch-up window. Should be bulletproof.",
-      parent_id: allEngMsgs[2]!.id, created_at: msgTime(),
-    });
-  }
-
-  // Thread on the Drizzle migration message
-  if (allEngMsgs[16]) {
-    msgOffset += 1;
-    await db.insert(schema.messages).values({
-      org_id: org!.id, space_id: engineering!.id, user_id: P,
-      content: "I've been bitten by this exact issue before. The trick is to never use `drizzle push` in development — always `generate` + `migrate`. That way the snapshot JSON stays in sync.",
-      parent_id: allEngMsgs[16]!.id, created_at: msgTime(),
-    });
-  }
-
-  // Thread in #general on the beta launch
-  if (allGenMsgs[0]) {
-    msgOffset += 1;
-    await db.insert(schema.messages).values({
-      org_id: org!.id, space_id: general!.id, user_id: S,
-      content: "I've created a checklist for the beta launch in the project board. 12 items — let's try to close them all by Thursday EOD.",
-      parent_id: allGenMsgs[0]!.id, created_at: msgTime(),
-    });
-    msgOffset += 1;
-    await db.insert(schema.messages).values({
-      org_id: org!.id, space_id: general!.id, user_id: A,
-      content: "Just reviewed the list. I think we can defer the custom emoji and message forwarding — not critical for beta. That leaves 10 items.",
-      parent_id: allGenMsgs[0]!.id, created_at: msgTime(),
-    });
-    msgOffset += 1;
-    await db.insert(schema.messages).values({
-      org_id: org!.id, space_id: general!.id, user_id: M,
-      content: "Agreed. Let's focus on core chat + tasks + agent. Everything else is nice-to-have for beta.",
-      parent_id: allGenMsgs[0]!.id, created_at: msgTime(),
-    });
-  }
-
-  console.log('Added thread replies');
-
-  // ── More #general conversation — team standup style ──
-  msgOffset += 5;
-  await msg(general!.id, S, "Morning everyone. Quick standup:\n\n**Yesterday:** Set up sprint board with estimates for all 15 Deft v1 tasks. Reviewed Priya's notification preferences PR.\n**Today:** Writing the CI/CD pipeline for GitHub Actions. Should have lint + build + deploy by EOD.\n**Blockers:** None.");
-  await msg(general!.id, R, "**Yesterday:** Finished the JWT refresh interceptor. Also started on the thread side panel — got the basic layout rendering.\n**Today:** Thread panel replies + Socket.io broadcast for new replies.\n**Blockers:** None, but I need design input on the thread panel width from Arjun.");
-  await msg(general!.id, A, "**Yesterday:** Reviewed the design system tokens and pushed the dark mode CSS variables. Started the task detail panel mockup.\n**Today:** Finishing the task detail panel — status, priority, assignee, description, comments section.\n**Blockers:** Waiting on the Figma components from the icon audit.");
-  await msg(general!.id, P, "**Yesterday:** Fixed the hydration mismatch bug (PR #34). Started on the notification preferences UI.\n**Today:** Notification settings page — per-space mute, mention-only mode, DND schedule.\n**Blockers:** Need the notification API schema finalized — Rahul, can we sync on that?");
-  await msg(general!.id, M, "Great updates. Rahul + Priya, sync on the notification schema today. Arjun, I'll review your task panel mockup after lunch. Sara, let me know when CI/CD is up so I can test the deploy flow.");
-
-  // ── More #design conversation ──
-  msgOffset += 3;
-  await msg(design!.id, A, "Pushed updated mockups for the task detail panel. Key changes:\n\n1. Moved comments to a separate tab to keep the main view clean\n2. Added an activity timeline on the right rail\n3. Status badge is now a dropdown, not a separate button\n\nFigma link in the thread.");
-  await msg(design!.id, P, "Love the tabbed approach. One suggestion — can we add a \"Linked messages\" tab too? When the agent cross-references a chat message with a task, it would show up there.");
-  await msg(design!.id, M, "That's a great idea, Priya. Arjun, can you add that to the mockup? Also, the activity timeline should show who changed what — not just \"status changed\" but \"Rahul moved to In Progress\".");
-  await msg(design!.id, A, "On it. I'll also add the linked messages tab. Should have the updated version by tomorrow.");
-  await msg(design!.id, S, "The font pairing is really working well. Inter for body + JetBrains Mono for code and metadata — gives it that technical but approachable feel. Nice work.");
-  await msg(design!.id, A, "Thanks! The trick was getting the weight right — Inter at 400 for body, 500 for labels, 600 for headings. Anything heavier looks clunky in dark mode.");
-  await msg(design!.id, M, "What about the mobile breakpoints? We should at least have the sidebar collapse to a hamburger menu on tablet.");
-  await msg(design!.id, A, "Already in the spec — sidebar collapses at 768px to an icon-only rail, and at 640px it becomes a slide-over overlay. The main content area is always full-width on mobile.");
-
-  // ── More #random — team culture ──
-  msgOffset += 3;
-  await msg(random!.id, P, "Has anyone used Arc browser? I just switched from Chrome and it's incredible. The sidebar tabs are so much better for context switching.");
-  await msg(random!.id, A, "I've been on Arc for 6 months. The split view is amazing for frontend work — code on the left, browser on the right. Also the command bar (Cmd+T) is exactly what we're building for Deft's command palette.");
-  await msg(random!.id, R, "Still on Firefox. Old habits die hard. But I'll admit the Arc command bar looks nice.");
-  await msg(random!.id, M, "I use Arc for personal, Chrome for work (DevTools are still slightly better for debugging WebSocket frames). The spaces feature in Arc is interesting — might inspire our workspace switching UI.");
-  await msg(random!.id, S, "Speaking of browsers, reminder that we need to test Deft on Safari before beta. Last time I checked, our CSS backdrop-filter wasn't rendering on iOS Safari.");
-  await msg(random!.id, A, "Good call. I'll add it to the QA checklist. Also we should test on Firefox — some of the CSS custom properties might behave differently.");
-  await msg(random!.id, P, "I can handle Safari testing — I have a MacBook with the latest Safari. Anyone have a Windows machine for Edge testing?");
-  await msg(random!.id, R, "I've got a Windows laptop. I'll test on Edge and Firefox on Windows. Let's aim to have cross-browser testing done by Wednesday.");
-  msgOffset += 2;
-  await msg(random!.id, M, "Team lunch at Dosa Corner confirmed for Thursday 12:30pm. I made a reservation for 6 (leaving one seat for future hires 😄). Sara, can you make it?");
-  await msg(random!.id, S, "Wouldn't miss it! I've heard the masala dosa is life-changing.");
-  await msg(random!.id, A, "Order the filter coffee. Trust me.");
-
-  // ── More DM: Maneek ↔ Rahul — deeper conversation ──
-  msgOffset += 2;
-  await msg(dm!.id, R, "Hey, the Zephyr demo is set up on Railway. URL: https://demo.deft.dev. Pre-populated with a workspace called 'Zephyr Engineering' — 3 spaces, 15 tasks, some fake agent conversations.");
-  await msg(dm!.id, M, "Perfect. I just ran through it — looks great. One thing: can you make the agent suggest creating a task when someone types something that sounds actionable? That would really wow them.");
-  await msg(dm!.id, R, "Already working on it. The classifier detects 'task_create' intent. When confidence > 0.7, it shows an inline suggestion card. Should be live in the demo by tonight.");
-  await msg(dm!.id, M, "That's exactly what I was thinking. Also — they asked about pricing. I'm thinking:\n\n- **Free:** Up to 5 users, 1 project, basic AI (100 queries/month)\n- **Pro:** $8/user/month, unlimited projects, full AI, integrations\n- **Enterprise:** Custom pricing, SSO, audit logs, dedicated support\n\nThoughts?");
-  await msg(dm!.id, R, "Pricing feels right. The free tier is generous enough to get teams hooked. Pro at $8 is competitive with Linear ($8) and way cheaper than Slack ($12.50) + Linear combined. The AI angle justifies the price.");
-  await msg(dm!.id, M, "Exactly my thinking. The pitch is: \"You're paying $20/user/month for Slack + Linear + AI tools. Deft gives you all three for $8.\" Let's finalize this after the Zephyr demo.");
-
-  // ── More DM: Maneek ↔ Priya ──
-  msgOffset += 2;
-  await msg(dmManeekPriya!.id, P, "Quick question about the notification preferences. Should we store them per-space or globally? Like, should a user be able to mute #random but get all notifications from #engineering?");
-  await msg(dmManeekPriya!.id, M, "Per-space. That's how Slack does it and users expect that level of control. Store it on the space_members table — add a `notification_pref` enum: 'all', 'mentions', 'none'.");
-  await msg(dmManeekPriya!.id, P, "Makes sense. I'll add the column and build the UI. Should be a simple dropdown in the channel header.");
-  await msg(dmManeekPriya!.id, M, "Perfect. Also, when a user is in DND mode, we should still collect notifications but not deliver them. When DND ends, show a summary: \"You missed 12 messages in 3 channels.\"");
-  await msg(dmManeekPriya!.id, P, "Oh that's a nice touch. I'll add that to the spec. The notification panel can have a \"While you were away\" section at the top.");
-
-  // ── More DM: Maneek ↔ Sara ──
-  msgOffset += 2;
-  await msg(dmManeekSara!.id, M, "Sara, I've been thinking about the CI/CD setup. Can we add a preview deploy for each PR? So when someone opens a PR, a temporary URL gets posted in the PR comment with a running instance of that branch.");
-  await msg(dmManeekSara!.id, S, "That's doable with Railway's preview environments. Each PR gets its own deploy with its own Postgres. The only thing we'd need to handle is seeding the preview DB with test data.");
-  await msg(dmManeekSara!.id, M, "Let's use the same seed script we use for development. The preview environment just needs to run `npx tsx packages/db/seed.ts` after the deploy.");
-  await msg(dmManeekSara!.id, S, "I'll set that up in the GitHub Actions workflow. Also — should we run the test suite in CI? We don't have many tests yet but setting up the pipeline now means we're ready when we write them.");
-  await msg(dmManeekSara!.id, M, "Yes. Even if it's just type-checking and lint for now. Having the pipeline green/red on every PR sets the right culture from day one.");
-
-  console.log('Added life to the workspace');
-
-  // ── More task comments — real development discussion ──
-  await db.insert(schema.taskComments).values([
-    { org_id: org!.id, task_id: createdTasks[4]!, user_id: priya!.id, content: 'Started the notification preferences UI. Using a simple dropdown per channel: All messages / Mentions only / Nothing. Screenshot in the PR.' },
-    { org_id: org!.id, task_id: createdTasks[4]!, user_id: sara!.id, content: 'Looks clean. One thought — add a "Same as default" option so users don\'t have to configure every single channel.' },
-    { org_id: org!.id, task_id: createdTasks[5]!, user_id: sara!.id, content: 'CI pipeline is live! GitHub Actions workflow: lint → type-check → build. Takes about 2 minutes. Deploy to Railway triggered on push to main.' },
-    { org_id: org!.id, task_id: createdTasks[5]!, user_id: rahul!.id, content: 'Nice, just saw it run on my PR. One thing — can we cache the pnpm install step? It\'s taking 45 seconds and the cache should bring it to ~5s.' },
-    { org_id: org!.id, task_id: createdTasks[5]!, user_id: sara!.id, content: 'Good call, added `actions/cache@v4` with pnpm store path. Install now takes 4 seconds on cache hit. Total pipeline: 1m 20s.' },
-    { org_id: org!.id, task_id: createdTasks[6]!, user_id: arjun!.id, content: 'Onboarding flow wireframes done. 4 steps: 1) Create account 2) Name your org 3) Invite teammates 4) Create your first channel. Each step has a progress bar and skip option.' },
-    { org_id: org!.id, task_id: createdTasks[9]!, user_id: arjun!.id, content: 'Task detail panel v2 is up. Added tabbed view (Details / Comments / Activity / Linked). Status is a dropdown now. Priority uses colored dots. Assignee shows avatar + name with click-to-change.' },
-    { org_id: org!.id, task_id: createdTasks[9]!, user_id: maneek!.id, content: 'This looks really good. The tabbed approach is much cleaner than the scroll-everything-in-one-view approach. Ship it.' },
-    { org_id: org!.id, task_id: createdTasks[11]!, user_id: priya!.id, content: 'Member management is ready for review. Covers: add member by email, remove member, role badges (owner/admin/member/guest), and a "Leave channel" option in the member panel.' },
-    { org_id: org!.id, task_id: dsTIds[3]!, user_id: arjun!.id, content: 'Color palette documented with full WCAG contrast ratios. Every text/background pairing passes AA. The accent violet (#9080FA) on dark surface (#201F22) has a 5.8:1 ratio — well above the 4.5:1 minimum.' },
-    { org_id: org!.id, task_id: dsTIds[6]!, user_id: priya!.id, content: 'Dark mode tokens are in. 28 CSS custom properties organized by function: surface hierarchy (8), text (5), accent (6), status (5), utility (4). All referenced via var() — zero hardcoded colors in components.' },
-  ]);
-
-  // ── Add due dates to some tasks ──
-  const tomorrow = new Date(); tomorrow.setDate(tomorrow.getDate() + 1); tomorrow.setHours(17, 0, 0, 0);
-  const nextWeek = new Date(); nextWeek.setDate(nextWeek.getDate() + 7); nextWeek.setHours(17, 0, 0, 0);
-  const yesterday = new Date(); yesterday.setDate(yesterday.getDate() - 1); yesterday.setHours(17, 0, 0, 0);
-  const twoDaysAgo = new Date(); twoDaysAgo.setDate(twoDaysAgo.getDate() - 2); twoDaysAgo.setHours(17, 0, 0, 0);
-
-  await db.update(schema.tasks).set({ due_date: tomorrow }).where(eq(schema.tasks.id, createdTasks[7]!));
-  await db.update(schema.tasks).set({ due_date: tomorrow }).where(eq(schema.tasks.id, createdTasks[5]!));
-  await db.update(schema.tasks).set({ due_date: nextWeek }).where(eq(schema.tasks.id, createdTasks[4]!));
-  await db.update(schema.tasks).set({ due_date: nextWeek }).where(eq(schema.tasks.id, createdTasks[6]!));
-  await db.update(schema.tasks).set({ due_date: yesterday }).where(eq(schema.tasks.id, createdTasks[9]!)); // overdue!
-  await db.update(schema.tasks).set({ due_date: twoDaysAgo }).where(eq(schema.tasks.id, createdTasks[10]!)); // overdue!
-  await db.update(schema.tasks).set({ due_date: nextWeek }).where(eq(schema.tasks.id, dsTIds[3]!));
-  await db.update(schema.tasks).set({ due_date: nextWeek }).where(eq(schema.tasks.id, dsTIds[5]!));
-
-  console.log('Added due dates (including 2 overdue tasks)');
-
-  // ── More labels ──
-  const [infraLabel] = await db.insert(schema.labels).values({ org_id: org!.id, name: 'infra', color: '#f59e0b' }).returning();
-  const [uxLabel] = await db.insert(schema.labels).values({ org_id: org!.id, name: 'ux', color: '#ec4899' }).returning();
-  const [p0Label] = await db.insert(schema.labels).values({ org_id: org!.id, name: 'critical', color: '#dc2626' }).returning();
+  // ── Labels ──
+  const [urgentLbl] = await db.insert(schema.labels).values({ org_id: org!.id, name: 'urgent', color: '#dc2626' }).returning();
+  const [audit] = await db.insert(schema.labels).values({ org_id: org!.id, name: 'audit', color: '#eab308' }).returning();
+  const [weather] = await db.insert(schema.labels).values({ org_id: org!.id, name: 'weather', color: '#0ea5e9' }).returning();
+  await db.insert(schema.labels).values({ org_id: org!.id, name: 'pests', color: '#16a34a' });
+  const [capex] = await db.insert(schema.labels).values({ org_id: org!.id, name: 'capex', color: '#7c3aed' }).returning();
+  const [buyer] = await db.insert(schema.labels).values({ org_id: org!.id, name: 'buyer', color: '#f97316' }).returning();
+  const [heritage] = await db.insert(schema.labels).values({ org_id: org!.id, name: 'heritage', color: '#be185d' }).returning();
 
   await db.insert(schema.taskLabels).values([
-    { task_id: createdTasks[5]!, label_id: infraLabel!.id },
-    { task_id: createdTasks[10]!, label_id: infraLabel!.id },
-    { task_id: createdTasks[4]!, label_id: uxLabel!.id },
-    { task_id: createdTasks[6]!, label_id: uxLabel!.id },
-    { task_id: createdTasks[7]!, label_id: p0Label!.id },
-    { task_id: dsTIds[6]!, label_id: uxLabel!.id },
+    { task_id: taskIds['HARV1']!, label_id: urgentLbl!.id }, { task_id: taskIds['HARV1']!, label_id: weather!.id },
+    { task_id: taskIds['HARV6']!, label_id: urgentLbl!.id }, { task_id: taskIds['HARV6']!, label_id: buyer!.id },
+    { task_id: taskIds['HARV7']!, label_id: urgentLbl!.id }, { task_id: taskIds['HARV7']!, label_id: audit!.id },
+    { task_id: taskIds['HARV12']!, label_id: audit!.id },
+    { task_id: taskIds['HARV10']!, label_id: weather!.id },
+    { task_id: taskIds['HARV4']!, label_id: heritage!.id },
+    { task_id: taskIds['HARV5']!, label_id: heritage!.id },
+    { task_id: taskIds['WHL1']!, label_id: buyer!.id }, { task_id: taskIds['WHL1']!, label_id: urgentLbl!.id },
+    { task_id: taskIds['WHL2']!, label_id: buyer!.id }, { task_id: taskIds['WHL2']!, label_id: heritage!.id },
+    { task_id: taskIds['WHL4']!, label_id: buyer!.id },
+    { task_id: taskIds['WHL8']!, label_id: heritage!.id },
+    { task_id: taskIds['GH31']!, label_id: capex!.id }, { task_id: taskIds['GH31']!, label_id: heritage!.id },
+    { task_id: taskIds['GH32']!, label_id: capex!.id },
+    { task_id: taskIds['GH34']!, label_id: capex!.id },
+    { task_id: taskIds['GH36']!, label_id: capex!.id },
   ]);
 
-  console.log('Added more labels (infra, ux, critical)');
-
-  // ── User statuses — show people are active ──
-  await db.update(schema.users).set({
-    status_emoji: '🎯', status_text: 'Heads down — do not disturb',
-  }).where(eq(schema.users.id, rahul!.id));
-
-  await db.update(schema.users).set({
-    status_emoji: '🏠', status_text: 'Working remotely',
-  }).where(eq(schema.users.id, priya!.id));
-
-  await db.update(schema.users).set({
-    title: 'Design Lead',
-  }).where(eq(schema.users.id, arjun!.id));
-
-  await db.update(schema.users).set({
-    title: 'Engineering Manager',
-  }).where(eq(schema.users.id, sara!.id));
-
-  await db.update(schema.users).set({
-    title: 'Founder & CEO',
-  }).where(eq(schema.users.id, maneek!.id));
-
-  console.log('Set user statuses and titles');
-
-  // ── More notifications for Maneek — varied types ──
-  await db.insert(schema.notifications).values([
-    { org_id: org!.id, user_id: maneek!.id, type: 'mention', title: 'Priya mentioned you in #engineering', body: 'Hey @Maneek can you review the notification preferences PR?', link: `/chat?space=${engineering!.id}`, is_read: false },
-    { org_id: org!.id, user_id: maneek!.id, type: 'task_updated', title: 'Sara moved DEFT-5 to In Progress', body: 'Set up CI/CD pipeline', link: '/tasks?task=DEFT-5', is_read: false },
-    { org_id: org!.id, user_id: maneek!.id, type: 'message', title: 'Arjun in #design', body: 'Pushed updated mockups for the task detail panel...', link: `/chat?space=${design!.id}`, is_read: false },
-    { org_id: org!.id, user_id: maneek!.id, type: 'mention', title: 'Rahul replied to your message', body: 'Good call, added actions/cache@v4 with pnpm store path...', link: `/chat?space=${engineering!.id}`, is_read: true },
-    { org_id: org!.id, user_id: maneek!.id, type: 'task_assigned', title: 'You were assigned DEFT-13', body: 'Database schema design', link: '/tasks?task=DEFT-13', is_read: true },
+  // ── Task comments ──
+  await db.insert(schema.taskComments).values([
+    { org_id: org!.id, task_id: taskIds['HARV1']!, user_id: C, content: 'Eastern Ag confirmed Monday 7am install. 4-hour job. They\'ll need the south field clear of equipment.' },
+    { org_id: org!.id, task_id: taskIds['HARV1']!, user_id: T, content: 'I\'ll move the tractor and the drip lines Sunday evening so they\'re clear by Monday morning.' },
+    { org_id: org!.id, task_id: taskIds['HARV1']!, user_id: D, content: 'Good. Sage — note in the QC log that the netting is non-permeable; spray applications stop the day before install.' },
+    { org_id: org!.id, task_id: taskIds['HARV7']!, user_id: Sg, content: 'Station is set up. Clipboard + pen + hand sanitizer + signage in English and Spanish. Cesar is briefing the crew at 5:50am tomorrow.' },
+    { org_id: org!.id, task_id: taskIds['HARV7']!, user_id: C, content: 'Crew is aware. They know I will walk anyone back to the station if they\'re caught skipping.' },
+    { org_id: org!.id, task_id: taskIds['HARV12']!, user_id: Sg, content: 'Tuesday 2pm confirmed. I\'ll bring the dry-run checklist + the binder from last year\'s audit. Diego — please block 90 minutes, we have a lot to cover.' },
+    { org_id: org!.id, task_id: taskIds['HARV4']!, user_id: M, content: 'Truss count on GH-2 Sun Gold: 144 trusses with at least one ripe fruit. Conservative pull: 80 lbs Thursday.' },
+    { org_id: org!.id, task_id: taskIds['HARV6']!, user_id: T, content: 'New logger arrived Friday. I tested it Saturday — works as spec\'d, dual-PDF output. Sunbelt will have everything they need at the dock.' },
+    { org_id: org!.id, task_id: taskIds['WHL1']!, user_id: L, content: 'Marigold confirmed we can hit 1,200/wk for 6 weeks with the Beefsteak block. Conservative — peak yield is 1,400/wk so we have buffer. Sending the signed contract back to Sunbelt today.' },
+    { org_id: org!.id, task_id: taskIds['WHL1']!, user_id: M, content: 'Confirmed. The Beefsteak block is healthier this year than last — better fruit set, slightly larger size profile. We will be fine on supply.' },
+    { org_id: org!.id, task_id: taskIds['WHL2']!, user_id: L, content: 'Asha wants the heritage box mix priced separately from the slicers. I\'m thinking $4.20/lb for the heritage mix (Cherokee Purple, Brandywine, San Marzano) vs $1.85/lb for the slicers. That tracks our retail premium.' },
+    { org_id: org!.id, task_id: taskIds['WHL2']!, user_id: D, content: 'Good. Don\'t undersell the heritage premium — they will pay for the story.' },
+    { org_id: org!.id, task_id: taskIds['GH31']!, user_id: M, content: 'Revised BOM going to Diego today. Key changes: dedicated dehumidifier from day 1 (not phase 2), zoned irrigation with 4 zones instead of 2, ferti-station with two reservoirs.' },
+    { org_id: org!.id, task_id: taskIds['GH31']!, user_id: D, content: 'Approved in principle. Send me the updated number and I\'ll sign off formally.' },
+    { org_id: org!.id, task_id: taskIds['GH35']!, user_id: M, content: 'Baker Creek confirmed: Brandywine Sudduth, Cherokee Purple, Black Krim in stock. Aunt Ruby\'s German Green is backordered 4 weeks — substituting with Lillian\'s Yellow Heirloom.' },
   ]);
 
-  // Notifications for other users too
-  await db.insert(schema.notifications).values([
-    { org_id: org!.id, user_id: rahul!.id, type: 'mention', title: 'Maneek mentioned you in DM', body: 'Can you put together a quick demo environment...', link: '/chat', is_read: false },
-    { org_id: org!.id, user_id: rahul!.id, type: 'task_updated', title: 'Priya moved DEFT-11 to In Review', body: 'Space member management', link: '/tasks?task=DEFT-11', is_read: false },
-    { org_id: org!.id, user_id: priya!.id, type: 'task_assigned', title: 'Sara assigned you DEFT-4', body: 'Build notification preferences UI', link: '/tasks?task=DEFT-4', is_read: false },
-    { org_id: org!.id, user_id: arjun!.id, type: 'mention', title: 'Maneek in #design', body: 'Arjun, can you add the linked messages tab...', link: `/chat?space=${design!.id}`, is_read: false },
-    { org_id: org!.id, user_id: sara!.id, type: 'task_updated', title: 'Rahul completed DEFT-14', body: 'Real-time chat messaging', link: '/tasks?task=DEFT-14', is_read: true },
-  ]);
-
-  console.log('Added more notifications for all users');
-
-  // ── More task activity — realistic history ──
+  // ── Task activity ──
   await db.insert(schema.taskActivity).values([
-    { org_id: org!.id, task_id: createdTasks[4]!, user_id: sara!.id, action: 'assigned', field: 'assignee_id', old_value: null, new_value: priya!.id },
-    { org_id: org!.id, task_id: createdTasks[5]!, user_id: maneek!.id, action: 'assigned', field: 'assignee_id', old_value: null, new_value: rahul!.id },
-    { org_id: org!.id, task_id: createdTasks[5]!, user_id: sara!.id, action: 'status_changed', field: 'status', old_value: 'todo', new_value: 'in_progress' },
-    { org_id: org!.id, task_id: createdTasks[6]!, user_id: sara!.id, action: 'assigned', field: 'assignee_id', old_value: null, new_value: arjun!.id },
-    { org_id: org!.id, task_id: createdTasks[9]!, user_id: maneek!.id, action: 'priority_changed', field: 'priority', old_value: 'p2', new_value: 'p1' },
-    { org_id: org!.id, task_id: dsTIds[6]!, user_id: arjun!.id, action: 'assigned', field: 'assignee_id', old_value: null, new_value: priya!.id },
-    { org_id: org!.id, task_id: dsTIds[6]!, user_id: priya!.id, action: 'status_changed', field: 'status', old_value: 'todo', new_value: 'in_progress' },
+    { org_id: org!.id, task_id: taskIds['HARV1']!, user_id: D, action: 'created', field: null, old_value: null, new_value: null },
+    { org_id: org!.id, task_id: taskIds['HARV1']!, user_id: D, action: 'assigned', field: 'assignee_id', old_value: null, new_value: C },
+    { org_id: org!.id, task_id: taskIds['HARV1']!, user_id: C, action: 'status_changed', field: 'status', old_value: 'todo', new_value: 'in_progress' },
+    { org_id: org!.id, task_id: taskIds['HARV7']!, user_id: Sg, action: 'status_changed', field: 'status', old_value: 'todo', new_value: 'in_progress' },
+    { org_id: org!.id, task_id: taskIds['HARV12']!, user_id: Sg, action: 'status_changed', field: 'status', old_value: 'todo', new_value: 'in_progress' },
+    { org_id: org!.id, task_id: taskIds['WHL1']!, user_id: L, action: 'status_changed', field: 'status', old_value: 'in_progress', new_value: 'in_review' },
+    { org_id: org!.id, task_id: taskIds['WHL1']!, user_id: D, action: 'priority_changed', field: 'priority', old_value: 'p1', new_value: 'p0' },
+    { org_id: org!.id, task_id: taskIds['WHL8']!, user_id: L, action: 'status_changed', field: 'status', old_value: 'in_progress', new_value: 'in_review' },
+    { org_id: org!.id, task_id: taskIds['WHL9']!, user_id: L, action: 'status_changed', field: 'status', old_value: 'in_review', new_value: 'done' },
+    { org_id: org!.id, task_id: taskIds['WHL10']!, user_id: L, action: 'status_changed', field: 'status', old_value: 'in_progress', new_value: 'done' },
+    { org_id: org!.id, task_id: taskIds['GH31']!, user_id: M, action: 'status_changed', field: 'status', old_value: 'todo', new_value: 'in_progress' },
+    { org_id: org!.id, task_id: taskIds['GH35']!, user_id: M, action: 'status_changed', field: 'status', old_value: 'todo', new_value: 'in_progress' },
+    { org_id: org!.id, task_id: taskIds['GH36']!, user_id: D, action: 'assigned', field: 'assignee_id', old_value: M, new_value: D },
+    { org_id: org!.id, task_id: taskIds['GH38']!, user_id: D, action: 'status_changed', field: 'status', old_value: 'in_review', new_value: 'done' },
   ]);
 
-  console.log('Added more task activity history');
+  // ── Task watchers ──
+  await db.insert(schema.taskWatchers).values([
+    { task_id: taskIds['HARV1']!, user_id: D }, { task_id: taskIds['HARV1']!, user_id: M },
+    { task_id: taskIds['HARV12']!, user_id: D },
+    { task_id: taskIds['WHL1']!, user_id: D }, { task_id: taskIds['WHL1']!, user_id: M },
+    { task_id: taskIds['WHL4']!, user_id: D },
+    { task_id: taskIds['GH31']!, user_id: D },
+    { task_id: taskIds['GH36']!, user_id: M },
+  ]);
 
-  // ── Set read positions for other users too ──
-  // Rahul has read #general fully but not the latest #engineering messages
-  const lastGenMsg = allGenMsgs[allGenMsgs.length - 1];
-  if (lastGenMsg) {
-    await db.update(schema.spaceMembers).set({
-      last_read_message_id: lastGenMsg.id,
-      last_read_at: new Date(),
-    }).where(and(
-      eq(schema.spaceMembers.space_id, general!.id),
-      eq(schema.spaceMembers.user_id, rahul!.id),
-    ));
+  // ── Task ↔ message provenance (source_message_id) ──
+  await db.update(schema.tasks).set({ source_message_id: gh1.id }).where(eq(schema.tasks.id, taskIds['GH37']!));
+  await db.update(schema.tasks).set({ source_message_id: fo1.id }).where(eq(schema.tasks.id, taskIds['HARV1']!));
+  await db.update(schema.tasks).set({ source_message_id: s1.id }).where(eq(schema.tasks.id, taskIds['WHL1']!));
+  await db.update(schema.tasks).set({ source_message_id: hr1.id }).where(eq(schema.tasks.id, taskIds['HARV2']!));
+
+  console.log('Created task comments, activity, labels, watchers');
+
+  // ── Wiki Pages (knowledge graph) ──
+  function slugify(s: string) { return s.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, ''); }
+
+  const wikiDefs = [
+    {
+      type: 'resource' as const, title: 'Tomato Variety Guide',
+      summary: 'Reference for every variety we grow — flavor, days to maturity, best use, retail premium.',
+      content: `<h1>Tomato Variety Guide — Testers Tomatoes 2026</h1>
+<h2>Slicers (conventional, wholesale program)</h2>
+<ul>
+<li><strong>Beefsteak</strong> — 80-90 days, 1lb+ fruit, our wholesale workhorse. Sunbelt contract @ $1.85/lb. Yield: 1,200-1,400 lbs/wk peak from the Beefsteak block.</li>
+<li><strong>Roma</strong> — 75 days, dense paste-style. South field, hail-vulnerable. Sunbelt slicer fill + farmers market staple.</li>
+<li><strong>San Marzano</strong> — 80 days, classic paste, middle field. Heritage box mix component.</li>
+</ul>
+<h2>Heritage (premium tier, farmers market + Field Co-op)</h2>
+<ul>
+<li><strong>Cherokee Purple</strong> — 80 days, smoky-sweet, retails $6.50/lb. Heat-sensitive; pull early or display in shade. Row 7, GH-2.</li>
+<li><strong>Brandywine (Sudduth strain)</strong> — 85 days, the gold standard for flavor. Slow yielder. Rows 11-13, GH-2.</li>
+<li><strong>Aunt Ruby's German Green</strong> — 85 days, green-when-ripe, divisive but loyal fans. Sometimes substituted with Lillian's Yellow Heirloom if backordered.</li>
+<li><strong>Black Krim</strong> — 75 days, dusky purple-red. Solid producer for the heritage box.</li>
+</ul>
+<h2>Cherry / Snacking</h2>
+<ul>
+<li><strong>Sun Gold</strong> — 65 days, candy-sweet orange cherry. The farmers-market crowd favorite. GH-2 trial: 15% larger trusses than 2025. Pick into 25-lb totes only.</li>
+</ul>`,
+      tags: ['varieties', 'heritage', 'wholesale', 'farmers-market'],
+    },
+    {
+      type: 'procedure' as const, title: 'Pest Management Playbook',
+      summary: 'IPM protocol per pest and per block (organic vs conventional). Approved chemicals only.',
+      content: `<h1>Integrated Pest Management — 2026</h1>
+<h2>Early Blight (Alternaria solani)</h2>
+<p>Most common issue in late spring on the Cherokee Purples when humidity is high. Watch for concentric brown leaf lesions.</p>
+<ul>
+<li>Organic block: <strong>Copper octanoate</strong> (OMRI listed), 7-day re-entry.</li>
+<li>Conventional block: <strong>Mancozeb</strong>, 5-day pre-harvest interval. DO NOT MIX with organic.</li>
+</ul>
+<h2>Tomato Hornworm</h2>
+<p>Hand-pick early (eggs on leaf underside). If outbreak: <strong>Bt</strong> (Bacillus thuringiensis), safe up to harvest.</p>
+<h2>Aphids / Whitefly</h2>
+<p>Insecticidal soap weekly during peak. Greenhouse-side: yellow sticky traps every 30 ft.</p>
+<h2>Sign-off requirements</h2>
+<p>Every application logged in the spray binder. Block, chemical, rate, applicator name, weather, re-entry date. Sage spot-checks weekly. The GAP audit will pull this binder.</p>`,
+      tags: ['pests', 'audit', 'organic', 'spray-log'],
+    },
+    {
+      type: 'procedure' as const, title: 'Irrigation Schedules — Greenhouse vs Field',
+      summary: 'Watering by variety and block. Emitter flush procedure for hard-water buildup.',
+      content: `<h1>Irrigation Schedule</h1>
+<h2>GH-2 — Drip on emitters</h2>
+<p>Slicers: 3 minutes morning + 4 minutes afternoon. Heritage: 4 + 3, slightly drier afternoon to discourage cracking.</p>
+<h2>Field (south + middle) — T-tape</h2>
+<p>Romas: 35 min at 5am, push to 8am if forecast >85°F. San Marzanos: 30 min daily, 6am.</p>
+<h2>Emitter flush procedure (hard water deposits)</h2>
+<ol>
+<li>1% citric acid solution in the main reservoir.</li>
+<li>Run 30 minutes through the line — solution sits in the emitters.</li>
+<li>Switch back to clean water, run 15 minutes to flush.</li>
+</ol>
+<p>Works on both GH drip emitters AND field T-tape. Run quarterly or whenever flow drops 20%+.</p>`,
+      tags: ['irrigation', 'maintenance'],
+    },
+    {
+      type: 'procedure' as const, title: 'Cold Storage & Cold-Chain Protocol',
+      summary: 'Post-harvest handling for wholesale buyers. Pulp temps, refrigeration spec, dock procedure.',
+      content: `<h1>Cold-Chain Protocol</h1>
+<h2>Refrigeration spec</h2>
+<p>Cold room: <strong>52°F ± 2°F</strong>, 85% RH. Tomatoes do NOT belong below 50°F (chill injury).</p>
+<h2>Pulp temperature logging</h2>
+<p>Pre-trip: measured at the harvest room before loading. Post-trip: measured at the buyer's dock before unload. Both logged in the new dual-PDF logger as a single record per load.</p>
+<h2>Buyer specs</h2>
+<ul>
+<li><strong>Sunbelt:</strong> 50-55°F, requires printed PDF at dock receiving.</li>
+<li><strong>Green Leaf:</strong> 52-58°F, less strict but they pull pulp temps randomly.</li>
+<li><strong>Field Co-op:</strong> TBD — Lina to confirm during Friday walkthrough.</li>
+</ul>
+<h2>The May 14 Green Leaf incident</h2>
+<p>Cold truck compressor leak meant the Tuesday delivery arrived at 64°F. Credit memo issued, compressor serviced. Going forward — every truck pulls pulp temps BEFORE leaving the lot AND on arrival.</p>`,
+      tags: ['cold-chain', 'wholesale', 'audit', 'incident'],
+    },
+    {
+      type: 'entity' as const, title: 'Wholesale Buyer Directory',
+      summary: 'Active and prospective buyer contacts, spec sheets, payment terms.',
+      content: `<h1>Wholesale Buyer Directory</h1>
+<h2>Active</h2>
+<h3>Sunbelt Produce — Fresno DC</h3>
+<p>Contact: Marcus Halverson, Produce Buyer. (559) 555-0148. Net 21. Spec: 50-55°F. Current contract: 1,200 lbs/wk Beefsteak, $1.85/lb FOB, May 26 - July 6.</p>
+<h3>Green Leaf Distribution — LA</h3>
+<p>Contact: Mira Diaz, Production Planning (NEW as of April 2026 — replaces Janet Wu). (213) 555-0192. Net 30. Spec: 52-58°F. Open order: mixed slicers, ~600 lbs/wk on standing PO.</p>
+<h2>Prospective</h2>
+<h3>Field Co-op (Bay Area regional)</h3>
+<p>Contact: Asha Mehta, Sourcing Manager. (510) 555-0177. Farm visit scheduled Friday May 24, 10am. Heritage-mix interest. No contract yet.</p>
+<h3>Whole Foods Pacific Northwest (confidential — exploratory only)</h3>
+<p>Year-round program discussion. Off the table until GH-3 is operational and we have a clean 6-month run with regional buyers. Revisit October 2026.</p>`,
+      tags: ['buyers', 'contacts'],
+    },
+    {
+      type: 'resource' as const, title: 'Farmers Market Pricing Strategy',
+      summary: 'Per-variety retail price tiers and weather-adjusted displays.',
+      content: `<h1>Farmers Market Pricing — 2026</h1>
+<h2>Conventional tier</h2>
+<ul><li>Beefsteak slicers: $3.00/lb</li><li>Roma: $2.50/lb</li></ul>
+<h2>Heritage tier (premium)</h2>
+<ul><li>Cherokee Purple: $6.50/lb</li><li>Brandywine: $7.00/lb</li><li>San Marzano: $4.50/lb</li><li>Black Krim: $5.50/lb</li><li>Aunt Ruby's German Green: $6.50/lb</li></ul>
+<h2>Snacking</h2>
+<ul><li>Sun Gold cherries: $5.00/pint</li></ul>
+<h2>Heat-day adjustments</h2>
+<p>Forecast >85°F: shift display to Sun Golds, Romas, Beefsteak slicers. Skip heritages (sunscald + lost premium). Bring second 10x10 pop-up for shade.</p>`,
+      tags: ['farmers-market', 'pricing'],
+    },
+    {
+      type: 'resource' as const, title: 'Greenhouse Climate Setpoints',
+      summary: 'Target temp + RH per greenhouse. Dehumidifier sizing rule of thumb.',
+      content: `<h1>Greenhouse Climate</h1>
+<h2>GH-1 (legacy, conventional slicers)</h2>
+<p>Day: 75°F / 65% RH. Night: 62°F / 75% RH. Acceptable RH ceiling 80%.</p>
+<h2>GH-2 (current heritage + Sun Gold trial)</h2>
+<p>Day: 73°F / 60% RH. Night: 60°F / 70% RH. <strong>Critical:</strong> RH ceiling 70% to prevent early blight on Cherokee Purples (lesson from May 2026 episode).</p>
+<h2>GH-3 (under build — heritage-only)</h2>
+<p>Spec target: same as GH-2 but with zoned humidity control and a dedicated dehumidifier sized 1 BTU per 2 sqft of canopy. The GH-2 dehumidifier was undersized at 1:3 — going to 1:2 for headroom.</p>`,
+      tags: ['greenhouse', 'climate', 'specs'],
+    },
+    {
+      type: 'procedure' as const, title: 'Food Safety Audit Checklist (USDA GAP)',
+      summary: 'Pre-audit checklist for the June 18 USDA GAP inspection.',
+      content: `<h1>USDA-GAP Pre-Audit Checklist</h1>
+<p>Annual inspection scheduled <strong>June 18, 2026</strong>. Dry-run with Sage <strong>May 28</strong>.</p>
+<h2>Records to have ready</h2>
+<ul>
+<li>Handwashing log (sign-in sheets from harvest room entrance station). Goal: 100% compliance for the 30 days preceding the audit.</li>
+<li>Spray binder (every application logged with block / chemical / rate / applicator / weather / re-entry).</li>
+<li>Water test results (irrigation source water, last 12 months).</li>
+<li>Cold storage temp logs (continuous, with manual checks 2x daily).</li>
+<li>Traceability — every wholesale load needs a lot code tied back to harvest date + block.</li>
+<li>Pulp temp logs for every wholesale delivery (new dual-PDF logger).</li>
+</ul>
+<h2>Walk-through points</h2>
+<p>Harvest room entrance (sign-in station), cold storage compressor service log, spray binder, water test binder, traceability lot codes on outgoing pallets.</p>`,
+      tags: ['audit', 'gap', 'food-safety'],
+    },
+  ];
+
+  const wikiIds: Record<string, string> = {};
+  for (const w of wikiDefs) {
+    const slug = slugify(w.title);
+    const [page] = await db.insert(schema.wikiPages).values({
+      org_id: org!.id, scope: 'org', type: w.type, title: w.title, slug,
+      summary: w.summary, content: w.content, tags: w.tags, confidence: 0.95,
+    }).returning();
+    wikiIds[slug] = page!.id;
   }
 
-  // Rahul has read engineering up to message 45 (5 unread)
-  if (allEngMsgs[44]) {
-    await db.update(schema.spaceMembers).set({
-      last_read_message_id: allEngMsgs[44]!.id,
-      last_read_at: new Date(allEngMsgs[44]!.created_at || new Date()),
-    }).where(and(
-      eq(schema.spaceMembers.space_id, engineering!.id),
-      eq(schema.spaceMembers.user_id, rahul!.id),
-    ));
+  // Wiki cross-links (knowledge graph internal edges)
+  await db.insert(schema.wikiLinks).values([
+    { org_id: org!.id, source_page_id: wikiIds['tomato-variety-guide']!, target_page_id: wikiIds['farmers-market-pricing-strategy']!, context: 'Heritage premium tier pricing tracks the variety profiles' },
+    { org_id: org!.id, source_page_id: wikiIds['tomato-variety-guide']!, target_page_id: wikiIds['greenhouse-climate-setpoints']!, context: 'Heritage humidity ceiling drives GH-2 setpoint' },
+    { org_id: org!.id, source_page_id: wikiIds['pest-management-playbook']!, target_page_id: wikiIds['food-safety-audit-checklist-usda-gap']!, context: 'Spray binder is a GAP audit artifact' },
+    { org_id: org!.id, source_page_id: wikiIds['cold-storage-cold-chain-protocol']!, target_page_id: wikiIds['wholesale-buyer-directory']!, context: 'Per-buyer cold-chain specs' },
+    { org_id: org!.id, source_page_id: wikiIds['cold-storage-cold-chain-protocol']!, target_page_id: wikiIds['food-safety-audit-checklist-usda-gap']!, context: 'Pulp temp logs are GAP artifacts' },
+    { org_id: org!.id, source_page_id: wikiIds['irrigation-schedules-greenhouse-vs-field']!, target_page_id: wikiIds['greenhouse-climate-setpoints']!, context: 'Irrigation and climate co-tuned' },
+    { org_id: org!.id, source_page_id: wikiIds['greenhouse-climate-setpoints']!, target_page_id: wikiIds['pest-management-playbook']!, context: 'RH ceiling prevents blight — the GH-2 lesson' },
+  ]);
+
+  console.log('Created 8 wiki pages with internal cross-links');
+
+  // ── Cross-references (knowledge graph: link messages ↔ tasks ↔ tasks) ──
+  await db.insert(schema.crossReferences).values([
+    { org_id: org!.id, source_type: 'message', source_id: fo1.id, target_type: 'task', target_id: taskIds['HARV1']!, context: 'Hail risk message spawned the hail-netting install task', created_by: D },
+    { org_id: org!.id, source_type: 'message', source_id: s1.id, target_type: 'task', target_id: taskIds['WHL1']!, context: 'Sunbelt call recap spawned the contract task', created_by: D },
+    { org_id: org!.id, source_type: 'message', source_id: gh1.id, target_type: 'task', target_id: taskIds['GH37']!, context: 'Dehumidifier failure informs GH-3 spec', created_by: M },
+    { org_id: org!.id, source_type: 'message', source_id: gh2.id, target_type: 'task', target_id: taskIds['HARV12']!, context: 'Blight risk feeds into pre-audit dry-run', created_by: Sg },
+    { org_id: org!.id, source_type: 'message', source_id: hr1.id, target_type: 'task', target_id: taskIds['HARV2']!, context: 'Harvest plan ↔ Monday Roma harvest task', created_by: C },
+    { org_id: org!.id, source_type: 'message', source_id: hr1.id, target_type: 'task', target_id: taskIds['HARV4']!, context: 'Thursday Sun Gold pull from the harvest plan', created_by: C },
+    { org_id: org!.id, source_type: 'message', source_id: lg1.id, target_type: 'task', target_id: taskIds['HARV6']!, context: 'Truck rotation message ↔ Sunbelt delivery task', created_by: T },
+    { org_id: org!.id, source_type: 'task', source_id: taskIds['HARV1']!, target_type: 'task', target_id: taskIds['HARV10']!, context: 'Hail netting + hoop house panels — same weather event prep', created_by: C },
+    { org_id: org!.id, source_type: 'task', source_id: taskIds['HARV12']!, target_type: 'task', target_id: taskIds['HARV7']!, context: 'Audit dry-run depends on handwashing station being live', created_by: Sg },
+    { org_id: org!.id, source_type: 'task', source_id: taskIds['WHL1']!, target_type: 'task', target_id: taskIds['HARV6']!, context: 'Sunbelt contract drives Tuesday delivery cadence', created_by: L },
+    { org_id: org!.id, source_type: 'task', source_id: taskIds['WHL2']!, target_type: 'task', target_id: taskIds['HARV5']!, context: 'Field Co-op visit ↔ Cherokee Purple selective pick', created_by: L },
+    { org_id: org!.id, source_type: 'task', source_id: taskIds['GH37']!, target_type: 'task', target_id: taskIds['GH31']!, context: 'GH-2 lessons feed GH-3 BOM revision', created_by: M },
+  ]);
+
+  // ── Tags + entity_tags (the second axis of the knowledge graph) ──
+  const tagDefs = [
+    { name: 'audit', color: '#eab308' },
+    { name: 'weather', color: '#0ea5e9' },
+    { name: 'heritage', color: '#be185d' },
+    { name: 'buyer', color: '#f97316' },
+    { name: 'gh-3', color: '#0ea5e9' },
+    { name: 'pricing', color: '#10b981' },
+    { name: 'irrigation', color: '#06b6d4' },
+    { name: 'cold-chain', color: '#6366f1' },
+  ];
+  const tagIds: Record<string, string> = {};
+  for (const t of tagDefs) {
+    const [tag] = await db.insert(schema.tags).values({ org_id: org!.id, name: t.name, color: t.color }).returning();
+    tagIds[t.name] = tag!.id;
   }
 
-  console.log('Set read positions for other users');
+  const entityTagBindings: { tag: string; type: 'message' | 'task' | 'note'; id: string }[] = [
+    { tag: 'audit', type: 'task', id: taskIds['HARV7']! },
+    { tag: 'audit', type: 'task', id: taskIds['HARV12']! },
+    { tag: 'weather', type: 'task', id: taskIds['HARV1']! },
+    { tag: 'weather', type: 'task', id: taskIds['HARV10']! },
+    { tag: 'weather', type: 'message', id: fo1.id },
+    { tag: 'heritage', type: 'task', id: taskIds['HARV4']! },
+    { tag: 'heritage', type: 'task', id: taskIds['HARV5']! },
+    { tag: 'heritage', type: 'task', id: taskIds['WHL2']! },
+    { tag: 'heritage', type: 'task', id: taskIds['GH31']! },
+    { tag: 'buyer', type: 'task', id: taskIds['WHL1']! },
+    { tag: 'buyer', type: 'task', id: taskIds['WHL2']! },
+    { tag: 'buyer', type: 'task', id: taskIds['WHL4']! },
+    { tag: 'buyer', type: 'message', id: s1.id },
+    { tag: 'gh-3', type: 'task', id: taskIds['GH31']! },
+    { tag: 'gh-3', type: 'task', id: taskIds['GH32']! },
+    { tag: 'gh-3', type: 'task', id: taskIds['GH35']! },
+    { tag: 'gh-3', type: 'task', id: taskIds['GH36']! },
+    { tag: 'gh-3', type: 'task', id: taskIds['GH37']! },
+    { tag: 'gh-3', type: 'task', id: taskIds['GH38']! },
+    { tag: 'cold-chain', type: 'task', id: taskIds['HARV6']! },
+    { tag: 'cold-chain', type: 'task', id: taskIds['WHL5']! },
+    { tag: 'cold-chain', type: 'task', id: taskIds['HARV9']! },
+  ];
+  for (const b of entityTagBindings) {
+    await db.insert(schema.entityTags).values({
+      org_id: org!.id, tag_id: tagIds[b.tag]!, entity_type: b.type, entity_id: b.id,
+    }).catch(() => {});
+  }
 
-  // ── Re-seed the platform bundle (Defty system user) ──
-  // The wipe above deletes the well-known Defty user (deft-agent@system.local). Re-insert
-  // him so chat @deft mentions keep working in the demo workspace. Bundled skills/templates
-  // and employee templates are re-seeded by the api-side `seed-platform-bundles.ts`,
-  // which the root `db:seed:demo` proxy runs after this script.
-  await seedDeftyUser(db);
+  console.log('Created cross-references, tags, and entity tags (knowledge graph)');
 
-  console.log('\nDemo seed complete!');
-  console.log('Login credentials:');
-  console.log('  maneek@test.com / test1234 (owner)');
-  console.log('  rahul@test.com  / test1234 (member)');
-  console.log('  priya@test.com  / test1234 (member)');
-  console.log('  arjun@test.com  / test1234 (member)');
-  console.log('  sara@test.com   / test1234 (member)');
-  console.log('Projects: Deft v1 (DEFT), Design System (DS)');
+  // ── Notes (personal + shared) ──
+  const notes = [
+    {
+      user: diego!, title: 'Sunday strategy notes — May 25', icon: '🧭', pinned: true, visibility: 'private' as const,
+      content: `<h1>What's on my mind</h1>
+<h2>This week's high-leverage moves</h2>
+<ul>
+<li>Hail netting on south field MUST happen Monday. Weather is a coin flip; netting is the cheaper outcome.</li>
+<li>Sunbelt contract returns Friday. 14% price lift over last year — anchor $2.00 for 2027.</li>
+<li>Asha Mehta visit Friday — this is the bigger long-term win. Heritage premium story.</li>
+</ul>
+<h2>Quiet move: GH-3 heritage pivot</h2>
+<p>Marigold and I aligned this week — GH-3 is heritage-only, not "general purpose". Doubles the per-sqft margin. Permit follow-up is on me; calling the inspector Monday.</p>
+<h2>Confidential: Whole Foods PNW</h2>
+<p>Off the table until October. Don't even mention it to the team. Lina has the cost model.</p>
+<h2>People notes</h2>
+<ul>
+<li>Sage is doing exactly the right thing about the GAP audit — back her up publicly Monday.</li>
+<li>Tomás is overloaded with the cold truck servicing fallout. Check in.</li>
+</ul>`,
+    },
+    {
+      user: marigold!, title: 'GH-3 BOM revision — working draft', icon: '📋', pinned: true, visibility: 'private' as const,
+      content: `<h1>GH-3 Revised BOM (heritage-only pivot)</h1>
+<h2>Changes from v1</h2>
+<ol>
+<li><strong>Climate:</strong> dedicated 24,000 BTU dehumidifier from day 1 (was phase 2). +$3,400.</li>
+<li><strong>Irrigation:</strong> 4 zones instead of 2 — heritage varieties want differentiated schedules. +$2,100 in additional valves + manifold.</li>
+<li><strong>Ferti-station:</strong> dual reservoir (one organic, one conventional). +$1,800.</li>
+<li><strong>Sensors:</strong> CO2 + airflow added — heritage varieties are pickier. +$900.</li>
+<li><strong>Soil:</strong> deeper grading + compost amendment from Madsen Farms. +$4,800.</li>
+</ol>
+<h2>Total delta</h2>
+<p>+$13,000 from original BOM. New total: $187,400. Diego approved in principle, needs formal signoff.</p>
+<h2>Justification</h2>
+<p>Heritage retail premium is 2.6x conventional slicers. The build delta pays back in <strong>~6 months</strong> of farmers market sales + Field Co-op contract.</p>`,
+    },
+    {
+      user: lina!, title: 'Asha Mehta visit prep — Friday', icon: '🤝', pinned: true, visibility: 'private' as const,
+      content: `<h1>Field Co-op walkthrough — May 24, 10am</h1>
+<h2>Tour route</h2>
+<ol>
+<li>GH-2 entrance → Sun Gold trusses (the wow factor)</li>
+<li>Cherokee Purple Row 12 (NOT picked yet — full display)</li>
+<li>Walk out to south field → Roma block (talk operations)</li>
+<li>Harvest room → cold storage (food safety story)</li>
+<li>Office tasting — heritage box: Cherokee Purple, Brandywine, San Marzano slices</li>
+</ol>
+<h2>Pricing to pitch</h2>
+<ul>
+<li>Heritage box mix: <strong>$4.20/lb FOB</strong> (retail comp $6.50/lb)</li>
+<li>Slicer fill: $1.85/lb FOB (matches Sunbelt)</li>
+<li>Minimum order: 200 lbs/wk on heritage, 400 lbs/wk on slicers</li>
+</ul>
+<h2>Asks</h2>
+<p>Net 30 payment terms. We deliver Wed mornings. They commit to a 6-week trial.</p>
+<h2>Risks</h2>
+<p>If Cherokee Purple block hits early blight before Friday (humidity issue Marigold flagged), the heritage pitch loses its visual. Backup: pull the Brandywines (Row 11-13) as the show variety.</p>`,
+    },
+    {
+      user: sage!, title: 'GAP audit dry-run agenda', icon: '✅', pinned: false, visibility: 'org' as const,
+      content: `<h1>GAP Audit Dry-Run — May 28, 2pm</h1>
+<p>Walking Diego through the actual audit flow so there are zero surprises June 18.</p>
+<h2>Records review (30 min)</h2>
+<ul>
+<li>Handwashing sign-in compliance — Goal: 100% for the 30 days before audit</li>
+<li>Spray binder — full year of entries</li>
+<li>Water test results — annual + last quarterly</li>
+<li>Cold storage temp logs — continuous trace</li>
+<li>Traceability — lot codes on outgoing pallets back to harvest date + block</li>
+</ul>
+<h2>Walkthrough (45 min)</h2>
+<p>Same route the auditor will take: parking → harvest room entrance (sign-in station) → cold storage → spray storage → field. I'll point out anything that's still rough.</p>
+<h2>Gap remediation (15 min)</h2>
+<p>Whatever I find that's not ready, we ticket and assign before Diego leaves.</p>`,
+    },
+    {
+      user: cesar!, title: 'Hail playbook (south field)', icon: '⚠️', pinned: false, visibility: 'org' as const,
+      content: `<h1>Hail Response — South Field</h1>
+<h2>Pre-event (T-72h)</h2>
+<p>NOAA + Weather Underground both show >25% hail risk → call Eastern Ag for netting. Lead time 72h for install crew.</p>
+<h2>During event</h2>
+<p>If netting is up: nothing to do. If not: walk the rows after the event to mark damaged fruit with flagging tape for selective pick.</p>
+<h2>Post-event triage</h2>
+<p>Damaged fruit goes to the farmers market "salvage tier" at $1.50/lb (still sellable as sauce-grade if not broken-skinned). Anything broken-skinned: compost.</p>
+<h2>Lesson from May 2025</h2>
+<p>We didn't net last year — lost 40% of the Roma block to a freak late-May hail event. Cost: ~$22k revenue. Netting at $8,640 is a no-brainer.</p>`,
+    },
+    {
+      user: tomas!, title: 'Cold truck service log', icon: '🚚', pinned: false, visibility: 'org' as const,
+      content: `<h1>Cold Truck — 2026 Service Log</h1>
+<table>
+<tr><th>Date</th><th>Service</th><th>Cost</th><th>Notes</th></tr>
+<tr><td>Feb 4</td><td>Annual inspection</td><td>$340</td><td>Compressor fitting noted as "watch"</td></tr>
+<tr><td>May 14</td><td>Emergency: compressor leak</td><td>$1,820</td><td>Caused warm delivery to Green Leaf — credit memo issued. Replaced fitting + recharged R-410A.</td></tr>
+<tr><td>May 21</td><td>Post-repair verification</td><td>$0</td><td>Confirmed pulp temp held at 51°F over 5hr LA trip.</td></tr>
+</table>
+<h2>Going forward</h2>
+<p>Pulp temps logged BEFORE departure on EVERY trip, regardless of buyer requirement. Catches issues at the lot, not at the dock.</p>`,
+    },
+    {
+      user: marigold!, title: 'Seed inventory — 2026', icon: '🌱', pinned: false, visibility: 'org' as const,
+      content: `<h1>Seed Stock (as of May 25)</h1>
+<h2>Conventional</h2>
+<ul><li>Beefsteak: 2 lbs (~6,000 seeds). Enough for 2026 + 2027.</li><li>Roma: 0.5 lb. Need 0.5 lb more for 2027.</li><li>San Marzano: 0.25 lb. Ordering 0.5 lb.</li></ul>
+<h2>Heritage (Baker Creek + Johnny's)</h2>
+<ul><li>Cherokee Purple: 800 seeds, fresh 2026 packet.</li><li>Brandywine (Sudduth): 400 seeds, fresh 2026 packet.</li><li>Black Krim: 600 seeds, fresh.</li><li>Aunt Ruby's German Green: BACKORDERED — sub Lillian's Yellow Heirloom (400 seeds confirmed).</li><li>Mortgage Lifter: ordered, not yet arrived.</li><li>Green Zebra: 300 seeds, fresh.</li></ul>
+<h2>Snacking</h2>
+<ul><li>Sun Gold F1: 2 packets (~200 seeds total). Enough for GH-2 + farmers market trial.</li></ul>
+<h2>To order by June 1</h2>
+<p>Mortgage Lifter (confirm), Lillian's Yellow Heirloom (substitution), Roma top-up.</p>`,
+    },
+    {
+      user: diego!, title: 'Pricing strategy — 2027 anchor', icon: '💰', pinned: false, visibility: 'private' as const,
+      content: `<h1>Pricing Strategy — 2027</h1>
+<h2>Slicers</h2>
+<p>2026 contracted at $1.85 (Sunbelt). Anchor 2027 at $2.00. Sunbelt has shown willingness to pay; competitors are higher. Don't undersell.</p>
+<h2>Heritage</h2>
+<p>$4.20/lb wholesale (per Field Co-op pitch). Retail at $6.50/lb. Margin story to buyers: scarcity + flavor differentiation.</p>
+<h2>Farmers market</h2>
+<p>Hold current pricing through 2026; revisit when GH-3 comes online — if heritage volume grows 2x, may need to dial back retail premium to $6.00 to move volume. Watch.</p>
+<h2>Whole Foods (confidential, not in play yet)</h2>
+<p>If we go national in 2027, the conversation changes. National volume + branded program = sub-$3 wholesale even on heritage, made up on volume. Decide in Q4 after GH-3 reality check.</p>`,
+    },
+    {
+      user: lina!, title: 'Farmers market — Saturday playbook', icon: '🏪', pinned: false, visibility: 'org' as const,
+      content: `<h1>Farmers Market — Saturday</h1>
+<h2>Forecast-driven display</h2>
+<p>Check NOAA Thursday for Saturday's high.</p>
+<ul>
+<li><strong>&lt;80°F:</strong> full heritage display, premium up front. Cherokee Purple + Brandywine center stage.</li>
+<li><strong>80-87°F:</strong> heritage in the shaded back row, slicers + Sun Golds up front. Watch for sun fade on heritages.</li>
+<li><strong>&gt;87°F:</strong> heritage off the table (or in a cooler with samples only). Sun Gold + slicers only. Second pop-up for shade.</li>
+</ul>
+<h2>Signage</h2>
+<p>Variety education cards next to each crate. Customers will pay 2x for the story.</p>
+<h2>Crew</h2>
+<p>2 people: one selling, one restocking + customer questions. Start 7am setup, market opens 8am.</p>`,
+    },
+  ];
+
+  const noteIds: Record<string, string> = {};
+  for (const n of notes) {
+    const [note] = await db.insert(schema.notes).values({
+      org_id: org!.id, user_id: n.user.id, title: n.title, icon: n.icon, content: n.content,
+      is_pinned: n.pinned, visibility: n.visibility,
+    }).returning();
+    noteIds[n.title] = note!.id;
+  }
+
+  // Tag a few notes
+  await db.insert(schema.entityTags).values([
+    { org_id: org!.id, tag_id: tagIds['heritage']!, entity_type: 'note', entity_id: noteIds['Asha Mehta visit prep — Friday']! },
+    { org_id: org!.id, tag_id: tagIds['buyer']!, entity_type: 'note', entity_id: noteIds['Asha Mehta visit prep — Friday']! },
+    { org_id: org!.id, tag_id: tagIds['gh-3']!, entity_type: 'note', entity_id: noteIds['GH-3 BOM revision — working draft']! },
+    { org_id: org!.id, tag_id: tagIds['audit']!, entity_type: 'note', entity_id: noteIds['GAP audit dry-run agenda']! },
+    { org_id: org!.id, tag_id: tagIds['weather']!, entity_type: 'note', entity_id: noteIds['Hail playbook (south field)']! },
+    { org_id: org!.id, tag_id: tagIds['cold-chain']!, entity_type: 'note', entity_id: noteIds['Cold truck service log']! },
+    { org_id: org!.id, tag_id: tagIds['pricing']!, entity_type: 'note', entity_id: noteIds['Pricing strategy — 2027 anchor']! },
+  ]);
+
+  console.log('Created 9 notes');
+
+  // ── Notifications ──
+  await db.insert(schema.notifications).values([
+    { org_id: org!.id, user_id: D, type: 'mention', title: 'Lina in #sales-and-buyers', body: 'Sunbelt call recap: $1.85/lb, 1,200 lbs/wk, 6 weeks. Decision by Friday.', link: `/chat?space=${sales!.id}`, is_read: false },
+    { org_id: org!.id, user_id: D, type: 'task_assigned', title: 'Marigold assigned you GH3-6', body: 'Construction permit — county inspector follow-up', link: '/tasks?task=GH3-6', is_read: false },
+    { org_id: org!.id, user_id: D, type: 'task_updated', title: 'Sage moved HARV-7 to In Progress', body: 'Hand-washing sign-in station', link: '/tasks?task=HARV-7', is_read: true },
+    { org_id: org!.id, user_id: D, type: 'message', title: 'Marigold in #greenhouse', body: 'GH-2 climate log overnight: humidity peaked at 84%...', link: `/chat?space=${greenhouse!.id}`, is_read: false },
+    { org_id: org!.id, user_id: M, type: 'mention', title: 'Diego in #greenhouse', body: 'Order a second dehumidifier. Pull from GH-3 budget if you have to.', link: `/chat?space=${greenhouse!.id}`, is_read: true },
+    { org_id: org!.id, user_id: L, type: 'task_updated', title: 'Diego raised WHL-1 priority to p0', body: 'Sunbelt 6-week contract — sign and return', link: '/tasks?task=WHL-1', is_read: false },
+    { org_id: org!.id, user_id: C, type: 'mention', title: 'Diego in #field-ops', body: '"Do it. Better insurance than insurance." (re: hail netting)', link: `/chat?space=${fieldOps!.id}`, is_read: true },
+    { org_id: org!.id, user_id: Sg, type: 'mention', title: 'Diego in DM', body: 'Tuesday 2pm. Block it on my calendar.', link: `/chat?space=${dmDS!.id}`, is_read: false },
+    { org_id: org!.id, user_id: T, type: 'task_assigned', title: 'Cesar assigned you HARV-10', body: 'Stage hoop house side panels for fast deployment', link: '/tasks?task=HARV-10', is_read: false },
+  ]);
+
+  // ── Read positions — partial unread for Diego ──
+  const genMsgs = await db.select({ id: schema.messages.id, created_at: schema.messages.created_at })
+    .from(schema.messages).where(eq(schema.messages.space_id, general!.id))
+    .orderBy(asc(schema.messages.created_at));
+  if (genMsgs.length > 5) {
+    const anchor = genMsgs[Math.max(0, genMsgs.length - 4)]!;
+    await db.update(schema.spaceMembers).set({
+      last_read_message_id: anchor.id, last_read_at: new Date(anchor.created_at),
+    }).where(and(eq(schema.spaceMembers.space_id, general!.id), eq(schema.spaceMembers.user_id, D)));
+  }
+
+  // ── Audit log breadcrumbs ──
+  await db.insert(schema.auditLog).values([
+    { org_id: org!.id, actor_type: 'user', actor_id: D, action: 'create', entity_type: 'org', entity_id: org!.id, metadata: { source: 'seed-demo' } },
+    { org_id: org!.id, actor_type: 'user', actor_id: L, action: 'update', entity_type: 'task', entity_id: taskIds['WHL1']!, before_state: { status: 'in_progress' }, after_state: { status: 'in_review' } },
+    { org_id: org!.id, actor_type: 'user', actor_id: D, action: 'update', entity_type: 'task', entity_id: taskIds['WHL1']!, before_state: { priority: 'p1' }, after_state: { priority: 'p0' } },
+    { org_id: org!.id, actor_type: 'user', actor_id: Sg, action: 'update', entity_type: 'task', entity_id: taskIds['HARV7']!, before_state: { status: 'todo' }, after_state: { status: 'in_progress' } },
+  ]);
+
+  console.log('\n✅ Testers Tomatoes demo seed complete!\n');
+  console.log('Login (password for everyone: tomato123):');
+  console.log('  diego@testers-tomatoes.com     (owner, Farm Manager)');
+  console.log('  marigold@testers-tomatoes.com  (admin, Head Grower)');
+  console.log('  cesar@testers-tomatoes.com     (member, Field Supervisor)');
+  console.log('  lina@testers-tomatoes.com      (member, Sales Lead)');
+  console.log('  tomas@testers-tomatoes.com     (member, Logistics)');
+  console.log('  sage@testers-tomatoes.com      (member, QC + Food Safety)\n');
+  console.log('Projects: HARV (Spring Harvest), WHL (Wholesale Expansion), GH3 (Greenhouse 3 Build-out)');
+  console.log(`OpenAI key: ${OPENAI_KEY ? '✅ stored encrypted on orgs.ai_config' : 'not set (workspace boots without LLM; set SEED_OPENAI_KEY to enable)'}`);
 
   await pool.end();
 }


### PR DESCRIPTION
## Summary
- `packages/db/seed-demo.ts` rewritten around a fictional family tomato farm.
- 6 users (Diego owner + Marigold / Cesar / Lina / Tomás / Sage), 10 spaces incl. 6 Defty 1:1 DMs with role-personalized welcomes, 79 chat messages with reactions / pins / threads, 3 projects, 30 tasks across all statuses, 8 wiki pages with internal cross-links, 9 notes, 12 cross-references, 29 entity-tags.
- Defty (the built-in agent) is created inline so the seed boots a working agent surface on its own.
- Re-runnable — wipes 50+ tables in reverse dep order (incl. new ones: `task_watchers`, `wiki_links`, `wiki_pages`, `entity_tags`, `tags`, `notes`).
- Adds `DEMO-WALKTHROUGH.md` — a public-safe tester walkthrough (login table, week-in-the-life scenario, 5 demo arcs, "what's intentionally NOT in seed" caveats). **No droplet links, no live-instance details.**

Why this seed: the prior Deft Labs seed felt thin. The tomato farm has *stakes* in every channel — a hail warning, a wholesale contract, a humidity problem, an audit deadline — so the agent + cross-reference + wiki features have something real to chew on.

## Files
- `packages/db/seed-demo.ts` (rewritten)
- `DEMO-WALKTHROUGH.md` (new)

## Test plan
- [ ] `pnpm db:seed:demo` on a fresh DB completes without error
- [ ] Re-running `pnpm db:seed:demo` succeeds (idempotent wipe)
- [ ] Login as `diego@testers-tomatoes.com` / `tomato123` → dashboard populated
- [ ] Defty DM is pinned at top of DM list for each user
- [ ] `@deft` in chat with `SEED_OPENAI_KEY` configured returns a synthesized answer
- [ ] Wiki page links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)