### PR TITLE
Add agent and worker timeouts

### DIFF
--- a/apps/api/src/lib/agent-runner.ts
+++ b/apps/api/src/lib/agent-runner.ts
@@ -122,6 +122,8 @@ export async function runAgentQuery(params: {
    * task-detail UI can render a live status strip. No-op when unset.
    */
   taskId?: string;
+  /** Abort signal for worker-level cancellation/timeouts. */
+  abortSignal?: AbortSignal;
   /**
    * Surface context — what kind of space the agent is replying in. Drives
    * tone (DM = 1:1 conversation, channel = many viewers) and is appended
@@ -358,6 +360,7 @@ export async function runAgentQuery(params: {
       messages: apiMessages,
       tools,
       maxTokens: 4096,
+      abortSignal: params.abortSignal,
     });
 
     if (response.usage) {

--- a/apps/api/src/lib/llm.ts
+++ b/apps/api/src/lib/llm.ts
@@ -136,7 +136,7 @@ async function callAnthropic(
   },
 ): Promise<{ text: string; toolCalls?: any[]; usage?: { input: number; output: number }; model: string }> {
   const Anthropic = (await import('@anthropic-ai/sdk')).default;
-  const client = new Anthropic({ apiKey });
+  const client = new Anthropic({ apiKey, timeout: 60_000, maxRetries: 1 });
 
   // Filter out system messages — Anthropic uses the system parameter instead
   const nonSystemMessages = params.messages.filter((m) => m.role !== 'system');
@@ -217,6 +217,7 @@ async function callOpenAI(
       Authorization: `Bearer ${apiKey}`,
     },
     body: JSON.stringify(body),
+    signal: AbortSignal.timeout(60_000),
   });
 
   if (!response.ok) {
@@ -274,6 +275,7 @@ async function callOllama(
       messages: apiMessages,
       stream: false,
     }),
+    signal: AbortSignal.timeout(60_000),
   });
 
   if (!response.ok) {

--- a/apps/api/src/workers/handlers/agent-reply.ts
+++ b/apps/api/src/workers/handlers/agent-reply.ts
@@ -174,6 +174,8 @@ export async function handleAgentReply(job: JobData): Promise<void> {
     // Call the agent reasoning engine with a 60s hard timeout so a stuck
     // MCP tool / Anthropic call can never wedge the worker.
     const AGENT_TIMEOUT_MS = 60_000;
+    const abort = new AbortController();
+    const timeout = setTimeout(() => abort.abort(), AGENT_TIMEOUT_MS);
     const result = await Promise.race([
       runAgentQuery({
         content: promptContent,
@@ -190,11 +192,12 @@ export async function handleAgentReply(job: JobData): Promise<void> {
           name: space.name,
           otherMemberName,
         } : undefined,
+        abortSignal: abort.signal,
       }),
       new Promise<never>((_, reject) =>
         setTimeout(() => reject(new Error('agent-reply: runAgentQuery timeout after 60s')), AGENT_TIMEOUT_MS),
       ),
-    ]);
+    ]).finally(() => clearTimeout(timeout));
 
     if (!result.text) {
       console.warn('[agent-reply] Agent returned empty text, skipping reply');

--- a/apps/api/src/workers/index.ts
+++ b/apps/api/src/workers/index.ts
@@ -44,6 +44,22 @@ const CRON_KEYS: Record<string, string> = {
   'ics-sync': 'cron:ics-sync',
 };
 
+const JOB_TIMEOUT_MS = Number.parseInt(process.env.DEFT_JOB_TIMEOUT_MS ?? '120000', 10);
+
+function runWithTimeout<T>(promise: Promise<T>, label: string): Promise<T> {
+  if (!Number.isFinite(JOB_TIMEOUT_MS) || JOB_TIMEOUT_MS <= 0) return promise;
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const guard = new Promise<never>((_, reject) => {
+    timeout = setTimeout(
+      () => reject(new Error(`${label} timed out after ${JOB_TIMEOUT_MS}ms`)),
+      JOB_TIMEOUT_MS,
+    );
+  });
+  return Promise.race([promise, guard]).finally(() => {
+    if (timeout) clearTimeout(timeout);
+  });
+}
+
 // ─── Lazy-loaded handler registry ───
 async function getAgentJobHandler(jobName: string): Promise<JobHandler | null> {
   switch (jobName) {
@@ -228,7 +244,10 @@ export function startWorkers(): void {
         }
 
         try {
-          await handler({ id: job.id, name: job.name, data: job.data });
+          await runWithTimeout(
+            handler({ id: job.id, name: job.name, data: job.data }),
+            `Job ${job.name} (${job.id.slice(0, 8)})`,
+          );
           await completeJob(job.id);
           console.log(`[worker] Job ${job.name} (${job.id.slice(0, 8)}) completed`);
 


### PR DESCRIPTION
## Summary
- Add worker-level timeout guarding with `DEFT_JOB_TIMEOUT_MS` so stuck jobs do not wedge the worker loop.
- Thread abort signals into agent query execution for reply jobs.
- Add bounded provider calls for Anthropic, OpenAI-compatible, and Ollama-style LLM calls without introducing any required provider dependency.

## Tests
- `pnpm --filter @deft/api typecheck`