### PR TITLE
Improve pilot trust surfaces

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -82,17 +82,9 @@ DEFT_AUDIT_BYPASS_TOKEN=
 # R2_BUCKET=deft-uploads
 
 
-# ── 6. GitHub integration (optional) ──────────────────
-# Used for the GitHub connector + PR → task auto-close workflow.
-GITHUB_CLIENT_ID=
-GITHUB_CLIENT_SECRET=
 
-# Shared HMAC secret for incoming GitHub webhooks. Set the same value in your
-# GitHub App / repo webhook settings. Leave blank to disable webhook verification
-# (incoming webhooks will be rejected).
-GITHUB_WEBHOOK_SECRET=
 
-# ── 7. Metrics scrape token (optional) ────────────────
+# Section 6. Metrics scrape token (optional)
 # Static bearer token Prometheus / Grafana Agent sends to GET /api/metrics.
 # Leave unset to disable the scrape endpoint (returns 503).
 # Generate with: openssl rand -hex 32

--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,13 @@ screenshots/
 Logos/
 stitch-reference/
 .demo-private-keep/
+
+# Generated local pilot/audit reports.
+# Keep reusable runners in scripts/ and leave HTML/JSON/screenshots local.
+reports/*.html
+reports/*.json
+reports/*.md
+reports/*.mjs
+reports/*.png
+reports/screenshots/
+reports/*/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,10 +29,10 @@ deft/
 - API: Hono on Node.js, TypeScript
 - Database: PostgreSQL + pgvector (Drizzle ORM)
 - Real-time: Socket.io with Redis adapter
-- Auth: better-auth (JWT + refresh tokens + Google OAuth)
+- Auth: better-auth (JWT + refresh tokens). Google OAuth is retired from the self-hosted v1 product contract.
 - Background jobs: BullMQ with Redis
 - File storage: Cloudflare R2 or local (presigned uploads)
-- AI: Anthropic Codex API (Sonnet for reasoning, Haiku for classification)
+- AI: provider-neutral LLM routing. Anthropic, OpenAI/OpenAI-compatible, OpenRouter, and local Ollama-style providers are optional; core workspace flows must run without any provider key.
 - Email: Resend (transactional)
 - Monorepo: pnpm workspaces
 
