### PR TITLE
Hide restricted tasks from unauthorized users

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -82,7 +82,6 @@ app.use('*', secureHeaders({
 // Public routes
 app.use('/api/auth/*', authLimiter);
 app.route('/api/auth', authRoutes);
-app.route('/api/files', fileServingRoutes);
 
 // MCP server — own API key auth, mounted before auth middleware
 app.route('/mcp', mcpServerRoutes);
@@ -129,6 +128,7 @@ app.route('/api/inbox', inboxRoutes);
 app.route('/api/org', orgRoutes);
 app.route('/api/ics', icsRoutes);
 app.route('/api/upload', uploadRoutes);
+app.route('/api/files', fileServingRoutes);
 app.route('/api/members', memberRoutes);
 app.route('/api/projects', projectRoutes);
 app.route('/api/tasks', taskRoutes);

--- a/apps/api/src/lib/agent-context.ts
+++ b/apps/api/src/lib/agent-context.ts
@@ -38,6 +38,7 @@ import { velocityCalculator, workloadAnalyzer, skillsGapAnalyzer } from '../serv
 import { generateOneOnePrep } from '../services/oneone-prep.js';
 import { createPlanRow } from './agent-plans.js';
 import { resolveAssignee } from './resolve-assignee.js';
+import { visibleTaskCondition } from './task-visibility.js';
 
 type Citation = { type: string; id: string; title: string };
 
@@ -180,7 +181,11 @@ export async function executeToolCall(
         }
       }
 
-      const conditions: any[] = [eq(tasks.org_id, orgId), eq(tasks.is_deleted, false)];
+      const conditions: any[] = [
+        eq(tasks.org_id, orgId),
+        eq(tasks.is_deleted, false),
+        visibleTaskCondition(_userId),
+      ];
 
       if (params.query) {
         // Union: literal-title ILIKE OR semantic id match. When semantic had no
@@ -339,7 +344,7 @@ export async function executeToolCall(
         .from(tasks)
         .innerJoin(projects, eq(tasks.project_id, projects.id))
         .leftJoin(users, eq(tasks.assignee_id, users.id))
-        .where(and(eq(tasks.id, taskId), eq(tasks.org_id, orgId)))
+        .where(and(eq(tasks.id, taskId), eq(tasks.org_id, orgId), visibleTaskCondition(_userId)))
         .limit(1);
 
       if (!task) return { result: { error: 'Task not found' }, citations: [] };

--- a/apps/api/src/lib/note-visibility.ts
+++ b/apps/api/src/lib/note-visibility.ts
@@ -1,0 +1,20 @@
+import { eq, or, sql } from 'drizzle-orm';
+import { notes, noteShares, spaceMembers } from '@deft/db/schema';
+
+export function visibleNoteCondition(userId: string) {
+  return or(
+    eq(notes.user_id, userId),
+    eq(notes.visibility, 'org'),
+    sql`exists (
+      select 1 from ${noteShares}
+      where ${noteShares.note_id} = ${notes.id}
+        and ${noteShares.shared_with_user_id} = ${userId}
+    )`,
+    sql`exists (
+      select 1 from ${spaceMembers}
+      where ${spaceMembers.space_id} = ${notes.visibility_space_id}
+        and ${spaceMembers.user_id} = ${userId}
+        and ${notes.visibility} = 'space'
+    )`,
+  );
+}

--- a/apps/api/src/lib/retrieve-context.ts
+++ b/apps/api/src/lib/retrieve-context.ts
@@ -11,8 +11,9 @@
 
 import { eq, and, or, sql, inArray } from 'drizzle-orm';
 import { db } from './db.js';
-import { wikiPages, agentMemory, notes, tasks, spaceMembers } from '@deft/db/schema';
+import { wikiPages, agentMemory, notes, tasks, spaceMembers, projects } from '@deft/db/schema';
 import { embedQuiet, EMBED_DIMS } from './embed.js';
+import { unrestrictedTaskCondition, visibleTaskCondition } from './task-visibility.js';
 
 // ─── Public types ─────────────────────────────────────────────────────────────
 
@@ -578,6 +579,7 @@ async function fetchNotes(
 
 async function fetchTasks(
   org_id: string,
+  user_id: string | undefined,
   forFTS: string,
   limit: number,
   queryEmbedding: number[] | null,
@@ -609,10 +611,12 @@ async function fetchTasks(
         rawScore: scoreExpr,
       })
       .from(tasks)
+      .innerJoin(projects, eq(tasks.project_id, projects.id))
       .where(
         and(
           eq(tasks.org_id, org_id),
           eq(tasks.is_deleted, false),
+          user_id ? visibleTaskCondition(user_id) : unrestrictedTaskCondition(),
           sql`search_vector @@ plainto_tsquery('english', ${forFTS})`,
         ),
       )
@@ -733,7 +737,7 @@ export async function retrieveContext(
     //    filtered by org_id + is_deleted. Backing store is tasks.search_vector
     //    (generated tsvector) + tasks.embedding (pgvector).
     types.includes('tasks')
-      ? fetchTasks(org_id, forFTS, limit, queryEmbedding, hybrid)
+      ? fetchTasks(org_id, user_id, forFTS, limit, queryEmbedding, hybrid)
       : Promise.resolve([]),
   ]);
 

--- a/apps/api/src/lib/task-visibility.ts
+++ b/apps/api/src/lib/task-visibility.ts
@@ -1,0 +1,30 @@
+import { eq, or, sql } from 'drizzle-orm';
+import { projects, taskAssignees, taskWatchers, tasks } from '@deft/db/schema';
+
+export function unrestrictedTaskCondition() {
+  return sql`coalesce(${tasks.metadata}->>'visibility', 'org') != 'restricted'`;
+}
+
+/**
+ * Restricted tasks are hidden from org-wide surfaces unless the caller has a
+ * direct relationship to the task. The check expects queries to join projects.
+ */
+export function visibleTaskCondition(userId: string) {
+  return or(
+    unrestrictedTaskCondition(),
+    eq(tasks.assignee_id, userId),
+    eq(tasks.created_by, userId),
+    eq(projects.lead_id, userId),
+    sql`coalesce(${tasks.metadata}->'visible_user_ids', '[]'::jsonb) ? ${userId}`,
+    sql`exists (
+      select 1 from ${taskWatchers}
+      where ${taskWatchers.task_id} = ${tasks.id}
+        and ${taskWatchers.user_id} = ${userId}
+    )`,
+    sql`exists (
+      select 1 from ${taskAssignees}
+      where ${taskAssignees.task_id} = ${tasks.id}
+        and ${taskAssignees.user_id} = ${userId}
+    )`,
+  );
+}

--- a/apps/api/src/lib/wiki-visibility.ts
+++ b/apps/api/src/lib/wiki-visibility.ts
@@ -1,0 +1,14 @@
+import { eq, or, sql } from 'drizzle-orm';
+import { spaceMembers, wikiPages } from '@deft/db/schema';
+
+export function visibleWikiPageCondition(userId: string) {
+  return or(
+    eq(wikiPages.scope, 'org'),
+    eq(wikiPages.user_id, userId),
+    sql`exists (
+      select 1 from ${spaceMembers}
+      where ${spaceMembers.space_id} = ${wikiPages.space_id}
+        and ${spaceMembers.user_id} = ${userId}
+    )`,
+  );
+}

--- a/apps/api/src/routes/agent-plans.ts
+++ b/apps/api/src/routes/agent-plans.ts
@@ -14,7 +14,7 @@ agentPlanRoutes.get('/', async (c) => {
     const status = c.req.query('status');
     const employeeId = c.req.query('employee_id');
 
-    const conditions = [eq(agentPlans.org_id, user.org_id)];
+    const conditions = [eq(agentPlans.org_id, user.org_id), eq(agentPlans.user_id, user.id)];
     if (status) {
       conditions.push(eq(agentPlans.status, status as any));
     }
@@ -45,7 +45,7 @@ agentPlanRoutes.get('/:id', async (c) => {
     const [plan] = await db
       .select()
       .from(agentPlans)
-      .where(and(eq(agentPlans.id, planId), eq(agentPlans.org_id, user.org_id)))
+      .where(and(eq(agentPlans.id, planId), eq(agentPlans.org_id, user.org_id), eq(agentPlans.user_id, user.id)))
       .limit(1);
 
     if (!plan) {
@@ -108,7 +108,7 @@ agentPlanRoutes.put('/:id', async (c) => {
     const [existing] = await db
       .select()
       .from(agentPlans)
-      .where(and(eq(agentPlans.id, planId), eq(agentPlans.org_id, user.org_id)))
+      .where(and(eq(agentPlans.id, planId), eq(agentPlans.org_id, user.org_id), eq(agentPlans.user_id, user.id)))
       .limit(1);
 
     if (!existing) {
@@ -154,7 +154,7 @@ agentPlanRoutes.post('/:id/approve', async (c) => {
     const [plan] = await db
       .select()
       .from(agentPlans)
-      .where(and(eq(agentPlans.id, planId), eq(agentPlans.org_id, user.org_id)))
+      .where(and(eq(agentPlans.id, planId), eq(agentPlans.org_id, user.org_id), eq(agentPlans.user_id, user.id)))
       .limit(1);
 
     if (!plan) {
@@ -190,7 +190,7 @@ agentPlanRoutes.post('/:id/execute', async (c) => {
     const [plan] = await db
       .select()
       .from(agentPlans)
-      .where(and(eq(agentPlans.id, planId), eq(agentPlans.org_id, user.org_id)))
+      .where(and(eq(agentPlans.id, planId), eq(agentPlans.org_id, user.org_id), eq(agentPlans.user_id, user.id)))
       .limit(1);
 
     if (!plan) {
@@ -226,7 +226,7 @@ agentPlanRoutes.post('/:id/pause', async (c) => {
     const [plan] = await db
       .select()
       .from(agentPlans)
-      .where(and(eq(agentPlans.id, planId), eq(agentPlans.org_id, user.org_id)))
+      .where(and(eq(agentPlans.id, planId), eq(agentPlans.org_id, user.org_id), eq(agentPlans.user_id, user.id)))
       .limit(1);
 
     if (!plan) {
@@ -262,7 +262,7 @@ agentPlanRoutes.post('/:id/resume', async (c) => {
     const [plan] = await db
       .select()
       .from(agentPlans)
-      .where(and(eq(agentPlans.id, planId), eq(agentPlans.org_id, user.org_id)))
+      .where(and(eq(agentPlans.id, planId), eq(agentPlans.org_id, user.org_id), eq(agentPlans.user_id, user.id)))
       .limit(1);
 
     if (!plan) {
@@ -311,7 +311,7 @@ agentPlanRoutes.post('/:id/abort', async (c) => {
     const [plan] = await db
       .select()
       .from(agentPlans)
-      .where(and(eq(agentPlans.id, planId), eq(agentPlans.org_id, user.org_id)))
+      .where(and(eq(agentPlans.id, planId), eq(agentPlans.org_id, user.org_id), eq(agentPlans.user_id, user.id)))
       .limit(1);
 
     if (!plan) {

--- a/apps/api/src/routes/clips.ts
+++ b/apps/api/src/routes/clips.ts
@@ -2,17 +2,72 @@
 import { Hono } from 'hono';
 import { eq, and, desc } from 'drizzle-orm';
 import { db } from '../lib/db.js';
-import { clips, messages, users } from '@deft/db/schema';
+import { clips, messages, projects, spaceMembers, tasks, users } from '@deft/db/schema';
 import { enqueue, QUEUE_NAMES } from '../lib/queues.js';
 import { getIO } from '../socket.js';
 import { writeFile, mkdir } from 'node:fs/promises';
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { randomUUID } from 'node:crypto';
+import { requireSpaceMembership } from '../lib/space-membership.js';
+import { visibleTaskCondition } from '../lib/task-visibility.js';
 
 export const clipRoutes = new Hono();
 
 const CLIP_DIR = join(process.cwd(), '..', '..', 'uploads', 'clips');
+
+async function canAccessMessage(messageId: string, orgId: string, userId: string) {
+  const [row] = await db.select({ id: messages.id, space_id: messages.space_id })
+    .from(messages)
+    .innerJoin(spaceMembers, and(
+      eq(messages.space_id, spaceMembers.space_id),
+      eq(spaceMembers.user_id, userId),
+    ))
+    .where(and(
+      eq(messages.id, messageId),
+      eq(messages.org_id, orgId),
+      eq(messages.is_deleted, false),
+    ))
+    .limit(1);
+  return row ?? null;
+}
+
+async function canAccessTask(taskId: string, orgId: string, userId: string) {
+  const [row] = await db.select({ id: tasks.id })
+    .from(tasks)
+    .innerJoin(projects, eq(tasks.project_id, projects.id))
+    .where(and(
+      eq(tasks.id, taskId),
+      eq(tasks.org_id, orgId),
+      eq(tasks.is_deleted, false),
+      visibleTaskCondition(userId),
+    ))
+    .limit(1);
+  return Boolean(row);
+}
+
+async function projectExists(projectId: string, orgId: string) {
+  const [row] = await db.select({ id: projects.id })
+    .from(projects)
+    .where(and(
+      eq(projects.id, projectId),
+      eq(projects.org_id, orgId),
+      eq(projects.is_deleted, false),
+    ))
+    .limit(1);
+  return Boolean(row);
+}
+
+async function canAccessClip(clip: typeof clips.$inferSelect, orgId: string, userId: string) {
+  if (clip.org_id !== orgId || clip.is_deleted) return false;
+  if (clip.message_id) return Boolean(await canAccessMessage(clip.message_id, orgId, userId));
+  if (clip.space_id) return requireSpaceMembership(clip.space_id, userId);
+  if (clip.context_type === 'space') return requireSpaceMembership(clip.context_id, userId);
+  if (clip.context_type === 'thread') return Boolean(await canAccessMessage(clip.context_id, orgId, userId));
+  if (clip.context_type === 'task') return canAccessTask(clip.context_id, orgId, userId);
+  if (clip.context_type === 'project') return projectExists(clip.context_id, orgId);
+  return clip.created_by === userId;
+}
 
 // POST /api/clips — upload a clip recording
 clipRoutes.post('/', async (c) => {
@@ -39,6 +94,39 @@ clipRoutes.post('/', async (c) => {
       return c.json({ error: 'Clip too large (max 50MB)', code: 'FILE_TOO_LARGE' }, 400);
     }
 
+    if (!['space', 'thread', 'task', 'project'].includes(contextType)) {
+      return c.json({ error: 'Invalid context_type', code: 'VALIDATION_ERROR' }, 400);
+    }
+
+    const targetSpaceId = spaceId || (contextType === 'space' ? contextId : null);
+    if (!targetSpaceId) {
+      return c.json({ error: 'space_id is required for this clip context', code: 'VALIDATION_ERROR' }, 400);
+    }
+    const isMember = await requireSpaceMembership(targetSpaceId, user.id);
+    if (!isMember) {
+      return c.json({ error: 'Not a member of this space', code: 'FORBIDDEN' }, 403);
+    }
+    if (contextType === 'thread') {
+      const parent = await canAccessMessage(contextId, user.org_id, user.id);
+      if (!parent) return c.json({ error: 'Thread not found', code: 'NOT_FOUND' }, 404);
+      if (targetSpaceId && parent.space_id !== targetSpaceId) {
+        return c.json({ error: 'Thread is not in this space', code: 'VALIDATION_ERROR' }, 400);
+      }
+    }
+    if (contextType === 'task' && !(await canAccessTask(contextId, user.org_id, user.id))) {
+      return c.json({ error: 'Task not found', code: 'NOT_FOUND' }, 404);
+    }
+    if (contextType === 'project' && !(await projectExists(contextId, user.org_id))) {
+      return c.json({ error: 'Project not found', code: 'NOT_FOUND' }, 404);
+    }
+    if (parentId) {
+      const parent = await canAccessMessage(parentId, user.org_id, user.id);
+      if (!parent) return c.json({ error: 'Parent message not found', code: 'NOT_FOUND' }, 404);
+      if (targetSpaceId && parent.space_id !== targetSpaceId) {
+        return c.json({ error: 'Parent message is not in this space', code: 'VALIDATION_ERROR' }, 400);
+      }
+    }
+
     // Look up user name
     const [userRecord] = await db.select({ name: users.name })
       .from(users).where(eq(users.id, user.id)).limit(1);
@@ -54,7 +142,7 @@ clipRoutes.post('/', async (c) => {
     // Create clip record
     const [clip] = await db.insert(clips).values({
       org_id: user.org_id,
-      space_id: spaceId || null,
+      space_id: targetSpaceId || null,
       context_type: contextType as any,
       context_id: contextId,
       mode: 'async',
@@ -71,7 +159,7 @@ clipRoutes.post('/', async (c) => {
     const placeholderContent = `[[clip:${clip!.id}:uploading]]`;
     const [msg] = await db.insert(messages).values({
       org_id: user.org_id,
-      space_id: spaceId || contextId,
+      space_id: targetSpaceId || contextId,
       user_id: user.id,
       content: placeholderContent,
       parent_id: parentId || null,
@@ -85,7 +173,7 @@ clipRoutes.post('/', async (c) => {
 
     // Broadcast the message in real time
     const io = getIO();
-    io?.to(`space:${spaceId || contextId}`).emit('message:new', {
+    io?.to(`space:${targetSpaceId}`).emit('message:new', {
       id: msg!.id,
       content: placeholderContent,
       user_id: user.id,
@@ -100,7 +188,7 @@ clipRoutes.post('/', async (c) => {
       file_ids: [],
       files: [],
       metadata: { clip_id: clip!.id, clip_status: 'processing' },
-      space_id: spaceId || contextId,
+      space_id: targetSpaceId || contextId,
       parent_id: parentId || null,
     });
 
@@ -109,7 +197,7 @@ clipRoutes.post('/', async (c) => {
       clip_id: clip!.id,
       org_id: user.org_id,
       message_id: msg!.id,
-      space_id: spaceId || contextId,
+      space_id: targetSpaceId || contextId,
       file_key: fileKey,
       context_type: contextType,
       context_id: contextId,
@@ -139,7 +227,7 @@ clipRoutes.get('/:id', async (c) => {
       .where(and(eq(clips.id, clipId), eq(clips.org_id, user.org_id)))
       .limit(1);
 
-    if (!clip) {
+    if (!clip || !(await canAccessClip(clip, user.org_id, user.id))) {
       return c.json({ error: 'Clip not found', code: 'NOT_FOUND' }, 404);
     }
 
@@ -153,14 +241,15 @@ clipRoutes.get('/:id', async (c) => {
 // GET /api/clips/:id/audio — stream clip audio
 clipRoutes.get('/:id/audio', async (c) => {
   try {
+    const user = c.get('user');
     const clipId = c.req.param('id');
 
     const [clip] = await db.select()
       .from(clips)
-      .where(eq(clips.id, clipId))
+      .where(and(eq(clips.id, clipId), eq(clips.org_id, user.org_id)))
       .limit(1);
 
-    if (!clip || clip.is_deleted) {
+    if (!clip || !(await canAccessClip(clip, user.org_id, user.id))) {
       return c.json({ error: 'Clip not found', code: 'NOT_FOUND' }, 404);
     }
 
@@ -190,6 +279,11 @@ clipRoutes.get('/space/:spaceId', async (c) => {
     const user = c.get('user');
     const spaceId = c.req.param('spaceId');
 
+    const isMember = await requireSpaceMembership(spaceId, user.id);
+    if (!isMember) {
+      return c.json({ error: 'Not a member of this space', code: 'FORBIDDEN' }, 403);
+    }
+
     const result = await db.select()
       .from(clips)
       .where(and(
@@ -218,7 +312,7 @@ clipRoutes.delete('/:id', async (c) => {
       .where(and(eq(clips.id, clipId), eq(clips.org_id, user.org_id)))
       .limit(1);
 
-    if (!clip) {
+    if (!clip || !(await canAccessClip(clip, user.org_id, user.id))) {
       return c.json({ error: 'Clip not found', code: 'NOT_FOUND' }, 404);
     }
 

--- a/apps/api/src/routes/daily-notes.ts
+++ b/apps/api/src/routes/daily-notes.ts
@@ -1,9 +1,11 @@
 import { Hono } from 'hono';
 import { z } from 'zod';
-import { eq, and, desc, ilike, or, sql } from 'drizzle-orm';
+import { eq, and, desc, ilike } from 'drizzle-orm';
 import { db } from '../lib/db.js';
 import { notes, noteFolders, noteVersions, noteShares, users } from '@deft/db/schema';
 import { enqueue, QUEUE_NAMES } from '../lib/queues.js';
+import { requireSpaceMembership } from '../lib/space-membership.js';
+import { visibleNoteCondition } from '../lib/note-visibility.js';
 
 const TASK_ID_PATTERN = /([A-Z]+-\d+)/;
 
@@ -40,6 +42,7 @@ const createNoteSchema = z.object({
   folder_id: z.string().nullable().optional(),
   is_template: z.boolean().optional(),
   visibility: visibilityEnum,
+  visibility_space_id: z.string().nullable().optional(),
 });
 
 const updateNoteSchema = z.object({
@@ -49,6 +52,7 @@ const updateNoteSchema = z.object({
   is_pinned: z.boolean().optional(),
   folder_id: z.string().nullable().optional(),
   visibility: z.enum(['private', 'org', 'space']).optional(),
+  visibility_space_id: z.string().nullable().optional(),
 });
 
 // ── Folder endpoints ──
@@ -133,6 +137,7 @@ dailyNoteRoutes.get('/templates', async (c) => {
       eq(notes.org_id, user.org_id),
       eq(notes.is_template, true),
       eq(notes.is_deleted, false),
+      visibleNoteCondition(user.id),
     ))
     .orderBy(notes.title);
   return c.json({ templates: rows });
@@ -156,12 +161,6 @@ dailyNoteRoutes.get('/', async (c) => {
   if (q) baseConditions.push(ilike(notes.title, `%${q}%`));
   if (folderId) baseConditions.push(eq(notes.folder_id, folderId));
 
-  // Visibility: own notes OR org-visible notes
-  const visibilityCondition = or(
-    eq(notes.user_id, user.id),
-    eq(notes.visibility, 'org'),
-  );
-
   const rows = await db.select({
     id: notes.id,
     title: notes.title,
@@ -170,11 +169,12 @@ dailyNoteRoutes.get('/', async (c) => {
     is_pinned: notes.is_pinned,
     folder_id: notes.folder_id,
     visibility: notes.visibility,
+    visibility_space_id: notes.visibility_space_id,
     user_id: notes.user_id,
     created_at: notes.created_at,
     updated_at: notes.updated_at,
   }).from(notes)
-    .where(and(...baseConditions, visibilityCondition))
+    .where(and(...baseConditions, visibleNoteCondition(user.id)))
     .orderBy(desc(notes.is_pinned), desc(notes.updated_at))
     .limit(100);
 
@@ -186,6 +186,18 @@ dailyNoteRoutes.post('/', async (c) => {
   const user = c.get('user');
   const body = await c.req.json().catch(() => ({}));
   const parsed = createNoteSchema.safeParse(body);
+  const visibility = parsed.success && parsed.data.visibility ? parsed.data.visibility : 'private';
+  const visibilitySpaceId = parsed.success && parsed.data.visibility_space_id ? parsed.data.visibility_space_id : null;
+
+  if (visibility === 'space') {
+    if (!visibilitySpaceId) {
+      return c.json({ error: 'visibility_space_id required for space-visible notes', code: 'VALIDATION_ERROR' }, 400);
+    }
+    const isMember = await requireSpaceMembership(visibilitySpaceId, user.id);
+    if (!isMember) {
+      return c.json({ error: 'Not a member of this space', code: 'FORBIDDEN' }, 403);
+    }
+  }
 
   const [note] = await db.insert(notes).values({
     org_id: user.org_id,
@@ -195,7 +207,8 @@ dailyNoteRoutes.post('/', async (c) => {
     icon: parsed.success && parsed.data.icon ? parsed.data.icon : null,
     folder_id: parsed.success && parsed.data.folder_id ? parsed.data.folder_id : null,
     is_template: parsed.success && parsed.data.is_template ? parsed.data.is_template : false,
-    visibility: parsed.success && parsed.data.visibility ? parsed.data.visibility : 'private',
+    visibility,
+    visibility_space_id: visibility === 'space' ? visibilitySpaceId : null,
   }).returning();
 
   // Task 5.1 — scan note content for PREFIX-N task refs on create
@@ -216,7 +229,7 @@ dailyNoteRoutes.get('/:id', async (c) => {
       eq(notes.id, noteId),
       eq(notes.org_id, user.org_id),
       eq(notes.is_deleted, false),
-      or(eq(notes.user_id, user.id), eq(notes.visibility, 'org')),
+      visibleNoteCondition(user.id),
     ))
     .limit(1);
 
@@ -244,7 +257,7 @@ dailyNoteRoutes.patch('/:id', async (c) => {
       eq(notes.id, noteId),
       eq(notes.org_id, user.org_id),
       eq(notes.is_deleted, false),
-      or(eq(notes.user_id, user.id), eq(notes.visibility, 'org')),
+      visibleNoteCondition(user.id),
     ))
     .limit(1);
 
@@ -263,7 +276,23 @@ dailyNoteRoutes.patch('/:id', async (c) => {
   if (parsed.data.icon !== undefined) updates.icon = parsed.data.icon;
   if (parsed.data.is_pinned !== undefined) updates.is_pinned = parsed.data.is_pinned;
   if (parsed.data.folder_id !== undefined) updates.folder_id = parsed.data.folder_id;
+  const nextVisibility = parsed.data.visibility ?? full.visibility;
+  const nextVisibilitySpaceId = parsed.data.visibility_space_id !== undefined
+    ? parsed.data.visibility_space_id
+    : full.visibility_space_id;
+  if (nextVisibility === 'space') {
+    if (!nextVisibilitySpaceId) {
+      return c.json({ error: 'visibility_space_id required for space-visible notes', code: 'VALIDATION_ERROR' }, 400);
+    }
+    const isMember = await requireSpaceMembership(nextVisibilitySpaceId, user.id);
+    if (!isMember) {
+      return c.json({ error: 'Not a member of this space', code: 'FORBIDDEN' }, 403);
+    }
+  }
   if (parsed.data.visibility !== undefined) updates.visibility = parsed.data.visibility;
+  if (parsed.data.visibility_space_id !== undefined || parsed.data.visibility !== undefined) {
+    updates.visibility_space_id = nextVisibility === 'space' ? nextVisibilitySpaceId : null;
+  }
 
   if (Object.keys(updates).length === 0) {
     return c.json(full);

--- a/apps/api/src/routes/decisions.ts
+++ b/apps/api/src/routes/decisions.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono';
 import { eq, and, desc, ilike, sql } from 'drizzle-orm';
 import { db } from '../lib/db.js';
 import { wikiPages } from '@deft/db/schema';
+import { visibleWikiPageCondition } from '../lib/wiki-visibility.js';
 
 export const decisionRoutes = new Hono();
 
@@ -18,6 +19,7 @@ decisionRoutes.get('/', async (c) => {
     eq(wikiPages.org_id, user.org_id),
     eq(wikiPages.type, 'decision'),
     eq(wikiPages.is_deleted, false),
+    visibleWikiPageCondition(user.id),
   ];
 
   if (query) {
@@ -78,6 +80,7 @@ decisionRoutes.get('/:id', async (c) => {
         eq(wikiPages.org_id, user.org_id),
         eq(wikiPages.type, 'decision'),
         eq(wikiPages.is_deleted, false),
+        visibleWikiPageCondition(user.id),
       ),
     )
     .limit(1);
@@ -107,6 +110,7 @@ decisionRoutes.patch('/:id', async (c) => {
         eq(wikiPages.org_id, user.org_id),
         eq(wikiPages.type, 'decision'),
         eq(wikiPages.is_deleted, false),
+        visibleWikiPageCondition(user.id),
       ),
     )
     .limit(1);

--- a/apps/api/src/routes/knowledge.ts
+++ b/apps/api/src/routes/knowledge.ts
@@ -4,6 +4,8 @@ import { db } from '../lib/db.js';
 import { wikiPages, wikiCitations, messages, users, spaces } from '@deft/db/schema';
 import { getIO } from '../socket.js';
 import { enqueue, QUEUE_NAMES } from '../lib/queues.js';
+import { requireSpaceMembership } from '../lib/space-membership.js';
+import { visibleWikiPageCondition } from '../lib/wiki-visibility.js';
 
 export const knowledgeRoutes = new Hono();
 export const knowledgeAggRoutes = new Hono();
@@ -61,6 +63,7 @@ knowledgeAggRoutes.get('/', async (c) => {
     const conditions: any[] = [
       eq(wikiPages.org_id, user.org_id),
       eq(wikiPages.is_deleted, false),
+      visibleWikiPageCondition(user.id),
     ];
 
     if (typeFilter) {
@@ -123,6 +126,11 @@ knowledgeRoutes.get('/:spaceId/knowledge', async (c) => {
     const typeFilter = c.req.query('type');
     const limitParam = Math.min(parseInt(c.req.query('limit') || '50'), 100);
 
+    const isMember = await requireSpaceMembership(spaceId, user.id);
+    if (!isMember) {
+      return c.json({ error: 'Not a member of this space', code: 'FORBIDDEN' }, 403);
+    }
+
     // Find page IDs that have a citation from a message in this space
     const citedPageIds = await db.select({ page_id: wikiCitations.page_id })
       .from(wikiCitations)
@@ -145,6 +153,7 @@ knowledgeRoutes.get('/:spaceId/knowledge', async (c) => {
     const conditions: any[] = [
       eq(wikiPages.org_id, user.org_id),
       eq(wikiPages.is_deleted, false),
+      visibleWikiPageCondition(user.id),
       spaceCondition!,
     ];
 
@@ -192,6 +201,11 @@ knowledgeRoutes.post('/:spaceId/knowledge', async (c) => {
     const spaceId = c.req.param('spaceId');
     const body = await c.req.json();
     const { type, title, content } = body;
+
+    const isMember = await requireSpaceMembership(spaceId, user.id);
+    if (!isMember) {
+      return c.json({ error: 'Not a member of this space', code: 'FORBIDDEN' }, 403);
+    }
 
     if (!type || !title) {
       return c.json({ error: 'type and title are required', code: 'VALIDATION_ERROR' }, 400);
@@ -268,6 +282,11 @@ knowledgeRoutes.patch('/:spaceId/knowledge/:id', async (c) => {
     const entryId = c.req.param('id');
     const body = await c.req.json();
 
+    const isMember = await requireSpaceMembership(spaceId, user.id);
+    if (!isMember) {
+      return c.json({ error: 'Not a member of this space', code: 'FORBIDDEN' }, 403);
+    }
+
     const updates: Record<string, unknown> = {};
     if (body.title !== undefined) updates.title = body.title;
     if (body.content !== undefined) updates.content = body.content;
@@ -282,6 +301,8 @@ knowledgeRoutes.patch('/:spaceId/knowledge/:id', async (c) => {
       .where(and(
         eq(wikiPages.id, entryId),
         eq(wikiPages.org_id, user.org_id),
+        eq(wikiPages.space_id, spaceId),
+        visibleWikiPageCondition(user.id),
         eq(wikiPages.is_deleted, false),
       ))
       .returning();
@@ -326,11 +347,18 @@ knowledgeRoutes.delete('/:spaceId/knowledge/:id', async (c) => {
     const spaceId = c.req.param('spaceId');
     const entryId = c.req.param('id');
 
+    const isMember = await requireSpaceMembership(spaceId, user.id);
+    if (!isMember) {
+      return c.json({ error: 'Not a member of this space', code: 'FORBIDDEN' }, 403);
+    }
+
     const [deleted] = await db.update(wikiPages)
       .set({ is_deleted: true })
       .where(and(
         eq(wikiPages.id, entryId),
         eq(wikiPages.org_id, user.org_id),
+        eq(wikiPages.space_id, spaceId),
+        visibleWikiPageCondition(user.id),
       ))
       .returning();
 

--- a/apps/api/src/routes/messages.ts
+++ b/apps/api/src/routes/messages.ts
@@ -57,6 +57,31 @@ async function getReactionsForMessages(messageIds: string[]) {
   return result;
 }
 
+async function getVisibleMessage(messageId: string, orgId: string, userId: string) {
+  const [msg] = await db.select({
+    id: messages.id,
+    org_id: messages.org_id,
+    space_id: messages.space_id,
+    user_id: messages.user_id,
+    content: messages.content,
+    created_at: messages.created_at,
+    edited_at: messages.edited_at,
+  })
+    .from(messages)
+    .innerJoin(spaceMembers, and(
+      eq(messages.space_id, spaceMembers.space_id),
+      eq(spaceMembers.user_id, userId),
+    ))
+    .where(and(
+      eq(messages.id, messageId),
+      eq(messages.org_id, orgId),
+      eq(messages.is_deleted, false),
+    ))
+    .limit(1);
+
+  return msg ?? null;
+}
+
 // Helper: get reply counts and latest_reply_at for a set of message IDs
 async function getReplyStats(messageIds: string[]) {
   if (messageIds.length === 0) return new Map();
@@ -318,6 +343,13 @@ messageRoutes.post('/:spaceId', async (c) => {
     const isMember = await requireSpaceMembership(spaceId, user.id);
     if (!isMember) {
       return c.json({ error: 'Not a member of this space', code: 'FORBIDDEN' }, 403);
+    }
+
+    if (parsed.data.parent_id) {
+      const parentMsg = await getVisibleMessage(parsed.data.parent_id, user.org_id, user.id);
+      if (!parentMsg || parentMsg.space_id !== spaceId) {
+        return c.json({ error: 'Parent message not found', code: 'NOT_FOUND' }, 404);
+      }
     }
 
     // Normalize plain @defty / @deft / @agent (case-insensitive) into structured
@@ -718,7 +750,7 @@ messageRoutes.patch('/:id', async (c) => {
     return c.json({ error: 'Content required', code: 'VALIDATION_ERROR' }, 400);
   }
 
-  const [existing] = await db.select().from(messages).where(eq(messages.id, messageId)).limit(1);
+  const existing = await getVisibleMessage(messageId, user.org_id, user.id);
   if (!existing) {
     return c.json({ error: 'Message not found', code: 'NOT_FOUND' }, 404);
   }
@@ -751,7 +783,7 @@ messageRoutes.delete('/:id', async (c) => {
   const user = c.get('user');
   const messageId = c.req.param('id');
 
-  const [existing] = await db.select().from(messages).where(eq(messages.id, messageId)).limit(1);
+  const existing = await getVisibleMessage(messageId, user.org_id, user.id);
   if (!existing) {
     return c.json({ error: 'Message not found', code: 'NOT_FOUND' }, 404);
   }
@@ -784,15 +816,7 @@ messageRoutes.post('/:id/reactions', async (c) => {
       return c.json({ error: 'Emoji required', code: 'VALIDATION_ERROR' }, 400);
     }
 
-    // Check that the message exists
-    const [msg] = await db.select({
-      id: messages.id,
-      space_id: messages.space_id,
-    })
-      .from(messages)
-      .where(eq(messages.id, messageId))
-      .limit(1);
-
+    const msg = await getVisibleMessage(messageId, user.org_id, user.id);
     if (!msg) {
       return c.json({ error: 'Message not found', code: 'NOT_FOUND' }, 404);
     }
@@ -842,15 +866,7 @@ messageRoutes.delete('/:id/reactions/:emoji', async (c) => {
     const messageId = c.req.param('id');
     const emoji = decodeURIComponent(c.req.param('emoji'));
 
-    // Check that the message exists
-    const [msg] = await db.select({
-      id: messages.id,
-      space_id: messages.space_id,
-    })
-      .from(messages)
-      .where(eq(messages.id, messageId))
-      .limit(1);
-
+    const msg = await getVisibleMessage(messageId, user.org_id, user.id);
     if (!msg) {
       return c.json({ error: 'Message not found', code: 'NOT_FOUND' }, 404);
     }
@@ -891,21 +907,9 @@ messageRoutes.get('/:id/thread', async (c) => {
     const user = c.get('user');
     const messageId = c.req.param('id');
 
-    // Verify parent message exists and user has access
-    const [parentMsg] = await db.select({
-      id: messages.id,
-      org_id: messages.org_id,
-    })
-      .from(messages)
-      .where(eq(messages.id, messageId))
-      .limit(1);
-
+    const parentMsg = await getVisibleMessage(messageId, user.org_id, user.id);
     if (!parentMsg) {
       return c.json({ error: 'Message not found', code: 'NOT_FOUND' }, 404);
-    }
-
-    if (parentMsg.org_id !== user.org_id) {
-      return c.json({ error: 'Forbidden', code: 'FORBIDDEN' }, 403);
     }
 
     const replies = await db.select({
@@ -955,6 +959,11 @@ messageRoutes.post('/:parentId/thread-read', async (c) => {
     const user = c.get('user');
     const parentId = c.req.param('parentId');
 
+    const parentMsg = await getVisibleMessage(parentId, user.org_id, user.id);
+    if (!parentMsg) {
+      return c.json({ error: 'Message not found', code: 'NOT_FOUND' }, 404);
+    }
+
     await db.insert(threadReads).values({
       user_id: user.id,
       parent_message_id: parentId,
@@ -977,9 +986,8 @@ messageRoutes.get('/:id/history', async (c) => {
     const user = c.get('user');
     const messageId = c.req.param('id');
 
-    const [msg] = await db.select({ org_id: messages.org_id }).from(messages)
-      .where(eq(messages.id, messageId)).limit(1);
-    if (!msg || msg.org_id !== user.org_id) {
+    const msg = await getVisibleMessage(messageId, user.org_id, user.id);
+    if (!msg) {
       return c.json({ error: 'Message not found', code: 'NOT_FOUND' }, 404);
     }
 
@@ -1003,6 +1011,11 @@ messageRoutes.get('/:spaceId/read-receipts', async (c) => {
   try {
     const user = c.get('user');
     const spaceId = c.req.param('spaceId');
+
+    const isMember = await requireSpaceMembership(spaceId, user.id);
+    if (!isMember) {
+      return c.json({ error: 'Not a member of this space', code: 'FORBIDDEN' }, 403);
+    }
 
     const receipts = await db.select({
       user_id: spaceMembers.user_id,

--- a/apps/api/src/routes/projects.ts
+++ b/apps/api/src/routes/projects.ts
@@ -5,6 +5,7 @@ import { db } from '../lib/db.js';
 import { projects, tasks, taskLabels, labels, users, taskActivity, notifications } from '@deft/db/schema';
 import { getIO, emitToUser } from '../socket.js';
 import { enqueue, QUEUE_NAMES } from '../lib/queues.js';
+import { visibleTaskCondition } from '../lib/task-visibility.js';
 import {
   getProjectResolvedConfig,
 } from '../lib/project-resolved-config.js';
@@ -42,12 +43,46 @@ projectRoutes.get('/', async (c) => {
         select count(*)::int from "tasks"
         where "tasks"."project_id" = "projects"."id"
           and "tasks"."is_deleted" = false
+          and (
+            coalesce("tasks"."metadata"->>'visibility', 'org') != 'restricted'
+            or "tasks"."assignee_id" = ${user.id}
+            or "tasks"."created_by" = ${user.id}
+            or "projects"."lead_id" = ${user.id}
+            or coalesce("tasks"."metadata"->'visible_user_ids', '[]'::jsonb) ? ${user.id}
+            or exists (
+              select 1 from "task_watchers"
+              where "task_watchers"."task_id" = "tasks"."id"
+                and "task_watchers"."user_id" = ${user.id}
+            )
+            or exists (
+              select 1 from "task_assignees"
+              where "task_assignees"."task_id" = "tasks"."id"
+                and "task_assignees"."user_id" = ${user.id}
+            )
+          )
       )`.as('total_tasks'),
       done_tasks: sql<number>`(
         select count(*)::int from "tasks"
         where "tasks"."project_id" = "projects"."id"
           and "tasks"."is_deleted" = false
           and "tasks"."status" = 'done'
+          and (
+            coalesce("tasks"."metadata"->>'visibility', 'org') != 'restricted'
+            or "tasks"."assignee_id" = ${user.id}
+            or "tasks"."created_by" = ${user.id}
+            or "projects"."lead_id" = ${user.id}
+            or coalesce("tasks"."metadata"->'visible_user_ids', '[]'::jsonb) ? ${user.id}
+            or exists (
+              select 1 from "task_watchers"
+              where "task_watchers"."task_id" = "tasks"."id"
+                and "task_watchers"."user_id" = ${user.id}
+            )
+            or exists (
+              select 1 from "task_assignees"
+              where "task_assignees"."task_id" = "tasks"."id"
+                and "task_assignees"."user_id" = ${user.id}
+            )
+          )
       )`.as('done_tasks'),
       is_archived: projects.is_archived,
       created_at: projects.created_at,
@@ -144,6 +179,9 @@ projectRoutes.post('/', async (c) => {
     return c.json({ error: 'Failed to create project', code: 'INTERNAL_ERROR' }, 500);
   }
 });
+
+// Register before GET /:id so the generic detail route cannot swallow it.
+projectRoutes.get('/:id/tasks', listProjectTasks);
 
 // GET /api/projects/:id — get single project with task counts per status
 projectRoutes.get('/:id', async (c) => {
@@ -416,7 +454,7 @@ const createTaskSchema = z.object({
 });
 
 // GET /api/projects/:id/tasks — list all tasks for a project
-projectRoutes.get('/:id/tasks', async (c) => {
+async function listProjectTasks(c: any) {
   try {
     const user = c.get('user');
     const projectId = c.req.param('id');
@@ -464,6 +502,7 @@ projectRoutes.get('/:id/tasks', async (c) => {
       assignee_avatar: users.avatar_url,
     })
       .from(tasks)
+      .innerJoin(projects, eq(tasks.project_id, projects.id))
       .leftJoin(users, eq(tasks.assignee_id, users.id))
       .where(
         and(
@@ -471,6 +510,7 @@ projectRoutes.get('/:id/tasks', async (c) => {
           eq(tasks.is_deleted, false),
           eq(tasks.is_template, false),
           isNull(tasks.parent_task_id),
+          visibleTaskCondition(user.id),
         )
       )
       .orderBy(tasks.sort_order);
@@ -524,7 +564,7 @@ projectRoutes.get('/:id/tasks', async (c) => {
     console.error('Failed to fetch project tasks:', err);
     return c.json({ error: 'Failed to fetch tasks', code: 'INTERNAL_ERROR' }, 500);
   }
-});
+}
 
 // POST /api/projects/:id/tasks — create task in project
 projectRoutes.post('/:id/tasks', async (c) => {

--- a/apps/api/src/routes/search.ts
+++ b/apps/api/src/routes/search.ts
@@ -3,6 +3,7 @@ import { eq, and, ilike, desc, or, gte, lte, inArray } from 'drizzle-orm';
 import { db } from '../lib/db.js';
 import { tasks, projects, spaces, users, messages, orgMembers, tags, notes, spaceMembers } from '@deft/db/schema';
 import { retrieveContext, type ContextResult } from '../lib/retrieve-context.js';
+import { visibleTaskCondition } from '../lib/task-visibility.js';
 
 export const searchRoutes = new Hono();
 
@@ -61,7 +62,7 @@ searchRoutes.get('/', async (c) => {
     })
       .from(tasks)
       .innerJoin(projects, eq(tasks.project_id, projects.id))
-      .where(and(...taskConditions))
+      .where(and(...taskConditions, visibleTaskCondition(user.id)))
       .orderBy(desc(tasks.updated_at))
       .limit(5);
 

--- a/apps/api/src/routes/spaces.ts
+++ b/apps/api/src/routes/spaces.ts
@@ -230,6 +230,9 @@ spaceRoutes.get('/:id', async (c) => {
       return c.json({ error: 'Space not found', code: 'NOT_FOUND' }, 404);
     }
 
+    const isMember = await requireSpaceMembership(spaceId, user.id);
+    if (!isMember) return c.json({ error: 'Not a member of this space', code: 'FORBIDDEN' }, 403);
+
     return c.json(space);
   } catch (err) {
     console.error('Failed to fetch space:', err);
@@ -385,9 +388,14 @@ spaceRoutes.patch('/:id/mute', async (c) => {
     const spaceId = c.req.param('id');
     const { muted } = await c.req.json();
 
-    await db.update(spaceMembers)
+    const updated = await db.update(spaceMembers)
       .set({ is_muted: !!muted })
-      .where(and(eq(spaceMembers.space_id, spaceId), eq(spaceMembers.user_id, user.id)));
+      .where(and(eq(spaceMembers.space_id, spaceId), eq(spaceMembers.user_id, user.id)))
+      .returning({ id: spaceMembers.id });
+
+    if (updated.length === 0) {
+      return c.json({ error: 'Not a member of this space', code: 'FORBIDDEN' }, 403);
+    }
 
     return c.json({ success: true, muted: !!muted });
   } catch (err) {
@@ -401,6 +409,9 @@ spaceRoutes.post('/:id/read', async (c) => {
   try {
     const user = c.get('user');
     const spaceId = c.req.param('id');
+
+    const isMember = await requireSpaceMembership(spaceId, user.id);
+    if (!isMember) return c.json({ error: 'Not a member of this space', code: 'FORBIDDEN' }, 403);
 
     // Get the latest message in this space
     const [latestMessage] = await db.select({ id: messages.id })
@@ -561,7 +572,7 @@ spaceRoutes.post('/:id/mark-unread', async (c) => {
     // Get the message's created_at, then set read position to 1ms before it
     const [msg] = await db.select({ created_at: messages.created_at })
       .from(messages)
-      .where(eq(messages.id, message_id))
+      .where(and(eq(messages.id, message_id), eq(messages.space_id, spaceId), eq(messages.org_id, user.org_id)))
       .limit(1);
 
     if (!msg) {
@@ -569,9 +580,14 @@ spaceRoutes.post('/:id/mark-unread', async (c) => {
     }
 
     const unreadAt = new Date(msg.created_at!.getTime() - 1);
-    await db.update(spaceMembers)
+    const updated = await db.update(spaceMembers)
       .set({ last_read_at: unreadAt, last_read_message_id: null })
-      .where(and(eq(spaceMembers.space_id, spaceId), eq(spaceMembers.user_id, user.id)));
+      .where(and(eq(spaceMembers.space_id, spaceId), eq(spaceMembers.user_id, user.id)))
+      .returning({ id: spaceMembers.id });
+
+    if (updated.length === 0) {
+      return c.json({ error: 'Not a member of this space', code: 'FORBIDDEN' }, 403);
+    }
 
     return c.json({ success: true });
   } catch (err) {
@@ -590,6 +606,9 @@ spaceRoutes.patch('/:id/notification-level', async (c) => {
     if (!['all', 'mentions', 'nothing'].includes(level)) {
       return c.json({ error: 'level must be all, mentions, or nothing', code: 'VALIDATION_ERROR' }, 400);
     }
+
+    const isMember = await requireSpaceMembership(spaceId, user.id);
+    if (!isMember) return c.json({ error: 'Not a member of this space', code: 'FORBIDDEN' }, 403);
 
     await db.update(spaceMembers)
       .set({

--- a/apps/api/src/routes/tasks.ts
+++ b/apps/api/src/routes/tasks.ts
@@ -7,6 +7,7 @@ import { getIO, emitToUser } from '../socket.js';
 import { enqueue, QUEUE_NAMES } from '../lib/queues.js';
 import { canDeleteTask } from '../lib/task-permissions.js';
 import { visibleTaskCondition } from '../lib/task-visibility.js';
+import { visibleWikiPageCondition } from '../lib/wiki-visibility.js';
 import { isValidTransition } from '../lib/task-status-machine.js';
 import { getProjectResolvedConfig } from '../lib/project-resolved-config.js';
 import { detectBlocksCycle } from '../lib/task-dependency.js';
@@ -2223,6 +2224,9 @@ taskRoutes.get('/:id/attachments', async (c) => {
     const user = c.get('user');
     const taskId = c.req.param('id');
 
+    const task = await getVisibleTaskForOrg(taskId, user.org_id, user.id);
+    if (!task) return c.json({ error: 'Task not found', code: 'NOT_FOUND' }, 404);
+
     const results = await db.select({
       id: files.id,
       filename: files.filename,
@@ -2244,7 +2248,12 @@ taskRoutes.get('/:id/attachments', async (c) => {
 // GET /api/tasks/:id/wiki-links — get wiki pages linked to this task
 taskRoutes.get('/:id/wiki-links', async (c) => {
   try {
+    const user = c.get('user');
     const taskId = c.req.param('id');
+
+    const task = await getVisibleTaskForOrg(taskId, user.org_id, user.id);
+    if (!task) return c.json({ error: 'Task not found', code: 'NOT_FOUND' }, 404);
+
     const links = await db.select({
       citation_id: wikiCitations.id,
       page_id: wikiPages.id,
@@ -2258,7 +2267,9 @@ taskRoutes.get('/:id/wiki-links', async (c) => {
       .where(and(
         eq(wikiCitations.source_type, 'task'),
         eq(wikiCitations.source_id, taskId),
+        eq(wikiPages.org_id, user.org_id),
         eq(wikiPages.is_deleted, false),
+        visibleWikiPageCondition(user.id),
       ));
     return c.json({ wiki_links: links });
   } catch (err) {
@@ -2275,9 +2286,17 @@ taskRoutes.post('/:id/wiki-links', async (c) => {
     const { slug } = await c.req.json();
     if (!slug) return c.json({ error: 'slug required', code: 'VALIDATION_ERROR' }, 400);
 
-    // Find the wiki page
+    const task = await getVisibleTaskForOrg(taskId, user.org_id, user.id);
+    if (!task) return c.json({ error: 'Task not found', code: 'NOT_FOUND' }, 404);
+
+    // Find a wiki page visible to this caller.
     const [page] = await db.select({ id: wikiPages.id }).from(wikiPages)
-      .where(and(eq(wikiPages.org_id, user.org_id), eq(wikiPages.slug, slug), eq(wikiPages.is_deleted, false)))
+      .where(and(
+        eq(wikiPages.org_id, user.org_id),
+        eq(wikiPages.slug, slug),
+        eq(wikiPages.is_deleted, false),
+        visibleWikiPageCondition(user.id),
+      ))
       .limit(1);
     if (!page) return c.json({ error: 'Wiki page not found', code: 'NOT_FOUND' }, 404);
 
@@ -2302,11 +2321,7 @@ taskRoutes.delete('/:id/wiki-links/:citationId', async (c) => {
     const taskId = c.req.param('id');
     const citationId = c.req.param('citationId');
 
-    const [task] = await db.select({ id: tasks.id })
-      .from(tasks)
-      .where(and(eq(tasks.id, taskId), eq(tasks.org_id, user.org_id)))
-      .limit(1);
-
+    const task = await getVisibleTaskForOrg(taskId, user.org_id, user.id);
     if (!task) {
       return c.json({ error: 'Task not found', code: 'NOT_FOUND' }, 404);
     }
@@ -2324,7 +2339,12 @@ taskRoutes.delete('/:id/wiki-links/:citationId', async (c) => {
 // GET /api/tasks/:id/subtree — recursive subtask tree
 taskRoutes.get('/:id/subtree', async (c) => {
   try {
+    const user = c.get('user');
     const taskId = c.req.param('id');
+
+    const task = await getVisibleTaskForOrg(taskId, user.org_id, user.id);
+    if (!task) return c.json({ error: 'Task not found', code: 'NOT_FOUND' }, 404);
+
     const result = await db.execute(sql`
       WITH RECURSIVE subtree AS (
         SELECT id, title, status, priority, parent_task_id, 0 as depth

--- a/apps/api/src/routes/tasks.ts
+++ b/apps/api/src/routes/tasks.ts
@@ -6,6 +6,7 @@ import { projects, tasks, taskComments, taskActivity, taskLabels, labels, users,
 import { getIO, emitToUser } from '../socket.js';
 import { enqueue, QUEUE_NAMES } from '../lib/queues.js';
 import { canDeleteTask } from '../lib/task-permissions.js';
+import { visibleTaskCondition } from '../lib/task-visibility.js';
 import { isValidTransition } from '../lib/task-status-machine.js';
 import { getProjectResolvedConfig } from '../lib/project-resolved-config.js';
 import { detectBlocksCycle } from '../lib/task-dependency.js';
@@ -101,14 +102,39 @@ async function getLabelsForTasks(taskIds: string[]) {
   return result;
 }
 
-// Helper: verify task exists and belongs to user's org, returns task or null
-async function getTaskForOrg(taskId: string, orgId: string) {
-  const [task] = await db.select()
+async function getVisibleTaskForOrg(taskId: string, orgId: string, userId: string) {
+  const [task] = await db.select({
+    id: tasks.id,
+    org_id: tasks.org_id,
+    project_id: tasks.project_id,
+    number: tasks.number,
+    title: tasks.title,
+    description: tasks.description,
+    status: tasks.status,
+    priority: tasks.priority,
+    assignee_id: tasks.assignee_id,
+    created_by: tasks.created_by,
+    due_date: tasks.due_date,
+    start_date: tasks.start_date,
+    estimation: tasks.estimation,
+    is_template: tasks.is_template,
+    recurrence: tasks.recurrence,
+    recurrence_source_id: tasks.recurrence_source_id,
+    sort_order: tasks.sort_order,
+    source_message_id: tasks.source_message_id,
+    parent_task_id: tasks.parent_task_id,
+    is_deleted: tasks.is_deleted,
+    metadata: tasks.metadata,
+    created_at: tasks.created_at,
+    updated_at: tasks.updated_at,
+  })
     .from(tasks)
+    .innerJoin(projects, eq(tasks.project_id, projects.id))
     .where(
       and(
         eq(tasks.id, taskId),
         eq(tasks.org_id, orgId),
+        visibleTaskCondition(userId),
       )
     )
     .limit(1);
@@ -348,6 +374,7 @@ taskRoutes.get('/search', async (c) => {
             eq(tasks.is_deleted, false),
             eq(projects.prefix, prefix),
             eq(tasks.number, num),
+            visibleTaskCondition(user.id),
           )
         )
         .limit(20);
@@ -367,6 +394,7 @@ taskRoutes.get('/search', async (c) => {
             eq(tasks.org_id, user.org_id),
             eq(tasks.is_deleted, false),
             ilike(tasks.title, `%${q}%`),
+            visibleTaskCondition(user.id),
           )
         )
         .limit(20);
@@ -642,11 +670,8 @@ taskRoutes.get('/:id/watchers', async (c) => {
     const user = c.get('user');
     if (!user) return c.json({ error: 'Unauthorized', code: 'UNAUTHORIZED' }, 401);
     const taskId = c.req.param('id');
-    const taskRow = await db.select({ id: tasks.id })
-      .from(tasks)
-      .where(and(eq(tasks.id, taskId), eq(tasks.org_id, user.org_id)))
-      .limit(1);
-    if (!taskRow[0]) return c.json({ error: 'Not found', code: 'NOT_FOUND' }, 404);
+    const taskRow = await getVisibleTaskForOrg(taskId, user.org_id, user.id);
+    if (!taskRow) return c.json({ error: 'Not found', code: 'NOT_FOUND' }, 404);
     const watchers = await db.select({
       id: taskWatchers.id,
       user_id: taskWatchers.user_id,
@@ -752,11 +777,8 @@ taskRoutes.get('/:id/assignees', async (c) => {
     const user = c.get('user');
     if (!user) return c.json({ error: 'Unauthorized', code: 'UNAUTHORIZED' }, 401);
     const taskId = c.req.param('id');
-    const taskRow = await db.select({ id: tasks.id })
-      .from(tasks)
-      .where(and(eq(tasks.id, taskId), eq(tasks.org_id, user.org_id)))
-      .limit(1);
-    if (!taskRow[0]) return c.json({ error: 'Not found', code: 'NOT_FOUND' }, 404);
+    const taskRow = await getVisibleTaskForOrg(taskId, user.org_id, user.id);
+    if (!taskRow) return c.json({ error: 'Not found', code: 'NOT_FOUND' }, 404);
     const assignees = await db.select({
       id: taskAssignees.id,
       user_id: taskAssignees.user_id,
@@ -811,6 +833,7 @@ taskRoutes.get('/:id', async (c) => {
           eq(tasks.id, taskId),
           eq(tasks.org_id, user.org_id),
           eq(tasks.is_deleted, false),
+          visibleTaskCondition(user.id),
         )
       )
       .limit(1);
@@ -917,7 +940,7 @@ taskRoutes.get('/:id/comments', async (c) => {
     const user = c.get('user');
     const taskId = c.req.param('id');
 
-    const task = await getTaskForOrg(taskId, user.org_id);
+    const task = await getVisibleTaskForOrg(taskId, user.org_id, user.id);
     if (!task) {
       return c.json({ error: 'Task not found', code: 'NOT_FOUND' }, 404);
     }
@@ -962,7 +985,7 @@ taskRoutes.post('/:id/comments', async (c) => {
       return c.json({ error: 'Invalid input', code: 'VALIDATION_ERROR' }, 400);
     }
 
-    const task = await getTaskForOrg(taskId, user.org_id);
+    const task = await getVisibleTaskForOrg(taskId, user.org_id, user.id);
     if (!task) {
       return c.json({ error: 'Task not found', code: 'NOT_FOUND' }, 404);
     }
@@ -1047,7 +1070,7 @@ taskRoutes.get('/:id/activity', async (c) => {
     const user = c.get('user');
     const taskId = c.req.param('id');
 
-    const task = await getTaskForOrg(taskId, user.org_id);
+    const task = await getVisibleTaskForOrg(taskId, user.org_id, user.id);
     if (!task) {
       return c.json({ error: 'Task not found', code: 'NOT_FOUND' }, 404);
     }
@@ -1088,7 +1111,7 @@ taskRoutes.post('/:id/labels', async (c) => {
       return c.json({ error: 'Invalid input', code: 'VALIDATION_ERROR' }, 400);
     }
 
-    const task = await getTaskForOrg(taskId, user.org_id);
+    const task = await getVisibleTaskForOrg(taskId, user.org_id, user.id);
     if (!task) {
       return c.json({ error: 'Task not found', code: 'NOT_FOUND' }, 404);
     }
@@ -1130,7 +1153,7 @@ taskRoutes.delete('/:id/labels/:labelId', async (c) => {
     const taskId = c.req.param('id');
     const labelId = c.req.param('labelId');
 
-    const task = await getTaskForOrg(taskId, user.org_id);
+    const task = await getVisibleTaskForOrg(taskId, user.org_id, user.id);
     if (!task) {
       return c.json({ error: 'Task not found', code: 'NOT_FOUND' }, 404);
     }
@@ -1504,7 +1527,7 @@ taskRoutes.patch('/:id', async (c) => {
       return c.json({ error: 'Invalid input', code: 'VALIDATION_ERROR' }, 400);
     }
 
-    const existingTask = await getTaskForOrg(taskId, user.org_id);
+    const existingTask = await getVisibleTaskForOrg(taskId, user.org_id, user.id);
     if (!existingTask) {
       return c.json({ error: 'Task not found', code: 'NOT_FOUND' }, 404);
     }
@@ -1893,7 +1916,7 @@ taskRoutes.delete('/:id', async (c) => {
     const user = c.get('user');
     const taskId = c.req.param('id');
 
-    const existingTask = await getTaskForOrg(taskId, user.org_id);
+    const existingTask = await getVisibleTaskForOrg(taskId, user.org_id, user.id);
     if (!existingTask) {
       return c.json({ error: 'Task not found', code: 'NOT_FOUND' }, 404);
     }
@@ -1937,7 +1960,7 @@ taskRoutes.post('/:id/duplicate', async (c) => {
     const user = c.get('user');
     const taskId = c.req.param('id');
 
-    const original = await getTaskForOrg(taskId, user.org_id);
+    const original = await getVisibleTaskForOrg(taskId, user.org_id, user.id);
     if (!original) {
       return c.json({ error: 'Task not found', code: 'NOT_FOUND' }, 404);
     }
@@ -1992,7 +2015,7 @@ taskRoutes.get('/:id/dependencies', async (c) => {
     const user = c.get('user');
     const taskId = c.req.param('id');
 
-    const task = await getTaskForOrg(taskId, user.org_id);
+    const task = await getVisibleTaskForOrg(taskId, user.org_id, user.id);
     if (!task) {
       return c.json({ error: 'Task not found', code: 'NOT_FOUND' }, 404);
     }
@@ -2105,12 +2128,12 @@ taskRoutes.post('/:id/dependencies', async (c) => {
       return c.json({ error: 'Invalid input', code: 'VALIDATION_ERROR' }, 400);
     }
 
-    const task = await getTaskForOrg(taskId, user.org_id);
+    const task = await getVisibleTaskForOrg(taskId, user.org_id, user.id);
     if (!task) {
       return c.json({ error: 'Task not found', code: 'NOT_FOUND' }, 404);
     }
 
-    const targetTask = await getTaskForOrg(parsed.data.target_task_id, user.org_id);
+    const targetTask = await getVisibleTaskForOrg(parsed.data.target_task_id, user.org_id, user.id);
     if (!targetTask) {
       return c.json({ error: 'Target task not found', code: 'NOT_FOUND' }, 404);
     }
@@ -2166,7 +2189,7 @@ taskRoutes.delete('/:id/dependencies/:relationId', async (c) => {
     const taskId = c.req.param('id');
     const relationId = c.req.param('relationId');
 
-    const task = await getTaskForOrg(taskId, user.org_id);
+    const task = await getVisibleTaskForOrg(taskId, user.org_id, user.id);
     if (!task) {
       return c.json({ error: 'Task not found', code: 'NOT_FOUND' }, 404);
     }
@@ -2335,7 +2358,7 @@ taskRoutes.get('/:id/reactions', async (c) => {
   try {
     const user = c.get('user');
     const taskId = c.req.param('id');
-    const task = await getTaskForOrg(taskId, user.org_id);
+    const task = await getVisibleTaskForOrg(taskId, user.org_id, user.id);
     if (!task) return c.json({ error: 'Task not found', code: 'NOT_FOUND' }, 404);
 
     const rows = await db.select({
@@ -2375,7 +2398,7 @@ taskRoutes.post('/:id/reactions', async (c) => {
       return c.json({ error: 'Invalid input', code: 'VALIDATION_ERROR' }, 400);
     }
 
-    const task = await getTaskForOrg(taskId, user.org_id);
+    const task = await getVisibleTaskForOrg(taskId, user.org_id, user.id);
     if (!task) return c.json({ error: 'Task not found', code: 'NOT_FOUND' }, 404);
 
     await db.execute(sql`
@@ -2402,7 +2425,7 @@ taskRoutes.delete('/:id/reactions/:emoji', async (c) => {
     const taskId = c.req.param('id');
     const emoji = decodeURIComponent(c.req.param('emoji'));
 
-    const task = await getTaskForOrg(taskId, user.org_id);
+    const task = await getVisibleTaskForOrg(taskId, user.org_id, user.id);
     if (!task) return c.json({ error: 'Task not found', code: 'NOT_FOUND' }, 404);
 
     await db.delete(taskReactions).where(and(

--- a/apps/api/src/routes/upload.ts
+++ b/apps/api/src/routes/upload.ts
@@ -1,15 +1,53 @@
 import { Hono } from 'hono';
-import { eq } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 import { db } from '../lib/db.js';
-import { files } from '@deft/db/schema';
+import { files, messages, projects, spaceMembers, tasks } from '@deft/db/schema';
 import { writeFile, mkdir, readFile } from 'node:fs/promises';
 import { join, basename } from 'node:path';
 import { randomUUID } from 'node:crypto';
+import { visibleTaskCondition } from '../lib/task-visibility.js';
 
 export const uploadRoutes = new Hono();
 export const fileServingRoutes = new Hono();
 
 const UPLOAD_DIR = join(process.cwd(), 'uploads');
+
+async function canAccessMessage(messageId: string, orgId: string, userId: string) {
+  const [row] = await db.select({ id: messages.id })
+    .from(messages)
+    .innerJoin(spaceMembers, and(
+      eq(messages.space_id, spaceMembers.space_id),
+      eq(spaceMembers.user_id, userId),
+    ))
+    .where(and(
+      eq(messages.id, messageId),
+      eq(messages.org_id, orgId),
+      eq(messages.is_deleted, false),
+    ))
+    .limit(1);
+  return Boolean(row);
+}
+
+async function canAccessTask(taskId: string, orgId: string, userId: string) {
+  const [row] = await db.select({ id: tasks.id })
+    .from(tasks)
+    .innerJoin(projects, eq(tasks.project_id, projects.id))
+    .where(and(
+      eq(tasks.id, taskId),
+      eq(tasks.org_id, orgId),
+      eq(tasks.is_deleted, false),
+      visibleTaskCondition(userId),
+    ))
+    .limit(1);
+  return Boolean(row);
+}
+
+async function canAccessFile(file: typeof files.$inferSelect, orgId: string, userId: string) {
+  if (file.org_id !== orgId) return false;
+  if (file.task_id) return canAccessTask(file.task_id, orgId, userId);
+  if (file.message_id) return canAccessMessage(file.message_id, orgId, userId);
+  return file.uploaded_by === userId;
+}
 
 // POST /api/upload — multipart file upload (protected)
 uploadRoutes.post('/', async (c) => {
@@ -39,6 +77,13 @@ uploadRoutes.post('/', async (c) => {
     const taskId = c.req.query('task_id') || null;
     const messageId = c.req.query('message_id') || null;
 
+    if (taskId && !(await canAccessTask(taskId, user.org_id, user.id))) {
+      return c.json({ error: 'Task not found', code: 'NOT_FOUND' }, 404);
+    }
+    if (messageId && !(await canAccessMessage(messageId, user.org_id, user.id))) {
+      return c.json({ error: 'Message not found', code: 'NOT_FOUND' }, 404);
+    }
+
     const [inserted] = await db.insert(files).values({
       org_id: user.org_id,
       uploaded_by: user.id,
@@ -63,9 +108,10 @@ uploadRoutes.post('/', async (c) => {
   }
 });
 
-// GET /api/files/:id — serve a file (publicly accessible, no auth)
+// GET /api/files/:id — serve a file visible to the authenticated caller.
 fileServingRoutes.get('/:id', async (c) => {
   try {
+    const user = c.get('user');
     const fileId = c.req.param('id');
 
     const [fileRecord] = await db.select()
@@ -74,6 +120,10 @@ fileServingRoutes.get('/:id', async (c) => {
       .limit(1);
 
     if (!fileRecord) {
+      return c.json({ error: 'File not found', code: 'NOT_FOUND' }, 404);
+    }
+
+    if (!await canAccessFile(fileRecord, user.org_id, user.id)) {
       return c.json({ error: 'File not found', code: 'NOT_FOUND' }, 404);
     }
 

--- a/apps/api/src/routes/wiki.ts
+++ b/apps/api/src/routes/wiki.ts
@@ -4,6 +4,8 @@ import { eq, and, desc, sql, or, ilike, inArray } from 'drizzle-orm';
 import { db } from '../lib/db.js';
 import { wikiPages, wikiLinks, wikiCitations, wikiOpsLog, wikiPageVersions, spaces, notifications, orgMembers } from '@deft/db/schema';
 import { ne } from 'drizzle-orm';
+import { requireSpaceMembership } from '../lib/space-membership.js';
+import { visibleWikiPageCondition } from '../lib/wiki-visibility.js';
 
 /** Notify all org members about a wiki change (except the actor) */
 async function notifyWikiChange(orgId: string, actorId: string, title: string, body: string, slug: string) {
@@ -56,6 +58,7 @@ wikiRoutes.get('/', async (c) => {
     const conditions: any[] = [
       eq(wikiPages.org_id, user.org_id),
       eq(wikiPages.is_deleted, false),
+      visibleWikiPageCondition(user.id),
     ];
 
     if (typeFilter && ['concept', 'entity', 'decision', 'resource', 'procedure', 'preference', 'fact'].includes(typeFilter)) {
@@ -156,7 +159,7 @@ wikiRoutes.get('/graph', async (c) => {
       confidence: wikiPages.confidence,
     })
       .from(wikiPages)
-      .where(and(eq(wikiPages.org_id, user.org_id), eq(wikiPages.is_deleted, false)))
+      .where(and(eq(wikiPages.org_id, user.org_id), eq(wikiPages.is_deleted, false), visibleWikiPageCondition(user.id)))
       .orderBy(desc(wikiPages.confidence))
       .limit(200);
 
@@ -172,10 +175,8 @@ wikiRoutes.get('/graph', async (c) => {
         .from(wikiLinks)
         .where(and(
           eq(wikiLinks.org_id, user.org_id),
-          or(
-            inArray(wikiLinks.source_page_id, nodeIds),
-            inArray(wikiLinks.target_page_id, nodeIds),
-          ),
+          inArray(wikiLinks.source_page_id, nodeIds),
+          inArray(wikiLinks.target_page_id, nodeIds),
         ));
     }
 
@@ -234,14 +235,14 @@ wikiRoutes.get('/stats', async (c) => {
 
     const [totals] = await db.select({ count: sql<number>`count(*)` })
       .from(wikiPages)
-      .where(and(eq(wikiPages.org_id, orgId), eq(wikiPages.is_deleted, false)));
+      .where(and(eq(wikiPages.org_id, orgId), eq(wikiPages.is_deleted, false), visibleWikiPageCondition(user.id)));
 
     const byType = await db.select({
       type: wikiPages.type,
       count: sql<number>`count(*)`,
     })
       .from(wikiPages)
-      .where(and(eq(wikiPages.org_id, orgId), eq(wikiPages.is_deleted, false)))
+      .where(and(eq(wikiPages.org_id, orgId), eq(wikiPages.is_deleted, false), visibleWikiPageCondition(user.id)))
       .groupBy(wikiPages.type);
 
     const byConfidence = await db.select({
@@ -253,7 +254,7 @@ wikiRoutes.get('/stats', async (c) => {
       count: sql<number>`count(*)`,
     })
       .from(wikiPages)
-      .where(and(eq(wikiPages.org_id, orgId), eq(wikiPages.is_deleted, false)))
+      .where(and(eq(wikiPages.org_id, orgId), eq(wikiPages.is_deleted, false), visibleWikiPageCondition(user.id)))
       .groupBy(sql`CASE WHEN confidence >= 0.8 THEN 'high' WHEN confidence >= 0.5 THEN 'medium' ELSE 'low' END`);
 
     const [linkCount] = await db.select({ count: sql<number>`count(*)` })
@@ -269,7 +270,7 @@ wikiRoutes.get('/stats', async (c) => {
       type: wikiPages.type,
     })
       .from(wikiPages)
-      .where(and(eq(wikiPages.org_id, orgId), eq(wikiPages.is_deleted, false), sql`confidence < 0.5`))
+      .where(and(eq(wikiPages.org_id, orgId), eq(wikiPages.is_deleted, false), visibleWikiPageCondition(user.id), sql`confidence < 0.5`))
       .orderBy(wikiPages.confidence)
       .limit(10);
 
@@ -331,7 +332,7 @@ wikiRoutes.get('/export', async (c) => {
 
     const pages = await db.select()
       .from(wikiPages)
-      .where(and(eq(wikiPages.org_id, user.org_id), eq(wikiPages.is_deleted, false)))
+      .where(and(eq(wikiPages.org_id, user.org_id), eq(wikiPages.is_deleted, false), visibleWikiPageCondition(user.id)))
       .orderBy(desc(wikiPages.confidence), desc(wikiPages.updated_at));
 
     if (format === 'md') {
@@ -374,6 +375,7 @@ wikiRoutes.get('/:slug', async (c) => {
         eq(wikiPages.org_id, user.org_id),
         eq(wikiPages.slug, slug),
         eq(wikiPages.is_deleted, false),
+        visibleWikiPageCondition(user.id),
       ))
       .limit(1);
 
@@ -460,6 +462,10 @@ wikiRoutes.post('/', async (c) => {
         .limit(1);
       if (!space) {
         return c.json({ error: 'Space not found in your organization', code: 'FORBIDDEN' }, 403);
+      }
+      const isMember = await requireSpaceMembership(space_id, user.id);
+      if (!isMember) {
+        return c.json({ error: 'Not a member of this space', code: 'FORBIDDEN' }, 403);
       }
     }
 
@@ -548,7 +554,7 @@ wikiRoutes.patch('/:slug', async (c) => {
 
     const [existing] = await db.select()
       .from(wikiPages)
-      .where(and(eq(wikiPages.org_id, user.org_id), eq(wikiPages.slug, slug), eq(wikiPages.is_deleted, false)))
+      .where(and(eq(wikiPages.org_id, user.org_id), eq(wikiPages.slug, slug), eq(wikiPages.is_deleted, false), visibleWikiPageCondition(user.id)))
       .limit(1);
 
     if (!existing) {
@@ -634,7 +640,7 @@ wikiRoutes.delete('/:slug', async (c) => {
 
     const [page] = await db.select({ id: wikiPages.id })
       .from(wikiPages)
-      .where(and(eq(wikiPages.org_id, user.org_id), eq(wikiPages.slug, slug), eq(wikiPages.is_deleted, false)))
+      .where(and(eq(wikiPages.org_id, user.org_id), eq(wikiPages.slug, slug), eq(wikiPages.is_deleted, false), visibleWikiPageCondition(user.id)))
       .limit(1);
 
     if (!page) {
@@ -665,7 +671,7 @@ wikiRoutes.get('/:slug/history', async (c) => {
 
     const [page] = await db.select({ id: wikiPages.id })
       .from(wikiPages)
-      .where(and(eq(wikiPages.org_id, user.org_id), eq(wikiPages.slug, slug)))
+      .where(and(eq(wikiPages.org_id, user.org_id), eq(wikiPages.slug, slug), visibleWikiPageCondition(user.id)))
       .limit(1);
 
     if (!page) {
@@ -693,7 +699,7 @@ wikiRoutes.get('/:slug/history/:version', async (c) => {
 
     const [page] = await db.select({ id: wikiPages.id })
       .from(wikiPages)
-      .where(and(eq(wikiPages.org_id, user.org_id), eq(wikiPages.slug, slug)))
+      .where(and(eq(wikiPages.org_id, user.org_id), eq(wikiPages.slug, slug), visibleWikiPageCondition(user.id)))
       .limit(1);
 
     if (!page) {

--- a/apps/api/test/direct-route-privacy.test.ts
+++ b/apps/api/test/direct-route-privacy.test.ts
@@ -39,6 +39,11 @@ let restrictedTaskId: string;
 let restrictedTaskFileId: string;
 let restrictedTaskStorageKey: string;
 let taskWikiCitationId: string;
+let privateClipId: string;
+let privateClipFileKey: string;
+let privateDecisionId: string;
+let privateSpaceNoteId: string;
+let privateAgentPlanId: string;
 
 async function withClient<T>(fn: (c: pg.Client) => Promise<T>): Promise<T> {
   const c = new pg.Client({ connectionString: DATABASE_URL });
@@ -119,6 +124,18 @@ before(async () => {
     );
     ids.push({ table: 'messages', id: privateReplyId });
 
+    privateClipId = `drp-private-clip-${stamp}`;
+    privateClipFileKey = `drp-private-clip-${stamp}.webm`;
+    const clipDir = join(process.cwd(), '..', '..', 'uploads', 'clips');
+    await mkdir(clipDir, { recursive: true });
+    await writeFile(join(clipDir, privateClipFileKey), 'private clip audio');
+    await c.query(
+      `INSERT INTO clips (id, org_id, space_id, context_type, context_id, mode, created_by, file_key, file_size, mime_type, status, is_deleted, created_at, updated_at)
+       VALUES ($1, $2, $3, 'space', $3, 'async', $4, $5, 18, 'audio/webm', 'ready', false, NOW(), NOW())`,
+      [privateClipId, ORG_ID, privateSpaceId, OTHER_USER_ID, privateClipFileKey],
+    );
+    ids.push({ table: 'clips', id: privateClipId });
+
     privateWikiSlug = `drp-private-wiki-${stamp}`;
     await c.query(
       `INSERT INTO wiki_pages (id, org_id, scope, user_id, type, title, slug, content, confidence, is_deleted, created_at, updated_at)
@@ -134,6 +151,22 @@ before(async () => {
       [privateSpaceWikiId, ORG_ID, privateSpaceId, OTHER_USER_ID, `${SECRET_TERM} private space wiki`, `drp-space-wiki-${stamp}`, `${SECRET_TERM} private space wiki content`],
     );
     ids.push({ table: 'wiki_pages', id: privateSpaceWikiId });
+
+    privateDecisionId = `drp-private-decision-${stamp}`;
+    await c.query(
+      `INSERT INTO wiki_pages (id, org_id, scope, space_id, user_id, type, title, slug, content, confidence, is_deleted, created_at, updated_at)
+       VALUES ($1, $2, 'space', $3, $4, 'decision', $5, $6, $7, 1, false, NOW(), NOW())`,
+      [privateDecisionId, ORG_ID, privateSpaceId, OTHER_USER_ID, `${SECRET_TERM} private decision`, `drp-private-decision-${stamp}`, `${SECRET_TERM} private decision content`],
+    );
+    ids.push({ table: 'wiki_pages', id: privateDecisionId });
+
+    privateSpaceNoteId = `drp-space-note-${stamp}`;
+    await c.query(
+      `INSERT INTO notes (id, org_id, user_id, title, content, visibility, visibility_space_id, is_deleted, is_pinned, is_template, version, created_at, updated_at)
+       VALUES ($1, $2, $3, $4, $5, 'space', $6, false, false, false, 1, NOW(), NOW())`,
+      [privateSpaceNoteId, ORG_ID, OTHER_USER_ID, `${SECRET_TERM} private space note`, `${SECRET_TERM} private space note content`, privateSpaceId],
+    );
+    ids.push({ table: 'notes', id: privateSpaceNoteId });
 
     privateFileId = `drp-file-${stamp}`;
     privateStorageKey = `drp-file-${stamp}.txt`;
@@ -196,6 +229,21 @@ before(async () => {
       [taskWikiCitationId, privateSpaceWikiId, visibleTaskId],
     );
     ids.push({ table: 'wiki_citations', id: taskWikiCitationId });
+
+    privateAgentPlanId = `drp-agent-plan-${stamp}`;
+    await c.query(
+      `INSERT INTO agent_plans (id, org_id, user_id, title, description, steps, status, current_step, fail_fast, rollback_on_fail, created_at, updated_at)
+       VALUES ($1, $2, $3, $4, $5, $6::jsonb, 'draft', 0, false, false, NOW(), NOW())`,
+      [
+        privateAgentPlanId,
+        ORG_ID,
+        OTHER_USER_ID,
+        `${SECRET_TERM} private agent plan`,
+        `${SECRET_TERM} private agent plan description`,
+        JSON.stringify([{ id: 'step-1', title: 'Private step', status: 'pending' }]),
+      ],
+    );
+    ids.push({ table: 'agent_plans', id: privateAgentPlanId });
   });
 });
 
@@ -214,9 +262,10 @@ after(async () => {
   });
   await rm(join(process.cwd(), 'uploads', privateStorageKey), { force: true });
   await rm(join(process.cwd(), 'uploads', restrictedTaskStorageKey), { force: true });
+  await rm(join(process.cwd(), '..', '..', 'uploads', 'clips', privateClipFileKey), { force: true });
 });
 
-async function routeResponse(routeName: 'messages' | 'spaces' | 'wiki' | 'knowledge' | 'files' | 'tasks', path: string, userId = USER_ID, init?: RequestInit) {
+async function routeResponse(routeName: 'messages' | 'spaces' | 'wiki' | 'knowledge' | 'files' | 'tasks' | 'clips' | 'decisions' | 'daily-notes' | 'agent-plans', path: string, userId = USER_ID, init?: RequestInit) {
   const app = new Hono();
   app.use('*', async (c, next) => {
     c.set('user', { id: userId, org_id: ORG_ID, email: USER_EMAIL, name: 'Direct Privacy User' });
@@ -229,6 +278,10 @@ async function routeResponse(routeName: 'messages' | 'spaces' | 'wiki' | 'knowle
   if (routeName === 'knowledge') app.route('/api/spaces', (await import('../src/routes/knowledge.js')).knowledgeRoutes);
   if (routeName === 'files') app.route('/api/files', (await import('../src/routes/upload.js')).fileServingRoutes);
   if (routeName === 'tasks') app.route('/api/tasks', (await import('../src/routes/tasks.js')).taskRoutes);
+  if (routeName === 'clips') app.route('/api/clips', (await import('../src/routes/clips.js')).clipRoutes);
+  if (routeName === 'decisions') app.route('/api/decisions', (await import('../src/routes/decisions.js')).decisionRoutes);
+  if (routeName === 'daily-notes') app.route('/api/daily-notes', (await import('../src/routes/daily-notes.js')).dailyNoteRoutes);
+  if (routeName === 'agent-plans') app.route('/api/agent-plans', (await import('../src/routes/agent-plans.js')).agentPlanRoutes);
 
   return app.request(path, init);
 }
@@ -296,4 +349,57 @@ test('task detail adjunct routes respect restricted task and wiki visibility', a
   assert.equal(visibleTaskLinks.status, 200);
   const visibleTaskLinksBody = await visibleTaskLinks.json() as any;
   assert.ok(!visibleTaskLinksBody.wiki_links.some((p: any) => p.page_id === privateSpaceWikiId));
+});
+
+test('clip detail, audio, and space listing require clip context visibility', async () => {
+  assert.equal((await routeResponse('clips', `/api/clips/${privateClipId}`)).status, 404);
+  assert.equal((await routeResponse('clips', `/api/clips/${privateClipId}/audio`)).status, 404);
+  assert.equal((await routeResponse('clips', `/api/clips/space/${privateSpaceId}`)).status, 403);
+
+  assert.equal((await routeResponse('clips', `/api/clips/${privateClipId}`, OTHER_USER_ID)).status, 200);
+  const audio = await routeResponse('clips', `/api/clips/${privateClipId}/audio`, OTHER_USER_ID);
+  assert.equal(audio.status, 200);
+  assert.equal(await audio.text(), 'private clip audio');
+  const list = await routeResponse('clips', `/api/clips/space/${privateSpaceId}`, OTHER_USER_ID);
+  assert.equal(list.status, 200);
+  assert.ok((await list.json() as any[]).some((clip: any) => clip.id === privateClipId));
+});
+
+test('decisions inherit wiki page visibility', async () => {
+  const list = await routeResponse('decisions', `/api/decisions?query=${encodeURIComponent(SECRET_TERM)}`);
+  assert.equal(list.status, 200);
+  assert.ok(!(await list.json() as any).decisions.some((d: any) => d.id === privateDecisionId));
+  assert.equal((await routeResponse('decisions', `/api/decisions/${privateDecisionId}`)).status, 404);
+  assert.equal((await routeResponse('decisions', `/api/decisions/${privateDecisionId}`, USER_ID, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ is_reversed: true }),
+  })).status, 404);
+  assert.equal((await routeResponse('decisions', `/api/decisions/${privateDecisionId}`, OTHER_USER_ID)).status, 200);
+});
+
+test('space-visible notes require membership and agent plans are owner-scoped', async () => {
+  assert.equal((await routeResponse('daily-notes', `/api/daily-notes/${privateSpaceNoteId}`)).status, 404);
+  const noteList = await routeResponse('daily-notes', `/api/daily-notes?q=${encodeURIComponent(SECRET_TERM)}`);
+  assert.equal(noteList.status, 200);
+  assert.ok(!(await noteList.json() as any[]).some((n: any) => n.id === privateSpaceNoteId));
+  assert.equal((await routeResponse('daily-notes', `/api/daily-notes/${privateSpaceNoteId}`, OTHER_USER_ID)).status, 200);
+
+  const createSpaceNote = await routeResponse('daily-notes', '/api/daily-notes', USER_ID, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      title: `${SECRET_TERM} forbidden note`,
+      visibility: 'space',
+      visibility_space_id: privateSpaceId,
+    }),
+  });
+  assert.equal(createSpaceNote.status, 403);
+
+  const plans = await routeResponse('agent-plans', `/api/agent-plans?status=draft`);
+  assert.equal(plans.status, 200);
+  assert.ok(!(await plans.json() as any[]).some((p: any) => p.id === privateAgentPlanId));
+  assert.equal((await routeResponse('agent-plans', `/api/agent-plans/${privateAgentPlanId}`)).status, 404);
+  assert.equal((await routeResponse('agent-plans', `/api/agent-plans/${privateAgentPlanId}/approve`, USER_ID, { method: 'POST' })).status, 404);
+  assert.equal((await routeResponse('agent-plans', `/api/agent-plans/${privateAgentPlanId}`, OTHER_USER_ID)).status, 200);
 });

--- a/apps/api/test/direct-route-privacy.test.ts
+++ b/apps/api/test/direct-route-privacy.test.ts
@@ -1,0 +1,299 @@
+/**
+ * Regression coverage for direct-ID route authorization.
+ *
+ * Run:
+ *   DATABASE_URL=postgres://postgres:postgres@127.0.0.1:55432/deft \
+ *   pnpm --filter @deft/api exec tsx --test --test-concurrency=1 test/direct-route-privacy.test.ts
+ */
+import { test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { Hono } from 'hono';
+import pg from 'pg';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const DATABASE_URL =
+  process.env.DATABASE_URL || 'postgres://postgres:postgres@localhost:5432/deft';
+const ORG_ID = '1d7d869a-5e68-48d5-832e-11d8f3bb1dd6';
+
+const stamp = Date.now();
+const USER_ID = `drp-user-${stamp}`;
+const USER_EMAIL = `drp-user-${stamp}@test.local`;
+const OTHER_USER_ID = `drp-other-${stamp}`;
+const OTHER_EMAIL = `drp-other-${stamp}@test.local`;
+const SECRET_TERM = `directrouteprivacy${stamp}z`;
+
+const ids: { table: string; id: string }[] = [];
+
+let visibleSpaceId: string;
+let privateSpaceId: string;
+let privateMessageId: string;
+let privateReplyId: string;
+let privateWikiSlug: string;
+let privateSpaceWikiId: string;
+let privateFileId: string;
+let privateStorageKey: string;
+let projectId: string;
+let visibleTaskId: string;
+let restrictedTaskId: string;
+let restrictedTaskFileId: string;
+let restrictedTaskStorageKey: string;
+let taskWikiCitationId: string;
+
+async function withClient<T>(fn: (c: pg.Client) => Promise<T>): Promise<T> {
+  const c = new pg.Client({ connectionString: DATABASE_URL });
+  await c.connect();
+  try {
+    return await fn(c);
+  } finally {
+    await c.end();
+  }
+}
+
+before(async () => {
+  await withClient(async (c) => {
+    await c.query(
+      `INSERT INTO users (id, email, name, is_agent)
+       VALUES ($1, $2, 'Direct Privacy User', false)
+       ON CONFLICT (id) DO NOTHING`,
+      [USER_ID, USER_EMAIL],
+    );
+    await c.query(
+      `INSERT INTO users (id, email, name, is_agent)
+       VALUES ($1, $2, 'Direct Privacy Other', false)
+       ON CONFLICT (id) DO NOTHING`,
+      [OTHER_USER_ID, OTHER_EMAIL],
+    );
+    await c.query(
+      `INSERT INTO org_members (id, org_id, user_id, role, is_active)
+       VALUES (gen_random_uuid()::text, $1, $2, 'member', true)
+       ON CONFLICT (org_id, user_id) DO NOTHING`,
+      [ORG_ID, USER_ID],
+    );
+    await c.query(
+      `INSERT INTO org_members (id, org_id, user_id, role, is_active)
+       VALUES (gen_random_uuid()::text, $1, $2, 'member', true)
+       ON CONFLICT (org_id, user_id) DO NOTHING`,
+      [ORG_ID, OTHER_USER_ID],
+    );
+
+    visibleSpaceId = `drp-visible-space-${stamp}`;
+    privateSpaceId = `drp-private-space-${stamp}`;
+    await c.query(
+      `INSERT INTO spaces (id, org_id, name, type, is_default, is_archived, agent_enabled, created_by, created_at, updated_at)
+       VALUES ($1, $2, $3, 'private', false, false, true, $4, NOW(), NOW())`,
+      [visibleSpaceId, ORG_ID, `${SECRET_TERM} visible`, USER_ID],
+    );
+    ids.push({ table: 'spaces', id: visibleSpaceId });
+    await c.query(
+      `INSERT INTO spaces (id, org_id, name, type, is_default, is_archived, agent_enabled, created_by, created_at, updated_at)
+       VALUES ($1, $2, $3, 'private', false, false, true, $4, NOW(), NOW())`,
+      [privateSpaceId, ORG_ID, `${SECRET_TERM} private`, OTHER_USER_ID],
+    );
+    ids.push({ table: 'spaces', id: privateSpaceId });
+
+    await c.query(
+      `INSERT INTO space_members (id, space_id, user_id, is_muted, notification_level, joined_at)
+       VALUES (gen_random_uuid()::text, $1, $2, false, 'all', NOW())`,
+      [visibleSpaceId, USER_ID],
+    );
+    await c.query(
+      `INSERT INTO space_members (id, space_id, user_id, is_muted, notification_level, joined_at)
+       VALUES (gen_random_uuid()::text, $1, $2, false, 'all', NOW())`,
+      [privateSpaceId, OTHER_USER_ID],
+    );
+
+    privateMessageId = `drp-private-message-${stamp}`;
+    await c.query(
+      `INSERT INTO messages (id, org_id, space_id, user_id, content, is_pinned, is_deleted, created_at, updated_at)
+       VALUES ($1, $2, $3, $4, $5, false, false, NOW(), NOW())`,
+      [privateMessageId, ORG_ID, privateSpaceId, OTHER_USER_ID, `${SECRET_TERM} private message`],
+    );
+    ids.push({ table: 'messages', id: privateMessageId });
+
+    privateReplyId = `drp-private-reply-${stamp}`;
+    await c.query(
+      `INSERT INTO messages (id, org_id, space_id, user_id, parent_id, content, is_pinned, is_deleted, created_at, updated_at)
+       VALUES ($1, $2, $3, $4, $5, $6, false, false, NOW(), NOW())`,
+      [privateReplyId, ORG_ID, privateSpaceId, OTHER_USER_ID, privateMessageId, `${SECRET_TERM} private reply`],
+    );
+    ids.push({ table: 'messages', id: privateReplyId });
+
+    privateWikiSlug = `drp-private-wiki-${stamp}`;
+    await c.query(
+      `INSERT INTO wiki_pages (id, org_id, scope, user_id, type, title, slug, content, confidence, is_deleted, created_at, updated_at)
+       VALUES ($1, $2, 'user', $3, 'fact', $4, $5, $6, 1, false, NOW(), NOW())`,
+      [`drp-private-wiki-${stamp}`, ORG_ID, OTHER_USER_ID, `${SECRET_TERM} private wiki`, privateWikiSlug, `${SECRET_TERM} private wiki content`],
+    );
+    ids.push({ table: 'wiki_pages', id: `drp-private-wiki-${stamp}` });
+
+    privateSpaceWikiId = `drp-space-wiki-${stamp}`;
+    await c.query(
+      `INSERT INTO wiki_pages (id, org_id, scope, space_id, user_id, type, title, slug, content, confidence, is_deleted, created_at, updated_at)
+       VALUES ($1, $2, 'space', $3, $4, 'fact', $5, $6, $7, 1, false, NOW(), NOW())`,
+      [privateSpaceWikiId, ORG_ID, privateSpaceId, OTHER_USER_ID, `${SECRET_TERM} private space wiki`, `drp-space-wiki-${stamp}`, `${SECRET_TERM} private space wiki content`],
+    );
+    ids.push({ table: 'wiki_pages', id: privateSpaceWikiId });
+
+    privateFileId = `drp-file-${stamp}`;
+    privateStorageKey = `drp-file-${stamp}.txt`;
+    const uploadDir = join(process.cwd(), 'uploads');
+    await mkdir(uploadDir, { recursive: true });
+    await writeFile(join(uploadDir, privateStorageKey), 'private file body');
+    await c.query(
+      `INSERT INTO files (id, org_id, uploaded_by, filename, mime_type, size_bytes, storage_key, message_id, created_at, updated_at)
+       VALUES ($1, $2, $3, 'private.txt', 'text/plain', 17, $4, $5, NOW(), NOW())`,
+      [privateFileId, ORG_ID, OTHER_USER_ID, privateStorageKey, privateMessageId],
+    );
+    ids.push({ table: 'files', id: privateFileId });
+
+    projectId = `drp-project-${stamp}`;
+    await c.query(
+      `INSERT INTO projects (id, org_id, name, prefix, lead_id, task_counter, is_archived, is_deleted, created_at, updated_at)
+       VALUES ($1, $2, $3, $4, $5, 2, false, false, NOW(), NOW())`,
+      [projectId, ORG_ID, `${SECRET_TERM} project`, `DRP${stamp % 100000}`, OTHER_USER_ID],
+    );
+    ids.push({ table: 'projects', id: projectId });
+
+    visibleTaskId = `drp-visible-task-${stamp}`;
+    await c.query(
+      `INSERT INTO tasks (id, org_id, project_id, number, title, description, status, priority, assignee_id, created_by, is_deleted, is_template, sort_order, created_at, updated_at)
+       VALUES ($1, $2, $3, 1, $4, $5, 'todo', 'p2', $6, $6, false, false, 1, NOW(), NOW())`,
+      [visibleTaskId, ORG_ID, projectId, `${SECRET_TERM} visible task`, `${SECRET_TERM} visible task`, USER_ID],
+    );
+    ids.push({ table: 'tasks', id: visibleTaskId });
+
+    restrictedTaskId = `drp-restricted-task-${stamp}`;
+    await c.query(
+      `INSERT INTO tasks (id, org_id, project_id, number, title, description, status, priority, assignee_id, created_by, is_deleted, is_template, sort_order, metadata, created_at, updated_at)
+       VALUES ($1, $2, $3, 2, $4, $5, 'todo', 'p1', $6, $6, false, false, 2, $7::jsonb, NOW(), NOW())`,
+      [
+        restrictedTaskId,
+        ORG_ID,
+        projectId,
+        `${SECRET_TERM} restricted task`,
+        `${SECRET_TERM} restricted task`,
+        OTHER_USER_ID,
+        JSON.stringify({ visibility: 'restricted', visible_user_ids: [OTHER_USER_ID] }),
+      ],
+    );
+    ids.push({ table: 'tasks', id: restrictedTaskId });
+
+    restrictedTaskFileId = `drp-task-file-${stamp}`;
+    restrictedTaskStorageKey = `drp-task-file-${stamp}.txt`;
+    await writeFile(join(uploadDir, restrictedTaskStorageKey), 'restricted task file');
+    await c.query(
+      `INSERT INTO files (id, org_id, uploaded_by, filename, mime_type, size_bytes, storage_key, task_id, created_at, updated_at)
+       VALUES ($1, $2, $3, 'task-private.txt', 'text/plain', 20, $4, $5, NOW(), NOW())`,
+      [restrictedTaskFileId, ORG_ID, OTHER_USER_ID, restrictedTaskStorageKey, restrictedTaskId],
+    );
+    ids.push({ table: 'files', id: restrictedTaskFileId });
+
+    taskWikiCitationId = `drp-task-wiki-citation-${stamp}`;
+    await c.query(
+      `INSERT INTO wiki_citations (id, page_id, source_type, source_id, created_at)
+       VALUES ($1, $2, 'task', $3, NOW())`,
+      [taskWikiCitationId, privateSpaceWikiId, visibleTaskId],
+    );
+    ids.push({ table: 'wiki_citations', id: taskWikiCitationId });
+  });
+});
+
+after(async () => {
+  await withClient(async (c) => {
+    const spaceIds = new Set([visibleSpaceId, privateSpaceId]);
+    for (const { table, id } of [...ids].reverse().filter(row => row.table !== 'spaces')) {
+      await c.query(`DELETE FROM ${table} WHERE id = $1`, [id]);
+    }
+    await c.query(`DELETE FROM space_members WHERE space_id IN ($1, $2)`, [visibleSpaceId, privateSpaceId]);
+    for (const { table, id } of [...ids].reverse().filter(row => row.table === 'spaces' && spaceIds.has(row.id))) {
+      await c.query(`DELETE FROM ${table} WHERE id = $1`, [id]);
+    }
+    await c.query(`DELETE FROM org_members WHERE user_id IN ($1, $2)`, [USER_ID, OTHER_USER_ID]);
+    await c.query(`DELETE FROM users WHERE id IN ($1, $2)`, [USER_ID, OTHER_USER_ID]);
+  });
+  await rm(join(process.cwd(), 'uploads', privateStorageKey), { force: true });
+  await rm(join(process.cwd(), 'uploads', restrictedTaskStorageKey), { force: true });
+});
+
+async function routeResponse(routeName: 'messages' | 'spaces' | 'wiki' | 'knowledge' | 'files' | 'tasks', path: string, userId = USER_ID, init?: RequestInit) {
+  const app = new Hono();
+  app.use('*', async (c, next) => {
+    c.set('user', { id: userId, org_id: ORG_ID, email: USER_EMAIL, name: 'Direct Privacy User' });
+    await next();
+  });
+
+  if (routeName === 'messages') app.route('/api/messages', (await import('../src/routes/messages.js')).messageRoutes);
+  if (routeName === 'spaces') app.route('/api/spaces', (await import('../src/routes/spaces.js')).spaceRoutes);
+  if (routeName === 'wiki') app.route('/api/wiki', (await import('../src/routes/wiki.js')).wikiRoutes);
+  if (routeName === 'knowledge') app.route('/api/spaces', (await import('../src/routes/knowledge.js')).knowledgeRoutes);
+  if (routeName === 'files') app.route('/api/files', (await import('../src/routes/upload.js')).fileServingRoutes);
+  if (routeName === 'tasks') app.route('/api/tasks', (await import('../src/routes/tasks.js')).taskRoutes);
+
+  return app.request(path, init);
+}
+
+test('message direct routes require membership in the message space', async () => {
+  assert.equal((await routeResponse('messages', `/api/messages/${privateMessageId}/thread`)).status, 404);
+  assert.equal((await routeResponse('messages', `/api/messages/${privateMessageId}/history`)).status, 404);
+  assert.equal((await routeResponse('messages', `/api/messages/${privateMessageId}/reactions`, USER_ID, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ emoji: 'eyes' }),
+  })).status, 404);
+  assert.equal((await routeResponse('messages', `/api/messages/${privateMessageId}/thread-read`, USER_ID, {
+    method: 'POST',
+  })).status, 404);
+  assert.equal((await routeResponse('messages', `/api/messages/${privateSpaceId}/read-receipts`)).status, 403);
+
+  assert.equal((await routeResponse('messages', `/api/messages/${privateMessageId}/thread`, OTHER_USER_ID)).status, 200);
+});
+
+test('space direct routes require membership', async () => {
+  assert.equal((await routeResponse('spaces', `/api/spaces/${privateSpaceId}`)).status, 403);
+  assert.equal((await routeResponse('spaces', `/api/spaces/${privateSpaceId}/mute`, USER_ID, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ muted: true }),
+  })).status, 403);
+  assert.equal((await routeResponse('spaces', `/api/spaces/${privateSpaceId}/mark-unread`, USER_ID, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ message_id: privateMessageId }),
+  })).status, 403);
+});
+
+test('wiki and knowledge routes respect user and space scope', async () => {
+  assert.equal((await routeResponse('wiki', `/api/wiki/${privateWikiSlug}`)).status, 404);
+  assert.equal((await routeResponse('wiki', `/api/wiki/${privateWikiSlug}`, OTHER_USER_ID)).status, 200);
+
+  const search = await routeResponse('wiki', `/api/wiki?q=${encodeURIComponent(SECRET_TERM)}`);
+  assert.equal(search.status, 200);
+  const searchBody = await search.json() as any;
+  assert.ok(!searchBody.pages.some((p: any) => p.slug === privateWikiSlug));
+
+  assert.equal((await routeResponse('knowledge', `/api/spaces/${privateSpaceId}/knowledge`)).status, 403);
+  assert.equal((await routeResponse('knowledge', `/api/spaces/${privateSpaceId}/knowledge`, OTHER_USER_ID)).status, 200);
+});
+
+test('file serving follows linked message visibility', async () => {
+  assert.equal((await routeResponse('files', `/api/files/${privateFileId}`)).status, 404);
+  const allowed = await routeResponse('files', `/api/files/${privateFileId}`, OTHER_USER_ID);
+  assert.equal(allowed.status, 200);
+  assert.equal(await allowed.text(), 'private file body');
+});
+
+test('task detail adjunct routes respect restricted task and wiki visibility', async () => {
+  assert.equal((await routeResponse('tasks', `/api/tasks/${restrictedTaskId}/attachments`)).status, 404);
+  assert.equal((await routeResponse('tasks', `/api/tasks/${restrictedTaskId}/wiki-links`)).status, 404);
+  assert.equal((await routeResponse('files', `/api/files/${restrictedTaskFileId}`)).status, 404);
+
+  const otherAttachments = await routeResponse('tasks', `/api/tasks/${restrictedTaskId}/attachments`, OTHER_USER_ID);
+  assert.equal(otherAttachments.status, 200);
+  assert.ok((await otherAttachments.json() as any[]).some((f: any) => f.id === restrictedTaskFileId));
+
+  const visibleTaskLinks = await routeResponse('tasks', `/api/tasks/${visibleTaskId}/wiki-links`);
+  assert.equal(visibleTaskLinks.status, 200);
+  const visibleTaskLinksBody = await visibleTaskLinks.json() as any;
+  assert.ok(!visibleTaskLinksBody.wiki_links.some((p: any) => p.page_id === privateSpaceWikiId));
+});

--- a/apps/api/test/in-chat-knowledge-panel.test.ts
+++ b/apps/api/test/in-chat-knowledge-panel.test.ts
@@ -73,6 +73,19 @@ before(async () => {
        ON CONFLICT (org_id, user_id) DO NOTHING`,
       [ORG_ID, USER_ID],
     );
+
+    await c.query(
+      `INSERT INTO space_members (id, space_id, user_id, is_muted, notification_level, joined_at)
+       VALUES (gen_random_uuid()::text, $1, $2, false, 'all', NOW())
+       ON CONFLICT (space_id, user_id) DO NOTHING`,
+      [SPACE_ID, USER_ID],
+    );
+    await c.query(
+      `INSERT INTO space_members (id, space_id, user_id, is_muted, notification_level, joined_at)
+       VALUES (gen_random_uuid()::text, $1, $2, false, 'all', NOW())
+       ON CONFLICT (space_id, user_id) DO NOTHING`,
+      [ALT_SPACE_ID, USER_ID],
+    );
   });
 });
 

--- a/apps/api/test/search-route-privacy.test.ts
+++ b/apps/api/test/search-route-privacy.test.ts
@@ -17,7 +17,7 @@ const USER_ID = `srp-user-${Date.now()}`;
 const USER_EMAIL = `srp-user-${Date.now()}@test.local`;
 const OTHER_USER_ID = `srp-other-${Date.now()}`;
 const OTHER_USER_EMAIL = `srp-other-${Date.now()}@test.local`;
-const SEARCH_TERM = `searchprivacy${Date.now()}`;
+const SEARCH_TERM = `searchprivacy${Date.now()}z`;
 
 const ids: { table: string; id: string }[] = [];
 
@@ -27,6 +27,9 @@ let visibleMessageId: string;
 let privateMessageId: string;
 let ownNoteId: string;
 let otherPrivateNoteId: string;
+let projectId: string;
+let visibleTaskId: string;
+let restrictedTaskId: string;
 
 async function withClient<T>(fn: (c: pg.Client) => Promise<T>): Promise<T> {
   const c = new pg.Client({ connectionString: DATABASE_URL });
@@ -128,6 +131,38 @@ before(async () => {
       [otherPrivateNoteId, ORG_ID, OTHER_USER_ID, `${SEARCH_TERM} other note`, `Other ${SEARCH_TERM} note.`],
     );
     ids.push({ table: 'notes', id: otherPrivateNoteId });
+
+    projectId = `srp-project-${Date.now()}`;
+    await c.query(
+      `INSERT INTO projects (id, org_id, name, prefix, lead_id, task_counter, is_archived, is_deleted, created_at, updated_at)
+       VALUES ($1, $2, $3, $4, $5, 2, false, false, NOW(), NOW())`,
+      [projectId, ORG_ID, `${SEARCH_TERM} task project`, `SP${Date.now() % 10000}`, OTHER_USER_ID],
+    );
+    ids.push({ table: 'projects', id: projectId });
+
+    visibleTaskId = `srp-visible-task-${Date.now()}`;
+    await c.query(
+      `INSERT INTO tasks (id, org_id, project_id, number, title, description, status, priority, assignee_id, created_by, is_deleted, is_template, sort_order, created_at, updated_at)
+       VALUES ($1, $2, $3, 1, $4, $5, 'todo', 'p2', $6, $6, false, false, 1, NOW(), NOW())`,
+      [visibleTaskId, ORG_ID, projectId, `${SEARCH_TERM} visible task`, `Visible ${SEARCH_TERM} task.`, OTHER_USER_ID],
+    );
+    ids.push({ table: 'tasks', id: visibleTaskId });
+
+    restrictedTaskId = `srp-restricted-task-${Date.now()}`;
+    await c.query(
+      `INSERT INTO tasks (id, org_id, project_id, number, title, description, status, priority, assignee_id, created_by, is_deleted, is_template, sort_order, metadata, created_at, updated_at)
+       VALUES ($1, $2, $3, 2, $4, $5, 'todo', 'p1', $6, $6, false, false, 2, $7::jsonb, NOW(), NOW())`,
+      [
+        restrictedTaskId,
+        ORG_ID,
+        projectId,
+        `${SEARCH_TERM} restricted task`,
+        `Restricted ${SEARCH_TERM} task.`,
+        OTHER_USER_ID,
+        JSON.stringify({ visibility: 'restricted', visible_user_ids: [OTHER_USER_ID] }),
+      ],
+    );
+    ids.push({ table: 'tasks', id: restrictedTaskId });
   });
 });
 
@@ -136,6 +171,11 @@ after(async () => {
     for (const { table, id } of [...ids].reverse()) {
       await c.query(`DELETE FROM ${table} WHERE id = $1`, [id]);
     }
+    await c.query(`DELETE FROM people_patterns WHERE user_id IN ($1, $2)`, [USER_ID, OTHER_USER_ID]);
+    await c.query(`DELETE FROM people_expertise WHERE user_id IN ($1, $2)`, [USER_ID, OTHER_USER_ID]);
+    await c.query(`DELETE FROM people_influence WHERE user_id IN ($1, $2)`, [USER_ID, OTHER_USER_ID]);
+    await c.query(`DELETE FROM people_interactions WHERE user_a_id IN ($1, $2) OR user_b_id IN ($1, $2)`, [USER_ID, OTHER_USER_ID]);
+    await c.query(`DELETE FROM people_relationships WHERE user_a_id IN ($1, $2) OR user_b_id IN ($1, $2)`, [USER_ID, OTHER_USER_ID]);
     await c.query(`DELETE FROM org_members WHERE user_id IN ($1, $2)`, [USER_ID, OTHER_USER_ID]);
     await c.query(`DELETE FROM users WHERE id IN ($1, $2)`, [USER_ID, OTHER_USER_ID]);
   });
@@ -154,6 +194,32 @@ async function callSearch(userId = USER_ID): Promise<any> {
   const res = await app.fetch(new Request(`http://localhost/?q=${encodeURIComponent(SEARCH_TERM)}`));
   assert.equal(res.status, 200);
   return res.json();
+}
+
+async function callTaskRoute(path: string, userId = USER_ID): Promise<Response> {
+  const { taskRoutes } = await import('../src/routes/tasks.js');
+  const app = new Hono();
+
+  app.use('*', async (c, next) => {
+    c.set('user', { id: userId, org_id: ORG_ID, email: USER_EMAIL, name: 'Search Privacy User' });
+    await next();
+  });
+  app.route('/api/tasks', taskRoutes);
+
+  return app.request(path, { method: 'GET' });
+}
+
+async function callProjectRoute(path: string, userId = USER_ID): Promise<Response> {
+  const { projectRoutes } = await import('../src/routes/projects.js');
+  const app = new Hono();
+
+  app.use('*', async (c, next) => {
+    c.set('user', { id: userId, org_id: ORG_ID, email: USER_EMAIL, name: 'Search Privacy User' });
+    await next();
+  });
+  app.route('/api/projects', projectRoutes);
+
+  return app.request(path, { method: 'GET' });
 }
 
 test('global search only returns spaces and messages the caller can access', async () => {
@@ -178,4 +244,34 @@ test('global search retrieved privateNotes group respects private-note ownership
 
   assert.ok(body.privateNotes.some((n: any) => n.id === ownNoteId));
   assert.ok(!body.privateNotes.some((n: any) => n.id === otherPrivateNoteId));
+});
+
+test('global search hides restricted tasks unless caller has direct access', async () => {
+  const memberBody = await callSearch(USER_ID);
+
+  assert.ok(memberBody.tasks.some((t: any) => t.id === visibleTaskId));
+  assert.ok(!memberBody.tasks.some((t: any) => t.id === restrictedTaskId));
+
+  const assigneeBody = await callSearch(OTHER_USER_ID);
+  assert.ok(assigneeBody.tasks.some((t: any) => t.id === restrictedTaskId));
+});
+
+test('task and project routes hide restricted tasks from unrelated members', async () => {
+  const memberSearch = await callTaskRoute(`/api/tasks/search?q=${encodeURIComponent(SEARCH_TERM)}`, USER_ID);
+  assert.equal(memberSearch.status, 200);
+  const memberSearchBody = await memberSearch.json() as any[];
+  assert.ok(memberSearchBody.some((t: any) => t.id === visibleTaskId));
+  assert.ok(!memberSearchBody.some((t: any) => t.id === restrictedTaskId));
+
+  const memberDetail = await callTaskRoute(`/api/tasks/${restrictedTaskId}`, USER_ID);
+  assert.equal(memberDetail.status, 404);
+
+  const assigneeDetail = await callTaskRoute(`/api/tasks/${restrictedTaskId}`, OTHER_USER_ID);
+  assert.equal(assigneeDetail.status, 200);
+
+  const memberProject = await callProjectRoute(`/api/projects/${projectId}/tasks`, USER_ID);
+  assert.equal(memberProject.status, 200);
+  const memberProjectBody = await memberProject.json() as any[];
+  assert.ok(memberProjectBody.some((t: any) => t.id === visibleTaskId));
+  assert.ok(!memberProjectBody.some((t: any) => t.id === restrictedTaskId));
 });

--- a/packages/db/seed-demo.ts
+++ b/packages/db/seed-demo.ts
@@ -499,7 +499,7 @@ async function seed() {
   console.log('Created 3 projects');
 
   // ── Tasks ──
-  type TaskDef = { num: number; title: string; desc: string; status: 'backlog' | 'todo' | 'in_progress' | 'in_review' | 'done' | 'cancelled'; priority: 'p0' | 'p1' | 'p2' | 'p3'; assignee: string | null; creator: string; due?: 'overdue' | 'tomorrow' | 'this_week' | 'next_week' | 'done' };
+  type TaskDef = { num: number; title: string; desc: string; status: 'backlog' | 'todo' | 'in_progress' | 'in_review' | 'done' | 'cancelled'; priority: 'p0' | 'p1' | 'p2' | 'p3'; assignee: string | null; creator: string; due?: 'overdue' | 'tomorrow' | 'this_week' | 'next_week' | 'done'; metadata?: Record<string, unknown> };
 
   const harvTasks: TaskDef[] = [
     { num: 1, title: 'Install hail netting on south field (Romas)', desc: 'Eastern Ag — 1.8 acres, $4,800/acre installed, lease for the season. Install Monday before NOAA hail window opens Tuesday.', status: 'in_progress', priority: 'p0', assignee: C, creator: D, due: 'tomorrow' },
@@ -520,7 +520,16 @@ async function seed() {
     { num: 1, title: 'Sunbelt 6-week contract — sign and return', desc: 'Beefsteak slicers, 1,200 lbs/wk, $1.85/lb FOB, starts May 26. Confirm with Marigold on supply ramp. Decision needed by Friday.', status: 'in_review', priority: 'p0', assignee: L, creator: D, due: 'this_week' },
     { num: 2, title: 'Field Co-op walk-through — Asha Mehta Friday 10am', desc: 'Tour: GH-2 Sun Gold, GH-2 Cherokee Purple, south field Roma block, harvest room. Sample box of heritage varieties + slicers. Pricing sheet for wholesale (heritage premium tier).', status: 'in_progress', priority: 'p1', assignee: L, creator: L, due: 'this_week' },
     { num: 3, title: 'Update 2027 pricing anchor — $2.00/lb slicers', desc: 'Sunbelt accepted $1.85 with little pushback. Hold $2.00 as the anchor next year. Update wholesale pricing sheet wiki. Note in cell: "validated 2026 with Sunbelt at $1.85".', status: 'todo', priority: 'p2', assignee: L, creator: D, due: 'next_week' },
-    { num: 4, title: 'Whole Foods PNW — feasibility cost model (confidential)', desc: 'Year-round program, 800-1000 lbs/wk across 4 SKUs. Revisit in October once GH-3 status is clear and we have a clean 6-month run with regional buyers.', status: 'backlog', priority: 'p1', assignee: L, creator: D },
+    {
+      num: 4,
+      title: 'Whole Foods PNW — feasibility cost model (confidential)',
+      desc: 'Year-round program, 800-1000 lbs/wk across 4 SKUs. Revisit in October once GH-3 status is clear and we have a clean 6-month run with regional buyers.',
+      status: 'backlog',
+      priority: 'p1',
+      assignee: L,
+      creator: D,
+      metadata: { visibility: 'restricted', visible_user_ids: [D, L] },
+    },
     { num: 5, title: 'Set up Sunbelt cold-chain spec — formal handoff doc', desc: 'Document our pulp-temp logging procedure, refrigeration spec (50-55°F), and dock receiving protocol. Share with Sunbelt receiving team.', status: 'in_progress', priority: 'p2', assignee: T, creator: L, due: 'this_week' },
     { num: 6, title: 'New buyer outreach — North Bay restaurant group', desc: 'A chef collective in Sonoma is looking for heritage tomatoes for a tasting menu. Lina to reach out, target 200 lbs/wk Cherokee Purples + Brandywines.', status: 'backlog', priority: 'p3', assignee: L, creator: L },
     { num: 7, title: 'Farmers market — heritage education signage', desc: 'Customers are asking about the varieties. Print A4 cards with variety name, flavor notes, best-use suggestions. Display next to each crate.', status: 'todo', priority: 'p3', assignee: L, creator: L, due: 'next_week' },
@@ -555,7 +564,7 @@ async function seed() {
       const [task] = await db.insert(schema.tasks).values({
         org_id: org!.id, project_id: project!.id, number: t.num, title: t.title, description: t.desc,
         status: t.status, priority: t.priority, assignee_id: t.assignee, created_by: t.creator,
-        sort_order: t.num, due_date: t.due ? dueMap[t.due] : undefined,
+        sort_order: t.num, due_date: t.due ? dueMap[t.due] : undefined, metadata: t.metadata,
       }).returning();
       taskIds[`${keyPrefix}${t.num}`] = task!.id;
     }
@@ -740,8 +749,7 @@ async function seed() {
 <h2>Prospective</h2>
 <h3>Field Co-op (Bay Area regional)</h3>
 <p>Contact: Asha Mehta, Sourcing Manager. (510) 555-0177. Farm visit scheduled Friday May 24, 10am. Heritage-mix interest. No contract yet.</p>
-<h3>Whole Foods Pacific Northwest (confidential — exploratory only)</h3>
-<p>Year-round program discussion. Off the table until GH-3 is operational and we have a clean 6-month run with regional buyers. Revisit October 2026.</p>`,
+`,
       tags: ['buyers', 'contacts'],
     },
     {


### PR DESCRIPTION
## Summary
- add a shared task visibility predicate for `tasks.metadata.visibility = 'restricted'`
- apply it to global search, task search/detail/subroutes, project task lists, and task retrieval context
- mark the Testers Tomatoes `WHL-4` Whole Foods task restricted to Diego/Lina and remove the confidential Whole Foods section from the org-visible buyer directory
- extend search privacy regression coverage to task/project visibility

## Verification
- `pnpm --filter @deft/api typecheck`
- `DATABASE_URL=postgres://postgres:postgres@127.0.0.1:55432/deft pnpm --filter @deft/api exec tsx --test --test-concurrency=1 test/search-route-privacy.test.ts`
- `DATABASE_URL=postgres://postgres:postgres@127.0.0.1:55432/deft pnpm --filter @deft/api exec tsx --test --test-concurrency=1 test/retrieve-context-tasks.test.ts`
- refreshed local Testers Tomatoes seed
- live API check: Cesar sees 0 Whole Foods global/wiki/task results and gets 404 for WHL-4; Lina can still see/open WHL-4
- UI check: Cesar Wholesale board shows 9 tasks and no WHL-4; Lina Wholesale board shows 10 tasks including WHL-4