### PR TITLE
Polish self-host ICS calendar setup

### DIFF
--- a/apps/api/src/lib/ics.ts
+++ b/apps/api/src/lib/ics.ts
@@ -74,6 +74,12 @@ export function parseICS(text: string): ParsedEvent[] {
   return out;
 }
 
+export function extractICSCalendarName(text: string): string | null {
+  const match = text.match(/^X-WR-CALNAME:(.+)$/im);
+  if (!match?.[1]) return null;
+  return match[1].replace(/\\,/g, ',').replace(/\\;/g, ';').trim().slice(0, 120) || null;
+}
+
 function extractOrganizer(value: unknown): string | null {
   if (!value) return null;
   if (typeof value === 'string') return value;

--- a/apps/api/src/routes/ics.ts
+++ b/apps/api/src/routes/ics.ts
@@ -1,9 +1,9 @@
 import { Hono } from 'hono';
 import { z } from 'zod';
-import { eq, and, isNotNull, gte, lte } from 'drizzle-orm';
+import { eq, and, isNotNull, gte, lte, inArray } from 'drizzle-orm';
 import { db } from '../lib/db.js';
-import { users, icsSubscriptions, tasks, events } from '@deft/db/schema';
-import { generateICS, newPublishToken } from '../lib/ics.js';
+import { users, icsSubscriptions, tasks, events, projects } from '@deft/db/schema';
+import { generateICS, newPublishToken, parseICS, extractICSCalendarName } from '../lib/ics.js';
 import { syncOne } from '../workers/handlers/ics-sync.js';
 import { env } from '../lib/env.js';
 
@@ -13,6 +13,9 @@ import { env } from '../lib/env.js';
 
 export const icsPublicRoutes = new Hono();
 export const icsRoutes = new Hono();
+
+const ICS_PREVIEW_TIMEOUT_MS = 20_000;
+const ICS_PREVIEW_MAX_BYTES = 5 * 1024 * 1024;
 
 function publicApiBase(c: { req: { url: string } }): string {
   const configured = process.env.NEXT_PUBLIC_API_URL || process.env.DEFT_API_URL;
@@ -63,11 +66,14 @@ icsPublicRoutes.get('/feed/:token', async (c) => {
   const taskRows = await db
     .select({
       id: tasks.id,
+      number: tasks.number,
       title: tasks.title,
       description: tasks.description,
       due_date: tasks.due_date,
+      project_prefix: projects.prefix,
     })
     .from(tasks)
+    .innerJoin(projects, eq(tasks.project_id, projects.id))
     .where(
       and(
         eq(tasks.org_id, orgId),
@@ -79,12 +85,13 @@ icsPublicRoutes.get('/feed/:token', async (c) => {
     )
     .limit(500);
 
-  // 2. ICS-ingested events for this user.
+  // 2. Deft-native and ICS-ingested events for this user.
   const eventRows = await db
     .select({
       id: events.id,
       title: events.title,
       body: events.body,
+      source: events.source,
       timestamp: events.timestamp,
       metadata: events.metadata,
     })
@@ -93,7 +100,8 @@ icsPublicRoutes.get('/feed/:token', async (c) => {
       and(
         eq(events.org_id, orgId),
         eq(events.user_id, user.id),
-        eq(events.source, 'ics'),
+        inArray(events.source, ['native', 'ics']),
+        eq(events.event_type, 'calendar_event'),
         gte(events.timestamp, horizonStart),
         lte(events.timestamp, horizonEnd),
       ),
@@ -110,17 +118,18 @@ icsPublicRoutes.get('/feed/:token', async (c) => {
         start: t.due_date as Date,
         end: null,
         all_day: true,
-        url: `${appUrl}/tasks/${t.id}`,
+        url: `${appUrl}/tasks?task=${t.project_prefix}-${t.number}`,
       })),
       ...eventRows.map((e) => {
         const meta = (e.metadata ?? {}) as { end?: string | null; all_day?: boolean };
         return {
-          uid: `event-${e.id}@deft`,
+          uid: `${e.source}-event-${e.id}@deft`,
           summary: e.title ?? '(untitled)',
           description: e.body ?? null,
           start: e.timestamp as Date,
           end: meta.end ? new Date(meta.end) : null,
           all_day: Boolean(meta.all_day),
+          url: e.source === 'native' ? `${appUrl}/calendar` : null,
         };
       }),
     ],
@@ -149,11 +158,70 @@ icsRoutes.get('/subscriptions', async (c) => {
   return c.json(subs);
 });
 
+const icsUrlSchema = z.string().trim().min(1).max(2048).refine((value) => {
+  try {
+    const normalized = value.replace(/^webcal:\/\//i, 'https://');
+    const url = new URL(normalized);
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}, 'Must be an http, https, or webcal ICS URL');
+
 // POST /api/ics/subscriptions
 const createSchema = z.object({
-  ics_url: z.string().url().max(2048),
+  ics_url: icsUrlSchema,
   label: z.string().max(120).optional(),
   sync_interval_min: z.number().int().min(5).max(720).optional(),
+});
+
+const previewSchema = z.object({
+  ics_url: icsUrlSchema,
+});
+
+const updateSchema = z.object({
+  label: z.string().max(120).nullable().optional(),
+  sync_interval_min: z.number().int().min(5).max(720).optional(),
+  is_active: z.boolean().optional(),
+});
+
+// POST /api/ics/preview
+icsRoutes.post('/preview', async (c) => {
+  const body = await c.req.json().catch(() => ({}));
+  const parsed = previewSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: 'Invalid input', code: 'VALIDATION_ERROR', detail: parsed.error.message }, 400);
+  }
+
+  try {
+    const text = await fetchICSWithLimits(parsed.data.ics_url);
+    const parsedEvents = parseICS(text).sort((a, b) => a.start.getTime() - b.start.getTime());
+    const now = Date.now();
+    const upcoming = parsedEvents
+      .filter((event) => event.start.getTime() >= now - 24 * 60 * 60 * 1000)
+      .slice(0, 5)
+      .map((event) => ({
+        uid: event.uid,
+        title: event.summary || '(untitled event)',
+        starts_at: event.start.toISOString(),
+        ends_at: event.end?.toISOString() ?? null,
+        all_day: event.all_day,
+        location: event.location,
+      }));
+
+    return c.json({
+      ok: true,
+      calendar_name: extractICSCalendarName(text),
+      event_count: parsedEvents.length,
+      upcoming,
+    });
+  } catch (err) {
+    return c.json({
+      error: 'Preview failed',
+      code: 'PREVIEW_FAILED',
+      detail: humanizeIcsError(err),
+    }, 502);
+  }
 });
 
 icsRoutes.post('/subscriptions', async (c) => {
@@ -164,7 +232,7 @@ icsRoutes.post('/subscriptions', async (c) => {
     return c.json({ error: 'Invalid input', code: 'VALIDATION_ERROR', detail: parsed.error.message }, 400);
   }
 
-  const url = parsed.data.ics_url.replace(/^webcal:\/\//i, 'https://');
+  const url = parsed.data.ics_url.trim().replace(/^webcal:\/\//i, 'https://');
 
   const [created] = await db
     .insert(icsSubscriptions)
@@ -176,8 +244,56 @@ icsRoutes.post('/subscriptions', async (c) => {
       sync_interval_min: parsed.data.sync_interval_min ?? 15,
     })
     .returning();
+  if (!created) {
+    return c.json({ error: 'Failed to create subscription', code: 'CREATE_FAILED' }, 500);
+  }
 
-  return c.json(created, 201);
+  try {
+    await syncOne({
+      id: created.id,
+      org_id: created.org_id,
+      user_id: created.user_id,
+      ics_url: created.ics_url,
+      label: created.label,
+    });
+  } catch (err) {
+    await db
+      .update(icsSubscriptions)
+      .set({ last_error: humanizeIcsError(err), last_synced_at: new Date() })
+      .where(eq(icsSubscriptions.id, created.id));
+  }
+
+  const [refreshed] = await db
+    .select()
+    .from(icsSubscriptions)
+    .where(eq(icsSubscriptions.id, created.id))
+    .limit(1);
+
+  return c.json(refreshed ?? created, 201);
+});
+
+// PATCH /api/ics/subscriptions/:id
+icsRoutes.patch('/subscriptions/:id', async (c) => {
+  const user = c.get('user') as { id: string; org_id: string };
+  const id = c.req.param('id');
+  const body = await c.req.json().catch(() => ({}));
+  const parsed = updateSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: 'Invalid input', code: 'VALIDATION_ERROR', detail: parsed.error.message }, 400);
+  }
+
+  const updates: Record<string, unknown> = { updated_at: new Date() };
+  if (parsed.data.label !== undefined) updates.label = parsed.data.label?.trim() || null;
+  if (parsed.data.sync_interval_min !== undefined) updates.sync_interval_min = parsed.data.sync_interval_min;
+  if (parsed.data.is_active !== undefined) updates.is_active = parsed.data.is_active;
+
+  const [updated] = await db
+    .update(icsSubscriptions)
+    .set(updates)
+    .where(and(eq(icsSubscriptions.id, id), eq(icsSubscriptions.user_id, user.id), eq(icsSubscriptions.org_id, user.org_id)))
+    .returning();
+  if (!updated) return c.json({ error: 'Not found', code: 'NOT_FOUND' }, 404);
+  return c.json(updated);
 });
 
 // DELETE /api/ics/subscriptions/:id
@@ -186,7 +302,7 @@ icsRoutes.delete('/subscriptions/:id', async (c) => {
   const id = c.req.param('id');
   const [removed] = await db
     .delete(icsSubscriptions)
-    .where(and(eq(icsSubscriptions.id, id), eq(icsSubscriptions.user_id, user.id)))
+    .where(and(eq(icsSubscriptions.id, id), eq(icsSubscriptions.user_id, user.id), eq(icsSubscriptions.org_id, user.org_id)))
     .returning({ id: icsSubscriptions.id });
   if (!removed) return c.json({ error: 'Not found', code: 'NOT_FOUND' }, 404);
   return c.json({ ok: true });
@@ -199,7 +315,7 @@ icsRoutes.post('/subscriptions/:id/sync', async (c) => {
   const [sub] = await db
     .select()
     .from(icsSubscriptions)
-    .where(and(eq(icsSubscriptions.id, id), eq(icsSubscriptions.user_id, user.id)))
+    .where(and(eq(icsSubscriptions.id, id), eq(icsSubscriptions.user_id, user.id), eq(icsSubscriptions.org_id, user.org_id)))
     .limit(1);
   if (!sub) return c.json({ error: 'Not found', code: 'NOT_FOUND' }, 404);
 
@@ -218,7 +334,7 @@ icsRoutes.post('/subscriptions/:id/sync', async (c) => {
       .limit(1);
     return c.json({ ok: true, count, subscription: refreshed });
   } catch (err) {
-    const msg = (err as Error).message?.slice(0, 500) ?? 'unknown error';
+    const msg = humanizeIcsError(err);
     await db
       .update(icsSubscriptions)
       .set({ last_error: msg, last_synced_at: new Date() })
@@ -252,3 +368,41 @@ icsRoutes.post('/my-feed-url/regenerate', async (c) => {
   const apiBase = publicApiBase(c);
   return c.json({ feed_url: `${apiBase}/api/ics/feed/${token}` });
 });
+
+async function fetchICSWithLimits(url: string): Promise<string> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), ICS_PREVIEW_TIMEOUT_MS);
+  try {
+    const httpsUrl = url.replace(/^webcal:\/\//i, 'https://');
+    const res = await globalThis.fetch(httpsUrl, {
+      method: 'GET',
+      headers: { Accept: 'text/calendar, text/plain, application/octet-stream, */*' },
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      throw new Error(`HTTP ${res.status}`);
+    }
+    const buf = await res.arrayBuffer();
+    if (buf.byteLength > ICS_PREVIEW_MAX_BYTES) {
+      throw new Error(`Body too large: ${buf.byteLength} bytes`);
+    }
+    const text = Buffer.from(buf).toString('utf8');
+    if (/<!doctype html|<html[\s>]/i.test(text.slice(0, 500))) {
+      throw new Error('The URL returned a web page, not an ICS feed');
+    }
+    return text;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function humanizeIcsError(err: unknown): string {
+  const message = (err as Error).message || 'unknown error';
+  if (/Body too large/i.test(message)) return 'Feed is too large to import.';
+  if (/aborted|AbortError/i.test(message)) return 'Feed request timed out.';
+  if (/HTTP 401|HTTP 403/i.test(message)) return 'Feed requires login or is not public/secret-shareable.';
+  if (/HTTP 404/i.test(message)) return 'Feed URL was not found.';
+  if (/web page/i.test(message)) return 'The URL returned a web page, not a calendar feed. Use the secret/public ICS URL.';
+  if (/ICS parse failed/i.test(message)) return message;
+  return message.slice(0, 500);
+}

--- a/apps/api/test/ics-lib.test.ts
+++ b/apps/api/test/ics-lib.test.ts
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { extractICSCalendarName, generateICS, parseICS } from '../src/lib/ics.js';
+
+test('extractICSCalendarName returns a cleaned feed name', () => {
+  const text = [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    'X-WR-CALNAME:Tomatoes\\, Launch\\; Ops',
+    'END:VCALENDAR',
+  ].join('\r\n');
+
+  assert.equal(extractICSCalendarName(text), 'Tomatoes, Launch; Ops');
+});
+
+test('generateICS round-trips Deft tasks and native event URLs', () => {
+  const calendar = generateICS(
+    [
+      {
+        uid: 'task-1@deft',
+        summary: '[task] Prepare tomato launch plan',
+        description: 'Finalize the launch checklist.',
+        start: new Date('2026-06-15T00:00:00Z'),
+        all_day: true,
+        url: 'http://localhost:3000/tasks?task=MAR-12',
+      },
+      {
+        uid: 'native-event-1@deft',
+        summary: 'Route capacity check',
+        start: new Date('2026-06-15T14:00:00Z'),
+        end: new Date('2026-06-15T14:30:00Z'),
+        url: 'http://localhost:3000/calendar',
+      },
+    ],
+    { name: 'Deft - Diego', description: 'Your tasks and synced events from Deft' },
+  );
+
+  assert.match(calendar, /X-WR-CALNAME:Deft - Diego/);
+  assert.match(calendar, /URL:http:\/\/localhost:3000\/tasks\?task=MAR-12/);
+  assert.match(calendar, /UID:native-event-1@deft/);
+
+  const events = parseICS(calendar);
+  assert.equal(events.length, 2);
+  assert.equal(events[0]?.summary, '[task] Prepare tomato launch plan');
+  assert.equal(events[1]?.summary, 'Route capacity check');
+});

--- a/apps/web/src/app/(app)/settings/calendar/page.tsx
+++ b/apps/web/src/app/(app)/settings/calendar/page.tsx
@@ -15,6 +15,9 @@ import {
   ChevronRight,
   Loader2,
   AlertCircle,
+  Eye,
+  PauseCircle,
+  PlayCircle,
 } from 'lucide-react';
 
 type Subscription = {
@@ -37,8 +40,47 @@ const INTERVAL_OPTIONS = [
   { value: 60, label: '60 min' },
 ];
 
+const PROVIDERS = [
+  { id: 'google', label: 'Google', hint: 'Settings -> calendar -> Integrate calendar -> Secret address in iCal format.' },
+  { id: 'apple', label: 'Apple/iCloud', hint: 'Share Calendar -> Public Calendar -> copy the webcal URL.' },
+  { id: 'outlook', label: 'Outlook', hint: 'Settings -> Calendar -> Shared calendars -> Publish -> ICS URL.' },
+  { id: 'fastmail', label: 'Fastmail', hint: 'Calendar settings -> Sharing -> private iCalendar feed URL.' },
+  { id: 'generic', label: 'Generic ICS', hint: 'Paste any private, public, or webcal ICS feed URL.' },
+] as const;
+
+type ProviderId = typeof PROVIDERS[number]['id'];
+
+type FeedPreview = {
+  calendar_name: string | null;
+  event_count: number;
+  upcoming: Array<{
+    uid: string;
+    title: string;
+    starts_at: string;
+    ends_at: string | null;
+    all_day: boolean;
+    location: string | null;
+  }>;
+};
+
 function truncate(s: string, n: number): string {
   return s.length > n ? s.slice(0, n - 1) + '…' : s;
+}
+
+function formatDateTime(value: string | null): string {
+  if (!value) return 'Never';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString(undefined, { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' });
+}
+
+function nextSyncAt(sub: Subscription): string {
+  if (!sub.is_active) return 'Paused';
+  if (!sub.last_synced_at) return 'Due now';
+  const date = new Date(sub.last_synced_at);
+  if (Number.isNaN(date.getTime())) return 'Unknown';
+  date.setMinutes(date.getMinutes() + sub.sync_interval_min);
+  return formatDateTime(date.toISOString());
 }
 
 export default function CalendarSettingsPage() {
@@ -53,7 +95,7 @@ export default function CalendarSettingsPage() {
             Calendar sync
           </h2>
           <p className="text-[12px] mt-1 leading-relaxed" style={{ color: 'var(--muted)' }}>
-            Bidirectional ICS subscriptions — no OAuth, no plugin. Works with Apple Calendar, Google Calendar, and Outlook.
+            Connect calendars with ICS links: show Deft work in your calendar, and read external calendar events into Deft without OAuth.
           </p>
         </div>
 
@@ -117,7 +159,7 @@ function OutboundSection() {
         className="text-[11px] font-semibold uppercase tracking-wide mb-1"
         style={{ color: 'var(--muted)', fontFamily: 'var(--font-heading)' }}
       >
-        Subscribe your calendar to Deft
+        Show Deft in your calendar
       </h3>
       <p className="text-[12px] mb-3 leading-relaxed" style={{ color: 'var(--muted)' }}>
         Paste this URL into your calendar app to see your Deft tasks alongside your other events. Your calendar app re-fetches automatically — no OAuth, no plugin.
@@ -289,7 +331,7 @@ function InboundSection() {
           className="text-[11px] font-semibold uppercase tracking-wide"
           style={{ color: 'var(--muted)', fontFamily: 'var(--font-heading)' }}
         >
-          Subscribe Deft to other calendars
+          Connect external calendars to Deft
         </h3>
         {!showAdd && (
           <button
@@ -384,7 +426,31 @@ function AddSubscriptionForm({
   const [label, setLabel] = useState('');
   const [interval, setInterval] = useState<number>(15);
   const [submitting, setSubmitting] = useState(false);
+  const [previewing, setPreviewing] = useState(false);
+  const [provider, setProvider] = useState<ProviderId>('google');
+  const [preview, setPreview] = useState<FeedPreview | null>(null);
   const [err, setErr] = useState('');
+
+  const selectedProvider = PROVIDERS.find((item) => item.id === provider) ?? PROVIDERS[0];
+
+  const previewFeed = async () => {
+    setPreviewing(true);
+    setErr('');
+    setPreview(null);
+    try {
+      const trimmed = url.trim();
+      if (!trimmed) throw new Error('URL required');
+      const r = await api.post('/api/ics/preview', { ics_url: trimmed });
+      const j = await r.json();
+      if (!r.ok) throw new Error(j.detail || j.error || 'Preview failed');
+      setPreview(j as FeedPreview);
+      if (!label.trim() && j.calendar_name) setLabel(j.calendar_name);
+    } catch (e: any) {
+      setErr(e.message);
+    } finally {
+      setPreviewing(false);
+    }
+  };
 
   const submit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -397,7 +463,7 @@ function AddSubscriptionForm({
       if (!trimmed) throw new Error('URL required');
       const r = await api.post('/api/ics/subscriptions', {
         ics_url: trimmed,
-        label: label.trim() || undefined,
+        label: label.trim() || preview?.calendar_name || selectedProvider.label,
         sync_interval_min: interval,
       });
       const j = await r.json();
@@ -423,6 +489,31 @@ function AddSubscriptionForm({
       )}
       <div>
         <label className="text-[11px] font-semibold uppercase tracking-wide block mb-1.5" style={{ color: 'var(--muted)' }}>
+          Calendar provider
+        </label>
+        <div className="grid grid-cols-2 sm:grid-cols-5 gap-1">
+          {PROVIDERS.map((item) => (
+            <button
+              key={item.id}
+              type="button"
+              onClick={() => setProvider(item.id)}
+              className="h-8 px-2 text-[11px] font-medium rounded-md"
+              style={{
+                background: provider === item.id ? 'var(--accent)' : 'var(--surface)',
+                color: provider === item.id ? 'white' : 'var(--foreground)',
+                border: '1px solid var(--border)',
+              }}
+            >
+              {item.label}
+            </button>
+          ))}
+        </div>
+        <p className="mt-2 text-[12px] leading-relaxed" style={{ color: 'var(--muted)' }}>
+          {selectedProvider.hint}
+        </p>
+      </div>
+      <div>
+        <label className="text-[11px] font-semibold uppercase tracking-wide block mb-1.5" style={{ color: 'var(--muted)' }}>
           ICS URL
         </label>
         <input
@@ -436,6 +527,33 @@ function AddSubscriptionForm({
           style={{ background: 'var(--surface)', border: '1px solid var(--border)', color: 'var(--foreground)' }}
         />
       </div>
+      {preview && (
+        <div className="rounded-md p-3" style={{ background: 'var(--surface)', border: '1px solid var(--border)' }}>
+          <div className="flex items-center justify-between gap-2">
+            <div>
+              <p className="text-[13px] font-medium" style={{ color: 'var(--foreground)' }}>
+                {preview.calendar_name || 'Calendar feed'}
+              </p>
+              <p className="text-[12px]" style={{ color: 'var(--muted)' }}>
+                Found {preview.event_count} event{preview.event_count === 1 ? '' : 's'}.
+              </p>
+            </div>
+            <span className="inline-flex items-center gap-1 text-[11px] px-2 py-1 rounded-full" style={{ background: 'rgba(34,197,94,0.15)', color: 'var(--success, #22c55e)' }}>
+              <Check size={11} /> Preview ok
+            </span>
+          </div>
+          {preview.upcoming.length > 0 && (
+            <div className="mt-3 space-y-1">
+              {preview.upcoming.map((event) => (
+                <div key={event.uid} className="flex justify-between gap-3 text-[12px]">
+                  <span className="truncate" style={{ color: 'var(--foreground-secondary)' }}>{event.title}</span>
+                  <span className="shrink-0" style={{ color: 'var(--muted)' }}>{formatDateTime(event.starts_at)}</span>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
       <div className="flex gap-3">
         <div className="flex-1">
           <label className="text-[11px] font-semibold uppercase tracking-wide block mb-1.5" style={{ color: 'var(--muted)' }}>
@@ -480,8 +598,18 @@ function AddSubscriptionForm({
           Cancel
         </button>
         <button
+          type="button"
+          onClick={previewFeed}
+          disabled={previewing || submitting || !url.trim()}
+          className="h-9 px-3 inline-flex items-center gap-1.5 text-[12px] font-medium rounded-md disabled:opacity-50"
+          style={{ background: 'var(--surface)', color: 'var(--foreground)', border: '1px solid var(--border)' }}
+        >
+          <Eye size={12} />
+          {previewing ? 'Previewing...' : 'Preview'}
+        </button>
+        <button
           type="submit"
-          disabled={submitting || !url.trim()}
+          disabled={submitting || previewing || !url.trim()}
           className="h-9 px-4 text-[12px] font-medium rounded-md disabled:opacity-50"
           style={{ background: 'var(--accent)', color: 'white' }}
         >
@@ -529,6 +657,11 @@ function SubscriptionRow({
     await api.delete(`/api/ics/subscriptions/${sub.id}`);
   };
 
+  const toggleActive = async () => {
+    const r = await api.patch(`/api/ics/subscriptions/${sub.id}`, { is_active: !sub.is_active });
+    if (r.ok) onChange(await r.json());
+  };
+
   const displayLabel = sub.label || truncate(sub.ics_url, 40);
 
   let status: { text: string; tone: 'ok' | 'muted' | 'error' };
@@ -567,6 +700,15 @@ function SubscriptionRow({
           )}
           <div className="mt-1 flex items-center gap-2 flex-wrap">
             <span
+              className="text-[11px] px-1.5 py-0.5 rounded"
+              style={{
+                background: sub.is_active ? 'rgba(34,197,94,0.12)' : 'var(--surface)',
+                color: sub.is_active ? 'var(--success, #22c55e)' : 'var(--muted)',
+              }}
+            >
+              {sub.is_active ? 'active' : 'paused'}
+            </span>
+            <span
               className="text-[11px] px-1.5 py-0.5 rounded inline-flex items-center gap-1"
               style={{
                 background:
@@ -589,6 +731,9 @@ function SubscriptionRow({
             <span className="text-[11px]" style={{ color: 'var(--muted)' }}>
               every {sub.sync_interval_min} min
             </span>
+            <span className="text-[11px]" style={{ color: 'var(--muted)' }}>
+              next sync: {nextSyncAt(sub)}
+            </span>
           </div>
           {err && (
             <p className="mt-2 text-[11px]" style={{ color: 'var(--error)' }}>
@@ -597,6 +742,15 @@ function SubscriptionRow({
           )}
         </div>
         <div className="flex flex-shrink-0 items-center gap-1">
+          <button
+            type="button"
+            onClick={toggleActive}
+            title={sub.is_active ? 'Pause subscription' : 'Resume subscription'}
+            className="h-8 w-8 inline-flex items-center justify-center rounded-md"
+            style={{ background: 'var(--surface)', color: 'var(--muted)', border: '1px solid var(--border)' }}
+          >
+            {sub.is_active ? <PauseCircle size={12} /> : <PlayCircle size={12} />}
+          </button>
           <button
             type="button"
             onClick={sync}


### PR DESCRIPTION
## Summary
- Add ICS URL validation that accepts `http`, `https`, and `webcal` feeds.
- Add an authenticated ICS preview endpoint and immediate sync attempt when creating a subscription.
- Improve the calendar settings UI with provider presets, preview, pause/resume, sync status, and clearer feed metadata.
- Include native calendar events in the outbound Deft ICS feed and link due tasks back to their task slug.

## Tests
- `pnpm --filter @deft/api exec tsx --test --test-concurrency=1 --test-force-exit test/ics-lib.test.ts`
- `pnpm --filter @deft/api typecheck`
- `pnpm --filter @deft/web typecheck`