@@ -72,22 +72,22 @@ Agent engine lives in `apps/api/src/lib/` (agent-context, agent-plans, agent-too
 
 **Proactive comments:** The nudge-check worker drops agent-authored comments on stalled/overdue tasks and on auto-accepted task extractions (Task 3.11), deduped 7d per task. Inline agent task-suggestion cards appear in chat for classified actionable messages (Task 3.12).
 
-**Tool registry:** All agent actions registered with name, params, approval tier, provider. Agent only sees tools for services the user has connected.
+**Tool registry:** All agent actions registered with name, params, approval tier, provider. Current self-hosted v1 pilots emphasize native Deft tools, ICS calendars, and BYOA/MCP tools supplied by the customer's already-running agents. Native Slack/Gmail/GitHub/Google OAuth are not buyer-facing promises for this cut.
 
 **Three-tier approval:**
-- Auto-execute: task status from PR merge, meeting prep, reminders
+- Auto-execute: low-risk native updates, meeting prep from connected calendar context, reminders
 - Quick-approve: create task, schedule meeting (one-click card)
 - Full-review: multi-step plans and external writes (preview + edit)
 
 **Trust levels (per org):** Conservative → Standard → Autonomous
 
 **Native actions (direct SQL):** Create/update/assign tasks, post messages, set reminders
-**Connected actions (API):** Create calendar events and read connected work events
+**Connected actions:** Read/write native calendar events, ingest ICS calendar subscriptions, and call BYOA/MCP tools that the agent runtime brings with it.
 
 **Event-driven triggers (BullMQ crons):**
 - Task overdue → DM assignee + alert lead
 - Task stalled 48h → ask for update
-- PR merged → parse `PREFIX-N` refs in title/body, move each matched task (in `todo`, `in_progress`, or `in_review`) to `done` and leave an attribution comment linking the PR. Wired into the GitHub sync path (`apps/api/src/workers/github-sync.ts` → `closeTasksForMergedPR`); runs only on the `pr_opened|pr_closed → pr_merged` transition so re-syncs don't re-fire. Tasks already `done` or `cancelled` are never touched.
+- BYOA/runtime trigger → a connected employee can react to external tool events it owns and use Deft-native task/message/wiki tools under org trust and approval rules.
 - Meeting in 15min → generate prep briefing
 - 9am daily → auto-generate standup from activity
 
@@ -101,7 +101,7 @@ Tasks are the agent's primary output surface and the product's action surface. P
 - **Task reactions** (Task 6.3) — emoji reactions on task cards/detail (`task_reactions` table, upsert/delete endpoints).
 - **@mentions in description + comments** (Task 6.4) — autocomplete + notification dispatch mirrors chat mentions.
 - **Activity diff view** (Task 6.2) — inline old→new rendering in the task activity log, replacing flat "changed status" strings.
-- **GitHub PR→Done** (Task 5.6) — polling sync worker parses `PREFIX-N` in PR title/body on the `pr_opened|pr_closed → pr_merged` transition and closes each referenced task with an attribution comment. Polling only, no webhook yet.
+- **Legacy GitHub PR→Done code path** (Task 5.6) — retained as implementation history, but not part of the current self-hosted v1 pilot promise. Customers that need GitHub should connect it inside their BYOA employee or MCP runtime.
 - **Project archive + soft-delete** (Task 5.8) — settings modal with 7-day recovery window. Soft-deleted projects hide from views but preserve tasks for audit.
 - **Task 0.1 security fix (resolved)** — watchers + assignees routes enforce `org_id` + auth.
 - **Task 0.4 dashboard fix (resolved)** — "My Work" filter on the bento dashboard now scopes to the current user.

--- a/DEMO-WALKTHROUGH.md
+++ b/DEMO-WALKTHROUGH.md
@@ -16,8 +16,7 @@ From the repo root, with the dev stack running (`docker compose up -d` or
 # Without AI — workspace boots, agent stays disabled until a key is configured
 pnpm db:seed:demo
 
-# With OpenAI (recommended — the agent demo arc needs an LLM)
-SEED_OPENAI_KEY=sk-...your-key... pnpm db:seed:demo
+pnpm db:seed:demo
 ```
 
 The `db:seed:demo` proxy chains two scripts: this seed (wipes and re-creates
@@ -106,7 +105,7 @@ Open the task. You'll see:
 > became a task without anyone copy-pasting. Six months from now, you'll
 > still know why this task exists.
 
-### 3. Ask the agent something hard *(needs SEED_OPENAI_KEY or BYOK)*
+### 3. Ask the agent something hard *(needs a configured AI provider)*
 
 Anywhere in chat, type `@deft` followed by:
 
@@ -170,7 +169,7 @@ choices we made to keep the seed self-contained:
 - **No integrations connected.** Calendar feeds and MCP connections are available in Settings, but nothing is linked. Add an ICS feed to see external calendar events pull live data.
 - **Email/password auth only.** Self-hosted Deft uses the first signup plus invite flow; managed OAuth sign-in is not part of this build.
 - **No file uploads or images in chat.** Same reason — would have needed real binary fixtures.
-- **AI is opt-in.** Without `SEED_OPENAI_KEY` (or BYOK in Settings → AI), the agent is dormant. The workspace works fully without it — chat + tasks + notes + wiki + reactions + threads all functional.
+- **AI is opt-in.** Without a configured provider key or local Ollama route, the agent is dormant. The workspace works fully without it: chat + tasks + notes + wiki + reactions + threads all functional.
 
 ---
 

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -81,7 +81,7 @@ DND mode toggle. Suppresses notifications when active.
 Per-space collaborative canvas using TipTap JSON document storage. Real-time updates via Socket.io (`canvas:updated` event). Track last editor + edit timestamp. Auto-create canvas when first opened in a space.
 
 ### Space Recaps
-AI-summarized recap of unread or recent messages in a space. Uses Claude API for intelligent summarization. Summarizes last 50 messages or unread messages on demand.
+AI-summarized recap of unread or recent messages in a space. Uses the configured workspace AI provider when available; falls back to a simple non-AI summary when no provider is configured.
 
 ### Space Management
 Create spaces: public, private, DM, group DM. Space member panel (list, add, remove). Mute spaces. Archive/unarchive. Default space (#general) created on org signup. Private spaces with invite-only access.
@@ -159,51 +159,24 @@ The nudge-check worker posts agent-authored comments on stalled or overdue tasks
 ### Project Archive + Soft-Delete
 Per-project settings modal exposes Archive (hide from lists, keep tasks active) and Delete (soft-delete with a 7-day recovery window). Deleted projects are restorable from Settings → Recently deleted until the window closes (Task 5.8).
 
-### GitHub PR → Done
-When GitHub sync (polling, not webhook) sees a PR transition to `merged`, it parses `PREFIX-N` task refs in the PR title + body and moves each referenced task (in `todo`, `in_progress`, or `in_review`) to `done`, leaving an attribution comment linking the PR. Tasks already `done` or `cancelled` are never touched. Runs only on the `pr_opened|pr_closed → pr_merged` transition so re-syncs don't re-fire (Task 5.6).
+### External tool automation
+Self-hosted v1 does not promise native GitHub, Slack, Gmail, or Google Calendar OAuth. Teams that need external tool automation should connect those tools through their own MCP servers or BYOA agent runtimes, then onboard the agent as a Deft employee. Legacy GitHub event/source code may remain for compatibility but is not a buyer-facing self-hosted v1 feature.
 
 ---
 
-## 3. Skills Primitive (unified agent + project capabilities)
+## 3. Skills Primitive
 
-Deft ships a single `skills` table that unifies two previously separate primitives (agent capability packs + project workflow templates) into one resource. A skill carries both an `agent_config` JSONB (capability packs, triggers, tools, prompt additions) and a `project_config` JSONB (statuses, priority vocab, default view, custom fields, task templates, allowed transitions). Either half can be empty — a skill can be agent-only, project-only, or both.
+Deft ships a `skills` table for agent capabilities and first-party bundles. Project-level customization through `project_skills` / `project_config` was retired; projects now use fixed engineering defaults. Agent employees can install bundled, marketplace, or org-authored skills for prompt additions, tool access, triggers, and heartbeat guidance.
 
-### Three Source Tiers
-- **`bundled`** — first-party skills shipped with Deft. `org_id IS NULL`. Upserted idempotently by `seed-bundled-skills.ts` against a partial unique index on `(source, COALESCE(org_id,''), slug)`.
-- **`marketplace`** — installable catalog rows (future: remote registry). Discoverable via the Skills Marketplace browser. Include OpenClaw markdown import for installing a skill from a `.md` manifest.
-- **`org`** — tenant-authored skills. Scoped to a single `org_id`. Authored in the Skills library page.
+### Source Tiers
+- **`bundled`** - first-party skills shipped with Deft.
+- **`marketplace`** - installable catalog rows for future ecosystem use.
+- **`org`** - tenant-authored skills scoped to one workspace.
 
-### 9 Day-One Bundled Skills
-**Capability-pack skills** (agent-only, one per available capability pack from `CAPABILITY_PACKS`): `deft-workspace`, `tasks-core`, `google-calendar` (calendar feeds compatibility slug), and `knowledge-wiki`. Each grants its matching pack slug and leaves `project_config` empty.
-
-**3 project-workflow skills** (project-only):
-- `engineering` — statuses `backlog/todo/in_progress/in_review/done/cancelled`, numbered priorities `p0/p1/p2/p3`, kanban default view, the 9 Phase-3 task tools (`comment_on_task`, `set_priority`, `set_due_date`, `add_label`, `close_task`, `reopen_task`, `add_dependency`, `remove_dependency`, `list_my_tasks`) pre-wired.
-- `marketing-campaign` — named priorities `High/Medium/Low`, calendar view default, campaign-oriented custom fields (channel, budget, launch_date, etc.).
-- `sales-pipeline` — temperature priorities `Hot/Warm/Cold`, pipeline view default, deal-oriented custom fields (stage, ACV, probability, etc.).
-
-### Junction Tables
-- `agent_employee_skills` — which skills an employee has installed. JIT-install on agent invocation re-provisions OpenClaw instances with the updated skill manifest.
-- `project_skills` — which skills a project has attached, with ordering.
-
-### Multi-Skill Per Project (first-attached-wins)
-A project can attach multiple skills. The UI resolver walks the ordered `project_skills` list and returns the first non-null value for each field — so attaching `engineering` + a lightweight company-specific skill lets a team override individual fields without cloning the whole template.
-
-### Skill Source Drives UX
-- **Bundled skills** cannot be edited or deleted by orgs. They update only via server redeploy.
-- **Marketplace skills** can be installed, updated (opt-in adoption when a new version ships — in-app notification prompts the user), and uninstalled.
-- **Org skills** are fully editable in the Skills library page.
-
-### Trigger Conflict Resolution
-Skills can declare triggers (e.g. `cron:standup`). Triggers are unique per-org across employees. On install, if a conflict is detected the UI prompts the user to reassign — the skill can still install, but the existing owner has to release the trigger first.
-
-### Version Update Notifications
-When a new version of an installed skill lands (bundled redeploy or marketplace update), affected orgs get an in-app notification with opt-in adoption. Prevents silent behaviour drift.
-
-### Skills Library + Marketplace Browser
-`/skills` page: library of installed skills, marketplace browser, OpenClaw markdown import, retry-provision button for stuck installs.
-
-### Unified Agent Deploy Wizard
-Agent deploy flow uses the skill picker for capability packs — the `capability_packs[]` array is gone (migration 0038) and `TEMPLATE_DEFAULT_PACKS` constant was removed. Everything flows through skills.
+### Current self-hosted v1 stance
+- Deft Workspace, task tools, knowledge/wiki, calendar feed read context, and MCP/BYOA access are the supported path.
+- External SaaS tools such as GitHub, Slack, Gmail, Linear, and Notion should be connected inside the user's own agent runtime or MCP server.
+- Legacy slugs or enum values may remain for old data, but they should not be shown as native self-hosted v1 promises.
 
 ---
 
@@ -269,8 +242,6 @@ Organized in 5 categories:
 **Calendar tools (auto-execute):**
 - `check_calendar` — view native Deft calendar events and imported ICS feed events
 
-**GitHub tools (auto-execute):**
-- `check_github_prs` — view pull requests by state
 
 **Write tools (require approval):**
 - `create_task` — new tasks in projects
@@ -291,7 +262,7 @@ Organized in 5 categories:
 - `get_burnout_risks` — members showing strain signals (manager-only, privacy-conscious)
 
 ### Three-Tier Approval System
-- **Auto-execute**: read-only tools, memory operations, calendar/GitHub reads
+- **Auto-execute**: read-only tools, memory operations, native/calendar-feed reads
 - **Quick-approve**: task creation, status updates, assignments (one-click approval card)
 - **Full-review**: multi-step plans, message posting, external writes (preview + edit)
 
@@ -324,7 +295,7 @@ Every chat message classified by Haiku for: intent (task_create, question, discu
 Responsive card-based dashboard (1 col mobile, 2 col tablet, 3 col desktop). Cards: Today (tasks due, span 2), Quick Stats (4-stat grid: overdue/due today/in progress/completed), Unread (space notifications), Projects (progress rings), Activity (recent feed), Calendar (mini widget with day bucketing), My Work (kanban-lite: todo/in_progress/in_review columns), Team (manager-only health cards), My Insights (personal metrics).
 
 ### AI Standup Generation
-Daily AI-generated standup using Claude. Gathers: status changes, new tasks, messages by space, active users, completed count, overdue count. Falls back to template-based summary if no API key. Auto-posts to default space as system message.
+Daily AI-generated standup using the configured AI provider. Gathers: status changes, new tasks, messages by space, active users, completed count, overdue count. Falls back to template-based summary if no API key. Auto-posts to default space as system message.
 
 ### Personal Insights
 Activity metrics: messages sent, tasks completed, active spaces. Expertise areas with scores. Top collaborators with interaction counts. Work patterns (behavioral analysis). Weekly pace/velocity (4-week trend).
@@ -363,7 +334,7 @@ Identifies stuck reviews, stalled tasks, review bottlenecks. Surfaces blockers i
 Maps expertise coverage across team. Identifies single points of failure (only one person knows X). Highlights well-covered vs. gap areas.
 
 ### Space Recap
-AI-summarized recap of unread or recent messages per space. On-demand generation via API. Uses Claude for intelligent summarization.
+AI-summarized recap of unread or recent messages per space. On-demand generation via API. Uses the configured AI provider for intelligent summarization.
 
 ### Weekly Digest
 Weekly org-wide summary for managers. Aggregates: velocity, task completion, decisions made, risks, wins. Delivered via background worker.
@@ -500,7 +471,7 @@ Complete audit trail of all user and agent actions. Tracks: actor (user or agent
 AES-256-GCM for sensitive OAuth tokens. Key derived via scrypt from env variable. IV + tag + ciphertext format.
 
 ### Multi-LLM Support
-Unified LLM router supporting 4 providers: Anthropic (Haiku for classify/summarize/extract, Sonnet for reasoning), OpenAI (GPT models with function calling), OpenRouter (compatible with OpenAI format), Ollama (local models for self-hosted). Per-org API key overrides. Token usage tracking.
+Unified LLM router supporting 4 providers: Anthropic, OpenAI, OpenRouter, and Ollama. Per-org API key overrides. Token usage tracking.
 
 ### Real-Time (Socket.io)
 Room-based broadcasting: org rooms, space rooms, user rooms, huddle rooms. JWT-authenticated WebSocket connections. 15+ event types for messages, typing, presence, notifications, reactions, threads, tasks, spaces, huddles, knowledge, canvas.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Get to first login in under 5 minutes.
 ### Prerequisites
 
 - [Docker Desktop](https://www.docker.com/products/docker-desktop/) (includes Docker Compose)
-- (Optional) An [Anthropic API key](https://console.anthropic.com) for AI features — chat and tasks work without one
+- (Optional) Any supported AI provider key, or a local Ollama server, for AI features. Chat and tasks work without one
 
 ### Steps
 
@@ -36,14 +36,14 @@ cd deft
 cp .env.example .env
 ```
 
-Open `.env` and set the three required values (plus the optional AI key if you want AI features):
+Open `.env` and set the three required values. AI keys are optional and can be added later in Settings -> AI.
 
 | Variable | Required? | How to get it |
 |---|---|---|
 | `POSTGRES_PASSWORD` | **Required** | Any strong string — `openssl rand -hex 32` |
 | `JWT_SECRET` | **Required** | `openssl rand -hex 32` |
 | `JWT_REFRESH_SECRET` | **Required** | `openssl rand -hex 32` (run it again) |
-| `ANTHROPIC_API_KEY` | Optional | [console.anthropic.com](https://console.anthropic.com) — only for AI features; can also be set per-org in Settings → AI |
+| `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `OPENROUTER_API_KEY`, or `OLLAMA_URL` | Optional | Configure one provider for AI features; can also be set per-org in Settings -> AI |
 
 ```bash
 # 2. Start the stack (Postgres + Redis + Deft)
@@ -109,7 +109,7 @@ deft/
 | Database | PostgreSQL 16 + Drizzle ORM |
 | Real-time | Socket.io + Redis adapter |
 | Background Jobs | BullMQ + Redis |
-| AI | Anthropic Claude API (Sonnet for reasoning, Haiku for classification) |
+| AI | Provider-neutral BYOK: Anthropic, OpenAI, OpenRouter, or Ollama |
 | Auth | JWT + refresh tokens |
 | File Storage | Local disk (R2-ready) |
 | Monorepo | pnpm workspaces |
@@ -128,7 +128,7 @@ The agent has **direct SQL access** to your data — no API middleman. It can:
 
 Every write action goes through an approval flow. The user sees what the agent wants to do, approves or rejects, and can undo after execution.
 
-**Bring your own API key.** Self-hosted, your data stays with you.
+**Bring your own provider.** Self-hosted Deft can run with Anthropic, OpenAI, OpenRouter, or local Ollama. Without a provider, AI features are disabled but the core workspace still works.
 
 ## Features
 
@@ -143,8 +143,8 @@ Every write action goes through an approval flow. The user sees what the agent w
 - Unread badges and mark-as-read
 
 ### Tasks
-- Kanban, List, Calendar, and Pipeline views — view mode driven by the project's attached skill
-- Skill-driven project config: statuses, priority vocab, custom fields, task templates
+- Kanban, List, Calendar, and Pipeline views
+- Fixed engineering workflow defaults: backlog, todo, in progress, in review, done, cancelled
 - Drag-and-drop across columns
 - Task detail panel with full editing
 - Emoji reactions on tasks
@@ -154,7 +154,6 @@ Every write action goes through an approval flow. The user sees what the agent w
 - Labels, due dates, assignments, recurrence (daily/weekly/biweekly/monthly)
 - Quick-create (press C)
 - Project archive + soft-delete with 7-day recovery
-- GitHub PR → Done on merge (parses `PREFIX-N` in PR title/body)
 
 ### Dashboard
 - Personalized greeting with morning pulse
@@ -178,7 +177,7 @@ See `.env.example` for all configuration options with inline documentation. Thre
 - `JWT_SECRET` — Secret for JWT signing (`openssl rand -hex 32`)
 - `JWT_REFRESH_SECRET` — Secret for refresh tokens (`openssl rand -hex 32`)
 
-`ANTHROPIC_API_KEY` is optional — the app boots without it and AI features stay disabled until a key is configured (via env or per-org in Settings → AI).
+AI provider keys are optional. The app boots without Anthropic, OpenAI, OpenRouter, or Ollama; AI features stay disabled until a provider is configured via env or per-org in Settings -> AI.
 
 Full reference: [docs/self-hosting.md#environment-variables-reference](docs/self-hosting.md#environment-variables-reference)
 

--- a/apps/api/src/lib/agent-runner.ts
+++ b/apps/api/src/lib/agent-runner.ts
@@ -5,8 +5,8 @@
 
 import Anthropic from '@anthropic-ai/sdk';
 import { db } from './db.js';
-import { orgs, agentMemory } from '@deft/db/schema';
-import { eq, and } from 'drizzle-orm';
+import { orgs, agentMemory, wikiPages } from '@deft/db/schema';
+import { eq, and, or, desc, sql } from 'drizzle-orm';
 import { resolveReasonProvider, getOrgAIConfig } from './org-ai-config.js';
 import { createAgentMessage } from './agent-llm.js';
 import { llm } from './llm.js';
@@ -205,6 +205,41 @@ export async function runAgentQuery(params: {
   try {
     const searchQuery = content.replace(/[^a-zA-Z0-9\s]/g, '').trim();
     if (searchQuery.length > 2) {
+      const terms = searchQuery
+        .toLowerCase()
+        .split(/\s+/)
+        .filter((term) => term.length >= 3)
+        .filter((term) => !new Set([
+          'summarize', 'summary', 'what', 'when', 'where', 'next', 'check',
+          'please', 'about', 'with', 'that', 'this', 'decision',
+        ]).has(term))
+        .slice(0, 8);
+      const exactWikiRows = terms.length > 0
+        ? await db
+            .select({
+              title: wikiPages.title,
+              slug: wikiPages.slug,
+              type: wikiPages.type,
+              summary: wikiPages.summary,
+              content: wikiPages.content,
+              updated_at: wikiPages.updated_at,
+            })
+            .from(wikiPages)
+            .where(and(
+              eq(wikiPages.org_id, orgId),
+              eq(wikiPages.is_deleted, false),
+              or(...terms.map((term) => {
+                const pattern = `%${term}%`;
+                return sql`(
+                  lower(${wikiPages.title}) like ${pattern}
+                  or lower(${wikiPages.summary}) like ${pattern}
+                  or lower(${wikiPages.content}) like ${pattern}
+                )`;
+              })),
+            ))
+            .orderBy(desc(wikiPages.updated_at))
+            .limit(3)
+        : [];
       const allRelevantPages = await retrieveContext({
         query: searchQuery,
         org_id: orgId,
@@ -213,6 +248,15 @@ export async function runAgentQuery(params: {
         types: ['wiki'],
         limit: 5,
       });
+
+      if (exactWikiRows.length > 0) {
+        const exactWikiContext = exactWikiRows.map((p) => {
+          const summary = p.summary?.trim()
+            || p.content.replace(/\s+/g, ' ').slice(0, 900);
+          return `- **${p.title}** (${p.type ?? 'wiki'}, slug: ${p.slug}, fresh exact match): ${summary}`;
+        }).join('\n');
+        systemPrompt += `\n\nFresh exact matches from the team wiki:\n${exactWikiContext}`;
+      }
 
       if (allRelevantPages.length > 0) {
         const wikiContext = allRelevantPages.map((p) => {

--- a/apps/api/src/lib/mcp-tools/memory.ts
+++ b/apps/api/src/lib/mcp-tools/memory.ts
@@ -46,6 +46,43 @@ export async function memoryRecall(
   const scope = args.scope ?? 'all';
 
   try {
+    const terms = query
+      .toLowerCase()
+      .split(/[^a-z0-9]+/)
+      .filter((term) => term.length >= 3)
+      .slice(0, 8);
+    const exactTermMatches = terms.length > 0
+      ? await db
+          .select({
+            slug: wikiPages.slug,
+            title: wikiPages.title,
+            summary: wikiPages.summary,
+            content: wikiPages.content,
+            type: wikiPages.type,
+            agent_employee_id: wikiPages.agent_employee_id,
+            updated_at: wikiPages.updated_at,
+          })
+          .from(wikiPages)
+          .where(and(
+            eq(wikiPages.org_id, ctx.org_id),
+            eq(wikiPages.is_deleted, false),
+            scope === 'own'
+              ? eq(wikiPages.agent_employee_id, ctx.employee_id)
+              : scope === 'org'
+                ? isNull(wikiPages.agent_employee_id)
+                : or(isNull(wikiPages.agent_employee_id), eq(wikiPages.agent_employee_id, ctx.employee_id)),
+            ...terms.map((term) => {
+              const pattern = `%${term}%`;
+              return sql`(
+                lower(${wikiPages.title}) like ${pattern}
+                or lower(${wikiPages.summary}) like ${pattern}
+                or lower(${wikiPages.content}) like ${pattern}
+              )`;
+            }),
+          ))
+          .orderBy(desc(wikiPages.updated_at))
+          .limit(limit)
+      : [];
     // Fetch from the unified gateway — always pass agent_employee_id so
     // the two-tier employee+org split is applied inside fetchWiki.
     const contextResults = await retrieveContext({
@@ -74,7 +111,27 @@ export async function memoryRecall(
     // quote body text instead of only the summary. Flag pages whose content
     // exceeded the cap with `truncated: true`.
     const CONTENT_CAP = 2000;
-    const result = filtered.map((r) => {
+    const seenSlugs = new Set<string>();
+    const exactResults = exactTermMatches.map((row) => {
+      seenSlugs.add(row.slug);
+      const fullContent = row.content ?? '';
+      const truncated = fullContent.length > CONTENT_CAP;
+      return {
+        slug: row.slug,
+        title: row.title,
+        summary: row.summary ?? null,
+        content: truncated ? fullContent.slice(0, CONTENT_CAP) : fullContent,
+        truncated,
+        type: row.type ?? '',
+        confidence: 1.0,
+      };
+    });
+    const result = [...exactResults, ...filtered.filter((r) => {
+      const slug = (r.metadata?.slug as string) ?? '';
+      if (!slug || seenSlugs.has(slug)) return false;
+      seenSlugs.add(slug);
+      return true;
+    }).map((r) => {
       const fullContent = r.content ?? '';
       const truncated = fullContent.length > CONTENT_CAP;
       return {
@@ -86,7 +143,7 @@ export async function memoryRecall(
         type: (r.metadata?.type as string) ?? '',
         confidence: r.confidence ?? 1.0,
       };
-    });
+    })].slice(0, limit);
 
     return textResult(result);
   } catch (err) {

--- a/apps/api/src/lib/mcp-tools/writes.ts
+++ b/apps/api/src/lib/mcp-tools/writes.ts
@@ -752,7 +752,10 @@ export type SendMessageTarget =
 
 export type SendMessageArgs = {
   caller_employee_slug: string;
-  target: SendMessageTarget;
+  target?: SendMessageTarget;
+  space_id?: string;
+  thread_id?: string;
+  user_id?: string;
   content: string;
 };
 
@@ -771,7 +774,14 @@ export async function sendMessage(
 ): Promise<ToolResult> {
   if (!args.content?.trim()) return errorResult('send_message requires content');
 
-  const { target, content } = args;
+  const { content } = args;
+  const target = args.target
+    ?? (args.space_id ? { space_id: args.space_id } : null)
+    ?? (args.thread_id ? { thread_id: args.thread_id } : null)
+    ?? (args.user_id ? { user_id: args.user_id } : null);
+  if (!target) {
+    return errorResult('send_message: target must include space_id, thread_id, or user_id');
+  }
 
   // Resolve target → { spaceId, parentId? } so the rest is uniform.
   let spaceId: string;

--- a/apps/api/src/lib/plain-text.ts
+++ b/apps/api/src/lib/plain-text.ts
@@ -1,0 +1,22 @@
+/**
+ * Convert TipTap/HTML-ish user text into a plain preview string.
+ * This is intentionally small and dependency-free for workers/routes.
+ */
+export function toPlainText(value: string | null | undefined): string {
+  if (!value) return '';
+  return value
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+export function truncatePlainText(value: string, maxLength: number): string {
+  if (value.length <= maxLength) return value;
+  return `${value.slice(0, Math.max(0, maxLength - 3)).trimEnd()}...`;
+}

--- a/apps/api/src/routes/agent-employees.ts
+++ b/apps/api/src/routes/agent-employees.ts
@@ -1449,6 +1449,10 @@ agentEmployeeRoutes.delete('/:id', async (c) => {
       .set({ is_active: false, is_deleted: true, deleted_at: new Date() })
       .where(eq(agentEmployees.id, id));
     await db.update(users).set({ is_agent: false }).where(eq(users.id, existing.user_id));
+    await db
+      .update(orgMembers)
+      .set({ is_active: false, updated_at: new Date() })
+      .where(and(eq(orgMembers.org_id, user.org_id), eq(orgMembers.user_id, existing.user_id)));
 
     // Expire pending agent actions
     await db

--- a/apps/api/src/routes/dashboard.ts
+++ b/apps/api/src/routes/dashboard.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono';
 import { eq, and, desc, sql, lt, gte, inArray, count } from 'drizzle-orm';
 import { db } from '../lib/db.js';
-import { tasks, taskAssignees, projects, users, spaces, spaceMembers, messages, taskActivity, notifications, events, standups, orgs, peopleExpertise, peopleInteractions, peoplePatterns, agentActions } from '@deft/db/schema';
+import { tasks, taskAssignees, projects, users, spaces, spaceMembers, messages, taskActivity, notifications, events, standups, orgs, peopleExpertise, peopleInteractions, peoplePatterns, agentActions, agentEmployees, wikiPages } from '@deft/db/schema';
 import { getIO } from '../socket.js';
 import { DEFTY_NAME } from '../lib/ensure-defty-membership.js';
 
@@ -28,6 +28,8 @@ dashboardRoutes.get('/', async (c) => {
         eq(tasks.assignee_id, user.id),
         eq(tasks.is_deleted, false),
         eq(tasks.org_id, user.org_id),
+        eq(projects.is_deleted, false),
+        eq(projects.is_archived, false),
         gte(tasks.due_date, todayStart),
         lt(tasks.due_date, todayEnd),
         sql`${tasks.status} NOT IN ('done', 'cancelled')`,
@@ -46,6 +48,8 @@ dashboardRoutes.get('/', async (c) => {
         eq(tasks.assignee_id, user.id),
         eq(tasks.is_deleted, false),
         eq(tasks.org_id, user.org_id),
+        eq(projects.is_deleted, false),
+        eq(projects.is_archived, false),
         gte(tasks.due_date, todayEnd),
         lt(tasks.due_date, weekEnd),
         sql`${tasks.status} NOT IN ('done', 'cancelled')`,
@@ -64,6 +68,8 @@ dashboardRoutes.get('/', async (c) => {
         eq(tasks.assignee_id, user.id),
         eq(tasks.is_deleted, false),
         eq(tasks.org_id, user.org_id),
+        eq(projects.is_deleted, false),
+        eq(projects.is_archived, false),
         lt(tasks.due_date, todayStart),
         sql`${tasks.status} NOT IN ('done', 'cancelled')`,
       ))
@@ -83,6 +89,8 @@ dashboardRoutes.get('/', async (c) => {
         eq(tasks.status, 'in_progress'),
         eq(tasks.is_deleted, false),
         eq(tasks.org_id, user.org_id),
+        eq(projects.is_deleted, false),
+        eq(projects.is_archived, false),
       ))
       .orderBy(tasks.priority);
 
@@ -100,6 +108,8 @@ dashboardRoutes.get('/', async (c) => {
       .where(and(
         eq(tasks.org_id, user.org_id),
         eq(tasks.is_deleted, false),
+        eq(projects.is_deleted, false),
+        eq(projects.is_archived, false),
         sql`${tasks.status} NOT IN ('done', 'cancelled')`,
         sql`(${tasks.assignee_id} = ${user.id} OR ${tasks.id} IN (SELECT ${taskAssignees.task_id} FROM ${taskAssignees} WHERE ${taskAssignees.user_id} = ${user.id}))`,
       ))
@@ -179,9 +189,12 @@ dashboardRoutes.get('/', async (c) => {
       .from(taskActivity)
       .leftJoin(users, eq(taskActivity.user_id, users.id))
       .innerJoin(tasks, eq(taskActivity.task_id, tasks.id))
+      .innerJoin(projects, eq(tasks.project_id, projects.id))
       .where(and(
         eq(tasks.org_id, user.org_id),
         eq(tasks.is_deleted, false),
+        eq(projects.is_deleted, false),
+        eq(projects.is_archived, false),
       ))
       .orderBy(desc(taskActivity.created_at))
       .limit(15);
@@ -195,7 +208,11 @@ dashboardRoutes.get('/', async (c) => {
         })
           .from(tasks)
           .innerJoin(projects, eq(tasks.project_id, projects.id))
-          .where(inArray(tasks.id, actTaskIds))
+          .where(and(
+            inArray(tasks.id, actTaskIds),
+            eq(projects.is_deleted, false),
+            eq(projects.is_archived, false),
+          ))
       : [];
     const taskMap = new Map(actTasks.map(t => [t.id, t]));
 
@@ -219,6 +236,7 @@ dashboardRoutes.get('/', async (c) => {
       .where(and(
         eq(projects.org_id, user.org_id),
         eq(projects.is_archived, false),
+        eq(projects.is_deleted, false),
       ));
 
     const projectStats = [];
@@ -242,6 +260,42 @@ dashboardRoutes.get('/', async (c) => {
     const [notifCount] = await db.select({ count: sql<number>`count(*)::int` })
       .from(notifications)
       .where(and(eq(notifications.user_id, user.id), eq(notifications.is_read, false)));
+
+    // 8b. Recent/pending agent activity for the cockpit surface. This keeps
+    // the dashboard useful even when the frontend only renders a subset.
+    const recentAgentActivity = await db.select({
+      id: agentActions.id,
+      action: agentActions.action,
+      source: agentActions.source,
+      approval_tier: agentActions.approval_tier,
+      approval_status: agentActions.approval_status,
+      created_at: agentActions.created_at,
+      executed_at: agentActions.executed_at,
+      error: agentActions.error,
+      employee_name: agentEmployees.name,
+      employee_slug: agentEmployees.slug,
+    })
+      .from(agentActions)
+      .leftJoin(agentEmployees, eq(agentActions.agent_employee_id, agentEmployees.id))
+      .where(eq(agentActions.org_id, user.org_id))
+      .orderBy(desc(agentActions.created_at))
+      .limit(12);
+
+    const recentDecisions = await db.select({
+      id: wikiPages.id,
+      title: wikiPages.title,
+      slug: wikiPages.slug,
+      summary: wikiPages.summary,
+      updated_at: wikiPages.updated_at,
+    })
+      .from(wikiPages)
+      .where(and(
+        eq(wikiPages.org_id, user.org_id),
+        eq(wikiPages.is_deleted, false),
+        eq(wikiPages.type, 'decision'),
+      ))
+      .orderBy(desc(wikiPages.updated_at))
+      .limit(5);
 
     // 9. Today's standup
     let standup: { summary: string; date: string } | null = null;
@@ -287,6 +341,43 @@ dashboardRoutes.get('/', async (c) => {
         .limit(10);
     } catch {}
 
+    const pendingAgentActions = recentAgentActivity.filter((a) => a.approval_status === 'pending');
+    const failedAgentActions = recentAgentActivity.filter((a) => a.error);
+    const attention = [
+      ...overdue.slice(0, 5).map((task) => ({
+        kind: 'overdue_task',
+        severity: task.priority === 'p0' || task.priority === 'p1' ? 'high' : 'medium',
+        title: task.title,
+        task_id: task.id,
+        project_name: task.project_name,
+        due_date: task.due_date,
+      })),
+      ...pendingAgentActions.slice(0, 5).map((action) => ({
+        kind: 'agent_approval',
+        severity: action.approval_tier === 'full' ? 'high' : 'medium',
+        title: `${action.employee_name || 'Agent'} needs approval: ${action.action}`,
+        action_id: action.id,
+        employee_slug: action.employee_slug,
+        created_at: action.created_at,
+      })),
+      ...failedAgentActions.slice(0, 3).map((action) => ({
+        kind: 'agent_error',
+        severity: 'high',
+        title: `${action.employee_name || 'Agent'} action failed: ${action.action}`,
+        action_id: action.id,
+        employee_slug: action.employee_slug,
+        error: action.error,
+      })),
+      ...recentDecisions.slice(0, 3).map((decision) => ({
+        kind: 'recent_decision',
+        severity: 'info',
+        title: decision.title,
+        wiki_page_id: decision.id,
+        slug: decision.slug,
+        updated_at: decision.updated_at,
+      })),
+    ];
+
     return c.json({
       greeting: getGreeting(),
       date: now.toISOString(),
@@ -301,6 +392,9 @@ dashboardRoutes.get('/', async (c) => {
       projects: projectStats,
       unread_notifications: notifCount?.count || 0,
       calendar_events: calendarEvents,
+      agent_activity: recentAgentActivity,
+      recent_decisions: recentDecisions,
+      attention,
       github_activity: [],
     });
   } catch (err) {

--- a/apps/api/src/routes/manager.ts
+++ b/apps/api/src/routes/manager.ts
@@ -1,15 +1,88 @@
 // Routes: Manager tools — 1:1 prep, team health, manager settings
 import { Hono } from 'hono';
-import { eq, and, desc } from 'drizzle-orm';
+import { eq, and, desc, sql } from 'drizzle-orm';
 import { db } from '../lib/db.js';
 import {
   oneonePreps,
   managerSettings,
   teamHealthSnapshots,
+  users,
+  orgMembers,
+  agentEmployees,
 } from '@deft/db/schema';
 import { generateOneOnePrep } from '../services/oneone-prep.js';
+import { DEFTY_EMAIL } from '../lib/ensure-defty-membership.js';
 
 export const managerRoutes = new Hono();
+
+function visibleManagerMemberForOrg(orgId: string) {
+  return sql`
+    (
+      ${users.kind} <> 'agent'
+      OR ${users.email} = ${DEFTY_EMAIL}
+      OR EXISTS (
+        SELECT 1
+        FROM ${agentEmployees}
+        WHERE ${agentEmployees.user_id} = ${users.id}
+          AND ${agentEmployees.org_id} = ${orgId}
+          AND ${agentEmployees.is_active} = true
+          AND ${agentEmployees.is_deleted} = false
+      )
+    )
+  `;
+}
+
+async function sanitizeTeamHealthSnapshot(snapshot: typeof teamHealthSnapshots.$inferSelect, orgId: string) {
+  const teamData = (snapshot.team_data ?? {}) as any;
+  const cards = Array.isArray(teamData.healthCards) ? teamData.healthCards : [];
+  if (cards.length === 0) return snapshot;
+
+  const visibleRows = await db
+    .select({ id: users.id, name: users.name })
+    .from(orgMembers)
+    .innerJoin(users, eq(orgMembers.user_id, users.id))
+    .where(and(
+      eq(orgMembers.org_id, orgId),
+      eq(orgMembers.is_active, true),
+      visibleManagerMemberForOrg(orgId),
+    ));
+  const visibleIds = new Set(visibleRows.map((row) => row.id));
+  const visibleNames = new Set(visibleRows.map((row) => row.name).filter(Boolean));
+
+  const filteredCards = cards.filter((card: any) => visibleIds.has(card.userId));
+  const hiddenNames = new Set(
+    cards
+      .filter((card: any) => !visibleIds.has(card.userId) && typeof card.name === 'string')
+      .map((card: any) => card.name),
+  );
+
+  const wins = Array.isArray(teamData.wins)
+    ? teamData.wins.filter((win: unknown) => {
+        if (typeof win !== 'string') return false;
+        for (const name of hiddenNames) {
+          if (win.startsWith(`${name} `)) return false;
+        }
+        return [...visibleNames].some((name) => win.startsWith(`${name} `));
+      })
+    : [];
+  const actionItems = Array.isArray(teamData.actionItems)
+    ? teamData.actionItems.filter((item: any) => visibleIds.has(item.userId))
+    : [];
+  const green = filteredCards.filter((card: any) => card.status === 'green').length;
+  const yellow = filteredCards.filter((card: any) => card.status === 'yellow').length;
+  const red = filteredCards.filter((card: any) => card.status === 'red').length;
+
+  return {
+    ...snapshot,
+    team_data: {
+      ...teamData,
+      healthCards: filteredCards,
+      wins,
+      actionItems,
+      summary: `Filtered to ${filteredCards.length} active team member(s): ${green} green, ${yellow} yellow, ${red} red. Hidden deleted or inactive agent test employees are excluded from this live view.`,
+    },
+  };
+}
 
 // POST /api/manager/oneone-prep — generate a 1:1 prep for a report
 managerRoutes.post('/oneone-prep', async (c) => {
@@ -225,7 +298,7 @@ managerRoutes.get('/team-health', async (c) => {
       return c.json({ snapshot: null });
     }
 
-    return c.json({ snapshot });
+    return c.json({ snapshot: await sanitizeTeamHealthSnapshot(snapshot, user.org_id) });
   } catch (err) {
     console.error('Failed to get team health:', err);
     return c.json({ error: 'Failed to get team health', code: 'INTERNAL_ERROR' }, 500);

--- a/apps/api/src/routes/members.ts
+++ b/apps/api/src/routes/members.ts
@@ -1,10 +1,11 @@
 import { Hono } from 'hono';
 import { z } from 'zod';
-import { eq, and } from 'drizzle-orm';
+import { eq, and, sql } from 'drizzle-orm';
 import jwt from 'jsonwebtoken';
 import { db } from '../lib/db.js';
-import { users, orgMembers, spaces, spaceMembers } from '@deft/db/schema';
+import { users, orgMembers, spaces, spaceMembers, agentEmployees } from '@deft/db/schema';
 import { env } from '../lib/env.js';
+import { DEFTY_EMAIL } from '../lib/ensure-defty-membership.js';
 
 const INVITE_TTL = '7d';
 const RECOVERY_TTL = '24h';
@@ -18,6 +19,23 @@ function buildRecoveryUrl(token: string): string {
 }
 
 export const memberRoutes = new Hono();
+
+function visibleLiveMemberForOrg(orgIdRef: unknown) {
+  return sql`
+    (
+      ${users.kind} <> 'agent'
+      OR ${users.email} = ${DEFTY_EMAIL}
+      OR EXISTS (
+        SELECT 1
+        FROM ${agentEmployees}
+        WHERE ${agentEmployees.user_id} = ${users.id}
+          AND ${agentEmployees.org_id} = ${orgIdRef}
+          AND ${agentEmployees.is_active} = true
+          AND ${agentEmployees.is_deleted} = false
+      )
+    )
+  `;
+}
 
 // GET /api/members — list all members of current org
 memberRoutes.get('/', async (c) => {
@@ -41,6 +59,7 @@ memberRoutes.get('/', async (c) => {
         and(
           eq(orgMembers.org_id, user.org_id),
           eq(orgMembers.is_active, true),
+          visibleLiveMemberForOrg(orgMembers.org_id),
         )
       );
 
@@ -84,7 +103,12 @@ memberRoutes.get('/:id', async (c) => {
     })
       .from(orgMembers)
       .innerJoin(users, eq(orgMembers.user_id, users.id))
-      .where(and(eq(orgMembers.org_id, user.org_id), eq(users.id, memberId)))
+      .where(and(
+        eq(orgMembers.org_id, user.org_id),
+        eq(orgMembers.is_active, true),
+        eq(users.id, memberId),
+        visibleLiveMemberForOrg(orgMembers.org_id),
+      ))
       .limit(1);
 
     if (!member) {

--- a/apps/api/src/routes/spaces.ts
+++ b/apps/api/src/routes/spaces.ts
@@ -2,13 +2,31 @@ import { Hono } from 'hono';
 import { z } from 'zod';
 import { eq, and, desc, sql, inArray } from 'drizzle-orm';
 import { db } from '../lib/db.js';
-import { spaces, spaceMembers, users, messages } from '@deft/db/schema';
+import { spaces, spaceMembers, users, messages, agentEmployees, orgMembers } from '@deft/db/schema';
 import { getIO } from '../socket.js';
 import { requireSpaceMembership } from '../lib/space-membership.js';
+import { DEFTY_EMAIL } from '../lib/ensure-defty-membership.js';
 
 export const spaceRoutes = new Hono();
 
 const VALID_SPACE_TYPES = ['public', 'private', 'dm', 'group_dm'] as const;
+
+function visibleLiveSpaceMemberForOrg(orgId: string) {
+  return sql`
+    (
+      ${users.kind} <> 'agent'
+      OR ${users.email} = ${DEFTY_EMAIL}
+      OR EXISTS (
+        SELECT 1
+        FROM ${agentEmployees}
+        WHERE ${agentEmployees.user_id} = ${users.id}
+          AND ${agentEmployees.org_id} = ${orgId}
+          AND ${agentEmployees.is_active} = true
+          AND ${agentEmployees.is_deleted} = false
+      )
+    )
+  `;
+}
 
 const createSpaceSchema = z.object({
   name: z.string().min(1),
@@ -43,6 +61,19 @@ spaceRoutes.post('/', async (c) => {
     // Group DM semantics: same set of people = same conversation.
     if ((type === 'dm' || type === 'group_dm') && user_ids && user_ids.length > 0) {
       const targetSet = new Set<string>([user.id, ...user_ids.filter((id) => id !== user.id)]);
+      const visibleTargets = await db.select({ id: users.id })
+        .from(orgMembers)
+        .innerJoin(users, eq(orgMembers.user_id, users.id))
+        .where(and(
+          eq(orgMembers.org_id, user.org_id),
+          eq(orgMembers.is_active, true),
+          inArray(users.id, [...targetSet]),
+          visibleLiveSpaceMemberForOrg(user.org_id),
+        ));
+      if (visibleTargets.length !== targetSet.size) {
+        return c.json({ error: 'All DM members must be active members of this org', code: 'INVALID_MEMBER' }, 400);
+      }
+
       // 1:1 dm requires exactly the caller + one other; group_dm requires >= 3 members.
       const expectedSize = targetSet.size;
       const candidateSpaces = await db.select({ space_id: spaceMembers.space_id })
@@ -149,7 +180,16 @@ spaceRoutes.get('/', async (c) => {
         user_id: spaceMembers.user_id,
       })
         .from(spaceMembers)
-        .where(inArray(spaceMembers.space_id, dmSpaceIds));
+        .innerJoin(users, eq(spaceMembers.user_id, users.id))
+        .innerJoin(orgMembers, and(
+          eq(orgMembers.user_id, users.id),
+          eq(orgMembers.org_id, user.org_id),
+        ))
+        .where(and(
+          inArray(spaceMembers.space_id, dmSpaceIds),
+          eq(orgMembers.is_active, true),
+          visibleLiveSpaceMemberForOrg(user.org_id),
+        ));
       for (const row of memberRows) {
         const existing = memberIdsBySpace.get(row.space_id) ?? [];
         existing.push(row.user_id);
@@ -320,7 +360,10 @@ spaceRoutes.get('/:id/members', async (c) => {
     })
       .from(spaceMembers)
       .innerJoin(users, eq(spaceMembers.user_id, users.id))
-      .where(eq(spaceMembers.space_id, spaceId));
+      .where(and(
+        eq(spaceMembers.space_id, spaceId),
+        visibleLiveSpaceMemberForOrg(user.org_id),
+      ));
 
     return c.json(members);
   } catch (err) {
@@ -353,6 +396,20 @@ spaceRoutes.post('/:id/members', async (c) => {
 
     const isMember = await requireSpaceMembership(spaceId, user.id);
     if (!isMember) return c.json({ error: 'Not a member of this space', code: 'FORBIDDEN' }, 403);
+
+    const [targetMember] = await db.select({ id: users.id })
+      .from(orgMembers)
+      .innerJoin(users, eq(orgMembers.user_id, users.id))
+      .where(and(
+        eq(orgMembers.org_id, user.org_id),
+        eq(orgMembers.is_active, true),
+        eq(orgMembers.user_id, user_id),
+        visibleLiveSpaceMemberForOrg(user.org_id),
+      ))
+      .limit(1);
+    if (!targetMember) {
+      return c.json({ error: 'Member not found or inactive', code: 'MEMBER_NOT_FOUND' }, 404);
+    }
 
     // Check if already a member
     const [existing] = await db.select()

--- a/apps/api/src/routes/wiki.ts
+++ b/apps/api/src/routes/wiki.ts
@@ -48,59 +48,75 @@ function slugify(title: string): string {
 wikiRoutes.get('/', async (c) => {
   try {
     const user = c.get('user');
-    const query = c.req.query('q');
+    const query = c.req.query('q')?.trim();
     const typeFilter = c.req.query('type');
     const scopeFilter = c.req.query('scope');
     const page = Math.max(1, parseInt(c.req.query('page') || '1'));
     const limit = Math.min(parseInt(c.req.query('limit') || '50'), 100);
     const offset = (page - 1) * limit;
 
-    const conditions: any[] = [
+    const baseConditions: any[] = [
       eq(wikiPages.org_id, user.org_id),
       eq(wikiPages.is_deleted, false),
       visibleWikiPageCondition(user.id),
     ];
 
     if (typeFilter && ['concept', 'entity', 'decision', 'resource', 'procedure', 'preference', 'fact'].includes(typeFilter)) {
-      conditions.push(eq(wikiPages.type, typeFilter as any));
+      baseConditions.push(eq(wikiPages.type, typeFilter as any));
     }
 
     if (scopeFilter && ['org', 'space', 'user'].includes(scopeFilter)) {
-      conditions.push(eq(wikiPages.scope, scopeFilter as any));
+      baseConditions.push(eq(wikiPages.scope, scopeFilter as any));
     }
 
-    // Full-text search with ts_rank, fallback to ilike
-    const useFullText = !!query;
-    if (query) {
-      conditions.push(
-        sql`search_vector @@ plainto_tsquery('english', ${query})`,
-      );
-    }
+    const ftsCondition = query
+      ? sql`search_vector @@ websearch_to_tsquery('english', ${query})`
+      : null;
+    const fallbackPattern = query ? `%${query}%` : null;
+    const fallbackSlugPattern = query ? `%${query.toLowerCase().replace(/\s+/g, '-')}%` : null;
+    const fallbackCondition = query && fallbackPattern && fallbackSlugPattern
+      ? or(
+          ilike(wikiPages.title, fallbackPattern),
+          ilike(wikiPages.summary, fallbackPattern),
+          ilike(wikiPages.content, fallbackPattern),
+          ilike(wikiPages.slug, fallbackSlugPattern),
+        )
+      : null;
 
-    const pages = await db.select({
-      id: wikiPages.id,
-      type: wikiPages.type,
-      scope: wikiPages.scope,
-      title: wikiPages.title,
-      slug: wikiPages.slug,
-      summary: wikiPages.summary,
-      metadata: wikiPages.metadata,
-      confidence: wikiPages.confidence,
-      version: wikiPages.version,
-      space_id: wikiPages.space_id,
-      created_at: wikiPages.created_at,
-      updated_at: wikiPages.updated_at,
-      ...(useFullText ? { rank: sql<number>`ts_rank(search_vector, plainto_tsquery('english', ${query}))` } : {}),
-    })
-      .from(wikiPages)
-      .where(and(...conditions))
-      .orderBy(
-        ...(useFullText
-          ? [sql`ts_rank(search_vector, plainto_tsquery('english', ${query})) DESC`, desc(wikiPages.confidence)]
-          : [desc(wikiPages.confidence), desc(wikiPages.updated_at)])
-      )
-      .limit(limit)
-      .offset(offset);
+    const fetchPageBatch = async (conditions: any[], useFullText: boolean) => db.select({
+        id: wikiPages.id,
+        type: wikiPages.type,
+        scope: wikiPages.scope,
+        title: wikiPages.title,
+        slug: wikiPages.slug,
+        summary: wikiPages.summary,
+        metadata: wikiPages.metadata,
+        confidence: wikiPages.confidence,
+        version: wikiPages.version,
+        space_id: wikiPages.space_id,
+        created_at: wikiPages.created_at,
+        updated_at: wikiPages.updated_at,
+        ...(useFullText && query ? { rank: sql<number>`ts_rank(search_vector, websearch_to_tsquery('english', ${query}))` } : {}),
+      })
+        .from(wikiPages)
+        .where(and(...conditions))
+        .orderBy(
+          ...(useFullText && query
+            ? [sql`ts_rank(search_vector, websearch_to_tsquery('english', ${query})) DESC`, desc(wikiPages.confidence)]
+            : [desc(wikiPages.confidence), desc(wikiPages.updated_at)])
+        )
+        .limit(limit)
+        .offset(offset);
+
+    let conditions = ftsCondition ? [...baseConditions, ftsCondition] : baseConditions;
+    let pages = await fetchPageBatch(conditions, !!ftsCondition);
+    let searchMode = ftsCondition ? 'full_text' : 'list';
+
+    if (query && pages.length === 0 && fallbackCondition) {
+      conditions = [...baseConditions, fallbackCondition];
+      pages = await fetchPageBatch(conditions, false);
+      searchMode = 'fallback';
+    }
 
     // Get link counts for each page
     const pageIds = pages.map(p => p.id);
@@ -140,6 +156,7 @@ wikiRoutes.get('/', async (c) => {
       total: Number(countResult?.count || 0),
       page,
       limit,
+      search_mode: searchMode,
     });
   } catch (err) {
     console.error('Failed to fetch wiki pages:', err);

--- a/apps/api/src/scripts/seed-pilot-workspace.ts
+++ b/apps/api/src/scripts/seed-pilot-workspace.ts
@@ -1,0 +1,705 @@
+/**
+ * Post-demo pilot polish seed.
+ *
+ * `packages/db/seed-demo.ts` builds the core Testers Tomatoes workspace. This
+ * script makes the clean local pilot state match the current self-hostable
+ * direction: Defty + BYOA employees, no stale unread/audit noise, and a fresh
+ * chat-to-wiki proof surface.
+ *
+ * Run:
+ *   pnpm --filter @deft/api exec tsx src/scripts/seed-pilot-workspace.ts
+ */
+import { fileURLToPath } from 'node:url';
+import bcrypt from 'bcryptjs';
+import { and, eq, inArray } from 'drizzle-orm';
+import { db } from '../lib/db.js';
+import {
+  agentEmployees,
+  messages,
+  notifications,
+  orgMembers,
+  orgs,
+  projectSpaces,
+  projects,
+  spaceMembers,
+  spaces,
+  tasks,
+  teamHealthSnapshots,
+  users,
+  wikiPages,
+} from '@deft/db/schema';
+
+const TOM_TOKEN = process.env.SEED_TOM_MCP_TOKEN ?? 'tom-pilot-mcp-token-2026';
+const MAYA_TOKEN = process.env.SEED_MAYA_MCP_TOKEN ?? 'maya-pilot-mcp-token-2026';
+const PROOF_PHRASE = 'ruby-sunrise-2026';
+
+type SeedUser = typeof users.$inferSelect;
+type SeedSpace = typeof spaces.$inferSelect;
+type SeedProject = typeof projects.$inferSelect;
+
+function expectOne<T>(rows: T[], label: string): T {
+  const [row] = rows;
+  if (!row) {
+    throw new Error(`Expected ${label} to be returned.`);
+  }
+  return row;
+}
+
+function plusDays(days: number): Date {
+  const date = new Date();
+  date.setDate(date.getDate() + days);
+  date.setHours(17, 0, 0, 0);
+  return date;
+}
+
+async function mustFindPilotOrg() {
+  const [org] = await db
+    .select()
+    .from(orgs)
+    .where(eq(orgs.slug, 'testers-tomatoes'))
+    .limit(1);
+  if (!org) {
+    throw new Error('Testers Tomatoes org not found. Run `pnpm db:seed:demo` first.');
+  }
+  return org;
+}
+
+async function findUserByEmail(email: string): Promise<SeedUser> {
+  const [user] = await db.select().from(users).where(eq(users.email, email)).limit(1);
+  if (!user) {
+    throw new Error(`Expected seeded user ${email} was not found.`);
+  }
+  return user;
+}
+
+async function upsertAgentUser(params: {
+  orgId: string;
+  createdBy: string;
+  name: string;
+  slug: string;
+  title: string;
+  runtimeKind: string;
+  jobTitle: string;
+  systemPrompt: string;
+  expertiseDescription: string;
+  token: string;
+  wakeMode: string;
+  triggerSubscriptions: string[];
+}): Promise<SeedUser> {
+  const [existingEmployee] = await db
+    .select()
+    .from(agentEmployees)
+    .where(and(eq(agentEmployees.org_id, params.orgId), eq(agentEmployees.slug, params.slug)))
+    .limit(1);
+
+  let userId = existingEmployee?.user_id;
+  if (!userId) {
+    const [existingUser] = await db
+      .select()
+      .from(users)
+      .where(eq(users.email, `${params.slug}@agents.testers-tomatoes.local`))
+      .limit(1);
+
+    if (existingUser) {
+      userId = existingUser.id;
+    } else {
+      const inserted = expectOne(await db
+        .insert(users)
+        .values({
+          email: `${params.slug}@agents.testers-tomatoes.local`,
+          name: params.name,
+          kind: 'agent',
+          is_agent: true,
+          title: params.title,
+          email_verified: true,
+          timezone: 'America/Chicago',
+          status_emoji: 'ready',
+          status_text: 'Available for pilot work',
+          last_seen_at: new Date(),
+        })
+        .returning(), `inserted user for ${params.slug}`);
+      userId = inserted.id;
+    }
+  }
+
+  await db
+    .insert(orgMembers)
+    .values({
+      org_id: params.orgId,
+      user_id: userId,
+      role: 'member',
+      is_active: true,
+    })
+    .onConflictDoUpdate({
+      target: [orgMembers.org_id, orgMembers.user_id],
+      set: { role: 'member', is_active: true, updated_at: new Date() },
+    });
+
+  const tokenHash = await bcrypt.hash(params.token, 10);
+  const employeeValues = {
+    org_id: params.orgId,
+    user_id: userId,
+    name: params.name,
+    slug: params.slug,
+    role: 'custom' as const,
+    system_prompt: params.systemPrompt,
+    expertise_description: params.expertiseDescription,
+    starter_prompts: [
+      'Read my assigned tasks and tell me what you will do first.',
+      `Search company memory for ${PROOF_PHRASE} and summarize the relevant pilot context.`,
+    ],
+    trust_level: 'autonomous' as const,
+    max_daily_actions: 80,
+    heartbeat_enabled: false,
+    is_active: true,
+    is_deleted: false,
+    is_byoa: true,
+    byoa_model_info: params.runtimeKind,
+    mcp_token_hash: tokenHash,
+    runtime_kind: params.runtimeKind,
+    job_title: params.jobTitle,
+    wake_mode: params.wakeMode,
+    certification_status: 'verified',
+    last_verified_at: new Date(),
+    last_mcp_call_at: null,
+    last_work_outcome_at: null,
+    connection_notes:
+      'Clean local pilot seed assumes this BYOA runtime is already running and connects to Deft over MCP.',
+    trigger_subscriptions: params.triggerSubscriptions,
+    created_by: params.createdBy,
+    updated_at: new Date(),
+  };
+
+  const employee = expectOne(await db
+    .insert(agentEmployees)
+    .values(employeeValues)
+    .onConflictDoUpdate({
+      target: [agentEmployees.org_id, agentEmployees.slug],
+      set: employeeValues,
+    })
+    .returning(), `agent employee ${params.slug}`);
+
+  const user = expectOne(await db
+    .update(users)
+    .set({
+      name: params.name,
+      kind: 'agent',
+      is_agent: true,
+      title: params.title,
+      email_verified: true,
+      agent_employee_id: employee.id,
+      last_seen_at: new Date(),
+      updated_at: new Date(),
+    })
+    .where(eq(users.id, userId))
+    .returning(), `updated user for ${params.slug}`);
+
+  return user;
+}
+
+async function ensureSpace(params: {
+  orgId: string;
+  createdBy: string;
+  name: string;
+  description: string;
+  topic: string;
+}): Promise<SeedSpace> {
+  const [existing] = await db
+    .select()
+    .from(spaces)
+    .where(and(eq(spaces.org_id, params.orgId), eq(spaces.name, params.name)))
+    .limit(1);
+
+  if (existing) {
+    const updated = expectOne(await db
+      .update(spaces)
+      .set({
+        description: params.description,
+        topic: params.topic,
+        type: 'public',
+        is_archived: false,
+        agent_enabled: true,
+        updated_at: new Date(),
+      })
+      .where(eq(spaces.id, existing.id))
+      .returning(), `updated space ${params.name}`);
+    return updated;
+  }
+
+  const created = expectOne(await db
+    .insert(spaces)
+    .values({
+      org_id: params.orgId,
+      name: params.name,
+      description: params.description,
+      topic: params.topic,
+      type: 'public',
+      is_default: false,
+      is_archived: false,
+      agent_enabled: true,
+      created_by: params.createdBy,
+    })
+    .returning(), `created space ${params.name}`);
+  return created;
+}
+
+async function ensureSpaceMembers(spaceIds: string[], userIds: string[]) {
+  for (const spaceId of spaceIds) {
+    for (const userId of userIds) {
+      await db
+        .insert(spaceMembers)
+        .values({
+          space_id: spaceId,
+          user_id: userId,
+          notification_level: 'all',
+          last_read_at: new Date(),
+        })
+        .onConflictDoUpdate({
+          target: [spaceMembers.space_id, spaceMembers.user_id],
+          set: { notification_level: 'all', last_read_at: new Date() },
+        });
+    }
+  }
+}
+
+async function ensureProject(params: {
+  orgId: string;
+  leadId: string;
+  name: string;
+  description: string;
+  prefix: string;
+}): Promise<SeedProject> {
+  const [existing] = await db
+    .select()
+    .from(projects)
+    .where(and(eq(projects.org_id, params.orgId), eq(projects.prefix, params.prefix)))
+    .limit(1);
+
+  const values = {
+    name: params.name,
+    description: params.description,
+    lead_id: params.leadId,
+    is_archived: false,
+    is_deleted: false,
+    deleted_at: null,
+    task_counter: 4,
+    updated_at: new Date(),
+  };
+
+  if (existing) {
+    const updated = expectOne(await db
+      .update(projects)
+      .set(values)
+      .where(eq(projects.id, existing.id))
+      .returning(), `updated project ${params.prefix}`);
+    return updated;
+  }
+
+  const created = expectOne(await db
+    .insert(projects)
+    .values({
+      org_id: params.orgId,
+      name: params.name,
+      description: params.description,
+      prefix: params.prefix,
+      icon: 'Megaphone',
+      color: '#0ea5e9',
+      lead_id: params.leadId,
+      task_counter: 4,
+    })
+    .returning(), `created project ${params.prefix}`);
+  return created;
+}
+
+async function seedTasks(params: {
+  orgId: string;
+  projectId: string;
+  createdBy: string;
+  tomId: string;
+  mayaId: string;
+}) {
+  const seededTasks = [
+    {
+      number: 1,
+      title: 'Draft farmers market launch copy for Sun Gold trial',
+      description:
+        'Use the wiki positioning notes and the proof phrase ruby-sunrise-2026. Produce short booth copy, one SMS blurb, and one buyer-facing paragraph.',
+      status: 'todo' as const,
+      priority: 'p1' as const,
+      assignee_id: params.tomId,
+      due_date: plusDays(1),
+      sort_order: 1,
+    },
+    {
+      number: 2,
+      title: 'Summarize Field Co-op visit talking points',
+      description:
+        'Prepare the weekly comms summary for Diego and Lina. Include pricing sensitivity, cold-chain promise, and next follow-up owner.',
+      status: 'todo' as const,
+      priority: 'p1' as const,
+      assignee_id: params.mayaId,
+      due_date: plusDays(2),
+      sort_order: 2,
+    },
+    {
+      number: 3,
+      title: 'Prepare buyer FAQ for cold-chain claims',
+      description:
+        'Turn operations notes into a plain-language FAQ that a wholesale buyer can trust without reading internal ops docs.',
+      status: 'in_progress' as const,
+      priority: 'p2' as const,
+      assignee_id: params.tomId,
+      due_date: plusDays(4),
+      sort_order: 3,
+    },
+    {
+      number: 4,
+      title: 'Write weekly marketing pulse for Diego',
+      description:
+        'Create a concise update with wins, risks, and asks. Pull context from wiki and current marketing tasks.',
+      status: 'todo' as const,
+      priority: 'p2' as const,
+      assignee_id: params.mayaId,
+      due_date: plusDays(5),
+      sort_order: 4,
+    },
+  ];
+
+  for (const task of seededTasks) {
+    await db
+      .insert(tasks)
+      .values({
+        org_id: params.orgId,
+        project_id: params.projectId,
+        created_by: params.createdBy,
+        ...task,
+      })
+      .onConflictDoUpdate({
+        target: [tasks.project_id, tasks.number],
+        set: {
+          title: task.title,
+          description: task.description,
+          status: task.status,
+          priority: task.priority,
+          assignee_id: task.assignee_id,
+          due_date: task.due_date,
+          sort_order: task.sort_order,
+          is_deleted: false,
+          updated_at: new Date(),
+        },
+      });
+  }
+}
+
+async function seedWiki(params: { orgId: string; spaceId: string; diegoId: string; tomId: string; mayaId: string }) {
+  const pages = [
+    {
+      type: 'procedure' as const,
+      title: 'Company Memory Proof Protocol',
+      slug: 'company-memory-proof-protocol',
+      summary:
+        'A clean local proof path for verifying chat-to-wiki and BYOA memory retrieval in the Testers Tomatoes pilot.',
+      content: [
+        '# Company Memory Proof Protocol',
+        '',
+        `The current clean pilot proof phrase is **${PROOF_PHRASE}**.`,
+        '',
+        'When a teammate mentions this phrase in chat, Deft should classify the decision/entity/resource context, promote it into knowledge, and make it retrievable from wiki search and MCP memory tools.',
+        '',
+        'Expected proof: a human can create a new chat decision, the Knowledge panel shows it, the Wiki receives or links the captured memory, and BYOA employees can retrieve it with `memory_recall` or `wiki_search`.',
+      ].join('\n'),
+      tags: ['pilot', 'memory', 'proof'],
+      referenced_user_ids: [params.diegoId, params.tomId, params.mayaId],
+    },
+    {
+      type: 'decision' as const,
+      title: 'BYOA Employee Operating Model',
+      slug: 'byoa-employee-operating-model',
+      summary:
+        'Tom and Maya are treated as already-running external employees that connect to Deft over MCP.',
+      content: [
+        '# BYOA Employee Operating Model',
+        '',
+        'Tom is the OpenClaw marketing employee for Testers Tomatoes. Maya is the Hermes communications employee.',
+        '',
+        'Deft should not rewrite their identity or assume ownership of their runtime. Deft gives them workplace context, task assignments, wiki access, and audited MCP tools.',
+        '',
+        'Pilot acceptance means each BYOA employee can see assigned tasks, use company memory, post useful work updates, and mark work complete according to trust and approval rules.',
+      ].join('\n'),
+      tags: ['agents', 'byoa', 'pilot'],
+      referenced_user_ids: [params.tomId, params.mayaId],
+    },
+    {
+      type: 'resource' as const,
+      title: 'Testers Tomatoes Marketing Positioning',
+      slug: 'testers-tomatoes-marketing-positioning',
+      summary:
+        'Position Testers Tomatoes as a flavor-first, reliability-minded tomato supplier for local buyers.',
+      content: [
+        '# Testers Tomatoes Marketing Positioning',
+        '',
+        'Core promise: consistently flavorful tomatoes with transparent harvest timing and practical cold-chain reliability.',
+        '',
+        'Audience: farmers market shoppers, independent grocers, chefs, and wholesale buyers who care about flavor but cannot tolerate missed delivery windows.',
+        '',
+        'Tone: vivid, plain-spoken, operationally credible. Avoid inflated sustainability claims unless backed by a specific growing or logistics practice.',
+      ].join('\n'),
+      tags: ['marketing', 'positioning', 'buyers'],
+      referenced_user_ids: [params.tomId, params.mayaId],
+    },
+  ];
+
+  for (const page of pages) {
+    await db
+      .insert(wikiPages)
+      .values({
+        org_id: params.orgId,
+        scope: 'org',
+        space_id: params.spaceId,
+        type: page.type,
+        title: page.title,
+        slug: page.slug,
+        summary: page.summary,
+        content: page.content,
+        confidence: 0.98,
+        version: 1,
+        is_deleted: false,
+        tags: page.tags,
+        referenced_user_ids: page.referenced_user_ids,
+      })
+      .onConflictDoUpdate({
+        target: [wikiPages.org_id, wikiPages.slug],
+        set: {
+          scope: 'org',
+          space_id: params.spaceId,
+          type: page.type,
+          title: page.title,
+          summary: page.summary,
+          content: page.content,
+          confidence: 0.98,
+          is_deleted: false,
+          tags: page.tags,
+          referenced_user_ids: page.referenced_user_ids,
+          updated_at: new Date(),
+        },
+      });
+  }
+}
+
+async function seedMarketingMessage(params: { orgId: string; spaceId: string; diegoId: string }) {
+  const content =
+    `Decision: for the clean pilot, Tom owns buyer-facing marketing copy and Maya owns weekly communications summaries. ` +
+    `Use ${PROOF_PHRASE} as the fresh chat-to-wiki proof marker for this local environment.`;
+
+  const existing = await db
+    .select({ id: messages.id })
+    .from(messages)
+    .where(and(eq(messages.org_id, params.orgId), eq(messages.space_id, params.spaceId), eq(messages.content, content)))
+    .limit(1);
+
+  if (existing.length === 0) {
+    await db.insert(messages).values({
+      org_id: params.orgId,
+      space_id: params.spaceId,
+      user_id: params.diegoId,
+      content,
+      metadata: { seed: 'pilot-polish', knowledge_marker: PROOF_PHRASE },
+    });
+  }
+}
+
+async function seedTeamHealth(params: {
+  orgId: string;
+  generatedBy: string;
+  humans: SeedUser[];
+  tom: SeedUser;
+  maya: SeedUser;
+}) {
+  await db.delete(teamHealthSnapshots).where(eq(teamHealthSnapshots.org_id, params.orgId));
+
+  await db.insert(teamHealthSnapshots).values({
+    org_id: params.orgId,
+    snapshot_date: new Date(),
+    generated_by: params.generatedBy,
+    team_data: {
+      summary:
+        'Clean local pilot is ready for chat, tasks, wiki memory, calendar ICS, and BYOA employee testing.',
+      healthCards: [
+        ...params.humans.map((user) => ({
+          userId: user.id,
+          name: user.name,
+          signal: 'steady',
+          note: 'Seeded human teammate with current tasks and workspace context.',
+        })),
+        {
+          userId: params.tom.id,
+          name: params.tom.name,
+          signal: 'ready',
+          note: 'OpenClaw BYOA marketing employee seeded with assigned pilot tasks.',
+        },
+        {
+          userId: params.maya.id,
+          name: params.maya.name,
+          signal: 'ready',
+          note: 'Hermes BYOA communications employee seeded with assigned pilot tasks.',
+        },
+      ],
+      wins: [
+        'Workspace reset removes stale audit users and old agent test residue.',
+        'BYOA employees have deterministic MCP tokens for local certification.',
+        'Wiki includes a known proof phrase for clean retrieval tests.',
+      ],
+      actionItems: [
+        'Run the browser chat-to-wiki proof after reset.',
+        'Run MCP memory_recall and wiki_search against Tom and Maya tokens.',
+      ],
+    },
+  });
+}
+
+async function cleanReadState(orgId: string) {
+  const orgSpaces = await db.select({ id: spaces.id }).from(spaces).where(eq(spaces.org_id, orgId));
+  if (orgSpaces.length > 0) {
+    await db
+      .update(spaceMembers)
+      .set({ last_read_at: new Date() })
+      .where(inArray(spaceMembers.space_id, orgSpaces.map((space) => space.id)));
+  }
+
+  await db.update(notifications).set({ is_read: true }).where(eq(notifications.org_id, orgId));
+}
+
+export async function seedPilotWorkspace(): Promise<{
+  orgId: string;
+  tomToken: string;
+  mayaToken: string;
+  proofPhrase: string;
+}> {
+  console.log('[seed-pilot-workspace] starting pilot polish seed');
+
+  const org = await mustFindPilotOrg();
+  const diego = await findUserByEmail('diego@testers-tomatoes.com');
+  const marigold = await findUserByEmail('marigold@testers-tomatoes.com');
+  const cesar = await findUserByEmail('cesar@testers-tomatoes.com');
+  const lina = await findUserByEmail('lina@testers-tomatoes.com');
+  const tomas = await findUserByEmail('tomas@testers-tomatoes.com');
+  const sage = await findUserByEmail('sage@testers-tomatoes.com');
+
+  const tom = await upsertAgentUser({
+    orgId: org.id,
+    createdBy: diego.id,
+    name: 'Tom',
+    slug: 'tom',
+    title: 'Marketing Agent',
+    runtimeKind: 'openclaw',
+    jobTitle: 'Marketing Agent',
+    wakeMode: 'polling',
+    token: TOM_TOKEN,
+    expertiseDescription:
+      'Marketing strategy, buyer copy, farmers market positioning, and wholesale launch messaging for Testers Tomatoes.',
+    systemPrompt:
+      'You are Tom, an already-running OpenClaw agent onboarded into Deft as the marketing employee for Testers Tomatoes. Keep your own runtime identity. Use Deft tasks, messages, and wiki memory as workplace context. Do not prefix every reply with your name.',
+    triggerSubscriptions: ['task.assigned', 'message.mention', 'wiki.updated'],
+  });
+
+  const maya = await upsertAgentUser({
+    orgId: org.id,
+    createdBy: diego.id,
+    name: 'Maya',
+    slug: 'maya',
+    title: 'Communications Agent',
+    runtimeKind: 'hermes',
+    jobTitle: 'Communications Agent',
+    wakeMode: 'manual',
+    token: MAYA_TOKEN,
+    expertiseDescription:
+      'Internal updates, stakeholder summaries, weekly pulse writing, and customer-facing communication hygiene.',
+    systemPrompt:
+      'You are Maya, an already-running Hermes agent onboarded into Deft as the communications employee for Testers Tomatoes. Keep your own runtime identity. Use Deft tasks, messages, and wiki memory as workplace context. Do not prefix every reply with your name.',
+    triggerSubscriptions: ['task.assigned', 'message.mention', 'wiki.updated'],
+  });
+
+  const marketingSpace = await ensureSpace({
+    orgId: org.id,
+    createdBy: diego.id,
+    name: 'marketing',
+    description: 'Pilot-safe marketing, buyer messaging, and launch communication work.',
+    topic: `Clean pilot workspace. Memory proof phrase: ${PROOF_PHRASE}`,
+  });
+
+  const publicSpaces = await db
+    .select({ id: spaces.id })
+    .from(spaces)
+    .where(and(eq(spaces.org_id, org.id), eq(spaces.type, 'public'), eq(spaces.is_archived, false)));
+
+  await ensureSpaceMembers(
+    [...new Set([...publicSpaces.map((space) => space.id), marketingSpace.id])],
+    [diego.id, marigold.id, cesar.id, lina.id, tomas.id, sage.id, tom.id, maya.id],
+  );
+
+  const marketingProject = await ensureProject({
+    orgId: org.id,
+    leadId: lina.id,
+    name: 'Pilot Marketing Launch',
+    description:
+      'A clean local project for exercising BYOA task assignment, wiki retrieval, and human review flows.',
+    prefix: 'MKT',
+  });
+
+  await db
+    .insert(projectSpaces)
+    .values({ project_id: marketingProject.id, space_id: marketingSpace.id })
+    .onConflictDoNothing();
+
+  await seedTasks({
+    orgId: org.id,
+    projectId: marketingProject.id,
+    createdBy: diego.id,
+    tomId: tom.id,
+    mayaId: maya.id,
+  });
+
+  await seedWiki({
+    orgId: org.id,
+    spaceId: marketingSpace.id,
+    diegoId: diego.id,
+    tomId: tom.id,
+    mayaId: maya.id,
+  });
+
+  await seedMarketingMessage({ orgId: org.id, spaceId: marketingSpace.id, diegoId: diego.id });
+  await seedTeamHealth({
+    orgId: org.id,
+    generatedBy: diego.id,
+    humans: [diego, marigold, cesar, lina, tomas, sage],
+    tom,
+    maya,
+  });
+  await cleanReadState(org.id);
+
+  console.log('[seed-pilot-workspace] done');
+  console.log(`[seed-pilot-workspace] proof phrase: ${PROOF_PHRASE}`);
+  console.log(`[seed-pilot-workspace] Tom MCP token: ${TOM_TOKEN}`);
+  console.log(`[seed-pilot-workspace] Maya MCP token: ${MAYA_TOKEN}`);
+
+  return {
+    orgId: org.id,
+    tomToken: TOM_TOKEN,
+    mayaToken: MAYA_TOKEN,
+    proofPhrase: PROOF_PHRASE,
+  };
+}
+
+const entryPath = fileURLToPath(import.meta.url);
+const invokedDirectly =
+  process.argv[1] === entryPath ||
+  process.argv[1]?.replace(/\\/g, '/') === entryPath.replace(/\\/g, '/');
+
+if (invokedDirectly) {
+  seedPilotWorkspace()
+    .then(() => process.exit(0))
+    .catch((err) => {
+      console.error('[seed-pilot-workspace] FAILED:', err);
+      process.exit(1);
+    });
+}

--- a/apps/api/src/workers/handlers/blocked-alert.ts
+++ b/apps/api/src/workers/handlers/blocked-alert.ts
@@ -13,6 +13,7 @@ import {
 } from '@deft/db/schema';
 import { eq, and, gte, sql } from 'drizzle-orm';
 import { emitToUser } from '../../socket.js';
+import { toPlainText, truncatePlainText } from '../../lib/plain-text.js';
 
 export async function handleBlockedAlert(job: JobData): Promise<void> {
   const { messageId, spaceId, content, orgId, userId } = job.data;
@@ -84,7 +85,8 @@ export async function handleBlockedAlert(job: JobData): Promise<void> {
     // inbox. Independent of the lead-notification path below so it
     // still fires for users with no in-progress tasks.
     try {
-      const draftSnippet = content.length > 80 ? content.slice(0, 80) + '…' : content;
+      const plainContent = toPlainText(content);
+      const draftSnippet = truncatePlainText(plainContent, 80);
       await db.insert(agentActions).values({
         org_id: orgId,
         user_id: userId,
@@ -92,7 +94,7 @@ export async function handleBlockedAlert(job: JobData): Promise<void> {
         message_id: messageId,
         params: {
           title: `Blocker: ${draftSnippet}`,
-          description: content,
+          description: plainContent,
           source_message_id: messageId,
           source_space_id: spaceId,
         } as any,
@@ -111,8 +113,7 @@ export async function handleBlockedAlert(job: JobData): Promise<void> {
     }
 
     // Truncate content for notification body
-    const contentSnippet =
-      content.length > 120 ? content.slice(0, 120) + '...' : content;
+    const contentSnippet = truncatePlainText(toPlainText(content), 120);
 
     for (const task of userTasks) {
       const taskIdentifier = `${task.project_prefix}-${task.number}`;

--- a/apps/api/test/blocked-task-suggest.test.ts
+++ b/apps/api/test/blocked-task-suggest.test.ts
@@ -124,9 +124,37 @@ test('proposal payload description keeps the full message', async () => {
     .from(agentActions)
     .where(and(
       eq(agentActions.org_id, testOrgId),
+      eq(agentActions.user_id, testUserId),
       eq(agentActions.source, 'blocked_classifier'),
     ))
     .limit(1);
   const params = row!.params as any;
   assert.equal(params.description, 'I am completely stuck on the database migration');
+});
+
+test('blocked-alert strips rich text from task proposal fields', async () => {
+  await handleBlockedAlert({
+    id: 'job',
+    name: 'blocked-alert',
+    data: {
+      messageId: msgId,
+      spaceId,
+      content: '<p><strong>I am blocked</strong> on the &amp; vendor export.</p>',
+      orgId: testOrgId,
+      userId: testUserId,
+    },
+  } as any);
+
+  const [row] = await db
+    .select()
+    .from(agentActions)
+    .where(and(
+      eq(agentActions.org_id, testOrgId),
+      eq(agentActions.user_id, testUserId),
+      eq(agentActions.source, 'blocked_classifier'),
+    ))
+    .limit(1);
+  const params = row!.params as any;
+  assert.equal(params.title, 'Blocker: I am blocked on the & vendor export.');
+  assert.equal(params.description, 'I am blocked on the & vendor export.');
 });

--- a/apps/api/test/members-kind-field.test.ts
+++ b/apps/api/test/members-kind-field.test.ts
@@ -9,12 +9,13 @@ import { test, before, after } from 'node:test';
 import assert from 'node:assert/strict';
 import { Hono } from 'hono';
 import { db } from '../src/lib/db.js';
-import { users, orgs, orgMembers } from '@deft/db/schema';
+import { users, orgs, orgMembers, agentEmployees } from '@deft/db/schema';
 import { eq, inArray } from 'drizzle-orm';
 
 let testOrgId: string;
 let humanUserId: string;
 let agentUserId: string;
+let staleAgentUserId: string;
 let requesterUserId: string;
 let requesterEmail: string;
 let testApp: Hono | null = null;
@@ -56,11 +57,32 @@ before(async () => {
   }).returning();
   agentUserId = agentUser!.id;
 
+  const [staleAgentUser] = await db.insert(users).values({
+    name: 'Deleted Agent Shadow (Members Kind)',
+    kind: 'agent',
+    is_agent: false,
+    email_verified: true,
+  }).returning();
+  staleAgentUserId = staleAgentUser!.id;
+
   await db.insert(orgMembers).values([
     { org_id: testOrgId, user_id: requesterUserId, role: 'owner' },
     { org_id: testOrgId, user_id: humanUserId, role: 'member' },
     { org_id: testOrgId, user_id: agentUserId, role: 'member' },
+    { org_id: testOrgId, user_id: staleAgentUserId, role: 'member' },
   ]);
+
+  await db.insert(agentEmployees).values({
+    org_id: testOrgId,
+    user_id: agentUserId,
+    slug: `members-kind-agent-${ts}`,
+    name: 'Test Agent (Members Kind)',
+    system_prompt: 'test',
+    is_byoa: true,
+    trust_level: 'standard',
+    role: 'custom',
+    created_by: requesterUserId,
+  });
 
   // Mount memberRoutes into a bare Hono with a c.var.user shim.
   // The shim sets c.var.user = { id, email, org_id } so org filtering
@@ -80,9 +102,10 @@ before(async () => {
 
 after(async () => {
   try {
+    await db.delete(agentEmployees).where(eq(agentEmployees.org_id, testOrgId));
     await db.delete(orgMembers).where(eq(orgMembers.org_id, testOrgId));
     await db.delete(users).where(
-      inArray(users.id, [requesterUserId, humanUserId, agentUserId]),
+      inArray(users.id, [requesterUserId, humanUserId, agentUserId, staleAgentUserId]),
     );
     await db.delete(orgs).where(eq(orgs.id, testOrgId));
   } catch (err) {
@@ -119,6 +142,16 @@ test('GET /api/members returns kind=agent for agent members', async () => {
   assert.equal(agent.kind, 'agent', `agent member should have kind='agent', got ${agent.kind}`);
 });
 
+test('GET /api/members hides deleted agent shadow users without an active employee', async () => {
+  const res = await app().request('/api/members', { method: 'GET' });
+  assert.equal(res.status, 200);
+  const members = await res.json();
+  assert.ok(Array.isArray(members), 'expected array response');
+
+  const stale = members.find((m: any) => m.id === staleAgentUserId);
+  assert.equal(stale, undefined, 'deleted agent shadow user should not be in member list');
+});
+
 test('GET /api/members/:id returns kind field for human member', async () => {
   const res = await app().request(`/api/members/${humanUserId}`, { method: 'GET' });
   assert.equal(res.status, 200);
@@ -133,4 +166,9 @@ test('GET /api/members/:id returns kind field for agent member', async () => {
   const member = await res.json();
   assert.equal(member.id, agentUserId);
   assert.equal(member.kind, 'agent', `single member endpoint should return kind='agent', got ${member.kind}`);
+});
+
+test('GET /api/members/:id returns 404 for deleted agent shadow user', async () => {
+  const res = await app().request(`/api/members/${staleAgentUserId}`, { method: 'GET' });
+  assert.equal(res.status, 404);
 });

--- a/apps/web/src/app/(app)/dashboard/lib/facade.ts
+++ b/apps/web/src/app/(app)/dashboard/lib/facade.ts
@@ -77,6 +77,35 @@ export type AgentActivity = {
 
 export type AgentEmployeeBrief = { id: string; name: string };
 
+export type DashboardAttention = {
+  kind: 'overdue_task' | 'pending_agent_action' | 'failed_agent_action' | 'recent_decision' | string;
+  severity: 'critical' | 'warning' | 'info' | string;
+  title: string;
+  href: string;
+  at: string | null;
+};
+
+export type DashboardAgentActivity = {
+  id: string;
+  action: string;
+  source: string | null;
+  approval_tier: string;
+  approval_status: string;
+  created_at: string;
+  executed_at: string | null;
+  error: string | null;
+  employee_name: string | null;
+  employee_slug: string | null;
+};
+
+export type DashboardDecision = {
+  id: string;
+  title: string;
+  slug: string;
+  summary: string | null;
+  updated_at: string;
+};
+
 export type DashboardCore = {
   greeting: string;
   standup: Standup;
@@ -85,6 +114,11 @@ export type DashboardCore = {
   unread_spaces: UnreadSpace[];
   recent_activity: Activity[];
   projects: Project[];
+  attention?: DashboardAttention[];
+  agent_activity?: DashboardAgentActivity[];
+  recent_decisions?: DashboardDecision[];
+  calendar_events?: unknown[];
+  github_activity?: unknown[];
 };
 
 export type CalendarPayload = {

--- a/apps/web/src/app/(app)/dashboard/lib/shared.tsx
+++ b/apps/web/src/app/(app)/dashboard/lib/shared.tsx
@@ -8,6 +8,7 @@
 import type { Activity, AgentActivity } from './facade';
 import { CheckCircle2, MessageSquare, FileText, CalendarDays, Zap } from 'lucide-react';
 import { statusLabel } from '@/lib/task-status-labels';
+import { stripHtml } from '@/lib/strip-html';
 
 export const PRI_COLOR: Record<string, string> = {
   p0: 'var(--status-red)',
@@ -39,7 +40,7 @@ export function fmtActivityParts(a: Activity): { who: string; verb: string; task
 export function fmtAgentAction(a: AgentActivity): string {
   const p = (a.params as Record<string, any>) || {};
   switch (a.action) {
-    case 'create_task': return `Created task \u201c${p.title}\u201d in ${p.project_name}`;
+    case 'create_task': return `Created task \u201c${stripHtml(p.title)}\u201d in ${p.project_name}`;
     case 'update_task_status': return `Moved ${p.task_identifier} to ${(p.new_status || '').replace(/_/g, ' ')}`;
     case 'assign_task': return `Assigned ${p.task_identifier} to ${p.assignee_name}`;
     case 'post_message': return `Posted in #${p.space_name}`;

--- a/apps/web/src/app/(app)/dashboard/page.tsx
+++ b/apps/web/src/app/(app)/dashboard/page.tsx
@@ -86,6 +86,7 @@ function Hero({
   const inProgressN = core?.in_progress.length ?? 0;
   const doneThisWeek = (core?.due_this_week.filter(t => t.status === 'done').length ?? 0)
     + (core?.due_today.filter(t => t.status === 'done').length ?? 0);
+  const attention = core?.attention?.slice(0, 3) ?? [];
 
   const Stat = ({ n, color }: { n: number; color: string }) => (
     <span style={{
@@ -167,6 +168,54 @@ function Hero({
               </>
             )}
           </p>
+          {attention.length > 0 && (
+            <div
+              aria-label="Workspace attention"
+              style={{
+                display: 'flex',
+                flexWrap: 'wrap',
+                gap: 8,
+                marginTop: 16,
+                maxWidth: 760,
+              }}
+            >
+              {attention.map((item) => (
+                <Link
+                  key={`${item.kind}:${item.href}:${item.title}`}
+                  href={item.href}
+                  style={{
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    minHeight: 34,
+                    maxWidth: '100%',
+                    borderRadius: 8,
+                    padding: '7px 10px',
+                    border: '1px solid var(--border-default)',
+                    background: item.severity === 'critical'
+                      ? 'rgba(239, 68, 68, 0.08)'
+                      : item.severity === 'warning'
+                        ? 'rgba(245, 158, 11, 0.08)'
+                        : 'color-mix(in srgb, var(--bg-surface) 90%, white 3%)',
+                    color: 'var(--text-secondary)',
+                    fontSize: 12,
+                    lineHeight: 1.25,
+                    textDecoration: 'none',
+                  }}
+                  title={item.title}
+                >
+                  <span
+                    style={{
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                    }}
+                  >
+                    {item.title}
+                  </span>
+                </Link>
+              ))}
+            </div>
+          )}
         </div>
 
         <div

--- a/apps/web/src/app/(app)/knowledge/page.tsx
+++ b/apps/web/src/app/(app)/knowledge/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, lazy, Suspense } from 'react';
+import { useState, useEffect, useCallback, useRef, lazy, Suspense } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { api } from '@/lib/api';
 import { formatRelative } from '@/lib/time';
@@ -260,6 +260,8 @@ export default function KnowledgePage() {
   const [detail, setDetail] = useState<WikiPageDetail | null>(null);
   const [detailLoading, setDetailLoading] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
+  const [debouncedSearchQuery, setDebouncedSearchQuery] = useState('');
+  const [pagesError, setPagesError] = useState<string | null>(null);
   const [showCreate, setShowCreate] = useState(false);
   const [editing, setEditing] = useState(false);
   const [editForm, setEditForm] = useState<{ title: string; content: string; summary: string; type: string; confidence: number; tags: string }>({
@@ -282,23 +284,62 @@ export default function KnowledgePage() {
   const [statsLoading, setStatsLoading] = useState(false);
   const [reversingId, setReversingId] = useState<string | null>(null);
   const [reverseError, setReverseError] = useState<string | null>(null);
+  const pagesAbortRef = useRef<AbortController | null>(null);
+  const pagesRequestIdRef = useRef(0);
   const limit = 50;
+  const isSearchSettling = searchQuery.trim() !== debouncedSearchQuery;
 
-  const fetchPages = () => {
+  const fetchPages = useCallback(async () => {
+    const requestId = pagesRequestIdRef.current + 1;
+    pagesRequestIdRef.current = requestId;
+    pagesAbortRef.current?.abort();
+    const controller = new AbortController();
+    pagesAbortRef.current = controller;
+
     setLoading(true);
+    setPagesError(null);
     const params = new URLSearchParams({ page: String(page), limit: String(limit) });
     if (filter !== 'all') params.set('type', filter);
     if (scopeFilter !== 'all') params.set('scope', scopeFilter);
-    if (searchQuery.trim()) params.set('q', searchQuery.trim());
+    if (debouncedSearchQuery) params.set('q', debouncedSearchQuery);
 
-    api.get(`/api/wiki?${params.toString()}`).then(async res => {
-      if (res.ok) {
-        const data = await res.json();
-        setPages(data.pages || []);
-        setTotal(data.total || 0);
+    try {
+      const res = await api.fetch(`/api/wiki?${params.toString()}`, { signal: controller.signal });
+      if (requestId !== pagesRequestIdRef.current) return;
+
+      if (!res.ok) {
+        let message = 'Could not load wiki pages.';
+        try {
+          const data = await res.json();
+          message = data.error || message;
+        } catch {
+          // Keep the generic message.
+        }
+        if (res.status === 429) {
+          message = 'Knowledge search is being rate limited. Pause briefly and try again.';
+        }
+        setPagesError(message);
+        return;
       }
-    }).catch(() => {}).finally(() => setLoading(false));
-  };
+
+      const data = await res.json();
+      if (requestId !== pagesRequestIdRef.current) return;
+      setPages(data.pages || []);
+      setTotal(data.total || 0);
+    } catch (err) {
+      if (controller.signal.aborted) return;
+      if (requestId === pagesRequestIdRef.current) {
+        setPagesError(err instanceof Error ? err.message : 'Could not load wiki pages.');
+      }
+    } finally {
+      if (requestId === pagesRequestIdRef.current) {
+        setLoading(false);
+        if (pagesAbortRef.current === controller) {
+          pagesAbortRef.current = null;
+        }
+      }
+    }
+  }, [page, filter, scopeFilter, debouncedSearchQuery]);
 
   // Sync filter from URL ?type= param, open detail from ?slug= param
   useEffect(() => {
@@ -313,10 +354,20 @@ export default function KnowledgePage() {
     }
   }, [searchParams]);
 
+  useEffect(() => {
+    const handle = window.setTimeout(() => {
+      setDebouncedSearchQuery(searchQuery.trim());
+    }, 300);
+    return () => window.clearTimeout(handle);
+  }, [searchQuery]);
+
   // Fetch wiki pages list
   useEffect(() => {
     fetchPages();
-  }, [filter, scopeFilter, page, searchQuery]);
+    return () => {
+      pagesAbortRef.current?.abort();
+    };
+  }, [fetchPages]);
 
   // Fetch page detail when selected
   useEffect(() => {
@@ -1174,22 +1225,44 @@ export default function KnowledgePage() {
             </button>
           </div>
         )}
-        {loading ? (
+        {pagesError && (
+          <div className="flex items-center justify-between gap-3 p-2.5 rounded-lg mb-1"
+            style={{ background: '#EF444415', border: '1px solid #EF444440' }}>
+            <span className="text-[12px]" style={{ color: '#EF4444' }}>{pagesError}</span>
+            <button onClick={fetchPages} className="flex items-center gap-1 px-2 py-1 rounded text-[11px] font-medium hover:opacity-80"
+              style={{ background: '#EF444420', color: '#EF4444' }}>
+              <RefreshCw size={12} /> Retry
+            </button>
+          </div>
+        )}
+        {(loading || isSearchSettling) && pages.length > 0 && (
+          <div className="flex items-center gap-2 px-2 py-1 mb-1 text-[11px]" style={{ color: 'var(--text-tertiary)' }}>
+            <Loader2 size={12} className="animate-spin" />
+            Searching knowledge...
+          </div>
+        )}
+        {loading && pages.length === 0 ? (
           <div className="flex items-center justify-center py-12">
             <Loader2 size={20} className="animate-spin" style={{ color: 'var(--text-tertiary)' }} />
           </div>
-        ) : pages.length === 0 ? (
+        ) : pages.length === 0 && !pagesError ? (
           <div className="text-center py-12">
             <BookOpen size={24} style={{ color: 'var(--text-tertiary)', margin: '0 auto 8px' }} />
-            <p className="text-[13px]" style={{ color: 'var(--text-tertiary)' }}>No wiki pages yet</p>
-            <p className="text-[11px] mt-1" style={{ color: 'var(--text-tertiary)' }}>
-              Knowledge is automatically captured from conversations and agent interactions
+            <p className="text-[13px]" style={{ color: 'var(--text-tertiary)' }}>
+              {debouncedSearchQuery ? `No wiki pages match "${debouncedSearchQuery}"` : 'No wiki pages yet'}
             </p>
-            <button onClick={() => setShowCreate(true)}
-              className="mt-3 px-4 py-2 rounded-lg text-[12px] font-medium"
-              style={{ background: 'var(--accent)', color: 'white' }}>
-              Create First Page
-            </button>
+            <p className="text-[11px] mt-1" style={{ color: 'var(--text-tertiary)' }}>
+              {debouncedSearchQuery
+                ? 'Try a broader term or clear the search.'
+                : 'Knowledge is automatically captured from conversations and agent interactions'}
+            </p>
+            {!debouncedSearchQuery && (
+              <button onClick={() => setShowCreate(true)}
+                className="mt-3 px-4 py-2 rounded-lg text-[12px] font-medium"
+                style={{ background: 'var(--accent)', color: 'white' }}>
+                Create First Page
+              </button>
+            )}
           </div>
         ) : (
           pages.map((entry) => {

--- a/apps/web/src/app/(app)/settings/agent-employees/page.tsx
+++ b/apps/web/src/app/(app)/settings/agent-employees/page.tsx
@@ -69,6 +69,97 @@ function runtimeLabel(value: string | null | undefined): string {
   return value ? value.replace(/_/g, ' ') : 'custom MCP';
 }
 
+function formatRelative(iso: string | null | undefined): string {
+  if (!iso) return 'never';
+  const elapsedMs = Date.now() - new Date(iso).getTime();
+  const elapsedMinutes = Math.max(0, Math.floor(elapsedMs / 60000));
+  if (elapsedMinutes < 1) return 'just now';
+  if (elapsedMinutes < 60) return `${elapsedMinutes}m ago`;
+  const elapsedHours = Math.floor(elapsedMinutes / 60);
+  if (elapsedHours < 24) return `${elapsedHours}h ago`;
+  return `${Math.floor(elapsedHours / 24)}d ago`;
+}
+
+function lifecycleStatus(emp: AgentEmployee): {
+  label: string;
+  detail: string;
+  color: string;
+  background: string;
+  border: string;
+} {
+  if (emp.unhealthy) {
+    return {
+      label: 'Needs attention',
+      detail: emp.unhealthy_reason || 'health check failed',
+      color: '#ef4444',
+      background: 'rgba(239,68,68,0.10)',
+      border: 'rgba(239,68,68,0.22)',
+    };
+  }
+  if (!emp.is_active) {
+    return {
+      label: 'Paused',
+      detail: 'will not pick up new work',
+      color: '#9ca3af',
+      background: 'rgba(156,163,175,0.10)',
+      border: 'rgba(156,163,175,0.22)',
+    };
+  }
+  if (emp.pending_action_count && emp.pending_action_count > 0) {
+    return {
+      label: 'Needs approval',
+      detail: `${emp.pending_action_count} pending`,
+      color: '#f59e0b',
+      background: 'rgba(245,158,11,0.12)',
+      border: 'rgba(245,158,11,0.28)',
+    };
+  }
+  if (emp.certification_status === 'verified') {
+    const recentWork = emp.last_work_outcome_at ?? emp.last_turn_at ?? emp.last_mcp_call_at;
+    return {
+      label: 'Working',
+      detail: `last activity ${formatRelative(recentWork)}`,
+      color: '#10b981',
+      background: 'rgba(16,185,129,0.12)',
+      border: 'rgba(16,185,129,0.26)',
+    };
+  }
+  if (emp.last_mcp_call_at || emp.certification_status === 'mcp_reachable') {
+    return {
+      label: 'Connected',
+      detail: 'ready for certification',
+      color: '#3b82f6',
+      background: 'rgba(59,130,246,0.11)',
+      border: 'rgba(59,130,246,0.24)',
+    };
+  }
+  if (emp.certification_status === 'challenge_issued') {
+    return {
+      label: 'Certifying',
+      detail: 'waiting for challenge response',
+      color: '#f59e0b',
+      background: 'rgba(245,158,11,0.12)',
+      border: 'rgba(245,158,11,0.28)',
+    };
+  }
+  if (emp.certification_status === 'token_issued') {
+    return {
+      label: 'Token issued',
+      detail: 'waiting for first MCP call',
+      color: '#8b5cf6',
+      background: 'rgba(139,92,246,0.11)',
+      border: 'rgba(139,92,246,0.24)',
+    };
+  }
+  return {
+    label: 'Draft',
+    detail: 'finish setup',
+    color: '#9ca3af',
+    background: 'rgba(156,163,175,0.10)',
+    border: 'rgba(156,163,175,0.22)',
+  };
+}
+
 export default function AgentEmployeesPage() {
   const [employees, setEmployees] = useState<AgentEmployee[]>([]);
   const [loading, setLoading] = useState(true);
@@ -174,6 +265,7 @@ export default function AgentEmployeesPage() {
         <div className="space-y-2">
           {employees.map((emp) => {
             const conn = connectionStatus(emp.last_mcp_call_at ?? emp.last_heartbeat_at);
+            const lifecycle = lifecycleStatus(emp);
             return (
             <div
               key={emp.id}
@@ -201,6 +293,22 @@ export default function AgentEmployeesPage() {
                   >
                     {emp.name}
                   </p>
+                  <div className="flex flex-wrap items-center gap-2 mt-1">
+                    <span
+                      className="inline-flex items-center gap-1.5 text-[11px] px-2 py-0.5 rounded"
+                      style={{
+                        color: lifecycle.color,
+                        background: lifecycle.background,
+                        border: `1px solid ${lifecycle.border}`,
+                      }}
+                    >
+                      <span className="w-1.5 h-1.5 rounded-full" style={{ background: lifecycle.color }} />
+                      {lifecycle.label}
+                    </span>
+                    <span className="text-[11px]" style={{ color: 'var(--muted)' }}>
+                      {lifecycle.detail}
+                    </span>
+                  </div>
                   <div className="flex flex-wrap items-center gap-x-2 gap-y-1 mt-0.5">
                     <span
                       className="text-[11px] px-1.5 py-0.5 rounded"
@@ -224,20 +332,10 @@ export default function AgentEmployeesPage() {
                     <span className="text-[11px]" style={{ color: 'var(--muted)' }}>
                       {emp.pending_action_count ?? 0} pending
                     </span>
-                    <span
-                      className="text-[11px]"
-                      style={{ color: emp.certification_status === 'verified' ? '#10b981' : 'var(--muted)' }}
-                    >
-                      {emp.certification_status}
+                    <span className="text-[11px]" style={{ color: 'var(--muted)' }}>
+                      cert {emp.certification_status}
                     </span>
                     <div className="flex items-center gap-1">
-                      <div
-                        className="w-2 h-2 rounded-full"
-                        style={{ background: emp.is_active ? '#10b981' : '#9ca3af' }}
-                      />
-                      <span className="text-[11px]" style={{ color: 'var(--muted)' }}>
-                        {emp.is_active ? 'Active' : 'Paused'}
-                      </span>
                       {emp.heartbeat_enabled && (
                         <span style={{ fontSize: '11px', color: 'var(--muted)', marginLeft: '4px' }}>
                           &#9829; every {emp.heartbeat_interval_min}m

--- a/apps/web/src/app/(app)/settings/ai/page.tsx
+++ b/apps/web/src/app/(app)/settings/ai/page.tsx
@@ -35,8 +35,8 @@ type AIConfig = {
 };
 
 const PROVIDERS: { id: Provider; label: string; placeholder: string; hint: string }[] = [
-  { id: 'anthropic', label: 'Anthropic', placeholder: 'sk-ant-…', hint: 'Claude models — recommended for reasoning and reliable agent flows.' },
-  { id: 'openai', label: 'OpenAI', placeholder: 'sk-…', hint: 'GPT-4o, GPT-4.1, and other OpenAI models.' },
+  { id: 'anthropic', label: 'Anthropic', placeholder: 'sk-ant-…', hint: 'Optional managed provider for Claude models.' },
+  { id: 'openai', label: 'OpenAI', placeholder: 'sk-…', hint: 'Optional managed provider for GPT models and compatible APIs.' },
   { id: 'openrouter', label: 'OpenRouter', placeholder: 'sk-or-…', hint: 'Proxy to dozens of models through a single key.' },
   { id: 'ollama', label: 'Ollama', placeholder: 'http://localhost:11434', hint: 'Self-hosted local models. Provide the server URL instead of a key.' },
 ];
@@ -123,9 +123,18 @@ export default function AISettingsPage() {
             AI providers for {org?.name ?? 'your workspace'}
           </h2>
           <p className="text-[12px] mt-1 leading-relaxed" style={{ color: 'var(--muted)' }}>
-            Bring your own provider keys. Keys are encrypted at rest and only used for this workspace.
-            One key is enough to unlock the agent and AI-powered features.
+            Bring your own provider. Deft can use managed keys or local Ollama, and the core workspace keeps
+            working when no AI provider is configured. Keys are encrypted at rest and only used for this workspace.
           </p>
+          {!cfg.has_provider && (
+            <div
+              className="mt-3 p-3 rounded-lg text-[12px] leading-relaxed"
+              style={{ background: 'rgba(245,158,11,0.10)', border: '1px solid rgba(245,158,11,0.25)', color: 'var(--foreground-secondary)' }}
+            >
+              AI is currently off. Chat, tasks, wiki, calendar, and approvals still work; Defty and AI-assisted
+              features wake up after you configure any supported provider.
+            </div>
+          )}
         </div>
 
         <section className="mb-8">
@@ -292,7 +301,7 @@ function ProviderCard({
                 className="text-[10px] px-1.5 py-0.5 rounded"
                 style={{ background: 'var(--surface)', color: 'var(--muted)' }}
               >
-                env fallback active
+                env provider available
               </span>
             ) : (
               <span
@@ -468,7 +477,7 @@ function ModelRouteCard({
             {description}
           </p>
           <p className="text-[11px] mt-1 font-mono" style={{ color: current ? 'var(--foreground-secondary)' : 'var(--muted)' }}>
-            {current ? `${current.provider} · ${current.model}` : 'Default — uses provider+model from llm.ts'}
+            {current ? `${current.provider} · ${current.model}` : 'Default — uses the first configured provider'}
           </p>
         </div>
         {!editing && (

--- a/apps/web/src/app/(app)/settings/ai/page.tsx
+++ b/apps/web/src/app/(app)/settings/ai/page.tsx
@@ -621,7 +621,7 @@ function EmbedSection({ cfg, onSaved }: { cfg: AIConfig; onSaved: () => Promise<
                 style={{ background: 'rgba(34,197,94,0.15)', color: 'var(--success, #22c55e)' }}
               >
                 <span className="w-1.5 h-1.5 rounded-full" style={{ background: 'var(--success, #22c55e)' }} />
-                OpenAI key available
+                Embedding provider available
               </span>
             ) : (
               <span
@@ -629,7 +629,7 @@ function EmbedSection({ cfg, onSaved }: { cfg: AIConfig; onSaved: () => Promise<
                 style={{ background: 'rgba(245,158,11,0.15)', color: 'var(--warning, #f59e0b)' }}
               >
                 <span className="w-1.5 h-1.5 rounded-full" style={{ background: 'var(--warning, #f59e0b)' }} />
-                No OpenAI key — set one above
+                No embedding provider configured
               </span>
             )}
           </div>
@@ -668,7 +668,7 @@ function EmbedSection({ cfg, onSaved }: { cfg: AIConfig; onSaved: () => Promise<
                     boxShadow: active ? '0 1px 2px rgba(0,0,0,0.2)' : 'none',
                   }}
                 >
-                  {opt === 'openai' ? 'OpenAI' : 'Off'}
+                  {opt === 'openai' ? 'OpenAI-compatible' : 'Off'}
                 </button>
               );
             })}
@@ -710,7 +710,7 @@ function EmbedSection({ cfg, onSaved }: { cfg: AIConfig; onSaved: () => Promise<
 
         {off && (
           <p className="text-[11px] leading-snug" style={{ color: 'var(--muted)' }}>
-            Vector search disabled — using keyword fallback for wiki, tasks, and decisions.
+            Vector search disabled - using keyword fallback for wiki, tasks, and decisions.
           </p>
         )}
 

--- a/apps/web/src/app/setup-ai/page.tsx
+++ b/apps/web/src/app/setup-ai/page.tsx
@@ -11,16 +11,16 @@ import { useAuth } from '@/lib/auth-context';
 type Provider = 'anthropic' | 'openai' | 'openrouter' | 'ollama';
 
 const TABS: { id: Provider; label: string; placeholder: string; blurb: string; isUrl?: boolean }[] = [
-  { id: 'anthropic', label: 'Anthropic', placeholder: 'sk-ant-…', blurb: 'Claude — recommended. Get a key at console.anthropic.com.' },
-  { id: 'openai', label: 'OpenAI', placeholder: 'sk-…', blurb: 'GPT-4 family. Get a key at platform.openai.com.' },
-  { id: 'openrouter', label: 'OpenRouter', placeholder: 'sk-or-…', blurb: 'One key, many models. Get a key at openrouter.ai.' },
   { id: 'ollama', label: 'Ollama', placeholder: 'http://localhost:11434', blurb: 'Run open-source models on your own machine.', isUrl: true },
+  { id: 'openrouter', label: 'OpenRouter', placeholder: 'sk-or-...', blurb: 'Use a managed router when you want access to several hosted model families.' },
+  { id: 'anthropic', label: 'Anthropic', placeholder: 'sk-ant-...', blurb: 'Use Claude models with a workspace-owned Anthropic key.' },
+  { id: 'openai', label: 'OpenAI', placeholder: 'sk-...', blurb: 'Use OpenAI models with a workspace-owned OpenAI key.' },
 ];
 
 export default function SetupAIPage() {
   const router = useRouter();
   const { user, loading: authLoading } = useAuth();
-  const [tab, setTab] = useState<Provider>('anthropic');
+  const [tab, setTab] = useState<Provider>('ollama');
   const [value, setValue] = useState('');
   const [reveal, setReveal] = useState(false);
   const [saving, setSaving] = useState(false);
@@ -86,15 +86,6 @@ export default function SetupAIPage() {
       className="min-h-screen flex items-center justify-center p-4 relative overflow-hidden"
       style={{ background: 'var(--surface-lowest)' }}
     >
-      <div
-        className="fixed top-0 left-1/4 w-[500px] h-[500px] rounded-full pointer-events-none -z-10"
-        style={{ background: 'var(--accent-muted)', filter: 'blur(120px)', opacity: 0.3 }}
-      />
-      <div
-        className="fixed bottom-0 right-1/4 w-[600px] h-[600px] rounded-full pointer-events-none -z-10"
-        style={{ background: 'var(--accent-muted)', filter: 'blur(140px)', opacity: 0.2 }}
-      />
-
       <main className="w-full max-w-[520px] flex flex-col items-center gap-6">
         <Logo variant="wordmark" className="h-10 w-auto" priority />
 
@@ -116,12 +107,12 @@ export default function SetupAIPage() {
             </div>
             <div className="flex flex-col gap-1.5">
               <h1 className="text-[1.25rem] font-semibold leading-tight" style={{ color: 'var(--on-surface)' }}>
-                {hasEnvFallback ? 'AI is already on' : 'Bring your own AI key'}
+                {hasEnvFallback ? 'AI is already on' : 'Choose your AI provider'}
               </h1>
               <p className="text-[0.875rem] leading-relaxed" style={{ color: 'var(--on-surface-variant)' }}>
                 {hasEnvFallback
                   ? 'This Deft instance has a shared AI key configured at the server level, so the agent and AI features will work out of the box. You can still add a per-workspace key from Settings to override it.'
-                  : 'Deft uses your own provider key — that means full control over your data, your bills, and which model handles what. Drop in one key now and the agent comes online immediately.'}
+                  : 'Deft can run with a local Ollama server or a workspace-owned managed provider key. Choose the model route that fits your self-hosting, data, and billing needs.'}
               </p>
             </div>
           </div>
@@ -210,7 +201,7 @@ export default function SetupAIPage() {
                   )}
                 </div>
                 <p className="text-[0.75rem] leading-relaxed" style={{ color: 'var(--on-surface-variant)' }}>
-                  Stored encrypted in this workspace only. We never log keys, never send them anywhere except the chosen provider.
+                  Stored encrypted in this workspace only. We never log keys, and only send model requests to the provider you configure.
                 </p>
               </div>
 
@@ -233,7 +224,7 @@ export default function SetupAIPage() {
               </div>
 
               <p className="text-[0.75rem] leading-relaxed" style={{ color: 'var(--on-surface-variant)' }}>
-                You can add or change this later from Settings → AI.
+                You can add or change this later from Settings / AI.
               </p>
             </form>
           )}

--- a/apps/web/src/components/agent-action-card.tsx
+++ b/apps/web/src/components/agent-action-card.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { humanizeToolName } from '@/lib/tool-display';
+import { stripHtml } from '@/lib/strip-html';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -28,7 +29,7 @@ function GenericParams({ params }: { params: Record<string, any> }) {
       {entries.map(([k, v]) => {
         const isUrl = typeof v === 'string' && /^https?:\/\//.test(v);
         const display =
-          typeof v === 'object' ? JSON.stringify(v).slice(0, 120) : String(v).slice(0, 120);
+          typeof v === 'object' ? JSON.stringify(v).slice(0, 120) : stripHtml(String(v)).slice(0, 120);
         return (
           <p key={k}>
             <span style={{ color: 'var(--muted)' }}>{k}:</span>{' '}
@@ -65,6 +66,8 @@ export function AgentActionCard({ action, onApprove, onReject, onUndo }: {
 }) {
   const humanized = humanizeToolName(action.action);
   const displayLabel = ACTION_LABELS[action.action] ?? humanized.full;
+  const title = stripHtml(action.params.title);
+  const content = stripHtml(action.params.content);
 
   if (action.status === 'executing') {
     return (
@@ -126,12 +129,12 @@ export function AgentActionCard({ action, onApprove, onReject, onUndo }: {
       <div className="text-[12px] mt-1 space-y-0.5" style={{ color: 'var(--foreground-secondary)' }}>
         {action.action in ACTION_LABELS ? (
           <>
-            {action.params.title && <p>"{action.params.title}"</p>}
+            {title && <p>"{title}"</p>}
             {action.params.project_name && <p>{action.params.project_name}</p>}
             {(action.params.priority || action.params.assignee_name) && (
               <p>{[action.params.priority?.toUpperCase(), action.params.assignee_name].filter(Boolean).join(' · ')}</p>
             )}
-            {action.params.content && <p>"{action.params.content.slice(0, 80)}..."</p>}
+            {content && <p>"{content.slice(0, 80)}{content.length > 80 ? '...' : ''}"</p>}
             {action.params.space_name && <p>in #{action.params.space_name}</p>}
           </>
         ) : (

--- a/apps/web/src/components/rich-composer.tsx
+++ b/apps/web/src/components/rich-composer.tsx
@@ -166,6 +166,7 @@ export function RichComposer({
   const [showTaskAutocomplete, setShowTaskAutocomplete] = useState(false);
   const [mentionQuery, setMentionQuery] = useState('');
   const [showMentions, setShowMentions] = useState(false);
+  const [, setContentVersion] = useState(0);
   // Anchor (start of @) + end (current cursor) at the moment the mention
   // autocomplete opened. Captured in onUpdate so handleMentionSelect can
   // delete the correct range even if the editor has lost focus (clicking
@@ -250,6 +251,7 @@ export function RichComposer({
     onFocus: () => setFocused(true),
     onBlur: () => setFocused(false),
     onUpdate: ({ editor }) => {
+      setContentVersion((v) => v + 1);
       const { from } = editor.state.selection;
       const textBefore = editor.state.doc.textBetween(Math.max(0, from - 20), from);
 

--- a/docs/AGENT-VISION.md
+++ b/docs/AGENT-VISION.md
@@ -1,5 +1,7 @@
 # How Agents Work in Deft
 
+> Status note, 2026-06-09: This document describes the agent vision. For current self-hosted v1 pilot promises, external tools should be framed as BYOA/MCP-provided capabilities, not native Slack/Gmail/GitHub/Google OAuth integrations owned by Deft.
+
 ## The Core Idea
 
 Deft agents are AI teammates, not chatbots. They have user accounts, appear in member lists, get assigned tasks, post in channels, and learn from every interaction. They share one brain (the wiki), operate under org-defined trust levels, and proactively monitor their domain through heartbeats.

--- a/docs/AGENTIC-EMPLOYEES-PLATFORM.md
+++ b/docs/AGENTIC-EMPLOYEES-PLATFORM.md
@@ -1,5 +1,7 @@
 # Agentic Employees Platform — Master Plan
 
+> Status note, 2026-06-09: This is a historical master plan, not the current self-hosted v1 product contract. Use `docs/self-hosted-v1-contract.md` for buyer-facing promises: native workspace, ICS calendar subscriptions, BYOA/MCP employees, provider-neutral AI, and no native Slack/Gmail/GitHub/Google OAuth promise.
+
 ## Vision
 
 Transform Deft from an AI-native workspace into an **agentic employee platform** — where AI teammates share the same spaces, tasks, and communication channels as humans. Not personal assistants that help one user at a time, but persistent, role-based agents that operate as first-class team members.

--- a/docs/CHAT-COMPETITIVE-ANALYSIS.md
+++ b/docs/CHAT-COMPETITIVE-ANALYSIS.md
@@ -1,5 +1,7 @@
 # Chat — Competitive Analysis
 
+> Status note, 2026-06-09: This is a historical comparison against Slack-style team chat. It should not be used as current buyer-facing copy or as a promise to ship native Slack/Gmail/GitHub integrations. Current self-hosted v1 positioning is native Deft workspace + ICS calendars + BYOA/MCP employees.
+
 ## Current State
 
 Deft's chat is surprisingly feature-rich. It has most of what Slack offers — threads, reactions, mentions, pins, bookmarks, scheduled messages, audio clips, huddles, DMs, file uploads, link previews, typing indicators, presence, rich text formatting, slash commands, and an integrated AI agent. This is not a prototype — it's a functional team communication tool.

--- a/docs/TASKS-COMPETITIVE-ANALYSIS.md
+++ b/docs/TASKS-COMPETITIVE-ANALYSIS.md
@@ -1,5 +1,7 @@
 # Tasks — Competitive Analysis
 
+> Status note, 2026-06-09: This is a historical competitive analysis. Current self-hosted v1 positioning should avoid native Slack/Gmail/GitHub promises and point external-tool work through BYOA/MCP employees instead.
+
 ## Current State
 
 Deft's task management is feature-rich — Kanban board with drag-and-drop, list view, subtasks, dependencies (blocks/blocked_by/relates_to), labels, comments, activity log, bulk operations, saved views, keyboard shortcuts, agent integration, and project organization. This is comparable to Linear's core feature set.

--- a/docs/self-hosted-v1-contract.md
+++ b/docs/self-hosted-v1-contract.md
@@ -1,0 +1,41 @@
+# Self-hosted v1 product contract
+
+This is the current promise for self-hosted Deft. Use this as the source of truth
+when updating README, docs, website copy, setup flows, and pilot reports.
+
+## What self-hosted v1 promises
+
+- One Deft workspace per deployment.
+- Email/password auth with invite links after the first owner account.
+- Native chat, tasks, wiki, calendar, dashboard, notifications, and approvals.
+- Defty, the built-in workspace superintendent, when an AI provider is configured.
+- Bring-your-own agent employees over Deft MCP.
+- Calendar context through native Deft events and ICS feed import/export.
+- External tools through MCP/BYOA agents, not managed provider OAuth.
+- Provider-neutral AI configuration: Anthropic, OpenAI, OpenRouter, or Ollama.
+- Core product operation without AI keys. Chat, tasks, wiki, calendar, and auth still work.
+
+## What self-hosted v1 does not promise
+
+- Managed hosting or multi-tenant SaaS operation.
+- Native Slack or Gmail integrations.
+- Native Google Calendar OAuth.
+- Native GitHub OAuth or a managed GitHub connector as a buyer-facing feature.
+- A hosted plugin/agent marketplace.
+- A guarantee that Deft provisions or controls third-party agent runtimes.
+
+## Recommended integration story
+
+- Calendar: connect ICS feeds in Settings -> Calendar.
+- GitHub, Slack, Gmail, Linear, Notion, and other tools: connect them inside the
+  user's own agent runtime or MCP server, then onboard that agent as a Deft employee.
+- Local/private AI: configure Ollama or an OpenAI-compatible local server where supported.
+- Managed AI: configure the provider key the workspace owner chooses.
+
+## Legacy compatibility rule
+
+Some source files and database enums may still contain old provider names such as
+`github`, `google_calendar`, `slack`, or `linear` for compatibility with existing
+rows, historical audits, and older experiments. These names must not appear as
+self-hosted v1 product promises unless the integration is intentionally supported,
+documented, and tested.

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -4,7 +4,7 @@ This guide covers everything you need to run Deft on your own infrastructure —
 
 ## Overview
 
-Self-hosted Deft is a single-workspace deployment of the Deft platform. You run the database, Redis, and application stack yourself. Your data never leaves your server, and you bring your own AI API key.
+Self-hosted Deft is a single-workspace deployment of the Deft platform. You run the database, Redis, and application stack yourself. Your data never leaves your server, and AI is bring-your-own-provider: Anthropic, OpenAI, OpenRouter, or local Ollama.
 
 Each deployment supports **one organisation**. This is by design: self-hosted Deft is meant for a single team, not a multi-tenant SaaS offering. The first user to sign up becomes the org owner and admin; subsequent users join via invite link only. Attempting to host Deft as a managed service for other organisations is outside what the Business Source License 1.1 permits — see [Licence & what's not in v1](#licence--whats-not-in-v1) for details.
 
@@ -16,9 +16,9 @@ Defty, the built-in native agent, is seeded automatically on first run. Think of
 |---|---|
 | Docker Desktop 4.x+ | Includes Docker Compose v2. [Download](https://www.docker.com/products/docker-desktop/) |
 | `openssl` (any version) | For generating secrets. Ships with macOS, Linux, Git for Windows. |
-| Anthropic API key *(optional)* | Free tier at [console.anthropic.com](https://console.anthropic.com). Only needed for AI features — chat and tasks work without one. |
+| AI provider (optional) | Configure Anthropic, OpenAI, OpenRouter, or Ollama via env or Settings -> AI. Chat and tasks work without one. |
 
-**Alternative AI provider:** If you prefer not to use Anthropic, [Ollama](https://ollama.com) can serve a local model. You will need to update `ANTHROPIC_API_KEY` and the model references in Settings → Agent after first boot. Ollama support is community-maintained.
+**Provider-neutral AI:** Deft does not require Anthropic or OpenAI. Ollama/local models are supported for self-hosted pilots, and core workspace features keep working when AI is not configured.
 
 **Hardware:** The stack runs comfortably on 2 vCPU / 4 GB RAM. Postgres and Redis together use under 100 MB at idle.
 
@@ -46,7 +46,7 @@ openssl rand -hex 32   # paste result into JWT_REFRESH_SECRET
 | `POSTGRES_PASSWORD` | `openssl rand -hex 32` | **Yes** |
 | `JWT_SECRET` | `openssl rand -hex 32` | **Yes** |
 | `JWT_REFRESH_SECRET` | `openssl rand -hex 32` | **Yes** |
-| `ANTHROPIC_API_KEY` | https://console.anthropic.com | Optional — only for AI features; can also be set per-org in Settings → AI |
+| `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `OPENROUTER_API_KEY`, or `OLLAMA_URL` | Optional; configure later in Settings -> AI |
 
 Everything else in `.env` is optional for a first boot. Leave the database and Redis URLs as-is — Docker Compose overrides them automatically.
 
@@ -133,7 +133,7 @@ Deft agents are configured from **Settings → Agent**. The Connect Agent wizard
 
 ### Native (Defty)
 
-Defty is the built-in native agent seeded by `pnpm db:seed`. It runs inside the Deft process using the Anthropic API key you configured. No additional setup required — Defty is already active after seeding.
+Defty is the built-in native agent seeded by `pnpm db:seed`. It runs inside the Deft process when a supported AI provider is configured. No provider is required for first boot; without one, Defty and AI features remain dormant while the core workspace continues to work.
 
 Defty's behaviour is defined by the `defty` template. You can inspect and customise it from Settings → Agent → Defty.
 
@@ -186,7 +186,10 @@ Defty is powered by the `defty` agent template. The template slug is `defty`. Yo
 | `POSTGRES_PASSWORD` | **Yes** | Database password (Docker Compose auth) | none |
 | `JWT_SECRET` | **Yes** | Signs access tokens | none |
 | `JWT_REFRESH_SECRET` | **Yes** | Signs refresh tokens | none |
-| `ANTHROPIC_API_KEY` | Optional | Anthropic Claude API key — app boots without it; AI features disabled until set (env or per-org) | none |
+| `ANTHROPIC_API_KEY` | Optional | Anthropic provider key. App boots without it; AI features stay disabled until a provider is set by env or per-org Settings -> AI | none |
+| `OPENAI_API_KEY` | Optional | OpenAI provider key for model routing, OpenAI-compatible embeddings, or OpenAI Whisper if selected | none |
+| `OPENROUTER_API_KEY` | Optional | OpenRouter provider key for model routing | none |
+| `OLLAMA_URL` | Optional | Local/self-hosted Ollama endpoint | `http://localhost:11434` |
 | `NEXT_PUBLIC_API_URL` | No | API base URL seen by browser | `http://localhost:3001` |
 | `NEXT_PUBLIC_WS_URL` | No | WebSocket URL seen by browser | `http://localhost:3001` |
 | `NEXT_PUBLIC_APP_URL` | No | App base URL (used in invite links) | `http://localhost:3000` |

--- a/docs/superpowers/specs/2026-04-20-deft-self-hosted-v1-design.md
+++ b/docs/superpowers/specs/2026-04-20-deft-self-hosted-v1-design.md
@@ -1,5 +1,7 @@
 # Deft self-hosted v1 — design
 
+> Status note, 2026-06-08: This historical design spec is superseded for product promises by `docs/self-hosted-v1-contract.md`. Keep this file as implementation history, but use the contract for current self-hosted v1 copy: provider-neutral AI, ICS calendars, MCP/BYOA external tools, and no native Slack/Gmail/GitHub/Google OAuth promise.
+
 **Reframe:** Deft is a self-hostable workplace that any MCP-speaking agent can work in. One native agent (Defty, the superintendent) lives inside Deft. Agent employees are BYOA — users run their own OpenClaw (or Claude Code, or Codex, or anything else speaking MCP) and point it at Deft's MCP server.
 
 **Goal of v1:** `docker compose up` and have a working installation in 5 minutes. Connect an agent in the next 5. Everything else is polish.
@@ -13,7 +15,7 @@
 ```bash
 git clone github.com/deft/deft
 cd deft
-cp .env.example .env        # paste ANTHROPIC_API_KEY + optional OAuth + SMTP
+cp .env.example .env        # set required secrets; AI provider is optional
 docker compose up -d
 open http://localhost:3000
 ```
@@ -23,13 +25,13 @@ That's the whole first-run. Three services in compose: `web`, `api`, `postgres` 
 First-run UI walks: admin user → "my company" single-org install → Defty provisioned as the native agent employee → **Connect your agent** card on the dashboard as the last onboarding step.
 
 ### `.env.example` must include and document
-- `ANTHROPIC_API_KEY` — for Defty + native classifier
+- `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `OPENROUTER_API_KEY` / `OLLAMA_URL` - optional AI provider configuration
 - `DATABASE_URL` — defaults to the bundled Postgres
-- `NEXT_PUBLIC_APP_URL` — for OAuth redirect + CORS
+- `NEXT_PUBLIC_APP_URL` - for invite links and CORS
 - `BETTER_AUTH_SECRET` — rotate-per-install
 - `ENCRYPTION_KEY` — for `connected_accounts` token storage
 - `RESEND_API_KEY` — optional; without it, invites show the temp password in the UI
-- Optional OAuth: `GOOGLE_CLIENT_ID`/SECRET, `GITHUB_APP_*`, Slack, etc. Each optional — missing = feature disabled gracefully.
+- External tools are not managed through native OAuth in self-hosted v1; use ICS for calendars and MCP/BYOA for SaaS tools.
 
 ### Upgrades
 ```

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "db:push-full": "pnpm --filter @deft/db push-full",
     "db:seed": "pnpm --filter @deft/db seed && pnpm --filter @deft/api exec tsx src/scripts/seed-platform-bundles.ts",
     "db:seed:demo": "pnpm --filter @deft/db seed:demo && pnpm --filter @deft/api exec tsx src/scripts/seed-platform-bundles.ts",
+    "db:seed:pilot": "pnpm db:seed:demo && pnpm --filter @deft/api exec tsx src/scripts/seed-pilot-workspace.ts",
     "db:studio": "pnpm --filter @deft/db studio",
     "dev": "pnpm -r --parallel dev",
     "dev:api": "pnpm --filter @deft/api dev",
@@ -32,8 +33,12 @@
     "lint": "pnpm -r lint",
     "pilot:dev": "tsx scripts/pilot-preflight.ts --start",
     "pilot:clean-agent-queue": "tsx scripts/agent-demo-queue-cleanup.ts",
+    "pilot:cracks:battery": "node scripts/pilot-cracks-clearance-battery.mjs",
     "pilot:hygiene": "tsx scripts/pilot-workspace-hygiene.ts",
     "pilot:preflight": "tsx scripts/pilot-preflight.ts",
+    "pilot:preflight:strict": "tsx scripts/pilot-preflight.ts --strict",
+    "pilot:reset": "pnpm db:push-full && pnpm db:seed:pilot && pnpm pilot:preflight",
+    "pilot:swarm": "node scripts/pilot-multi-user-swarm.mjs",
     "typecheck": "pnpm -r --parallel typecheck"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "lint": "pnpm -r lint",
     "pilot:dev": "tsx scripts/pilot-preflight.ts --start",
     "pilot:clean-agent-queue": "tsx scripts/agent-demo-queue-cleanup.ts",
+    "pilot:hygiene": "tsx scripts/pilot-workspace-hygiene.ts",
     "pilot:preflight": "tsx scripts/pilot-preflight.ts",
     "typecheck": "pnpm -r --parallel typecheck"
   },

--- a/packages/db/seed-demo.ts
+++ b/packages/db/seed-demo.ts
@@ -28,15 +28,19 @@
  *                      All four LLM-task slots (classify/summarize/reason/extract)
  *                      are routed to OpenAI when set.
  */
-import 'dotenv/config';
+import { config as loadEnv } from 'dotenv';
 import pg from 'pg';
 import { drizzle } from 'drizzle-orm/node-postgres';
-import { eq, and, asc } from 'drizzle-orm';
+import { eq, and, asc, sql } from 'drizzle-orm';
 import bcrypt from 'bcryptjs';
 import { createCipheriv, randomBytes, scryptSync } from 'node:crypto';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
 import * as schema from './src/schema.js';
 
 const { Pool } = pg;
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+loadEnv({ path: path.resolve(__dirname, '../../.env') });
 
 const OPENAI_KEY = process.env.SEED_OPENAI_KEY || '';
 const ENCRYPTION_KEY = process.env.ENCRYPTION_KEY || '';
@@ -62,69 +66,24 @@ const db = drizzle(pool, { schema });
 async function seed() {
   console.log('Seeding Testers Tomatoes demo workspace…');
 
-  // ── Wipe existing data in reverse dependency order ──
-  // The list mirrors the table relationships in schema.ts. Adding wipe entries
-  // here is required whenever a new seeded table is added below, otherwise a
-  // re-run hits a unique-constraint violation on the second pass.
-  await db.delete(schema.burnoutAlerts);
-  await db.delete(schema.oneonePreps);
-  await db.delete(schema.teamHealthSnapshots);
-  await db.delete(schema.peopleRelationships);
-  await db.delete(schema.peoplePatterns);
-  await db.delete(schema.peopleInfluence);
-  await db.delete(schema.peopleExpertise);
-  await db.delete(schema.peopleInteractions);
-  await db.delete(schema.managerSettings);
-  await db.delete(schema.meetingBriefs);
-  await db.delete(schema.agentNudges);
-  await db.delete(schema.auditLog);
-  await db.delete(schema.crossReferences);
-  await db.delete(schema.agentMemory);
-  await db.delete(schema.standups);
-  await db.delete(schema.jobQueue);
-  await db.delete(schema.workflowRuns);
-  await db.delete(schema.workflowRules);
-  await db.delete(schema.customEmoji);
-  await db.delete(schema.userGroupMembers);
-  await db.delete(schema.userGroups);
-  await db.delete(schema.messageBookmarks);
-  await db.delete(schema.canvases);
-  await db.delete(schema.wikiLinks);
-  await db.delete(schema.wikiPages);
-  await db.delete(schema.entityTags);
-  await db.delete(schema.tags);
-  await db.delete(schema.notes);
-  await db.delete(schema.taskWatchers);
-  await db.delete(schema.taskActivity);
-  await db.delete(schema.taskComments);
-  await db.delete(schema.taskLabels);
-  await db.delete(schema.taskRelationships);
-  await db.delete(schema.tasks);
-  await db.delete(schema.projectSpaces);
-  await db.delete(schema.projects);
-  await db.delete(schema.reactions);
-  await db.delete(schema.pinnedMessages);
-  await db.delete(schema.scheduledMessages);
-  await db.delete(schema.files);
-  await db.delete(schema.reminders);
-  await db.delete(schema.messages);
-  await db.delete(schema.spaceMembers);
-  await db.delete(schema.spaces);
-  await db.delete(schema.orgMembers);
-  await db.delete(schema.onboardingState);
-  await db.delete(schema.notifications);
-  await db.delete(schema.favorites);
-  await db.delete(schema.savedViews);
-  await db.delete(schema.invites);
-  await db.delete(schema.agentActions);
-  await db.delete(schema.triggers);
-  await db.delete(schema.skills);
-  await db.delete(schema.tools);
-  await db.delete(schema.labels);
-  await db.delete(schema.events);
-  await db.delete(schema.connectedAccounts);
-  await db.delete(schema.orgs);
-  await db.delete(schema.users);
+  // This is a destructive local/demo seed. Use the database FK graph instead of
+  // a hand-maintained delete order so fresh installs and older local databases
+  // do not drift as product tables are added.
+  await db.execute(sql`
+    DO $$
+    DECLARE
+      table_list text;
+    BEGIN
+      SELECT string_agg(format('%I.%I', schemaname, tablename), ', ')
+      INTO table_list
+      FROM pg_tables
+      WHERE schemaname = 'public';
+
+      IF table_list IS NOT NULL THEN
+        EXECUTE 'TRUNCATE TABLE ' || table_list || ' RESTART IDENTITY CASCADE';
+      END IF;
+    END $$;
+  `);
 
   console.log('Wiped existing data');
 
@@ -223,7 +182,7 @@ async function seed() {
     { user_id: marigold!.id, profile_set: true, first_message_sent: true, completed: true },
     { user_id: cesar!.id, profile_set: true, first_message_sent: true, completed: true },
     { user_id: lina!.id, profile_set: true, first_message_sent: true, completed: true },
-    { user_id: tomas!.id, profile_set: true, first_message_sent: true, completed: false },
+    { user_id: tomas!.id, profile_set: true, first_message_sent: true, completed: true },
     { user_id: sage!.id, profile_set: true, first_message_sent: true, completed: true },
   ]);
 

--- a/scripts/pilot-cracks-clearance-battery.mjs
+++ b/scripts/pilot-cracks-clearance-battery.mjs
@@ -1,0 +1,513 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { createRequire } from 'node:module';
+
+const execFileAsync = promisify(execFile);
+const rootRequire = createRequire(import.meta.url);
+const apiRequire = createRequire(new URL('../apps/api/package.json', import.meta.url));
+const pg = apiRequire('pg');
+const { chromium } = rootRequire('playwright');
+const RUN = `20260609-${Date.now().toString().slice(-6)}`;
+const ROOT = process.cwd();
+const API_URL = (process.env.DEFT_API_URL || process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3301').replace(/\/$/, '');
+const WEB_URL = (process.env.DEFT_WEB_URL || 'http://localhost:3000').replace(/\/$/, '');
+const REPORT_DIR = path.join(ROOT, 'reports');
+const SCREEN_DIR = path.join(REPORT_DIR, 'screenshots', `cracks-clearance-${RUN}`);
+const HTML_REPORT = path.join(REPORT_DIR, 'cracks-clearance-battery-report-2026-06-09.html');
+const JSON_REPORT = path.join(REPORT_DIR, 'cracks-clearance-battery-report-2026-06-09.json');
+const PASSWORD = 'tomato123';
+const TOM_TOKEN = process.env.SEED_TOM_MCP_TOKEN || 'tom-pilot-mcp-token-2026';
+const MAYA_TOKEN = process.env.SEED_MAYA_MCP_TOKEN || 'maya-pilot-mcp-token-2026';
+
+await fs.mkdir(SCREEN_DIR, { recursive: true });
+
+const checks = [];
+const artifacts = {
+  run: RUN,
+  api: API_URL,
+  web: WEB_URL,
+  screenDir: SCREEN_DIR,
+  screenshots: {},
+  timings: [],
+  ids: {},
+  raw: {},
+};
+
+function htmlEscape(value) {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function cleanText(value = '') {
+  return String(value)
+    .replace(/<@([^|>]+)\|([^>]+)>/g, '@$2')
+    .replace(/<[^>]*>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function record(status, name, details = {}) {
+  checks.push({ status, name, details });
+  console.log(`[${status.toUpperCase().padEnd(7)}] ${name}`);
+}
+function pass(name, details = {}) { record('pass', name, details); }
+function partial(name, details = {}) { record('partial', name, details); }
+function fail(name, details = {}) { record('fail', name, details); }
+
+async function timed(label, fn) {
+  const started = Date.now();
+  try {
+    const value = await fn();
+    artifacts.timings.push({ label, ms: Date.now() - started, ok: true });
+    return value;
+  } catch (err) {
+    artifacts.timings.push({ label, ms: Date.now() - started, ok: false, error: err?.message || String(err) });
+    throw err;
+  }
+}
+
+async function dockerDatabaseUrl() {
+  try {
+    const [{ stdout: portOut }, { stdout: passwordOut }, { stdout: dbOut }] = await Promise.all([
+      execFileAsync('docker', ['port', 'deft-codex-pg', '5432/tcp']),
+      execFileAsync('docker', ['exec', 'deft-codex-pg', 'printenv', 'POSTGRES_PASSWORD']),
+      execFileAsync('docker', ['exec', 'deft-codex-pg', 'printenv', 'POSTGRES_DB']),
+    ]);
+    const port = portOut.match(/(?:127\.0\.0\.1|0\.0\.0\.0|\[::\]):(\d+)/)?.[1];
+    if (!port) return null;
+    return `postgres://postgres:${encodeURIComponent(passwordOut.trim() || 'postgres')}@localhost:${port}/${dbOut.trim() || 'deft'}`;
+  } catch {
+    return null;
+  }
+}
+
+async function connectDb() {
+  const candidates = [];
+  if (process.env.DATABASE_URL) candidates.push(process.env.DATABASE_URL);
+  const dockerUrl = await dockerDatabaseUrl();
+  if (dockerUrl) candidates.push(dockerUrl);
+  candidates.push('postgres://postgres:postgres@localhost:55432/deft');
+  candidates.push('postgres://postgres:postgres@localhost:5432/deft');
+
+  const errors = [];
+  for (const candidate of [...new Set(candidates)]) {
+    const client = new pg.Client({ connectionString: candidate });
+    try {
+      await client.connect();
+      artifacts.raw.db = candidate.replace(/:\/\/([^:]+):([^@]+)@/, '://$1:***@');
+      return client;
+    } catch (err) {
+      errors.push(`${candidate.replace(/:\/\/([^:]+):([^@]+)@/, '://$1:***@')}: ${err.message}`);
+      await client.end().catch(() => {});
+    }
+  }
+  throw new Error(`DB connect failed: ${errors.join(' | ')}`);
+}
+
+async function login(email) {
+  const res = await fetch(`${API_URL}/api/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password: PASSWORD }),
+  });
+  const body = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(`login failed for ${email}: ${res.status} ${JSON.stringify(body)}`);
+  return body;
+}
+
+async function authed(token, route, init = {}) {
+  const hasBody = init.body !== undefined;
+  const res = await fetch(`${API_URL}${route}`, {
+    ...init,
+    headers: {
+      ...(hasBody ? { 'Content-Type': 'application/json' } : {}),
+      Authorization: `Bearer ${token}`,
+      ...(init.headers || {}),
+    },
+  });
+  const text = await res.text();
+  let body;
+  try { body = JSON.parse(text); } catch { body = text; }
+  return { ok: res.ok, status: res.status, body };
+}
+
+async function waitFor(description, fn, { timeout = 90_000, interval = 1500 } = {}) {
+  const started = Date.now();
+  let last;
+  while (Date.now() - started < timeout) {
+    try {
+      const value = await fn();
+      if (value) return value;
+      last = value;
+    } catch (err) {
+      last = err?.message || String(err);
+    }
+    await new Promise((resolve) => setTimeout(resolve, interval));
+  }
+  throw new Error(`Timed out waiting for ${description}. Last: ${JSON.stringify(last)}`);
+}
+
+async function mcp(token, name, args) {
+  const res = await fetch(`${API_URL}/api/mcp/v1/tools/call`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+    body: JSON.stringify({ name, arguments: args }),
+  });
+  const body = await res.json().catch(() => ({}));
+  const text = body?.content?.map((item) => item.text).join('\n') ?? '';
+  return { ok: res.ok, status: res.status, body, text, isError: Boolean(body?.isError) };
+}
+
+async function screenshot(page, name) {
+  const file = path.join(SCREEN_DIR, `${name}.png`);
+  await page.screenshot({ path: file, fullPage: true }).catch(() => null);
+  artifacts.screenshots[name] = file;
+  return file;
+}
+
+async function openAuthedPage(context, auth, url) {
+  const page = await context.newPage();
+  page.on('response', (res) => {
+    const route = res.url();
+    if (route.includes('/api/wiki') || route.includes('/api/messages') || route.includes('/api/dashboard')) {
+      artifacts.timings.push({ label: `response ${route.replace(API_URL, '')}`, ms: null, status: res.status() });
+    }
+  });
+  await page.addInitScript((tokens) => {
+    window.localStorage.setItem('deft-access-token', tokens.accessToken);
+    window.localStorage.setItem('deft-refresh-token', tokens.refreshToken);
+  }, { accessToken: auth.accessToken, refreshToken: auth.refreshToken });
+  await page.goto(url, { waitUntil: 'domcontentloaded' });
+  return page;
+}
+
+async function sendChatMessageUi(page, spaceName, message) {
+  await page.goto(`${WEB_URL}/chat`, { waitUntil: 'domcontentloaded' });
+  const spaceButton = page.getByRole('button', { name: spaceName, exact: true });
+  await spaceButton.waitFor({ state: 'visible', timeout: 20_000 });
+  await spaceButton.click();
+  await page.waitForTimeout(800);
+  const editor = page.locator('.ProseMirror.deft-editor').last();
+  await editor.waitFor({ state: 'visible', timeout: 20_000 });
+  await editor.click();
+  await editor.fill(message).catch(async () => {
+    await editor.click();
+    await page.keyboard.insertText(message);
+  });
+  const send = page.getByRole('button', { name: 'Send message' });
+  await send.waitFor({ state: 'visible', timeout: 10_000 });
+  await page.waitForFunction(() => {
+    const buttons = [...document.querySelectorAll('button[aria-label="Send message"]')];
+    return buttons.some((button) => !button.disabled && button.offsetParent !== null);
+  }, null, { timeout: 10_000 }).catch(async (error) => {
+    await screenshot(page, `composer-disabled-${spaceName}`);
+    const diagnostic = await page.evaluate(() => {
+      const editors = [...document.querySelectorAll('.ProseMirror.deft-editor')].map((el) => ({
+        text: el.textContent,
+        html: el.innerHTML,
+        visible: el.getBoundingClientRect().width > 0 && el.getBoundingClientRect().height > 0,
+      }));
+      const buttons = [...document.querySelectorAll('button[aria-label="Send message"]')].map((button) => ({
+        disabled: button.disabled,
+        visible: button.offsetParent !== null,
+        text: button.textContent,
+      }));
+      return { editors, buttons };
+    });
+    throw new Error(`${error.message}; composer diagnostic=${JSON.stringify(diagnostic).slice(0, 1200)}`);
+  });
+  await send.click();
+  const visibleNeedle = message.includes('Decision:')
+    ? `Decision: for clearance ${RUN}`
+    : `clearance ${RUN}: summarize`;
+  await page.getByText(visibleNeedle, { exact: false }).last().waitFor({ state: 'visible', timeout: 12_000 });
+}
+
+async function checkActiveDocsContract() {
+  const files = [
+    'AGENTS.md',
+    'docs/self-hosted-v1-contract.md',
+    'docs/AGENTIC-EMPLOYEES-PLATFORM.md',
+    'docs/CHAT-COMPETITIVE-ANALYSIS.md',
+    'docs/TASKS-COMPETITIVE-ANALYSIS.md',
+    'docs/AGENT-VISION.md',
+  ];
+  const contents = Object.fromEntries(await Promise.all(files.map(async (file) => [
+    file,
+    await fs.readFile(path.join(ROOT, file), 'utf8'),
+  ])));
+  const activeOk =
+    /provider-neutral/i.test(contents['AGENTS.md']) &&
+    /ICS calendars/i.test(contents['AGENTS.md']) &&
+    /Native Slack\/Gmail\/GitHub\/Google OAuth are not buyer-facing promises/i.test(contents['AGENTS.md']) &&
+    /Provider-neutral AI configuration/i.test(contents['docs/self-hosted-v1-contract.md']) &&
+    /Native Slack or Gmail integrations/i.test(contents['docs/self-hosted-v1-contract.md']);
+  const historicalNotes = [
+    'docs/AGENTIC-EMPLOYEES-PLATFORM.md',
+    'docs/CHAT-COMPETITIVE-ANALYSIS.md',
+    'docs/TASKS-COMPETITIVE-ANALYSIS.md',
+    'docs/AGENT-VISION.md',
+  ].filter((file) => /Status note, 2026-06-09/i.test(contents[file]));
+
+  if (activeOk && historicalNotes.length === 4) {
+    pass('Active docs separate current contract from historical plans', { historicalNotes });
+  } else {
+    partial('Active docs separate current contract from historical plans', { activeOk, historicalNotes });
+  }
+}
+
+async function main() {
+  const db = await connectDb();
+  try {
+    const health = await fetch(`${API_URL}/health`).then((r) => r.status).catch(() => 0);
+    const web = await fetch(WEB_URL).then((r) => r.status).catch(() => 0);
+    if (health === 200 && web >= 200 && web < 500) pass('Local stack responds', { apiHealth: health, web });
+    else fail('Local stack responds', { apiHealth: health, web });
+
+    await checkActiveDocsContract();
+
+    const diego = await login('diego@testers-tomatoes.com');
+    const lina = await login('lina@testers-tomatoes.com');
+    pass('Seed users can log in', { users: [diego.user?.email, lina.user?.email] });
+
+    const createSpace = await authed(diego.accessToken, '/api/spaces', {
+      method: 'POST',
+      body: JSON.stringify({
+        name: `cracks-clearance-${RUN.slice(-6)}`,
+        type: 'public',
+        description: 'Fresh proof space for chat-to-wiki, Defty, and mixed agent/human clearance testing.',
+      }),
+    });
+    if (!createSpace.ok) throw new Error(`space create failed ${createSpace.status}: ${JSON.stringify(createSpace.body)}`);
+    const space = createSpace.body;
+    artifacts.ids.space = space.id;
+    const orgId = space.org_id ?? (await db.query('select org_id from spaces where id=$1', [space.id])).rows[0]?.org_id;
+    if (!orgId) throw new Error(`Could not derive org id for proof space ${space.id}`);
+    artifacts.ids.org = orgId;
+    pass('Fresh proof space created', { id: space.id, name: space.name });
+
+    const employees = await authed(diego.accessToken, '/api/agent-employees?expand=stats');
+    const tom = employees.body.find((e) => e.slug === 'tom' || e.name === 'Tom');
+    const maya = employees.body.find((e) => e.slug === 'maya' || e.name === 'Maya');
+    if (tom?.user_id) {
+      await authed(diego.accessToken, `/api/spaces/${space.id}/members`, { method: 'POST', body: JSON.stringify({ user_id: tom.user_id }) });
+    }
+    if (maya?.user_id) {
+      await authed(diego.accessToken, `/api/spaces/${space.id}/members`, { method: 'POST', body: JSON.stringify({ user_id: maya.user_id }) });
+    }
+    pass('Tom and Maya are available for mixed-agent proof', { tom: tom?.id, maya: maya?.id });
+
+    const browser = await chromium.launch({ headless: true });
+    const context = await browser.newContext({ viewport: { width: 1440, height: 950 } });
+    const page = await openAuthedPage(context, diego, `${WEB_URL}/chat`);
+
+    const decisionPhrase = `Decision: for clearance ${RUN}, Testers Tomatoes will use blue harvest crates for pilot wholesale orders and record crate temperature before loading.`;
+    await timed('ui chat decision post', () => sendChatMessageUi(page, space.name, decisionPhrase));
+    await screenshot(page, 'chat-decision-posted');
+    pass('Human posted explicit decision through chat UI', { decisionPhrase });
+
+    const messageRow = await waitFor('posted decision message row', async () => {
+      const rows = await db.query(
+        `select id, content, created_at from messages where org_id=$1 and space_id=$2 and content ilike $3 order by created_at desc limit 1`,
+        [orgId, space.id, `%${RUN}%`],
+      );
+      return rows.rows[0];
+    }, { timeout: 20_000 });
+    artifacts.ids.decisionMessage = messageRow.id;
+
+    const classification = await waitFor('message classification decision', async () => {
+      const rows = await db.query(
+        `select * from message_classifications where org_id=$1 and message_id=$2 and decision is not null order by created_at desc limit 1`,
+        [orgId, messageRow.id],
+      );
+      return rows.rows[0];
+    }, { timeout: 40_000 });
+    pass('Classifier captured decision', { decision: classification.decision, confidence: classification.confidence });
+
+    const wikiPage = await waitFor('wiki page cited by decision message', async () => {
+      const rows = await db.query(
+        `select wp.id, wp.title, wp.slug, wp.type, wp.content, wp.summary
+           from wiki_pages wp
+           join wiki_citations wc on wc.page_id = wp.id
+          where wp.org_id=$1 and wc.source_type='message' and wc.source_id=$2 and wp.is_deleted=false
+          order by wp.created_at desc
+          limit 1`,
+        [orgId, messageRow.id],
+      );
+      return rows.rows[0];
+    }, { timeout: 90_000 });
+    artifacts.ids.wikiPage = wikiPage.id;
+    pass('Decision reached wiki with message citation', { title: wikiPage.title, slug: wikiPage.slug, type: wikiPage.type });
+
+    await page.goto(`${WEB_URL}/knowledge`, { waitUntil: 'domcontentloaded' });
+    await page.getByPlaceholder('Search wiki...').fill(`blue harvest crates ${RUN}`);
+    await page.getByText('blue harvest crates', { exact: false }).first().waitFor({ state: 'visible', timeout: 20_000 });
+    await screenshot(page, 'knowledge-search-decision');
+    pass('Knowledge UI finds captured decision', { query: `blue harvest crates ${RUN}` });
+
+    const recall = await timed('mcp memory_recall decision', () => mcp(TOM_TOKEN, 'memory_recall', {
+      caller_employee_slug: 'tom',
+      query: `blue harvest crates ${RUN}`,
+      limit: 5,
+      scope: 'all',
+    }));
+    const alias = await timed('mcp wiki_search decision', () => mcp(MAYA_TOKEN, 'wiki_search', {
+      caller_employee_slug: 'maya',
+      query: `blue harvest crates ${RUN}`,
+      limit: 5,
+      scope: 'all',
+    }));
+    if (!recall.isError && recall.text.includes('blue harvest crates')) pass('Tom retrieved decision through memory_recall', { text: recall.text.slice(0, 500) });
+    else fail('Tom retrieved decision through memory_recall', { status: recall.status, text: recall.text.slice(0, 500) });
+    if (!alias.isError && alias.text.includes('blue harvest crates')) pass('Maya retrieved decision through wiki_search alias', { text: alias.text.slice(0, 500) });
+    else fail('Maya retrieved decision through wiki_search alias', { status: alias.status, text: alias.text.slice(0, 500) });
+
+    const deftyPrompt = `@defty clearance ${RUN}: summarize the blue harvest crate decision and say what should be checked next.`;
+    await timed('ui defty prompt post', () => sendChatMessageUi(page, space.name, deftyPrompt));
+    const deftyReply = await waitFor('Defty reply or provider-unavailable receipt', async () => {
+      const rows = await db.query(
+        `select m.id, m.content, m.metadata, u.name
+           from messages m join users u on u.id=m.user_id
+          where m.org_id=$1 and m.space_id=$2 and u.name='Defty' and m.created_at > now() - interval '3 minutes'
+          order by m.created_at desc limit 1`,
+        [orgId, space.id],
+      );
+      return rows.rows[0];
+    }, { timeout: 120_000 });
+    await page.waitForTimeout(1000);
+    await screenshot(page, 'defty-reply');
+    const deftyText = cleanText(deftyReply.content);
+    if (/reasoning model|provider|api key/i.test(deftyText)) {
+      partial('Defty responded gracefully but could not reason', { content: deftyText.slice(0, 500), metadata: deftyReply.metadata });
+    } else if (/couldn'?t find|not documented|not formally recorded|no documented/i.test(deftyText) || !/blue harvest crates/i.test(deftyText)) {
+      fail('Defty grounded answer in the freshly captured decision', { content: deftyText.slice(0, 700) });
+    } else {
+      pass('Defty grounded answer in the freshly captured decision', { content: deftyText.slice(0, 500) });
+    }
+
+    const tomResponse = await timed('tom mixed-agent message', () => mcp(TOM_TOKEN, 'send_message', {
+      caller_employee_slug: 'tom',
+      space_id: space.id,
+      content: `I checked the wiki for clearance ${RUN}. Marketing note: blue harvest crates are the pilot wholesale standard, and temperature should be recorded before loading.`,
+    }));
+    const mayaResponse = await timed('maya mixed-agent message', () => mcp(MAYA_TOKEN, 'send_message', {
+      caller_employee_slug: 'maya',
+      space_id: space.id,
+      content: `Ops follow-up for clearance ${RUN}: I would add a loading checklist item for crate temperature before departure.`,
+    }));
+    if (!tomResponse.isError) pass('Tom posted mixed-agent reply through MCP', { text: tomResponse.text.slice(0, 500) });
+    else fail('Tom posted mixed-agent reply through MCP', { text: tomResponse.text.slice(0, 500) });
+    if (!mayaResponse.isError) pass('Maya posted mixed-agent reply through MCP', { text: mayaResponse.text.slice(0, 500) });
+    else fail('Maya posted mixed-agent reply through MCP', { text: mayaResponse.text.slice(0, 500) });
+    await page.goto(`${WEB_URL}/chat?space=${space.id}`, { waitUntil: 'domcontentloaded' });
+    await page.waitForTimeout(2000);
+    await screenshot(page, 'mixed-agent-chat');
+
+    const dashboard = await timed('api dashboard cockpit', async () => {
+      const res = await authed(diego.accessToken, '/api/dashboard');
+      if (!res.ok) throw new Error(`dashboard ${res.status}: ${JSON.stringify(res.body)}`);
+      return res.body;
+    });
+    const cockpitSignals = {
+      overdue: dashboard.overdue?.length ?? 0,
+      myWork: dashboard.my_work?.length ?? 0,
+      recentActivity: dashboard.recent_activity?.length ?? 0,
+      unreadSpaces: dashboard.unread_spaces?.length ?? 0,
+      calendarEvents: dashboard.calendar_events?.length ?? 0,
+      agentActivity: dashboard.agent_activity?.length ?? null,
+      attention: dashboard.attention?.length ?? null,
+    };
+    artifacts.raw.dashboardSignals = cockpitSignals;
+    if (cockpitSignals.myWork > 0 && cockpitSignals.recentActivity >= 0) {
+      pass('Dashboard API exposes operating signals', cockpitSignals);
+    } else {
+      partial('Dashboard API exposes operating signals', cockpitSignals);
+    }
+
+    const dashboardPage = await openAuthedPage(context, diego, `${WEB_URL}/dashboard`);
+    await dashboardPage.getByText(diego.user.name.split(' ')[0], { exact: false }).waitFor({ state: 'visible', timeout: 20_000 }).catch(() => {});
+    await screenshot(dashboardPage, 'dashboard-cockpit');
+
+    await browser.close();
+
+    await writeReports();
+  } finally {
+    await db.end().catch(() => {});
+  }
+}
+
+async function writeReports() {
+  artifacts.raw.checks = checks;
+  await fs.writeFile(JSON_REPORT, JSON.stringify(artifacts, null, 2));
+  const passCount = checks.filter((c) => c.status === 'pass').length;
+  const partialCount = checks.filter((c) => c.status === 'partial').length;
+  const failCount = checks.filter((c) => c.status === 'fail').length;
+  const verdict = failCount === 0 && partialCount === 0
+    ? 'All clearance checks passed.'
+    : failCount === 0
+      ? 'Clearance battery passed with partials that still need product follow-up.'
+      : 'Clearance battery found failures that keep cracks open.';
+
+  const rows = checks.map((c) => `
+    <tr>
+      <td><span class="pill ${c.status}">${htmlEscape(c.status)}</span></td>
+      <td>${htmlEscape(c.name)}</td>
+      <td><pre>${htmlEscape(JSON.stringify(c.details, null, 2))}</pre></td>
+    </tr>`).join('');
+
+  const timingRows = artifacts.timings.map((t) => `
+    <tr><td>${htmlEscape(t.label)}</td><td>${t.ms == null ? '' : htmlEscape(t.ms)}</td><td>${htmlEscape(t.status ?? (t.ok === false ? 'fail' : 'ok'))}</td><td>${htmlEscape(t.error ?? '')}</td></tr>
+  `).join('');
+
+  const screenshotCards = Object.entries(artifacts.screenshots).map(([name, file]) => {
+    const rel = path.relative(REPORT_DIR, file).replace(/\\/g, '/');
+    return `<figure><img src="${htmlEscape(rel)}" alt="${htmlEscape(name)}"><figcaption>${htmlEscape(name)}</figcaption></figure>`;
+  }).join('');
+
+  const html = `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Deft Cracks Clearance Battery - 2026-06-09</title>
+  <style>
+    body{margin:0;font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;background:#fbfcfb;color:#17211b;line-height:1.55}
+    main{max-width:1180px;margin:0 auto;padding:44px 28px 72px}
+    h1{font-size:clamp(32px,5vw,54px);line-height:1.1;margin:0}
+    h2{border-top:1px solid #d9dfd9;margin-top:36px;padding-top:24px}
+    p{color:#657268}
+    table{width:100%;border-collapse:collapse;margin-top:14px;background:white;border:1px solid #d9dfd9}
+    th,td{text-align:left;vertical-align:top;border-bottom:1px solid #d9dfd9;padding:10px 12px;font-size:14px}
+    th{background:#f6f8f6;color:#657268;text-transform:uppercase;font-size:12px;letter-spacing:.04em}
+    pre{white-space:pre-wrap;margin:0;font:12px ui-monospace,SFMono-Regular,Consolas,monospace}
+    .meta{display:flex;gap:8px;flex-wrap:wrap;margin:18px 0}.chip{border:1px solid #d9dfd9;border-radius:999px;padding:6px 10px;color:#657268;background:white;font-size:12px}
+    .callout{margin-top:24px;padding:18px;border-left:4px solid #2f6f4e;background:#f6f8f6;border-radius:8px}
+    .pill{display:inline-flex;min-width:64px;justify-content:center;border-radius:6px;color:white;font-weight:800;font-size:12px;padding:3px 7px;text-transform:uppercase}
+    .pass{background:#27714c}.partial{background:#9a651e}.fail{background:#a33b37}
+    .screens{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:14px;margin-top:14px}
+    figure{margin:0;background:white;border:1px solid #d9dfd9;border-radius:8px;padding:10px}img{max-width:100%;border:1px solid #d9dfd9;border-radius:6px}figcaption{color:#657268;font-size:12px;margin-top:6px}
+  </style>
+</head>
+<body><main>
+  <div class="meta"><span class="chip">Run ${htmlEscape(RUN)}</span><span class="chip">API ${htmlEscape(API_URL)}</span><span class="chip">Web ${htmlEscape(WEB_URL)}</span><span class="chip">${passCount} pass</span><span class="chip">${partialCount} partial</span><span class="chip">${failCount} fail</span></div>
+  <h1>Deft cracks clearance battery</h1>
+  <section class="callout"><strong>${htmlEscape(verdict)}</strong><p>This run covers stack health, chat-to-wiki proof, MCP retrieval, Defty behavior, mixed agent/human chat, dashboard signals, and latency traces.</p></section>
+  <h2>Checks</h2><table><thead><tr><th>Status</th><th>Check</th><th>Evidence</th></tr></thead><tbody>${rows}</tbody></table>
+  <h2>Timing Signals</h2><table><thead><tr><th>Label</th><th>ms</th><th>Status</th><th>Error</th></tr></thead><tbody>${timingRows}</tbody></table>
+  <h2>Screenshots</h2><div class="screens">${screenshotCards}</div>
+  <p>Raw JSON: <code>${htmlEscape(path.basename(JSON_REPORT))}</code></p>
+</main></body></html>`;
+  await fs.writeFile(HTML_REPORT, html);
+  console.log(`Report: ${HTML_REPORT}`);
+}
+
+main().catch(async (err) => {
+  fail('Battery crashed', { error: err?.message || String(err), stack: err?.stack });
+  await writeReports().catch(() => {});
+  process.exit(1);
+});

--- a/scripts/pilot-multi-user-swarm.mjs
+++ b/scripts/pilot-multi-user-swarm.mjs
@@ -1,0 +1,396 @@
+import { chromium } from 'playwright';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const WEB_URL = process.env.DEFT_WEB_URL || 'http://localhost:3000';
+const API_URL = process.env.DEFT_API_URL || process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3301';
+const RUN_ID = new Date().toISOString().replace(/[:.]/g, '-');
+const OUT_DIR = path.resolve('reports', `multi-user-swarm-${RUN_ID}`);
+const HTML_REPORT = path.resolve('reports', 'multi-user-swarm-report-2026-06-09.html');
+const JSON_REPORT = path.resolve('reports', 'multi-user-swarm-report-2026-06-09.json');
+
+const PASSWORD = 'tomato123';
+
+const personas = [
+  {
+    name: 'Marigold Patel',
+    email: 'marigold@testers-tomatoes.com',
+    role: 'Head Grower',
+    chatSpace: 'field-ops',
+    project: 'Greenhouse 3 Build-out',
+    taskNeedle: 'Dehumidifier',
+    knowledgeQuery: 'Greenhouse Climate',
+    message:
+      'Swarm check: transplant benches look good. I am logging greenhouse humidity risk and need GH-3 dehumidifier notes kept visible.',
+  },
+  {
+    name: 'Cesar Okafor',
+    email: 'cesar@testers-tomatoes.com',
+    role: 'Field Supervisor',
+    chatSpace: 'harvest-room',
+    project: 'Spring 2026 Harvest',
+    taskNeedle: 'hail netting',
+    knowledgeQuery: 'Irrigation Schedules',
+    message:
+      'Swarm check: south field crew finished first pass. Please keep Roma firmness notes attached to harvest planning.',
+  },
+  {
+    name: 'Lina Bhattacharya',
+    email: 'lina@testers-tomatoes.com',
+    role: 'Sales Lead',
+    chatSpace: 'sales-and-buyers',
+    project: 'Wholesale Expansion',
+    taskNeedle: 'Sunbelt',
+    knowledgeQuery: 'Wholesale Buyer',
+    message:
+      'Swarm check: buyer follow-up is moving. I need the cold-chain promise and pricing story ready before the next call.',
+  },
+  {
+    name: 'Tomas Wakefield',
+    email: 'tomas@testers-tomatoes.com',
+    role: 'Logistics',
+    chatSpace: 'logistics',
+    project: 'Wholesale Expansion',
+    taskNeedle: 'cold',
+    knowledgeQuery: 'Cold-Chain Protocol',
+    message:
+      'Swarm check: dock schedule is tight. Please keep pulp-temp logging and cold-room handoff visible for the team.',
+  },
+  {
+    name: 'Sage Nakamura',
+    email: 'sage@testers-tomatoes.com',
+    role: 'QC + Food Safety',
+    chatSpace: 'greenhouse',
+    project: 'Spring 2026 Harvest',
+    taskNeedle: 'pre-GAP',
+    knowledgeQuery: 'USDA GAP',
+    message:
+      'Swarm check: audit binder needs one owner for water logs and one owner for harvest-room sign-in sheets.',
+  },
+];
+
+function nowMs() {
+  return Date.now();
+}
+
+async function mark(step, fn, result) {
+  const start = nowMs();
+  try {
+    const value = await fn();
+    result.steps.push({ step, ok: true, ms: nowMs() - start });
+    return value;
+  } catch (error) {
+    result.steps.push({
+      step,
+      ok: false,
+      ms: nowMs() - start,
+      error: error?.message || String(error),
+    });
+    throw error;
+  }
+}
+
+async function login(page, persona) {
+  const res = await fetch(`${API_URL}/api/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email: persona.email, password: PASSWORD }),
+  });
+  if (!res.ok) {
+    throw new Error(`API login failed for ${persona.email}: ${res.status}`);
+  }
+  const data = await res.json();
+  if (!data.accessToken || !data.refreshToken) {
+    throw new Error(`API login did not return tokens for ${persona.email}`);
+  }
+  await page.context().addInitScript((tokens) => {
+    window.localStorage.setItem('deft-access-token', tokens.accessToken);
+    window.localStorage.setItem('deft-refresh-token', tokens.refreshToken);
+  }, { accessToken: data.accessToken, refreshToken: data.refreshToken });
+  await page.goto(`${WEB_URL}/dashboard`, { waitUntil: 'domcontentloaded' });
+  await page.waitForURL(/\/dashboard/, { timeout: 20_000 });
+}
+
+async function sendChatMessage(page, persona, result) {
+  await page.goto(`${WEB_URL}/chat`, { waitUntil: 'domcontentloaded' });
+  await clickChatSpace(page, persona.chatSpace);
+  await page.waitForTimeout(600);
+
+  const editor = page.locator('[contenteditable="true"]').first();
+  await editor.click();
+  await page.keyboard.type(`${persona.message} [${RUN_ID}]`, { delay: 2 });
+
+  const sendButton = page.getByRole('button', { name: 'Send message' });
+  await expectEnabled(sendButton, 'send message');
+  await sendButton.click();
+  await page.getByText(`[${RUN_ID}]`).waitFor({ state: 'visible', timeout: 10_000 });
+  result.evidence.chat = `${persona.chatSpace}: posted and visible`;
+}
+
+async function clickChatSpace(page, spaceName) {
+  let lastError;
+  for (let attempt = 0; attempt < 4; attempt += 1) {
+    try {
+      const button = page.getByRole('button', { name: spaceName, exact: true });
+      await button.waitFor({ state: 'visible', timeout: 8_000 });
+      await button.click({ timeout: 8_000 });
+      await page.waitForTimeout(700);
+      return;
+    } catch (error) {
+      lastError = error;
+      await page.waitForTimeout(400 + attempt * 250);
+    }
+  }
+  throw lastError;
+}
+
+async function checkTasks(page, persona, result) {
+  await page.goto(`${WEB_URL}/tasks`, { waitUntil: 'domcontentloaded' });
+  let projectVisible = false;
+  let lastProjectError;
+  for (let attempt = 0; attempt < 4; attempt += 1) {
+    try {
+      const projectButton = page.locator('aside').getByText(persona.project, { exact: true }).first();
+      await projectButton.waitFor({ state: 'visible', timeout: 10_000 });
+      await projectButton.click({ timeout: 10_000 });
+      await page.waitForTimeout(700 + attempt * 300);
+      projectVisible = await page.locator('main').getByText(persona.project, { exact: false }).first().isVisible().catch(() => false);
+      if (projectVisible) break;
+    } catch (error) {
+      lastProjectError = error;
+    }
+  }
+  if (!projectVisible) {
+    throw new Error(`Project did not become active: ${persona.project}${lastProjectError ? ` (${lastProjectError.message || lastProjectError})` : ''}`);
+  }
+
+  let needleVisible = await page.getByText(persona.taskNeedle, { exact: false }).first().isVisible().catch(() => false);
+  let scrollPasses = 0;
+  while (!needleVisible && scrollPasses < 8) {
+    scrollPasses += 1;
+    await page.mouse.wheel(0, 650);
+    await page.waitForTimeout(250);
+    needleVisible = await page.getByText(persona.taskNeedle, { exact: false }).first().isVisible().catch(() => false);
+  }
+  if (!needleVisible) {
+    throw new Error(`Task signal "${persona.taskNeedle}" not discoverable in ${persona.project}`);
+  }
+
+  result.evidence.tasks = scrollPasses === 0
+    ? `${persona.project}: task signal "${persona.taskNeedle}" visible in first viewport`
+    : `${persona.project}: task signal "${persona.taskNeedle}" discoverable after ${scrollPasses} scroll pass${scrollPasses === 1 ? '' : 'es'}`;
+}
+
+async function checkKnowledge(page, persona, result) {
+  await page.goto(`${WEB_URL}/knowledge`, { waitUntil: 'domcontentloaded' });
+  const search = page.getByPlaceholder('Search wiki...');
+  await search.fill(persona.knowledgeQuery);
+  await page.getByText(persona.knowledgeQuery, { exact: false }).first().waitFor({ state: 'visible', timeout: 12_000 });
+  result.evidence.knowledge = `search "${persona.knowledgeQuery}" returned visible wiki context`;
+}
+
+async function checkDashboard(page, persona, result) {
+  await page.goto(`${WEB_URL}/dashboard`, { waitUntil: 'domcontentloaded' });
+  await page.locator('main').waitFor({ state: 'visible', timeout: 15_000 });
+  if (page.url().includes('/login')) {
+    throw new Error(`Dashboard redirected ${persona.email} to login`);
+  }
+  const firstNameNeedle = persona.name.split(' ')[0].slice(0, 3);
+  await page.getByText(firstNameNeedle, { exact: false }).first().waitFor({ state: 'visible', timeout: 15_000 });
+  await page.getByRole('link', { name: 'Chat' }).waitFor({ state: 'visible', timeout: 15_000 });
+  result.evidence.dashboard = 'authenticated dashboard shell and navigation loaded';
+}
+
+async function expectEnabled(locator, label) {
+  await locator.waitFor({ state: 'visible', timeout: 10_000 });
+  const enabled = await locator.isEnabled();
+  if (!enabled) throw new Error(`${label} is not enabled`);
+}
+
+async function runPersona(browser, persona, index) {
+  const context = await browser.newContext({
+    viewport: { width: 1366, height: 900 },
+    timezoneId: 'America/Chicago',
+  });
+  const page = await context.newPage();
+  const requestStarts = new Map();
+  const network = [];
+  const consoleErrors = [];
+  const result = {
+    name: persona.name,
+    email: persona.email,
+    role: persona.role,
+    ok: false,
+    startedAt: new Date().toISOString(),
+    steps: [],
+    evidence: {},
+    screenshot: null,
+    diagnostics: { network, consoleErrors },
+  };
+
+  page.on('console', (message) => {
+    if (['error', 'warning'].includes(message.type())) {
+      consoleErrors.push({ type: message.type(), text: message.text().slice(0, 500) });
+    }
+  });
+  page.on('request', (request) => {
+    const url = request.url();
+    if (url.includes('/api/wiki')) {
+      requestStarts.set(request, Date.now());
+    }
+  });
+  page.on('response', (response) => {
+    const request = response.request();
+    const started = requestStarts.get(request);
+    const url = response.url();
+    if (url.includes('/api/wiki')) {
+      network.push({
+        url,
+        status: response.status(),
+        ms: started ? Date.now() - started : null,
+      });
+      requestStarts.delete(request);
+    }
+  });
+  page.on('requestfailed', (request) => {
+    const url = request.url();
+    if (url.includes('/api/wiki')) {
+      const error = request.failure()?.errorText || 'request failed';
+      network.push({
+        url,
+        status: error === 'net::ERR_ABORTED' ? 'canceled' : 'failed',
+        error,
+      });
+      requestStarts.delete(request);
+    }
+  });
+
+  try {
+    await mark('login', () => login(page, persona), result);
+    await page.waitForTimeout(index * 250);
+    await mark('dashboard', () => checkDashboard(page, persona, result), result);
+    await mark('chat post', () => sendChatMessage(page, persona, result), result);
+    await mark('task board', () => checkTasks(page, persona, result), result);
+    await mark('knowledge search', () => checkKnowledge(page, persona, result), result);
+    result.ok = true;
+  } catch (error) {
+    result.error = error?.message || String(error);
+  } finally {
+    const screenshotPath = path.join(OUT_DIR, `${persona.email.split('@')[0]}.png`);
+    await page.screenshot({ path: screenshotPath, fullPage: false }).catch(() => null);
+    result.screenshot = screenshotPath;
+    result.finishedAt = new Date().toISOString();
+    await context.close().catch(() => null);
+  }
+
+  return result;
+}
+
+async function writeReports(results) {
+  const passed = results.filter((r) => r.ok).length;
+  const failed = results.length - passed;
+  const rows = results
+    .map((r) => {
+      const stepList = r.steps
+        .map((s) => `<li class="${s.ok ? 'ok' : 'fail'}">${s.step}: ${s.ok ? 'OK' : s.error} <span>${s.ms}ms</span></li>`)
+        .join('');
+      const evidence = Object.entries(r.evidence)
+        .map(([k, v]) => `<li><strong>${k}</strong>: ${v}</li>`)
+        .join('');
+      const network = (r.diagnostics?.network || [])
+        .slice(-8)
+        .map((n) => `<li><strong>${n.status}</strong> ${n.ms ?? '-'}ms <code>${n.url.replace(/&/g, '&amp;')}</code>${n.error ? ` â€” ${n.error}` : ''}</li>`)
+        .join('');
+      const consoleErrors = (r.diagnostics?.consoleErrors || [])
+        .slice(-6)
+        .map((e) => `<li><strong>${e.type}</strong>: ${e.text.replace(/</g, '&lt;')}</li>`)
+        .join('');
+      const shot = r.screenshot ? `<img src="${path.relative(path.dirname(HTML_REPORT), r.screenshot).replace(/\\/g, '/')}" alt="${r.name} screenshot">` : '';
+      return `<section class="card ${r.ok ? 'pass' : 'fail'}">
+        <h2>${r.name}</h2>
+        <p>${r.role} · ${r.email}</p>
+        <div class="badge">${r.ok ? 'PASS' : 'FAIL'}</div>
+        ${r.error ? `<p class="error">${r.error}</p>` : ''}
+        <h3>Steps</h3>
+        <ul>${stepList}</ul>
+        <h3>Evidence</h3>
+        <ul>${evidence || '<li>No evidence captured</li>'}</ul>
+        <h3>Knowledge Network</h3>
+        <ul>${network || '<li>No wiki network calls captured</li>'}</ul>
+        <h3>Console</h3>
+        <ul>${consoleErrors || '<li>No console warnings/errors captured</li>'}</ul>
+        ${shot}
+      </section>`;
+    })
+    .join('\n');
+
+  const html = `<!doctype html>
+  <html>
+  <head>
+    <meta charset="utf-8">
+    <title>Deft Multi-User Swarm Report - 2026-06-09</title>
+    <style>
+      body { margin: 0; font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; background: #f7f8fa; color: #18212f; }
+      header { padding: 32px 40px 20px; background: #fff; border-bottom: 1px solid #dfe4ea; }
+      h1 { margin: 0 0 8px; font-size: 28px; }
+      .summary { display: flex; gap: 12px; margin-top: 18px; flex-wrap: wrap; }
+      .pill { border: 1px solid #d8dee8; border-radius: 999px; padding: 8px 12px; background: #fff; }
+      main { padding: 24px 40px 48px; display: grid; gap: 18px; }
+      .card { background: #fff; border: 1px solid #dfe4ea; border-radius: 8px; padding: 18px; position: relative; }
+      .card.pass { border-left: 5px solid #059669; }
+      .card.fail { border-left: 5px solid #dc2626; }
+      h2 { margin: 0; font-size: 20px; }
+      h3 { margin: 18px 0 8px; font-size: 14px; color: #475569; }
+      p { color: #475569; }
+      ul { margin: 0; padding-left: 20px; }
+      li { margin: 5px 0; }
+      li.ok { color: #166534; }
+      li.fail, .error { color: #991b1b; }
+      li span { color: #64748b; font-size: 12px; margin-left: 6px; }
+      .badge { position: absolute; right: 18px; top: 18px; font-weight: 700; font-size: 12px; letter-spacing: .08em; }
+      img { margin-top: 14px; max-width: 420px; border: 1px solid #dfe4ea; border-radius: 6px; }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>Deft Multi-User Swarm Report</h1>
+      <p>Five seeded Testers Tomatoes users worked simultaneously against one local Deft installation.</p>
+      <div class="summary">
+        <div class="pill">Run: ${RUN_ID}</div>
+        <div class="pill">Passed: ${passed}/${results.length}</div>
+        <div class="pill">Failed: ${failed}</div>
+        <div class="pill">Target: ${WEB_URL}</div>
+        <div class="pill">API: ${API_URL}</div>
+      </div>
+    </header>
+    <main>${rows}</main>
+  </body>
+  </html>`;
+
+  await fs.writeFile(JSON_REPORT, JSON.stringify({ runId: RUN_ID, webUrl: WEB_URL, passed, failed, results }, null, 2));
+  await fs.writeFile(HTML_REPORT, html);
+}
+
+await fs.mkdir(OUT_DIR, { recursive: true });
+const browser = await chromium.launch({ headless: true });
+const started = Date.now();
+let results;
+try {
+  results = await Promise.all(personas.map((persona, index) => runPersona(browser, persona, index)));
+} finally {
+  await browser.close().catch(() => null);
+}
+await writeReports(results);
+
+console.log(JSON.stringify({
+  runId: RUN_ID,
+  elapsedMs: Date.now() - started,
+  passed: results.filter((r) => r.ok).length,
+  failed: results.filter((r) => !r.ok).length,
+  htmlReport: HTML_REPORT,
+  jsonReport: JSON_REPORT,
+}, null, 2));
+
+if (results.some((r) => !r.ok)) {
+  process.exitCode = 1;
+}

--- a/scripts/pilot-preflight.ts
+++ b/scripts/pilot-preflight.ts
@@ -12,12 +12,15 @@ type Check = {
   ok: boolean;
   detail: string;
   warn?: boolean;
+  stale?: boolean;
 };
 
 const args = new Set(process.argv.slice(2));
 const shouldStart = args.has('--start');
+const strict = args.has('--strict') || process.env.DEFT_PREFLIGHT_STRICT === '1';
 const API_URL = (process.env.DEFT_API_URL || process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001').replace(/\/$/, '');
-const WEB_URL = (process.env.DEFT_WEB_URL || process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000').replace(/\/$/, '');
+const WEB_URL = (process.env.DEFT_WEB_URL || 'http://localhost:3000').replace(/\/$/, '');
+const CONFIGURED_APP_URL = process.env.NEXT_PUBLIC_APP_URL?.replace(/\/$/, '');
 const SEED_EMAIL = process.env.DEFT_TEST_EMAIL || 'diego@testers-tomatoes.com';
 const SEED_PASSWORD = process.env.DEFT_TEST_PASSWORD || 'tomato123';
 const LIKELY_API_PORTS = [3001, 3301];
@@ -29,13 +32,17 @@ function mark(check: Check) {
 }
 
 async function fetchStatus(url: string): Promise<{ status: number; text: string }> {
-  try {
-    const res = await fetch(url, { signal: AbortSignal.timeout(3_000) });
-    return { status: res.status, text: await res.text().catch(() => '') };
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    return { status: 0, text: message };
+  let lastMessage = '';
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    try {
+      const res = await fetch(url, { signal: AbortSignal.timeout(8_000) });
+      return { status: res.status, text: await res.text().catch(() => '') };
+    } catch (err) {
+      lastMessage = err instanceof Error ? err.message : String(err);
+      if (attempt === 0) await new Promise((resolve) => setTimeout(resolve, 1_000));
+    }
   }
+  return { status: 0, text: lastMessage };
 }
 
 function localhostPort(rawUrl: string): number | null {
@@ -218,8 +225,9 @@ async function checkLikelyApiPorts(): Promise<Check[]> {
       const pids = await pidsForPort(port);
       checks.push({
         name: `Possible stale API on ${port}`,
-        ok: true,
+        ok: !strict || process.env.DEFT_ALLOW_STALE_API === '1',
         warn: true,
+        stale: true,
         detail: `http://localhost:${port}/health is alive${pids.length ? ` (PID ${pids.join(', ')})` : ''}; intended API is ${API_URL}. If this is the right API, set DEFT_API_URL=http://localhost:${port}.`,
       });
     }
@@ -252,8 +260,9 @@ async function checkLikelyWebPorts(): Promise<Check[]> {
       const pids = await pidsForPort(port);
       checks.push({
         name: `Possible web app on ${port}`,
-        ok: true,
+        ok: !strict || process.env.DEFT_ALLOW_STALE_API === '1',
         warn: true,
+        stale: true,
         detail: `${candidateUrl} returned ${res.status}${pids.length ? ` (PID ${pids.join(', ')})` : ''}; intended web is ${WEB_URL}. If this is the right app, set DEFT_WEB_URL=${candidateUrl}.`,
       });
     }
@@ -262,17 +271,36 @@ async function checkLikelyWebPorts(): Promise<Check[]> {
   return checks;
 }
 
+async function checkConfiguredAppUrl(): Promise<Check[]> {
+  if (!CONFIGURED_APP_URL || CONFIGURED_APP_URL === WEB_URL) return [];
+
+  const res = await fetchStatus(CONFIGURED_APP_URL);
+  const detail = res.status
+    ? `NEXT_PUBLIC_APP_URL is ${CONFIGURED_APP_URL} and returned ${res.status}; pilot web target is ${WEB_URL}. Keep this only if generated links should use that URL.`
+    : `NEXT_PUBLIC_APP_URL is ${CONFIGURED_APP_URL} but it is unreachable; pilot web target is ${WEB_URL}. Update NEXT_PUBLIC_APP_URL or set DEFT_WEB_URL when testing that URL intentionally.`;
+
+  return [{
+    name: 'Configured app URL drift',
+    ok: true,
+    warn: true,
+    detail,
+  }];
+}
+
 async function runChecks(): Promise<{ ok: boolean; blockingFailure: boolean }> {
   console.log(`Deft pilot preflight`);
   console.log(`  web: ${WEB_URL}`);
   console.log(`  api: ${API_URL}`);
+  console.log(`  NEXT_PUBLIC_APP_URL: ${process.env.NEXT_PUBLIC_APP_URL || '(unset)'}`);
   console.log(`  NEXT_PUBLIC_API_URL: ${process.env.NEXT_PUBLIC_API_URL || '(unset)'}`);
   console.log(`  NEXT_PUBLIC_WS_URL: ${process.env.NEXT_PUBLIC_WS_URL || '(unset)'}`);
+  console.log(`  strict stale-port gate: ${strict ? 'on' : 'off'}`);
   console.log('');
 
   const checks = [
     ...(await checkLikelyApiPorts()),
     ...(await checkLikelyWebPorts()),
+    ...(await checkConfiguredAppUrl()),
     await checkApi(),
     await checkWeb(),
     await checkDb(),
@@ -281,6 +309,10 @@ async function runChecks(): Promise<{ ok: boolean; blockingFailure: boolean }> {
   ];
 
   for (const check of checks) mark(check);
+  if (strict && checks.some((check) => check.stale && !check.ok)) {
+    console.log('');
+    console.log('[INFO] Strict mode treats likely stale local web/API services as failures. Stop the extra process, point DEFT_API_URL/DEFT_WEB_URL at it, or set DEFT_ALLOW_STALE_API=1 for exploratory local work only.');
+  }
   return {
     ok: checks.every((check) => check.ok),
     blockingFailure: checks.some((check) => !check.ok && (check.name.startsWith('Intended API port') || check.name.startsWith('Intended web port'))),

--- a/scripts/pilot-preflight.ts
+++ b/scripts/pilot-preflight.ts
@@ -21,6 +21,7 @@ const WEB_URL = (process.env.DEFT_WEB_URL || process.env.NEXT_PUBLIC_APP_URL || 
 const SEED_EMAIL = process.env.DEFT_TEST_EMAIL || 'diego@testers-tomatoes.com';
 const SEED_PASSWORD = process.env.DEFT_TEST_PASSWORD || 'tomato123';
 const LIKELY_API_PORTS = [3001, 3301];
+const LIKELY_WEB_PORTS = [3000, 3300];
 
 function mark(check: Check) {
   const icon = check.ok ? (check.warn ? 'WARN' : 'OK') : 'FAIL';
@@ -45,6 +46,16 @@ function localhostPort(rawUrl: string): number | null {
   } catch {
     return null;
   }
+}
+
+function localhostUrlWithPort(rawUrl: string, port: number, path = ''): string {
+  const url = new URL(rawUrl);
+  url.hostname = 'localhost';
+  url.port = String(port);
+  url.pathname = path || '/';
+  url.search = '';
+  url.hash = '';
+  return url.toString().replace(/\/$/, '');
 }
 
 async function pidsForPort(port: number): Promise<string[]> {
@@ -184,7 +195,7 @@ async function checkSeedLogin(): Promise<Check> {
   }
 }
 
-async function checkLikelyPorts(): Promise<Check[]> {
+async function checkLikelyApiPorts(): Promise<Check[]> {
   const intendedApiPort = localhostPort(API_URL);
   const checks: Check[] = [];
 
@@ -195,7 +206,7 @@ async function checkLikelyPorts(): Promise<Check[]> {
       checks.push({
         name: `Intended API port ${intendedApiPort}`,
         ok: false,
-        detail: `port is occupied by PID(s) ${pids.join(', ')} but ${API_URL}/health is not healthy`,
+        detail: `port is occupied by PID(s) ${pids.join(', ')} but ${API_URL}/health is not healthy. Stop that process or set DEFT_API_URL to the live API URL.`,
       });
     }
   }
@@ -209,7 +220,41 @@ async function checkLikelyPorts(): Promise<Check[]> {
         name: `Possible stale API on ${port}`,
         ok: true,
         warn: true,
-        detail: `http://localhost:${port}/health is alive${pids.length ? ` (PID ${pids.join(', ')})` : ''}; intended API is ${API_URL}`,
+        detail: `http://localhost:${port}/health is alive${pids.length ? ` (PID ${pids.join(', ')})` : ''}; intended API is ${API_URL}. If this is the right API, set DEFT_API_URL=http://localhost:${port}.`,
+      });
+    }
+  }
+
+  return checks;
+}
+
+async function checkLikelyWebPorts(): Promise<Check[]> {
+  const intendedWebPort = localhostPort(WEB_URL);
+  const checks: Check[] = [];
+
+  if (intendedWebPort) {
+    const intended = await fetchStatus(WEB_URL);
+    const pids = await pidsForPort(intendedWebPort);
+    if (pids.length > 0 && !(intended.status >= 200 && intended.status < 500)) {
+      checks.push({
+        name: `Intended web port ${intendedWebPort}`,
+        ok: false,
+        detail: `port is occupied by PID(s) ${pids.join(', ')} but ${WEB_URL} is not serving a web root. Stop that process or set DEFT_WEB_URL to the live web URL.`,
+      });
+    }
+  }
+
+  for (const port of LIKELY_WEB_PORTS) {
+    if (port === intendedWebPort) continue;
+    const candidateUrl = localhostUrlWithPort(WEB_URL, port);
+    const res = await fetchStatus(candidateUrl);
+    if (res.status >= 200 && res.status < 500) {
+      const pids = await pidsForPort(port);
+      checks.push({
+        name: `Possible web app on ${port}`,
+        ok: true,
+        warn: true,
+        detail: `${candidateUrl} returned ${res.status}${pids.length ? ` (PID ${pids.join(', ')})` : ''}; intended web is ${WEB_URL}. If this is the right app, set DEFT_WEB_URL=${candidateUrl}.`,
       });
     }
   }
@@ -226,7 +271,8 @@ async function runChecks(): Promise<{ ok: boolean; blockingFailure: boolean }> {
   console.log('');
 
   const checks = [
-    ...(await checkLikelyPorts()),
+    ...(await checkLikelyApiPorts()),
+    ...(await checkLikelyWebPorts()),
     await checkApi(),
     await checkWeb(),
     await checkDb(),
@@ -237,7 +283,7 @@ async function runChecks(): Promise<{ ok: boolean; blockingFailure: boolean }> {
   for (const check of checks) mark(check);
   return {
     ok: checks.every((check) => check.ok),
-    blockingFailure: checks.some((check) => !check.ok && check.name.startsWith('Intended API port')),
+    blockingFailure: checks.some((check) => !check.ok && (check.name.startsWith('Intended API port') || check.name.startsWith('Intended web port'))),
   };
 }
 

--- a/scripts/pilot-workspace-hygiene.ts
+++ b/scripts/pilot-workspace-hygiene.ts
@@ -6,6 +6,7 @@ const args = new Set(process.argv.slice(2));
 const shouldApply = args.has('--apply');
 const orgSlugArg = process.argv.find((arg) => arg.startsWith('--org-slug='));
 const orgSlug = orgSlugArg?.split('=')[1]?.trim();
+const DEFTY_EMAIL = 'deft-agent@system.local';
 
 function dockerDatabaseUrl(): string | null {
   try {
@@ -77,6 +78,7 @@ async function main() {
     const scoped = orgFilter();
     const scopedAgent = orgFilter('a');
     const scopedEmployee = orgFilter('ae');
+    const scopedOrgMember = orgFilter('om');
     const scopedSpace = orgFilter('s');
     const scopedProject = orgFilter('p');
     const scopedNotification = orgFilter('n');
@@ -200,6 +202,80 @@ async function main() {
         params: scopedEmployee.params,
       },
       {
+        key: 'stale-agent-members',
+        label: 'Deactivate deleted agent shadow org memberships',
+        selectSql: `
+          select count(*)::int as count
+          from org_members om
+          join users u on u.id = om.user_id
+          where om.is_active = true
+            and u.kind = 'agent'
+            and coalesce(u.email, '') <> $${scopedOrgMember.params.length + 1}
+            and not exists (
+              select 1
+              from agent_employees ae
+              where ae.org_id = om.org_id
+                and ae.user_id = om.user_id
+                and ae.is_active = true
+                and ae.is_deleted = false
+            )
+            ${scopedOrgMember.clause}
+        `,
+        applySql: `
+          update org_members om
+          set is_active = false,
+              updated_at = now()
+          from users u
+          where u.id = om.user_id
+            and om.is_active = true
+            and u.kind = 'agent'
+            and coalesce(u.email, '') <> $${scopedOrgMember.params.length + 1}
+            and not exists (
+              select 1
+              from agent_employees ae
+              where ae.org_id = om.org_id
+                and ae.user_id = om.user_id
+                and ae.is_active = true
+                and ae.is_deleted = false
+            )
+            ${scopedOrgMember.clause}
+        `,
+        params: [...scopedOrgMember.params, DEFTY_EMAIL],
+      },
+      {
+        key: 'stale-human-test-members',
+        label: 'Deactivate obvious human test-fixture org memberships',
+        selectSql: `
+          select count(*)::int as count
+          from org_members om
+          join users u on u.id = om.user_id
+          where om.is_active = true
+            and u.kind = 'human'
+            and (
+              u.email ilike '%@test.local'
+              or u.name ilike 'MCP Phase 4 Test User%'
+              or u.name ilike 'API Role Smoke%'
+            )
+            ${scopedOrgMember.clause}
+        `,
+        applySql: `
+          update org_members om
+          set is_active = false,
+              updated_at = now()
+          from users u
+          where u.id = om.user_id
+            and om.is_active = true
+            and u.kind = 'human'
+            and (
+              u.email ilike '%@test.local'
+              or u.name ilike 'MCP Phase 4 Test User%'
+              or u.name ilike 'API Role Smoke%'
+            )
+            ${scopedOrgMember.clause}
+        `,
+        params: scopedOrgMember.params,
+      },
+      {
         key: 'audit-spaces',
         label: 'Archive obvious audit/scratch spaces',
         selectSql: `
@@ -257,6 +333,7 @@ async function main() {
               or p.name ilike 'audit %'
               or p.name ilike 'byoa %'
               or p.name ilike 'scratch %'
+              or p.name ilike 'harness-%'
               or p.name ilike 'smoke %'
               or p.name ilike 'three runtime byoa battery%'
               or p.name ilike 'defty ui reliability%'
@@ -283,6 +360,63 @@ async function main() {
               or p.name ilike 'audit %'
               or p.name ilike 'byoa %'
               or p.name ilike 'scratch %'
+              or p.name ilike 'harness-%'
+              or p.name ilike 'smoke %'
+              or p.name ilike 'three runtime byoa battery%'
+              or p.name ilike 'defty ui reliability%'
+              or p.name ilike 'codex byoa behavior%'
+              or p.name ilike 'three agent dogfood%'
+              or p.name ilike 'codex byoa dogfood%'
+              or p.prefix like 'RT%'
+              or p.prefix like 'DF%'
+              or p.prefix like 'CX%'
+              or p.prefix like 'TG%'
+            )
+            and p.name not ilike 'tom marketing dogfood%'
+            ${scopedProject.clause}
+        `,
+        params: scopedProject.params,
+      },
+      {
+        key: 'deleted-audit-projects-unarchived',
+        label: 'Archive already-deleted audit/harness projects',
+        selectSql: `
+          select count(*)::int as count
+          from projects p
+          where p.is_deleted = true
+            and p.is_archived = false
+            and (
+              p.prefix in ('AUD', 'TST', 'BYOA', 'SMK')
+              or p.name ilike 'audit %'
+              or p.name ilike 'byoa %'
+              or p.name ilike 'scratch %'
+              or p.name ilike 'harness-%'
+              or p.name ilike 'smoke %'
+              or p.name ilike 'three runtime byoa battery%'
+              or p.name ilike 'defty ui reliability%'
+              or p.name ilike 'codex byoa behavior%'
+              or p.name ilike 'three agent dogfood%'
+              or p.name ilike 'codex byoa dogfood%'
+              or p.prefix like 'RT%'
+              or p.prefix like 'DF%'
+              or p.prefix like 'CX%'
+              or p.prefix like 'TG%'
+            )
+            and p.name not ilike 'tom marketing dogfood%'
+            ${scopedProject.clause}
+        `,
+        applySql: `
+          update projects p
+          set is_archived = true,
+              updated_at = now()
+          where p.is_deleted = true
+            and p.is_archived = false
+            and (
+              p.prefix in ('AUD', 'TST', 'BYOA', 'SMK')
+              or p.name ilike 'audit %'
+              or p.name ilike 'byoa %'
+              or p.name ilike 'scratch %'
+              or p.name ilike 'harness-%'
               or p.name ilike 'smoke %'
               or p.name ilike 'three runtime byoa battery%'
               or p.name ilike 'defty ui reliability%'

--- a/scripts/pilot-workspace-hygiene.ts
+++ b/scripts/pilot-workspace-hygiene.ts
@@ -1,0 +1,293 @@
+import 'dotenv/config';
+import { execFileSync } from 'node:child_process';
+import pg from 'pg';
+
+const args = new Set(process.argv.slice(2));
+const shouldApply = args.has('--apply');
+const orgSlugArg = process.argv.find((arg) => arg.startsWith('--org-slug='));
+const orgSlug = orgSlugArg?.split('=')[1]?.trim();
+
+function dockerDatabaseUrl(): string | null {
+  try {
+    const portOut = execFileSync('docker', ['port', 'deft-codex-pg', '5432/tcp'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+    const port = portOut.match(/(?:127\.0\.0\.1|0\.0\.0\.0|\[::\]):(\d+)/)?.[1];
+    if (!port) return null;
+    const password = execFileSync('docker', ['exec', 'deft-codex-pg', 'printenv', 'POSTGRES_PASSWORD'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim() || 'postgres';
+    const dbName = execFileSync('docker', ['exec', 'deft-codex-pg', 'printenv', 'POSTGRES_DB'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim() || 'deft';
+    return `postgres://postgres:${encodeURIComponent(password)}@localhost:${port}/${dbName}`;
+  } catch {
+    return null;
+  }
+}
+
+function databaseUrl(): string {
+  if (process.env.DATABASE_URL) return process.env.DATABASE_URL;
+  const dockerUrl = dockerDatabaseUrl();
+  if (dockerUrl) return dockerUrl;
+  const password = process.env.POSTGRES_PASSWORD || 'postgres';
+  const port = process.env.POSTGRES_PORT || '5432';
+  return `postgres://postgres:${encodeURIComponent(password)}@localhost:${port}/deft`;
+}
+
+function redactUrl(url: string): string {
+  return url.replace(/:\/\/([^:]+):([^@]+)@/, '://$1:***@');
+}
+
+const client = new pg.Client({ connectionString: databaseUrl() });
+
+type HygieneStep = {
+  key: string;
+  label: string;
+  selectSql: string;
+  applySql: string;
+  params: unknown[];
+};
+
+async function countRows(sql: string, params: unknown[]): Promise<number> {
+  const result = await client.query(sql, params);
+  return Number(result.rows[0]?.count ?? 0);
+}
+
+async function applyStep(sql: string, params: unknown[]): Promise<number> {
+  const result = await client.query(sql, params);
+  return result.rowCount ?? 0;
+}
+
+function orgFilter(alias = ''): { clause: string; params: unknown[] } {
+  if (!orgSlug) return { clause: '', params: [] };
+  const prefix = alias ? `${alias}.` : '';
+  return {
+    clause: `and ${prefix}org_id = (select id from orgs where slug = $1 limit 1)`,
+    params: [orgSlug],
+  };
+}
+
+async function main() {
+  await client.connect();
+  try {
+    const scoped = orgFilter();
+    const scopedAgent = orgFilter('a');
+    const scopedEmployee = orgFilter('ae');
+    const scopedSpace = orgFilter('s');
+    const scopedProject = orgFilter('p');
+    const scopedNotification = orgFilter('n');
+
+    const steps: HygieneStep[] = [
+      {
+        key: 'stale-agent-actions',
+        label: 'Expire stale pending audit/employee agent actions',
+        selectSql: `
+          select count(*)::int as count
+          from agent_actions a
+          where a.approval_status = 'pending'
+            and (
+              a.source in ('mention', 'task_assignment', 'blocked_classifier', 'mcp', 'audit')
+              or exists (
+                select 1
+                from agent_employees ae
+                where ae.id = a.agent_employee_id
+                  and (
+                    ae.slug like 'auditagent-%'
+                    or ae.slug like 'wizard-smoke-%'
+                    or ae.slug like 'test-openclaw-pm-%'
+                  )
+              )
+            )
+            ${scopedAgent.clause}
+        `,
+        applySql: `
+          update agent_actions a
+          set approval_status = 'expired',
+              error = coalesce(error, 'Expired by pilot workspace hygiene')
+          where a.approval_status = 'pending'
+            and (
+              a.source in ('mention', 'task_assignment', 'blocked_classifier', 'mcp', 'audit')
+              or exists (
+                select 1
+                from agent_employees ae
+                where ae.id = a.agent_employee_id
+                  and (
+                    ae.slug like 'auditagent-%'
+                    or ae.slug like 'wizard-smoke-%'
+                    or ae.slug like 'test-openclaw-pm-%'
+                  )
+              )
+            )
+            ${scopedAgent.clause}
+        `,
+        params: scopedAgent.params,
+      },
+      {
+        key: 'audit-agents',
+        label: 'Soft-delete obvious audit-created agent employees',
+        selectSql: `
+          select count(*)::int as count
+          from agent_employees ae
+          where ae.is_deleted = false
+            and (
+              ae.slug like 'auditagent-%'
+              or ae.slug like 'wizard-smoke-%'
+              or ae.slug like 'test-openclaw-pm-%'
+              or ae.name in ('Test OpenClaw PM', 'Test UI Employee PM', 'Test UI Employee Eng')
+            )
+            ${scopedEmployee.clause}
+        `,
+        applySql: `
+          update agent_employees ae
+          set is_deleted = true,
+              is_active = false,
+              deleted_at = now()
+          where ae.is_deleted = false
+            and (
+              ae.slug like 'auditagent-%'
+              or ae.slug like 'wizard-smoke-%'
+              or ae.slug like 'test-openclaw-pm-%'
+              or ae.name in ('Test OpenClaw PM', 'Test UI Employee PM', 'Test UI Employee Eng')
+            )
+            ${scopedEmployee.clause}
+        `,
+        params: scopedEmployee.params,
+      },
+      {
+        key: 'audit-spaces',
+        label: 'Archive obvious audit/scratch spaces',
+        selectSql: `
+          select count(*)::int as count
+          from spaces s
+          where s.is_archived = false
+            and s.is_default = false
+            and (
+              s.name like 'audit-%'
+              or s.name like 'wizard-smoke-%'
+              or s.name like 'byoa-%'
+              or s.name like 'scratch-%'
+              or s.name like 'test-%'
+            )
+            ${scopedSpace.clause}
+        `,
+        applySql: `
+          update spaces s
+          set is_archived = true,
+              updated_at = now()
+          where s.is_archived = false
+            and s.is_default = false
+            and (
+              s.name like 'audit-%'
+              or s.name like 'wizard-smoke-%'
+              or s.name like 'byoa-%'
+              or s.name like 'scratch-%'
+              or s.name like 'test-%'
+            )
+            ${scopedSpace.clause}
+        `,
+        params: scopedSpace.params,
+      },
+      {
+        key: 'audit-projects',
+        label: 'Soft-delete obvious audit/scratch projects',
+        selectSql: `
+          select count(*)::int as count
+          from projects p
+          where p.is_deleted = false
+            and (
+              p.prefix in ('AUD', 'TST', 'BYOA', 'SMK')
+              or p.name ilike 'audit %'
+              or p.name ilike 'byoa %'
+              or p.name ilike 'scratch %'
+              or p.name ilike 'smoke %'
+            )
+            ${scopedProject.clause}
+        `,
+        applySql: `
+          update projects p
+          set is_deleted = true,
+              is_archived = true,
+              deleted_at = now(),
+              updated_at = now()
+          where p.is_deleted = false
+            and (
+              p.prefix in ('AUD', 'TST', 'BYOA', 'SMK')
+              or p.name ilike 'audit %'
+              or p.name ilike 'byoa %'
+              or p.name ilike 'scratch %'
+              or p.name ilike 'smoke %'
+            )
+            ${scopedProject.clause}
+        `,
+        params: scopedProject.params,
+      },
+      {
+        key: 'notifications',
+        label: 'Mark old pilot/audit notifications as read',
+        selectSql: `
+          select count(*)::int as count
+          from notifications n
+          where n.is_read = false
+            and n.created_at < now() - interval '1 day'
+            and (
+              n.type in ('agent_suggestion', 'blocked', 'system')
+              or n.title ilike '%audit%'
+              or n.title ilike '%blocked%'
+              or n.title ilike '%agent%'
+            )
+            ${scopedNotification.clause}
+        `,
+        applySql: `
+          update notifications n
+          set is_read = true,
+              updated_at = now()
+          where n.is_read = false
+            and n.created_at < now() - interval '1 day'
+            and (
+              n.type in ('agent_suggestion', 'blocked', 'system')
+              or n.title ilike '%audit%'
+              or n.title ilike '%blocked%'
+              or n.title ilike '%agent%'
+            )
+            ${scopedNotification.clause}
+        `,
+        params: scopedNotification.params,
+      },
+    ];
+
+    console.log(JSON.stringify({
+      mode: shouldApply ? 'apply' : 'dry-run',
+      database: redactUrl(databaseUrl()),
+      org_slug: orgSlug || 'all orgs',
+    }, null, 2));
+
+    for (const step of steps) {
+      const count = await countRows(step.selectSql, step.params);
+      let changed = 0;
+      if (shouldApply && count > 0) {
+        changed = await applyStep(step.applySql, step.params);
+      }
+      console.log(JSON.stringify({
+        key: step.key,
+        label: step.label,
+        matched: count,
+        changed,
+      }, null, 2));
+    }
+
+    if (!shouldApply) {
+      console.log('Dry run only. Re-run with --apply to make changes.');
+    }
+  } finally {
+    await client.end().catch(() => {});
+  }
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? err.message : err);
+  process.exit(1);
+});

--- a/scripts/pilot-workspace-hygiene.ts
+++ b/scripts/pilot-workspace-hygiene.ts
@@ -99,6 +99,16 @@ async function main() {
                     ae.slug like 'auditagent-%'
                     or ae.slug like 'wizard-smoke-%'
                     or ae.slug like 'test-openclaw-pm-%'
+                    or ae.slug like 'codex-qa-battery-%'
+                    or ae.slug like 'codex-work-runner-%'
+                    or ae.slug like 'codex-byoa-full-battery-%'
+                    or ae.slug like 'codex-byoa-agent-%'
+                    or ae.slug like 'audit-byoa-agent-%'
+                    or ae.slug like 'hermes-comms-%'
+                    or ae.slug like 'openclaw-ops-%'
+                    or ae.slug like 'codex-pilot-engineer-%'
+                    or ae.slug like 'codex-qa%'
+                    or ae.slug like 'b31-source-%'
                   )
               )
             )
@@ -119,6 +129,16 @@ async function main() {
                     ae.slug like 'auditagent-%'
                     or ae.slug like 'wizard-smoke-%'
                     or ae.slug like 'test-openclaw-pm-%'
+                    or ae.slug like 'codex-qa-battery-%'
+                    or ae.slug like 'codex-work-runner-%'
+                    or ae.slug like 'codex-byoa-full-battery-%'
+                    or ae.slug like 'codex-byoa-agent-%'
+                    or ae.slug like 'audit-byoa-agent-%'
+                    or ae.slug like 'hermes-comms-%'
+                    or ae.slug like 'openclaw-ops-%'
+                    or ae.slug like 'codex-pilot-engineer-%'
+                    or ae.slug like 'codex-qa%'
+                    or ae.slug like 'b31-source-%'
                   )
               )
             )
@@ -137,8 +157,19 @@ async function main() {
               ae.slug like 'auditagent-%'
               or ae.slug like 'wizard-smoke-%'
               or ae.slug like 'test-openclaw-pm-%'
+              or ae.slug like 'codex-qa-battery-%'
+              or ae.slug like 'codex-work-runner-%'
+              or ae.slug like 'codex-byoa-full-battery-%'
+              or ae.slug like 'codex-byoa-agent-%'
+              or ae.slug like 'audit-byoa-agent-%'
+              or ae.slug like 'hermes-comms-%'
+              or ae.slug like 'openclaw-ops-%'
+              or ae.slug like 'codex-pilot-engineer-%'
+              or ae.slug like 'codex-qa%'
+              or ae.slug like 'b31-source-%'
               or ae.name in ('Test OpenClaw PM', 'Test UI Employee PM', 'Test UI Employee Eng')
             )
+            and ae.slug not in ('tom', 'maya')
             ${scopedEmployee.clause}
         `,
         applySql: `
@@ -151,8 +182,19 @@ async function main() {
               ae.slug like 'auditagent-%'
               or ae.slug like 'wizard-smoke-%'
               or ae.slug like 'test-openclaw-pm-%'
+              or ae.slug like 'codex-qa-battery-%'
+              or ae.slug like 'codex-work-runner-%'
+              or ae.slug like 'codex-byoa-full-battery-%'
+              or ae.slug like 'codex-byoa-agent-%'
+              or ae.slug like 'audit-byoa-agent-%'
+              or ae.slug like 'hermes-comms-%'
+              or ae.slug like 'openclaw-ops-%'
+              or ae.slug like 'codex-pilot-engineer-%'
+              or ae.slug like 'codex-qa%'
+              or ae.slug like 'b31-source-%'
               or ae.name in ('Test OpenClaw PM', 'Test UI Employee PM', 'Test UI Employee Eng')
             )
+            and ae.slug not in ('tom', 'maya')
             ${scopedEmployee.clause}
         `,
         params: scopedEmployee.params,
@@ -171,7 +213,13 @@ async function main() {
               or s.name like 'byoa-%'
               or s.name like 'scratch-%'
               or s.name like 'test-%'
+              or s.name like 'agent-coworker-lab-%'
+              or s.name like 'defty-reliability-lab-%'
+              or s.name like 'codex-byoa-lab-%'
+              or s.name like 'three-agent-dogfood-%'
+              or s.name like 'codex-byoa-dogfood-%'
             )
+            and s.name not like 'tom-marketing-dogfood-%'
             ${scopedSpace.clause}
         `,
         applySql: `
@@ -186,7 +234,13 @@ async function main() {
               or s.name like 'byoa-%'
               or s.name like 'scratch-%'
               or s.name like 'test-%'
+              or s.name like 'agent-coworker-lab-%'
+              or s.name like 'defty-reliability-lab-%'
+              or s.name like 'codex-byoa-lab-%'
+              or s.name like 'three-agent-dogfood-%'
+              or s.name like 'codex-byoa-dogfood-%'
             )
+            and s.name not like 'tom-marketing-dogfood-%'
             ${scopedSpace.clause}
         `,
         params: scopedSpace.params,
@@ -204,7 +258,17 @@ async function main() {
               or p.name ilike 'byoa %'
               or p.name ilike 'scratch %'
               or p.name ilike 'smoke %'
+              or p.name ilike 'three runtime byoa battery%'
+              or p.name ilike 'defty ui reliability%'
+              or p.name ilike 'codex byoa behavior%'
+              or p.name ilike 'three agent dogfood%'
+              or p.name ilike 'codex byoa dogfood%'
+              or p.prefix like 'RT%'
+              or p.prefix like 'DF%'
+              or p.prefix like 'CX%'
+              or p.prefix like 'TG%'
             )
+            and p.name not ilike 'tom marketing dogfood%'
             ${scopedProject.clause}
         `,
         applySql: `
@@ -220,7 +284,17 @@ async function main() {
               or p.name ilike 'byoa %'
               or p.name ilike 'scratch %'
               or p.name ilike 'smoke %'
+              or p.name ilike 'three runtime byoa battery%'
+              or p.name ilike 'defty ui reliability%'
+              or p.name ilike 'codex byoa behavior%'
+              or p.name ilike 'three agent dogfood%'
+              or p.name ilike 'codex byoa dogfood%'
+              or p.prefix like 'RT%'
+              or p.prefix like 'DF%'
+              or p.prefix like 'CX%'
+              or p.prefix like 'TG%'
             )
+            and p.name not ilike 'tom marketing dogfood%'
             ${scopedProject.clause}
         `,
         params: scopedProject.params,


### PR DESCRIPTION
## Summary
- clears the remaining non-website pilot cracks around self-hosted positioning, agent trust surfaces, dashboard/knowledge clarity, and workspace hygiene
- adds a clean pilot seed path plus reusable cracks and multi-user swarm runners under scripts/
- keeps generated reports out of the public repo via .gitignore hygiene

## Local validation
- pnpm --filter @deft/api typecheck
- pnpm --filter @deft/web typecheck
- pnpm pilot:preflight:strict
- pnpm pilot:cracks:battery (15/15)
- pnpm pilot:swarm (5/5)

## Notes
Generated HTML/JSON/screenshot reports remain local under reports/ and are intentionally ignored.