### PR TITLE
[codex] Harden MCP tools and self-host setup

### DIFF
--- a/apps/api/src/lib/mcp-tools/human.ts
+++ b/apps/api/src/lib/mcp-tools/human.ts
@@ -5,6 +5,7 @@ import {
   connectedAccounts,
   events,
   messages,
+  oauthAuditEvents,
   orgMembers,
   orgs,
   projects,
@@ -26,6 +27,10 @@ export type HumanToolContext = {
   user_id: string;
   role: 'owner' | 'admin' | 'member' | 'guest';
   scopes: string[];
+  token_id?: string;
+  client_id?: string;
+  grant_id?: string;
+  principal_kind?: 'human' | 'oauth';
 };
 
 type HumanToolHandler = (args: any, ctx: HumanToolContext) => Promise<ToolResult>;
@@ -130,9 +135,15 @@ export const HUMAN_READ_TOOLS = new Set([
   'wiki_search',
   'memory_list',
   'list_my_tasks',
+  'task_get',
   'task_query',
+  'project_list',
+  'project_get',
+  'space_list',
+  'space_get',
   'thread_fetch',
   'member_list',
+  'member_get',
   'events_query',
   'messages_search',
   'project_progress',
@@ -143,6 +154,7 @@ export const HUMAN_WRITE_TOOLS = new Set([
   'memory_write',
   'task_create',
   'task_update',
+  'task_transition',
   'comment_on_task',
   'message_post',
 ]);
@@ -155,14 +167,21 @@ export const HUMAN_TOOLS: Record<string, HumanToolHandler> = {
   wiki_search: humanMemoryRecall,
   memory_list: humanMemoryList,
   list_my_tasks: humanListMyTasks,
+  task_get: humanTaskGet,
   memory_write: humanMemoryWrite,
   task_query: humanTaskQuery,
+  project_list: humanProjectList,
+  project_get: humanProjectGet,
+  space_list: humanSpaceList,
+  space_get: humanSpaceGet,
   task_create: humanTaskCreate,
   task_update: humanTaskUpdate,
+  task_transition: humanTaskTransition,
   comment_on_task: humanCommentOnTask,
   message_post: humanMessagePost,
   thread_fetch: humanThreadFetch,
   member_list: humanMemberList,
+  member_get: humanMemberGet,
   messages_search: humanMessagesSearch,
   project_progress: humanProjectProgress,
   team_workload: humanTeamWorkload,
@@ -175,6 +194,75 @@ function hasAnyScope(ctx: HumanToolContext, scopes: string[]): boolean {
 
 function requireAnyScope(ctx: HumanToolContext, scopes: string[]): ToolResult | null {
   return hasAnyScope(ctx, scopes) ? null : errorResult(`Missing MCP scope: ${scopes.join(' or ')}`);
+}
+
+function normalizeIdempotencyKey(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const key = value.trim();
+  if (!key) return null;
+  return key.slice(0, 160);
+}
+
+function storedToolResult(value: unknown): ToolResult | null {
+  if (!value || typeof value !== 'object') return null;
+  const maybe = value as Partial<ToolResult>;
+  if (!Array.isArray(maybe.content)) return null;
+  if (!maybe.content.every((item) => item && item.type === 'text' && typeof item.text === 'string')) return null;
+  return { content: maybe.content, isError: maybe.isError };
+}
+
+async function withIdempotency(
+  toolName: string,
+  args: { idempotency_key?: unknown },
+  ctx: HumanToolContext,
+  execute: () => Promise<ToolResult>,
+): Promise<ToolResult> {
+  const idempotencyKey = normalizeIdempotencyKey(args.idempotency_key);
+  if (!idempotencyKey) return execute();
+
+  const clientId = ctx.client_id ?? `personal-token:${ctx.token_id ?? 'unknown'}`;
+  const [existing] = await db
+    .select({ metadata: oauthAuditEvents.metadata })
+    .from(oauthAuditEvents)
+    .where(and(
+      eq(oauthAuditEvents.org_id, ctx.org_id),
+      eq(oauthAuditEvents.user_id, ctx.user_id),
+      eq(oauthAuditEvents.client_id, clientId),
+      eq(oauthAuditEvents.event, 'mcp_idempotency_result'),
+      sql`${oauthAuditEvents.metadata}->>'tool_name' = ${toolName}`,
+      sql`${oauthAuditEvents.metadata}->>'idempotency_key' = ${idempotencyKey}`,
+    ))
+    .orderBy(desc(oauthAuditEvents.created_at))
+    .limit(1);
+  const replay = storedToolResult(existing?.metadata?.result);
+  if (replay) return replay;
+
+  const result = await execute();
+  if (!result.isError) {
+    await db.insert(oauthAuditEvents).values({
+      org_id: ctx.org_id,
+      user_id: ctx.user_id,
+      client_id: clientId,
+      event: 'mcp_idempotency_result',
+      metadata: {
+        tool_name: toolName,
+        idempotency_key: idempotencyKey,
+        grant_id: ctx.grant_id ?? null,
+        principal_kind: ctx.principal_kind ?? 'human',
+        result,
+      },
+    });
+  }
+  return result;
+}
+
+function taskReference(projectPrefix: string | null, number: number | null): string | null {
+  if (!projectPrefix || !number) return null;
+  return `${projectPrefix}-${number}`;
+}
+
+function validTaskStatus(value: unknown): value is 'backlog' | 'todo' | 'in_progress' | 'in_review' | 'done' | 'cancelled' {
+  return typeof value === 'string' && ['backlog', 'todo', 'in_progress', 'in_review', 'done', 'cancelled'].includes(value);
 }
 
 export async function humanPlatformContext(_args: {}, ctx: HumanToolContext): Promise<ToolResult> {
@@ -433,6 +521,57 @@ export async function humanListMyTasks(args: { status?: string; include_complete
   return textResult(rows);
 }
 
+export async function humanTaskGet(args: { task_id?: string }, ctx: HumanToolContext): Promise<ToolResult> {
+  const scopeError = requireScope(ctx, 'read:tasks');
+  if (scopeError) return scopeError;
+  if (!args.task_id) return errorResult('task_get requires task_id');
+  if (!(await userCanSeeTask(ctx, args.task_id))) return errorResult('task_get: task not found');
+  const taskRows = await db.execute(sql`
+    SELECT
+      t.*,
+      p.name AS project_name,
+      p.prefix AS project_prefix,
+      (p.prefix || '-' || t.number) AS task_key,
+      assignee.name AS assignee_name,
+      assignee.email AS assignee_email,
+      creator.name AS created_by_name,
+      creator.email AS created_by_email
+    FROM tasks t
+    JOIN projects p ON p.id = t.project_id AND p.org_id = t.org_id
+    LEFT JOIN users assignee ON assignee.id = t.assignee_id
+    LEFT JOIN users creator ON creator.id = t.created_by
+    WHERE t.org_id = ${ctx.org_id}
+      AND t.id = ${args.task_id}
+      AND t.is_deleted = false
+    LIMIT 1
+  `);
+  const task = ((taskRows as any).rows ?? [])[0];
+  if (!task) return errorResult('task_get: task not found');
+  const comments = await db.execute(sql`
+    SELECT c.id, c.user_id, u.name AS user_name, u.email AS user_email, c.content, c.created_at
+    FROM task_comments c
+    LEFT JOIN users u ON u.id = c.user_id
+    WHERE c.org_id = ${ctx.org_id}
+      AND c.task_id = ${args.task_id}
+    ORDER BY c.created_at DESC
+    LIMIT 10
+  `);
+  const activity = await db.execute(sql`
+    SELECT a.id, a.user_id, u.name AS user_name, u.email AS user_email, a.action, a.field, a.old_value, a.new_value, a.created_at
+    FROM task_activity a
+    LEFT JOIN users u ON u.id = a.user_id
+    WHERE a.org_id = ${ctx.org_id}
+      AND a.task_id = ${args.task_id}
+    ORDER BY a.created_at DESC
+    LIMIT 10
+  `);
+  return textResult({
+    task,
+    recent_comments: ((comments as any).rows ?? []).reverse(),
+    recent_activity: ((activity as any).rows ?? []).reverse(),
+  });
+}
+
 export async function humanTaskQuery(args: { filter?: { status?: string; assignee_id?: string; project_id?: string }; limit?: number }, ctx: HumanToolContext): Promise<ToolResult> {
   const scopeError = requireScope(ctx, 'read:tasks');
   if (scopeError) return scopeError;
@@ -451,110 +590,307 @@ export async function humanTaskQuery(args: { filter?: { status?: string; assigne
   return textResult(rows.map((row) => row.task));
 }
 
-export async function humanTaskCreate(args: { title?: string; description?: string; project_id?: string; assignee_id?: string; priority?: string }, ctx: HumanToolContext): Promise<ToolResult> {
-  const scopeError = requireScope(ctx, 'write:tasks');
+export async function humanProjectList(args: { query?: string; include_archived?: boolean; limit?: number }, ctx: HumanToolContext): Promise<ToolResult> {
+  const scopeError = requireScope(ctx, 'read:workspace');
   if (scopeError) return scopeError;
-  if (!args.title?.trim()) return errorResult('task_create requires title');
-  let projectId = args.project_id ?? null;
-  if (!projectId) {
-    const [p] = await db.select({ id: projects.id }).from(projects).where(and(eq(projects.org_id, ctx.org_id), eq(projects.is_archived, false), eq(projects.is_deleted, false))).limit(1);
-    projectId = p?.id ?? null;
-  }
-  if (!projectId) return errorResult('task_create: no project available');
-  if (!(await userCanSeeProject(ctx, projectId))) return errorResult('task_create: project not found');
-  if (args.assignee_id) {
-    const [member] = await db
-      .select({ id: orgMembers.id })
-      .from(orgMembers)
-      .where(and(eq(orgMembers.org_id, ctx.org_id), eq(orgMembers.user_id, args.assignee_id), eq(orgMembers.is_active, true)))
-      .limit(1);
-    if (!member) return errorResult('task_create: assignee is not an active org member');
-  }
-  const counterRow = await db.execute(sql`UPDATE projects SET task_counter = task_counter + 1 WHERE id = ${projectId} AND org_id = ${ctx.org_id} AND is_deleted = false RETURNING task_counter`);
-  const first = ((counterRow as any).rows ?? [])[0] as { task_counter?: number } | undefined;
-  if (!first) return errorResult('task_create: project not found');
-  const [task] = await db.insert(tasks).values({
-    org_id: ctx.org_id,
-    project_id: projectId,
-    number: Number(first.task_counter),
-    title: args.title.trim(),
-    description: args.description ?? null,
-    priority: ['p0', 'p1', 'p2', 'p3'].includes(args.priority ?? '') ? args.priority as any : 'p2',
-    assignee_id: args.assignee_id ?? null,
-    created_by: ctx.user_id,
-  }).returning();
-  if (task) {
-    await db.insert(taskActivity).values({ org_id: ctx.org_id, task_id: task.id, user_id: ctx.user_id, action: 'created' });
-  }
-  return textResult(task);
+  const query = (args.query ?? '').trim().toLowerCase();
+  const limit = Math.min(Math.max(1, args.limit ?? 50), 100);
+  const rows = await db.execute(sql`
+    SELECT p.id, p.name, p.prefix, p.lead_id, lead.name AS lead_name, p.is_archived, p.created_at, p.updated_at,
+           count(t.id) FILTER (WHERE t.is_deleted = false AND t.status NOT IN ('done', 'cancelled'))::int AS open_tasks
+    FROM projects p
+    LEFT JOIN users lead ON lead.id = p.lead_id
+    LEFT JOIN tasks t ON t.project_id = p.id AND t.org_id = p.org_id
+    WHERE p.org_id = ${ctx.org_id}
+      AND p.is_deleted = false
+      AND (${args.include_archived ? sql`true` : sql`p.is_archived = false`})
+      AND (${query ? sql`lower(p.name) LIKE ${`%${query}%`} OR lower(p.prefix) LIKE ${`%${query}%`}` : sql`true`})
+    GROUP BY p.id, p.name, p.prefix, p.lead_id, lead.name, p.is_archived, p.created_at, p.updated_at
+    ORDER BY p.updated_at DESC
+    LIMIT ${limit}
+  `);
+  return textResult((rows as any).rows ?? []);
 }
 
-export async function humanTaskUpdate(args: { task_id?: string; patch?: Record<string, unknown> }, ctx: HumanToolContext): Promise<ToolResult> {
+export async function humanProjectGet(args: { project_id?: string }, ctx: HumanToolContext): Promise<ToolResult> {
+  const scopeError = requireScope(ctx, 'read:workspace');
+  if (scopeError) return scopeError;
+  if (!args.project_id) return errorResult('project_get requires project_id');
+  if (!(await userCanSeeProject(ctx, args.project_id))) return errorResult('project_get: project not found');
+  const rows = await db.execute(sql`
+    SELECT p.id, p.name, p.prefix, p.description, p.lead_id, lead.name AS lead_name, p.is_archived, p.created_at, p.updated_at,
+           count(t.id) FILTER (WHERE t.is_deleted = false)::int AS total_tasks,
+           count(t.id) FILTER (WHERE t.is_deleted = false AND t.status NOT IN ('done', 'cancelled'))::int AS open_tasks,
+           count(t.id) FILTER (WHERE t.is_deleted = false AND t.status = 'done')::int AS done_tasks
+    FROM projects p
+    LEFT JOIN users lead ON lead.id = p.lead_id
+    LEFT JOIN tasks t ON t.project_id = p.id AND t.org_id = p.org_id
+    WHERE p.org_id = ${ctx.org_id}
+      AND p.id = ${args.project_id}
+      AND p.is_deleted = false
+    GROUP BY p.id, p.name, p.prefix, p.description, p.lead_id, lead.name, p.is_archived, p.created_at, p.updated_at
+    LIMIT 1
+  `);
+  const project = ((rows as any).rows ?? [])[0];
+  if (!project) return errorResult('project_get: project not found');
+  const linkedSpaces = await db.execute(sql`
+    SELECT s.id, s.name, s.type
+    FROM project_spaces ps
+    JOIN spaces s ON s.id = ps.space_id AND s.org_id = ${ctx.org_id}
+    LEFT JOIN space_members sm ON sm.space_id = s.id AND sm.user_id = ${ctx.user_id}
+    WHERE ps.project_id = ${args.project_id}
+      AND (s.type = 'public' OR sm.id IS NOT NULL)
+      AND s.is_archived = false
+    ORDER BY s.name ASC
+  `);
+  return textResult({ project, linked_spaces: (linkedSpaces as any).rows ?? [] });
+}
+
+export async function humanSpaceList(args: { query?: string; type?: string; limit?: number }, ctx: HumanToolContext): Promise<ToolResult> {
+  const scopeError = requireScope(ctx, 'read:messages');
+  if (scopeError) return scopeError;
+  const query = (args.query ?? '').trim().toLowerCase();
+  const limit = Math.min(Math.max(1, args.limit ?? 50), 100);
+  const rows = await db.execute(sql`
+    SELECT s.id, s.name, s.type, s.description, s.is_default, s.created_at, s.updated_at,
+           count(sm_all.id)::int AS member_count
+    FROM spaces s
+    LEFT JOIN space_members sm ON sm.space_id = s.id AND sm.user_id = ${ctx.user_id}
+    LEFT JOIN space_members sm_all ON sm_all.space_id = s.id
+    WHERE s.org_id = ${ctx.org_id}
+      AND s.is_archived = false
+      AND (s.type = 'public' OR sm.id IS NOT NULL)
+      AND (${args.type ? sql`s.type = ${args.type}` : sql`true`})
+      AND (${query ? sql`lower(s.name) LIKE ${`%${query}%`} OR lower(coalesce(s.description, '')) LIKE ${`%${query}%`}` : sql`true`})
+    GROUP BY s.id, s.name, s.type, s.description, s.is_default, s.created_at, s.updated_at
+    ORDER BY s.is_default DESC, s.name ASC
+    LIMIT ${limit}
+  `);
+  return textResult((rows as any).rows ?? []);
+}
+
+export async function humanSpaceGet(args: { space_id?: string }, ctx: HumanToolContext): Promise<ToolResult> {
+  const scopeError = requireScope(ctx, 'read:messages');
+  if (scopeError) return scopeError;
+  if (!args.space_id) return errorResult('space_get requires space_id');
+  if (!(await userCanSeeSpace(ctx, args.space_id))) return errorResult('space_get: space not found');
+  const rows = await db.execute(sql`
+    SELECT s.id, s.name, s.type, s.description, s.is_default, s.created_at, s.updated_at
+    FROM spaces s
+    WHERE s.org_id = ${ctx.org_id}
+      AND s.id = ${args.space_id}
+      AND s.is_archived = false
+    LIMIT 1
+  `);
+  const space = ((rows as any).rows ?? [])[0];
+  if (!space) return errorResult('space_get: space not found');
+  const members = await db.execute(sql`
+    SELECT u.id, u.name, u.email, u.is_agent
+    FROM space_members sm
+    JOIN users u ON u.id = sm.user_id
+    WHERE sm.space_id = ${args.space_id}
+    ORDER BY u.name ASC
+    LIMIT 100
+  `);
+  return textResult({ space, members: (members as any).rows ?? [] });
+}
+
+export async function humanTaskCreate(args: { title?: string; description?: string; project_id?: string; assignee_id?: string; priority?: string; idempotency_key?: string }, ctx: HumanToolContext): Promise<ToolResult> {
+  const scopeError = requireScope(ctx, 'write:tasks');
+  if (scopeError) return scopeError;
+  const title = args.title?.trim();
+  if (!title) return errorResult('task_create requires title');
+  return withIdempotency('task_create', args, ctx, async () => {
+    let projectId = args.project_id ?? null;
+    if (!projectId) {
+      const [p] = await db.select({ id: projects.id }).from(projects).where(and(eq(projects.org_id, ctx.org_id), eq(projects.is_archived, false), eq(projects.is_deleted, false))).limit(1);
+      projectId = p?.id ?? null;
+    }
+    if (!projectId) return errorResult('task_create: no project available');
+    if (!(await userCanSeeProject(ctx, projectId))) return errorResult('task_create: project not found');
+    if (args.assignee_id) {
+      const [member] = await db
+        .select({ id: orgMembers.id })
+        .from(orgMembers)
+        .where(and(eq(orgMembers.org_id, ctx.org_id), eq(orgMembers.user_id, args.assignee_id), eq(orgMembers.is_active, true)))
+        .limit(1);
+      if (!member) return errorResult('task_create: assignee is not an active org member');
+    }
+    const counterRow = await db.execute(sql`UPDATE projects SET task_counter = task_counter + 1 WHERE id = ${projectId} AND org_id = ${ctx.org_id} AND is_deleted = false RETURNING task_counter`);
+    const first = ((counterRow as any).rows ?? [])[0] as { task_counter?: number } | undefined;
+    if (!first) return errorResult('task_create: project not found');
+    const [task] = await db.insert(tasks).values({
+      org_id: ctx.org_id,
+      project_id: projectId,
+      number: Number(first.task_counter),
+      title,
+      description: args.description ?? null,
+      priority: ['p0', 'p1', 'p2', 'p3'].includes(args.priority ?? '') ? args.priority as any : 'p2',
+      assignee_id: args.assignee_id ?? null,
+      created_by: ctx.user_id,
+    }).returning();
+    if (task) {
+      await db.insert(taskActivity).values({ org_id: ctx.org_id, task_id: task.id, user_id: ctx.user_id, action: 'created' });
+    }
+    return textResult(task);
+  });
+}
+
+export async function humanTaskUpdate(args: { task_id?: string; patch?: Record<string, unknown>; idempotency_key?: string }, ctx: HumanToolContext): Promise<ToolResult> {
   const scopeError = requireScope(ctx, 'write:tasks');
   if (scopeError) return scopeError;
   if (!args.task_id) return errorResult('task_update requires task_id');
-  const patch = args.patch ?? {};
-  const updates: Record<string, unknown> = {};
-  if (typeof patch.title === 'string') updates.title = patch.title;
-  if (typeof patch.description === 'string') updates.description = patch.description;
-  if (typeof patch.status === 'string') updates.status = patch.status;
-  if (typeof patch.priority === 'string') updates.priority = patch.priority;
-  if (typeof patch.assignee_id === 'string' || patch.assignee_id === null) updates.assignee_id = patch.assignee_id;
-  if (Object.keys(updates).length === 0) return errorResult('task_update requires at least one supported patch field');
-  if (!(await userCanSeeTask(ctx, args.task_id))) return errorResult('task_update: task not found');
-  if (typeof patch.assignee_id === 'string') {
-    const [member] = await db
-      .select({ id: orgMembers.id })
-      .from(orgMembers)
-      .where(and(eq(orgMembers.org_id, ctx.org_id), eq(orgMembers.user_id, patch.assignee_id), eq(orgMembers.is_active, true)))
-      .limit(1);
-    if (!member) return errorResult('task_update: assignee is not an active org member');
-  }
-  const [task] = await db.update(tasks).set(updates).where(and(eq(tasks.id, args.task_id), eq(tasks.org_id, ctx.org_id), eq(tasks.is_deleted, false))).returning();
-  if (!task) return errorResult('task_update: task not found');
-  await db.insert(taskActivity).values({ org_id: ctx.org_id, task_id: task.id, user_id: ctx.user_id, action: 'updated' });
-  return textResult(task);
+  const taskId = args.task_id;
+  return withIdempotency('task_update', args, ctx, async () => {
+    const patch = args.patch ?? {};
+    const updates: Record<string, unknown> = {};
+    if (typeof patch.title === 'string') updates.title = patch.title;
+    if (typeof patch.description === 'string') updates.description = patch.description;
+    if (patch.status !== undefined) {
+      if (!validTaskStatus(patch.status)) return errorResult('task_update requires valid status: backlog, todo, in_progress, in_review, done, or cancelled');
+      updates.status = patch.status;
+    }
+    if (typeof patch.priority === 'string') updates.priority = patch.priority;
+    if (typeof patch.assignee_id === 'string' || patch.assignee_id === null) updates.assignee_id = patch.assignee_id;
+    if (Object.keys(updates).length === 0) return errorResult('task_update requires at least one supported patch field');
+    if (!(await userCanSeeTask(ctx, taskId))) return errorResult('task_update: task not found');
+    const [existingTask] = await db.select().from(tasks).where(and(eq(tasks.id, taskId), eq(tasks.org_id, ctx.org_id), eq(tasks.is_deleted, false))).limit(1);
+    if (!existingTask) return errorResult('task_update: task not found');
+    if (typeof patch.assignee_id === 'string') {
+      const [member] = await db
+        .select({ id: orgMembers.id })
+        .from(orgMembers)
+        .where(and(eq(orgMembers.org_id, ctx.org_id), eq(orgMembers.user_id, patch.assignee_id), eq(orgMembers.is_active, true)))
+        .limit(1);
+      if (!member) return errorResult('task_update: assignee is not an active org member');
+    }
+    const [task] = await db.update(tasks).set(updates).where(and(eq(tasks.id, taskId), eq(tasks.org_id, ctx.org_id), eq(tasks.is_deleted, false))).returning();
+    if (!task) return errorResult('task_update: task not found');
+    const activityEntries: Array<{ action: string; field: string; old_value: string | null; new_value: string | null }> = [];
+    if (typeof updates.status === 'string' && updates.status !== existingTask.status) {
+      activityEntries.push({ action: 'status_changed', field: 'status', old_value: existingTask.status, new_value: updates.status });
+    }
+    if (typeof updates.priority === 'string' && updates.priority !== existingTask.priority) {
+      activityEntries.push({ action: 'priority_changed', field: 'priority', old_value: existingTask.priority, new_value: updates.priority });
+    }
+    if ('assignee_id' in updates && updates.assignee_id !== existingTask.assignee_id) {
+      activityEntries.push({ action: 'assigned', field: 'assignee_id', old_value: existingTask.assignee_id ?? null, new_value: (updates.assignee_id as string | null) ?? null });
+    }
+    if (typeof updates.title === 'string' && updates.title !== existingTask.title) {
+      activityEntries.push({ action: 'title_changed', field: 'title', old_value: existingTask.title, new_value: updates.title });
+    }
+    if (typeof updates.description === 'string' && updates.description !== (existingTask.description ?? null)) {
+      activityEntries.push({ action: 'description_changed', field: 'description', old_value: existingTask.description ?? null, new_value: updates.description });
+    }
+    if (activityEntries.length === 0) {
+      await db.insert(taskActivity).values({ org_id: ctx.org_id, task_id: task.id, user_id: ctx.user_id, action: 'updated' });
+    } else {
+      await db.insert(taskActivity).values(activityEntries.map((entry) => ({
+        org_id: ctx.org_id,
+        task_id: task.id,
+        user_id: ctx.user_id,
+        action: entry.action,
+        field: entry.field,
+        old_value: entry.old_value,
+        new_value: entry.new_value,
+      })));
+    }
+    return textResult(task);
+  });
 }
 
-export async function humanCommentOnTask(args: { task_id?: string; content?: string }, ctx: HumanToolContext): Promise<ToolResult> {
+export async function humanTaskTransition(args: { task_id?: string; status?: string; reason?: string; idempotency_key?: string }, ctx: HumanToolContext): Promise<ToolResult> {
+  const scopeError = requireScope(ctx, 'write:tasks');
+  if (scopeError) return scopeError;
+  if (!args.task_id) return errorResult('task_transition requires task_id');
+  if (!validTaskStatus(args.status)) return errorResult('task_transition requires valid status: backlog, todo, in_progress, in_review, done, or cancelled');
+  const taskId = args.task_id;
+  const status = args.status;
+  return withIdempotency('task_transition', args, ctx, async () => {
+    if (!(await userCanSeeTask(ctx, taskId))) return errorResult('task_transition: task not found');
+    const [existingTask] = await db
+      .select()
+      .from(tasks)
+      .where(and(eq(tasks.id, taskId), eq(tasks.org_id, ctx.org_id), eq(tasks.is_deleted, false)))
+      .limit(1);
+    if (!existingTask) return errorResult('task_transition: task not found');
+    if (existingTask.status === status) {
+      return textResult({ ...existingTask, unchanged: true, task_key: null });
+    }
+    const [task] = await db
+      .update(tasks)
+      .set({ status })
+      .where(and(eq(tasks.id, taskId), eq(tasks.org_id, ctx.org_id), eq(tasks.is_deleted, false)))
+      .returning();
+    if (!task) return errorResult('task_transition: task not found');
+    const [project] = await db.select({ prefix: projects.prefix }).from(projects).where(eq(projects.id, task.project_id)).limit(1);
+    await db.insert(taskActivity).values({
+      org_id: ctx.org_id,
+      task_id: task.id,
+      user_id: ctx.user_id,
+      action: 'status_changed',
+      field: 'status',
+      old_value: existingTask.status,
+      new_value: status,
+    });
+    return textResult({
+      ...task,
+      task_key: taskReference(project?.prefix ?? null, task.number),
+      transition: {
+        from: existingTask.status,
+        to: status,
+        reason: args.reason ?? null,
+      },
+    });
+  });
+}
+
+export async function humanCommentOnTask(args: { task_id?: string; content?: string; idempotency_key?: string }, ctx: HumanToolContext): Promise<ToolResult> {
   const scopeError = requireScope(ctx, 'write:tasks');
   if (scopeError) return scopeError;
   if (!args.task_id) return errorResult('comment_on_task requires task_id');
+  const taskId = args.task_id;
   const content = args.content?.trim();
   if (!content) return errorResult('comment_on_task requires content');
-  if (!(await userCanSeeTask(ctx, args.task_id))) return errorResult('comment_on_task: task not found');
-  const [comment] = await db.insert(taskComments).values({
-    org_id: ctx.org_id,
-    task_id: args.task_id,
-    user_id: ctx.user_id,
-    content,
-  }).returning();
-  await db.insert(taskActivity).values({ org_id: ctx.org_id, task_id: args.task_id, user_id: ctx.user_id, action: 'commented' });
-  return textResult(comment);
+  return withIdempotency('comment_on_task', args, ctx, async () => {
+    if (!(await userCanSeeTask(ctx, taskId))) return errorResult('comment_on_task: task not found');
+    const [comment] = await db.insert(taskComments).values({
+      org_id: ctx.org_id,
+      task_id: taskId,
+      user_id: ctx.user_id,
+      content,
+    }).returning();
+    await db.insert(taskActivity).values({ org_id: ctx.org_id, task_id: taskId, user_id: ctx.user_id, action: 'commented' });
+    return textResult(comment);
+  });
 }
 
-export async function humanMessagePost(args: { space_id?: string; content?: string; parent_id?: string }, ctx: HumanToolContext): Promise<ToolResult> {
+export async function humanMessagePost(args: { space_id?: string; content?: string; parent_id?: string; idempotency_key?: string }, ctx: HumanToolContext): Promise<ToolResult> {
   const scopeError = requireScope(ctx, 'write:messages');
   if (scopeError) return scopeError;
   if (!args.space_id) return errorResult('message_post requires space_id');
-  if (!args.content?.trim()) return errorResult('message_post requires content');
-  if (!(await userCanSeeSpace(ctx, args.space_id))) return errorResult('message_post: space not found or not visible to user');
-  if (args.parent_id) {
-    const [parent] = await db
-      .select({ id: messages.id, space_id: messages.space_id })
-      .from(messages)
-      .where(and(eq(messages.id, args.parent_id), eq(messages.org_id, ctx.org_id), eq(messages.is_deleted, false)))
-      .limit(1);
-    if (!parent || parent.space_id !== args.space_id) return errorResult('message_post: parent message not found in target space');
-  }
-  const [row] = await db.insert(messages).values({
-    org_id: ctx.org_id,
-    space_id: args.space_id,
-    user_id: ctx.user_id,
-    content: args.content,
-    parent_id: args.parent_id ?? null,
-  }).returning();
-  return textResult(row);
+  const spaceId = args.space_id;
+  const content = args.content?.trim();
+  if (!content) return errorResult('message_post requires content');
+  return withIdempotency('message_post', args, ctx, async () => {
+    if (!(await userCanSeeSpace(ctx, spaceId))) return errorResult('message_post: space not found or not visible to user');
+    if (args.parent_id) {
+      const [parent] = await db
+        .select({ id: messages.id, space_id: messages.space_id })
+        .from(messages)
+        .where(and(eq(messages.id, args.parent_id), eq(messages.org_id, ctx.org_id), eq(messages.is_deleted, false)))
+        .limit(1);
+      if (!parent || parent.space_id !== spaceId) return errorResult('message_post: parent message not found in target space');
+    }
+    const [row] = await db.insert(messages).values({
+      org_id: ctx.org_id,
+      space_id: spaceId,
+      user_id: ctx.user_id,
+      content,
+      parent_id: args.parent_id ?? null,
+    }).returning();
+    return textResult(row);
+  });
 }
 
 export async function humanThreadFetch(args: { parent_message_id?: string; limit?: number }, ctx: HumanToolContext): Promise<ToolResult> {
@@ -567,15 +903,39 @@ export async function humanThreadFetch(args: { parent_message_id?: string; limit
   return textResult({ parent, replies: replies.reverse() });
 }
 
-export async function humanMemberList(_args: {}, ctx: HumanToolContext): Promise<ToolResult> {
+export async function humanMemberList(args: { query?: string; include_agents?: boolean; limit?: number }, ctx: HumanToolContext): Promise<ToolResult> {
   const scopeError = requireScope(ctx, 'read:workspace');
   if (scopeError) return scopeError;
-  const rows = await db
-    .select({ id: users.id, name: users.name, email: users.email, role: orgMembers.role, is_agent: users.is_agent })
-    .from(orgMembers)
-    .innerJoin(users, eq(users.id, orgMembers.user_id))
-    .where(and(eq(orgMembers.org_id, ctx.org_id), eq(orgMembers.is_active, true)));
-  return textResult(rows);
+  const query = (args.query ?? '').trim().toLowerCase();
+  const rows = await db.execute(sql`
+    SELECT u.id, u.name, u.email, om.role, u.is_agent, om.is_active
+    FROM org_members om
+    JOIN users u ON u.id = om.user_id
+    WHERE om.org_id = ${ctx.org_id}
+      AND om.is_active = true
+      AND (${args.include_agents === false ? sql`u.is_agent = false` : sql`true`})
+      AND (${query ? sql`lower(u.name) LIKE ${`%${query}%`} OR lower(u.email) LIKE ${`%${query}%`}` : sql`true`})
+    ORDER BY u.is_agent ASC, u.name ASC
+    LIMIT ${Math.min(Math.max(1, args.limit ?? 100), 200)}
+  `);
+  return textResult((rows as any).rows ?? []);
+}
+
+export async function humanMemberGet(args: { user_id?: string; email?: string }, ctx: HumanToolContext): Promise<ToolResult> {
+  const scopeError = requireScope(ctx, 'read:workspace');
+  if (scopeError) return scopeError;
+  if (!args.user_id && !args.email) return errorResult('member_get requires user_id or email');
+  const rows = await db.execute(sql`
+    SELECT u.id, u.name, u.email, om.role, u.is_agent, om.is_active
+    FROM org_members om
+    JOIN users u ON u.id = om.user_id
+    WHERE om.org_id = ${ctx.org_id}
+      AND om.is_active = true
+      AND (${args.user_id ? sql`u.id = ${args.user_id}` : sql`lower(u.email) = ${args.email!.toLowerCase()}`})
+    LIMIT 1
+  `);
+  const member = ((rows as any).rows ?? [])[0];
+  return member ? textResult(member) : errorResult('member_get: member not found');
 }
 
 export async function humanMessagesSearch(args: { query?: string; limit?: number }, ctx: HumanToolContext): Promise<ToolResult> {
@@ -740,6 +1100,96 @@ export function buildHumanToolSchemas(agentSchemas: Array<Record<string, unknown
       },
     },
     {
+      name: 'task_get',
+      title: 'Get Deft Task',
+      description: 'Fetch one visible task by id, including project key, assignee, recent comments, and recent activity. Human personal-MCP read: requires read:tasks.',
+      annotations: { readOnlyHint: true },
+      inputSchema: {
+        type: 'object',
+        properties: { task_id: { type: 'string' } },
+        required: ['task_id'],
+      },
+    },
+    {
+      name: 'project_list',
+      title: 'List Deft Projects',
+      description: 'List active projects in the connected user workspace. Human personal-MCP read: requires read:workspace.',
+      annotations: { readOnlyHint: true },
+      inputSchema: {
+        type: 'object',
+        properties: {
+          query: { type: 'string' },
+          include_archived: { type: 'boolean' },
+          limit: { type: 'number', minimum: 1, maximum: 100 },
+        },
+      },
+    },
+    {
+      name: 'project_get',
+      title: 'Get Deft Project',
+      description: 'Fetch one project by id, including task counts and linked visible spaces. Human personal-MCP read: requires read:workspace.',
+      annotations: { readOnlyHint: true },
+      inputSchema: {
+        type: 'object',
+        properties: { project_id: { type: 'string' } },
+        required: ['project_id'],
+      },
+    },
+    {
+      name: 'space_list',
+      title: 'List Deft Spaces',
+      description: 'List public spaces and private spaces the connected user can access. Human personal-MCP read: requires read:messages.',
+      annotations: { readOnlyHint: true },
+      inputSchema: {
+        type: 'object',
+        properties: {
+          query: { type: 'string' },
+          type: { type: 'string', description: 'Optional space type such as public, private, or dm.' },
+          limit: { type: 'number', minimum: 1, maximum: 100 },
+        },
+      },
+    },
+    {
+      name: 'space_get',
+      title: 'Get Deft Space',
+      description: 'Fetch one visible space by id, including members. Human personal-MCP read: requires read:messages.',
+      annotations: { readOnlyHint: true },
+      inputSchema: {
+        type: 'object',
+        properties: { space_id: { type: 'string' } },
+        required: ['space_id'],
+      },
+    },
+    {
+      name: 'member_get',
+      title: 'Get Deft Member',
+      description: 'Fetch one active org member by user_id or email. Human personal-MCP read: requires read:workspace.',
+      annotations: { readOnlyHint: true },
+      inputSchema: {
+        type: 'object',
+        properties: {
+          user_id: { type: 'string' },
+          email: { type: 'string' },
+        },
+      },
+    },
+    {
+      name: 'task_transition',
+      title: 'Transition Deft Task',
+      description: 'Change one visible task status as the connected human user. Prefer this over task_update for status-only changes. Human personal-MCP write: requires write:tasks.',
+      annotations: { readOnlyHint: false, destructiveHint: false },
+      inputSchema: {
+        type: 'object',
+        properties: {
+          task_id: { type: 'string' },
+          status: { type: 'string', enum: ['backlog', 'todo', 'in_progress', 'in_review', 'done', 'cancelled'] },
+          reason: { type: 'string' },
+          idempotency_key: { type: 'string', description: 'Stable key for retry-safe writes. Reusing the same key returns the first successful result.' },
+        },
+        required: ['task_id', 'status'],
+      },
+    },
+    {
       name: 'comment_on_task',
       title: 'Comment On Deft Task',
       description: 'Add a comment to a visible task as the connected human user. Human personal-MCP write: requires write:tasks.',
@@ -749,6 +1199,7 @@ export function buildHumanToolSchemas(agentSchemas: Array<Record<string, unknown
         properties: {
           task_id: { type: 'string' },
           content: { type: 'string' },
+          idempotency_key: { type: 'string', description: 'Stable key for retry-safe writes. Reusing the same key returns the first successful result.' },
         },
         required: ['task_id', 'content'],
       },
@@ -764,6 +1215,13 @@ export function buildHumanToolSchemas(agentSchemas: Array<Record<string, unknown
       if (HUMAN_WRITE_TOOLS.has(String(next.name))) {
         next.description = `${next.description ?? ''} Human personal-MCP write: executes as the token owner and requires a matching write scope.`;
         next.annotations = { ...(next.annotations as Record<string, unknown> | undefined), readOnlyHint: false, destructiveHint: false };
+        const inputSchema = next.inputSchema as { properties?: Record<string, unknown> } | undefined;
+        if (inputSchema?.properties && !inputSchema.properties.idempotency_key) {
+          inputSchema.properties.idempotency_key = {
+            type: 'string',
+            description: 'Stable key for retry-safe writes. Reusing the same key returns the first successful result.',
+          };
+        }
       } else {
         next.description = `${next.description ?? ''} Human personal-MCP read: scoped to the token owner's Deft permissions.`;
         next.annotations = { ...(next.annotations as Record<string, unknown> | undefined), readOnlyHint: true };

--- a/apps/api/src/routes/mcp-server-v1.ts
+++ b/apps/api/src/routes/mcp-server-v1.ts
@@ -203,12 +203,18 @@ const HUMAN_TOOL_SCOPE: Record<string, string> = {
   fetch: 'read:workspace',
   platform_context: 'read:workspace',
   member_list: 'read:workspace',
+  member_get: 'read:workspace',
   events_query: 'read:calendar',
   memory_recall: 'read:wiki',
   wiki_search: 'read:wiki',
   memory_list: 'read:wiki',
   list_my_tasks: 'read:tasks',
+  task_get: 'read:tasks',
   task_query: 'read:tasks',
+  project_list: 'read:workspace',
+  project_get: 'read:workspace',
+  space_list: 'read:messages',
+  space_get: 'read:messages',
   project_progress: 'read:tasks',
   team_workload: 'read:tasks',
   thread_fetch: 'read:messages',
@@ -216,6 +222,7 @@ const HUMAN_TOOL_SCOPE: Record<string, string> = {
   memory_write: 'write:wiki',
   task_create: 'write:tasks',
   task_update: 'write:tasks',
+  task_transition: 'write:tasks',
   comment_on_task: 'write:tasks',
   message_post: 'write:messages',
 };
@@ -358,6 +365,10 @@ mcpServerV1Routes.post('/', async (c) => {
           user_id: principal.user_id,
           role: principal.role,
           scopes: principal.scopes,
+          token_id: principal.token_id,
+          client_id: principal.client_id,
+          grant_id: principal.grant_id,
+          principal_kind: principal.kind,
         });
         if (principal.kind === 'oauth') {
           await auditOAuth({
@@ -365,7 +376,20 @@ mcpServerV1Routes.post('/', async (c) => {
             userId: principal.user_id,
             clientId: principal.client_id ?? null,
             event: 'mcp_tool_call',
-            metadata: { tool_name: toolName, success: !result.isError, surface: 'jsonrpc' },
+            metadata: {
+              tool_name: toolName,
+              success: !result.isError,
+              surface: 'jsonrpc',
+              grant_id: principal.grant_id ?? null,
+              idempotency_key: typeof args.idempotency_key === 'string' ? args.idempotency_key : null,
+              target_id: typeof args.task_id === 'string'
+                ? args.task_id
+                : typeof args.space_id === 'string'
+                  ? args.space_id
+                  : typeof args.project_id === 'string'
+                    ? args.project_id
+                    : null,
+            },
           });
         }
         return result;
@@ -518,6 +542,10 @@ mcpServerV1Routes.post('/tools/call', async (c) => {
       user_id: principal.user_id,
       role: principal.role,
       scopes: principal.scopes,
+      token_id: principal.token_id,
+      client_id: principal.client_id,
+      grant_id: principal.grant_id,
+      principal_kind: principal.kind,
     });
     if (principal.kind === 'oauth') {
       await auditOAuth({
@@ -525,7 +553,20 @@ mcpServerV1Routes.post('/tools/call', async (c) => {
         userId: principal.user_id,
         clientId: principal.client_id ?? null,
         event: 'mcp_tool_call',
-        metadata: { tool_name: toolName, success: !result.isError, surface: 'legacy' },
+        metadata: {
+          tool_name: toolName,
+          success: !result.isError,
+          surface: 'legacy',
+          grant_id: principal.grant_id ?? null,
+          idempotency_key: typeof args.idempotency_key === 'string' ? args.idempotency_key : null,
+          target_id: typeof args.task_id === 'string'
+            ? args.task_id
+            : typeof args.space_id === 'string'
+              ? args.space_id
+              : typeof args.project_id === 'string'
+                ? args.project_id
+                : null,
+        },
       });
     }
     return c.json(result);

--- a/apps/api/src/routes/oauth-mcp.ts
+++ b/apps/api/src/routes/oauth-mcp.ts
@@ -1,8 +1,8 @@
 import { Hono } from 'hono';
 import { z } from 'zod';
-import { and, desc, eq, isNull } from 'drizzle-orm';
+import { and, desc, eq, isNotNull, isNull, sql } from 'drizzle-orm';
 import { db } from '../lib/db.js';
-import { oauthClients, oauthGrants, oauthAccessTokens, oauthRefreshTokens } from '@deft/db/schema';
+import { oauthClients, oauthGrants, oauthAccessTokens, oauthRefreshTokens, oauthAuditEvents } from '@deft/db/schema';
 import {
   OAuthMcpError,
   REMOTE_MCP_SCOPES,
@@ -267,7 +267,7 @@ oauthProtectedRoutes.post('/authorize', async (c) => {
 
 oauthProtectedRoutes.get('/grants', async (c) => {
   const user = c.get('user');
-  const rows = await db
+  const grants = await db
     .select({
       id: oauthGrants.id,
       client_id: oauthGrants.client_id,
@@ -280,6 +280,35 @@ oauthProtectedRoutes.get('/grants', async (c) => {
     .from(oauthGrants)
     .where(and(eq(oauthGrants.org_id, user.org_id), eq(oauthGrants.user_id, user.id), isNull(oauthGrants.revoked_at)))
     .orderBy(desc(oauthGrants.created_at));
+  const rows = await Promise.all(grants.map(async (grant) => {
+    const [lastUsed] = await db
+      .select({ last_used_at: oauthAccessTokens.last_used_at })
+      .from(oauthAccessTokens)
+      .where(and(eq(oauthAccessTokens.grant_id, grant.id), isNotNull(oauthAccessTokens.last_used_at)))
+      .orderBy(desc(oauthAccessTokens.last_used_at))
+      .limit(1);
+    const recentActions = await db
+      .select({
+        id: oauthAuditEvents.id,
+        event: oauthAuditEvents.event,
+        metadata: oauthAuditEvents.metadata,
+        created_at: oauthAuditEvents.created_at,
+      })
+      .from(oauthAuditEvents)
+      .where(and(
+        eq(oauthAuditEvents.org_id, user.org_id),
+        eq(oauthAuditEvents.user_id, user.id),
+        eq(oauthAuditEvents.client_id, grant.client_id),
+        sql`(${oauthAuditEvents.metadata}->>'grant_id' = ${grant.id} OR ${oauthAuditEvents.metadata}->>'grant_id' IS NULL)`,
+      ))
+      .orderBy(desc(oauthAuditEvents.created_at))
+      .limit(8);
+    return {
+      ...grant,
+      last_used_at: lastUsed?.last_used_at ?? null,
+      recent_actions: recentActions,
+    };
+  }));
   return c.json({ grants: rows });
 });
 

--- a/apps/api/test/oauth-mcp.test.ts
+++ b/apps/api/test/oauth-mcp.test.ts
@@ -40,6 +40,8 @@ const RESTRICTED_TASK_ID = `oauth-mcp-restricted-task-${TEST_ID}`;
 const PRIVATE_EVENT_ID = `oauth-mcp-private-event-${TEST_ID}`;
 const SPACE_ID = `oauth-mcp-space-${TEST_ID}`;
 const MESSAGE_ID = `oauth-mcp-message-${TEST_ID}`;
+const PRIVATE_SPACE_ID = `oauth-mcp-private-space-${TEST_ID}`;
+const PRIVATE_MESSAGE_ID = `oauth-mcp-private-message-${TEST_ID}`;
 const PRIVATE_PROOF = `PRIVATE-OAUTH-MCP-PROOF-${TEST_ID}`;
 
 let testApp: Hono;
@@ -69,6 +71,7 @@ async function cleanup() {
     await client.query(`DELETE FROM oauth_clients WHERE client_name LIKE 'OAuth MCP Test%'`);
     await client.query(`DELETE FROM events WHERE org_id = $1`, [ORG_ID]);
     await client.query(`DELETE FROM messages WHERE org_id = $1`, [ORG_ID]);
+    await client.query(`DELETE FROM space_members WHERE space_id IN ($1, $2)`, [SPACE_ID, PRIVATE_SPACE_ID]);
     await client.query(`DELETE FROM spaces WHERE org_id = $1`, [ORG_ID]);
     await client.query(`DELETE FROM task_comments WHERE org_id = $1`, [ORG_ID]);
     await client.query(`DELETE FROM task_activity WHERE org_id = $1`, [ORG_ID]);
@@ -166,6 +169,21 @@ async function seedWorkspace() {
       `INSERT INTO messages (id, org_id, space_id, user_id, content)
        VALUES ($1, $2, $3, $4, 'Salsa tasting thread for OAuth MCP contract tests')`,
       [MESSAGE_ID, ORG_ID, SPACE_ID, USER_ID],
+    );
+    await client.query(
+      `INSERT INTO spaces (id, org_id, name, type, created_by)
+       VALUES ($1, $2, 'oauth-mcp-private', 'private', $3)`,
+      [PRIVATE_SPACE_ID, ORG_ID, OTHER_USER_ID],
+    );
+    await client.query(
+      `INSERT INTO space_members (id, space_id, user_id)
+       VALUES ($1, $2, $3)`,
+      [`oauth-mcp-private-space-member-${TEST_ID}`, PRIVATE_SPACE_ID, OTHER_USER_ID],
+    );
+    await client.query(
+      `INSERT INTO messages (id, org_id, space_id, user_id, content)
+       VALUES ($1, $2, $3, $4, $5)`,
+      [PRIVATE_MESSAGE_ID, ORG_ID, PRIVATE_SPACE_ID, OTHER_USER_ID, `${PRIVATE_PROOF} private space message`],
     );
   });
 }
@@ -359,8 +377,54 @@ test('OAuth task-helper profile can comment on and update visible tasks', async 
   const names = new Set<string>(listBody.result.tools.map((tool: any) => tool.name));
   assert.ok(names.has('task_create'));
   assert.ok(names.has('task_update'));
+  assert.ok(names.has('task_transition'));
   assert.ok(names.has('comment_on_task'));
   assert.ok(names.has('message_post'));
+
+  const createArgs = {
+    title: `Retry-safe OAuth follow-up ${TEST_ID}`,
+    project_id: PROJECT_ID,
+    assignee_id: USER_ID,
+    priority: 'p2',
+    idempotency_key: `create-${TEST_ID}`,
+  };
+  const createRes = await jsonPost('/api/mcp/v1', {
+    jsonrpc: '2.0',
+    id: 29,
+    method: 'tools/call',
+    params: {
+      name: 'task_create',
+      arguments: createArgs,
+    },
+  }, token.access_token);
+  assert.equal(createRes.status, 200);
+  const createBody = (await createRes.json()) as any;
+  assert.equal(createBody.result.isError, false, JSON.stringify(createBody));
+  const createdTask = JSON.parse(createBody.result.content[0].text);
+  assert.equal(createdTask.title, createArgs.title);
+
+  const duplicateCreateRes = await jsonPost('/api/mcp/v1', {
+    jsonrpc: '2.0',
+    id: 291,
+    method: 'tools/call',
+    params: {
+      name: 'task_create',
+      arguments: createArgs,
+    },
+  }, token.access_token);
+  assert.equal(duplicateCreateRes.status, 200);
+  const duplicateCreateBody = (await duplicateCreateRes.json()) as any;
+  assert.equal(duplicateCreateBody.result.isError, false, JSON.stringify(duplicateCreateBody));
+  const duplicateCreatedTask = JSON.parse(duplicateCreateBody.result.content[0].text);
+  assert.equal(duplicateCreatedTask.id, createdTask.id, 'same idempotency key should replay the original task_create result');
+
+  await withClient(async (pgClient) => {
+    const count = await pgClient.query(
+      `SELECT count(*)::int AS count FROM tasks WHERE org_id = $1 AND title = $2`,
+      [ORG_ID, createArgs.title],
+    );
+    assert.equal(count.rows[0].count, 1, 'idempotent task_create must not create duplicates');
+  });
 
   const commentRes = await jsonPost('/api/mcp/v1', {
     jsonrpc: '2.0',
@@ -371,6 +435,7 @@ test('OAuth task-helper profile can comment on and update visible tasks', async 
       arguments: {
         task_id: TASK_ID,
         content: 'Codex task-helper contract test comment',
+        idempotency_key: `comment-${TEST_ID}`,
       },
     },
   }, token.access_token);
@@ -381,15 +446,56 @@ test('OAuth task-helper profile can comment on and update visible tasks', async 
   assert.equal(comment.task_id, TASK_ID);
   assert.equal(comment.user_id, USER_ID);
 
-  const updateRes = await jsonPost('/api/mcp/v1', {
+  const duplicateCommentRes = await jsonPost('/api/mcp/v1', {
+    jsonrpc: '2.0',
+    id: 311,
+    method: 'tools/call',
+    params: {
+      name: 'comment_on_task',
+      arguments: {
+        task_id: TASK_ID,
+        content: 'Codex task-helper contract test comment',
+        idempotency_key: `comment-${TEST_ID}`,
+      },
+    },
+  }, token.access_token);
+  assert.equal(duplicateCommentRes.status, 200);
+  const duplicateCommentBody = (await duplicateCommentRes.json()) as any;
+  assert.equal(duplicateCommentBody.result.isError, false, JSON.stringify(duplicateCommentBody));
+  const duplicateComment = JSON.parse(duplicateCommentBody.result.content[0].text);
+  assert.equal(duplicateComment.id, comment.id, 'same idempotency key should replay the original comment result');
+
+  const transitionRes = await jsonPost('/api/mcp/v1', {
     jsonrpc: '2.0',
     id: 32,
+    method: 'tools/call',
+    params: {
+      name: 'task_transition',
+      arguments: {
+        task_id: TASK_ID,
+        status: 'in_progress',
+        reason: 'contract test starts work',
+        idempotency_key: `transition-${TEST_ID}`,
+      },
+    },
+  }, token.access_token);
+  assert.equal(transitionRes.status, 200);
+  const transitionBody = (await transitionRes.json()) as any;
+  assert.equal(transitionBody.result.isError, false, JSON.stringify(transitionBody));
+  const transitionedTask = JSON.parse(transitionBody.result.content[0].text);
+  assert.equal(transitionedTask.id, TASK_ID);
+  assert.equal(transitionedTask.status, 'in_progress');
+
+  const updateRes = await jsonPost('/api/mcp/v1', {
+    jsonrpc: '2.0',
+    id: 321,
     method: 'tools/call',
     params: {
       name: 'task_update',
       arguments: {
         task_id: TASK_ID,
         patch: { status: 'done' },
+        idempotency_key: `update-${TEST_ID}`,
       },
     },
   }, token.access_token);
@@ -409,6 +515,7 @@ test('OAuth task-helper profile can comment on and update visible tasks', async 
       arguments: {
         space_id: SPACE_ID,
         content: 'Codex task-helper contract test completion message',
+        idempotency_key: `message-${TEST_ID}`,
       },
     },
   }, token.access_token);
@@ -418,6 +525,25 @@ test('OAuth task-helper profile can comment on and update visible tasks', async 
   const postedMessage = JSON.parse(messageBody.result.content[0].text);
   assert.equal(postedMessage.space_id, SPACE_ID);
   assert.equal(postedMessage.user_id, USER_ID);
+
+  const duplicateMessageRes = await jsonPost('/api/mcp/v1', {
+    jsonrpc: '2.0',
+    id: 341,
+    method: 'tools/call',
+    params: {
+      name: 'message_post',
+      arguments: {
+        space_id: SPACE_ID,
+        content: 'Codex task-helper contract test completion message',
+        idempotency_key: `message-${TEST_ID}`,
+      },
+    },
+  }, token.access_token);
+  assert.equal(duplicateMessageRes.status, 200);
+  const duplicateMessageBody = (await duplicateMessageRes.json()) as any;
+  assert.equal(duplicateMessageBody.result.isError, false, JSON.stringify(duplicateMessageBody));
+  const duplicateMessage = JSON.parse(duplicateMessageBody.result.content[0].text);
+  assert.equal(duplicateMessage.id, postedMessage.id, 'same idempotency key should replay the original message result');
 
   const blockedRes = await jsonPost('/api/mcp/v1', {
     jsonrpc: '2.0',
@@ -439,7 +565,7 @@ test('OAuth task-helper profile can comment on and update visible tasks', async 
 
 test('OAuth human MCP read tools match user-scoped wiki task and calendar visibility', async () => {
   const client = await registerClient();
-  const scopes = ['read:workspace', 'read:wiki', 'read:tasks', 'read:calendar'];
+  const scopes = ['read:workspace', 'read:wiki', 'read:tasks', 'read:messages', 'read:calendar'];
   const primaryToken = await issueOAuthToken(client.client_id, scopes, USER_ID);
   const otherToken = await issueOAuthToken(client.client_id, scopes, OTHER_USER_ID);
 
@@ -483,9 +609,14 @@ test('OAuth human MCP read tools match user-scoped wiki task and calendar visibi
   const primaryEvents = await callTool(primaryToken.access_token, 13, 'events_query', { limit: 50 });
   assert.ok(!primaryEvents.some((event: any) => event.id === PRIVATE_EVENT_ID));
 
+  const primarySpaces = await callTool(primaryToken.access_token, 131, 'space_list', { limit: 50 });
+  assert.ok(!primarySpaces.some((space: any) => space.id === PRIVATE_SPACE_ID));
+
   await callToolError(primaryToken.access_token, 14, 'fetch', { id: `wiki:${PRIVATE_WIKI_SLUG}` });
   await callToolError(primaryToken.access_token, 15, 'fetch', { id: `task:${RESTRICTED_TASK_ID}` });
   await callToolError(primaryToken.access_token, 16, 'fetch', { id: `event:${PRIVATE_EVENT_ID}` });
+  await callToolError(primaryToken.access_token, 161, 'space_get', { space_id: PRIVATE_SPACE_ID });
+  await callToolError(primaryToken.access_token, 162, 'fetch', { id: `message:${PRIVATE_MESSAGE_ID}` });
 
   const otherRecall = await callTool(otherToken.access_token, 17, 'memory_recall', { query: PRIVATE_PROOF, limit: 10 });
   assert.ok(otherRecall.some((page: any) => page.slug === PRIVATE_WIKI_SLUG), 'own user-scoped wiki page is visible');
@@ -495,6 +626,9 @@ test('OAuth human MCP read tools match user-scoped wiki task and calendar visibi
 
   const otherEvents = await callTool(otherToken.access_token, 19, 'events_query', { limit: 50 });
   assert.ok(otherEvents.some((event: any) => event.id === PRIVATE_EVENT_ID), 'own ICS event is visible');
+
+  const otherSpace = await callTool(otherToken.access_token, 191, 'space_get', { space_id: PRIVATE_SPACE_ID });
+  assert.equal(otherSpace.space.id, PRIVATE_SPACE_ID, 'private space is visible to members');
 });
 
 test('OAuth tools/list read catalog only advertises callable tools', async () => {
@@ -520,9 +654,15 @@ test('OAuth tools/list read catalog only advertises callable tools', async () =>
     wiki_search: { query: 'salsa tasting', limit: 5 },
     memory_list: { limit: 5 },
     list_my_tasks: { limit: 5 },
+    task_get: { task_id: TASK_ID },
     task_query: { limit: 5 },
+    project_list: { limit: 5 },
+    project_get: { project_id: PROJECT_ID },
+    space_list: { limit: 5 },
+    space_get: { space_id: SPACE_ID },
     thread_fetch: { parent_message_id: MESSAGE_ID, limit: 5 },
-    member_list: {},
+    member_list: { limit: 5 },
+    member_get: { user_id: USER_ID },
     events_query: { limit: 5 },
     messages_search: { query: 'salsa', limit: 5 },
     project_progress: { project_id: PROJECT_ID },

--- a/apps/web/src/app/(app)/settings/mcp-access/page.tsx
+++ b/apps/web/src/app/(app)/settings/mcp-access/page.tsx
@@ -32,15 +32,44 @@ type RemoteReadiness = {
   profile: string;
 };
 
+type OAuthAuditAction = {
+  id: string;
+  event: string;
+  metadata: Record<string, unknown> | null;
+  created_at: string;
+};
+
 type OAuthGrant = {
   id: string;
   client_id: string;
   app_name: string;
   connector_profile: string;
   scopes: string[];
+  last_used_at: string | null;
   created_at: string;
   updated_at: string;
+  recent_actions: OAuthAuditAction[];
 };
+
+function formatDate(value: string | null | undefined) {
+  return value ? new Date(value).toLocaleString() : 'never';
+}
+
+function actionTitle(action: OAuthAuditAction) {
+  const metadata = action.metadata ?? {};
+  const toolName = typeof metadata.tool_name === 'string' ? metadata.tool_name : null;
+  return toolName ?? action.event.replaceAll('_', ' ');
+}
+
+function actionDetail(action: OAuthAuditAction) {
+  const metadata = action.metadata ?? {};
+  const pieces = [
+    typeof metadata.surface === 'string' ? metadata.surface : null,
+    typeof metadata.target_id === 'string' ? metadata.target_id : null,
+    typeof metadata.success === 'boolean' ? (metadata.success ? 'ok' : 'failed') : null,
+  ].filter(Boolean);
+  return pieces.length > 0 ? pieces.join(' / ') : 'recorded';
+}
 
 export default function McpAccessPage() {
   const [tokens, setTokens] = useState<McpToken[]>([]);
@@ -246,7 +275,7 @@ export default function McpAccessPage() {
           <div className="flex items-center justify-between gap-3">
             <div>
               <h2 className="text-[14px] font-semibold" style={{ color: 'var(--text-primary)' }}>Client config</h2>
-          <p className="text-[12px]" style={{ color: 'var(--text-secondary)' }}>Use this shape in Claude Desktop, Claude Code, ChatGPT MCP apps, or any streamable HTTP MCP client.</p>
+              <p className="text-[12px]" style={{ color: 'var(--text-secondary)' }}>Use this shape in Claude Desktop, Claude Code, ChatGPT MCP apps, or any streamable HTTP MCP client.</p>
             </div>
             <button type="button" onClick={() => copy('config', clientConfig)} className="inline-flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-[12px]" style={{ border: '1px solid var(--border-default)', color: 'var(--text-primary)' }}>
               <Copy size={13} /> Copy
@@ -263,9 +292,9 @@ export default function McpAccessPage() {
             <div className="flex-1 min-w-0">
               <div className="flex items-center justify-between gap-3">
                 <div>
-                  <h2 className="text-[15px] font-semibold" style={{ color: 'var(--text-primary)' }}>Remote AI apps</h2>
+                  <h2 className="text-[15px] font-semibold" style={{ color: 'var(--text-primary)' }}>Connected AI apps</h2>
                   <p className="text-[12px] mt-1" style={{ color: 'var(--text-secondary)' }}>
-                    For ChatGPT and Claude web. This testable build exposes a read-only Knowledge connector over OAuth.
+                    For ChatGPT, Claude web, Codex, and OAuth MCP clients. Connected apps act as you, inside the scopes you approve.
                   </p>
                 </div>
                 <span className="text-[11px] rounded-md px-2 py-1" style={{ background: remote?.https_ready ? 'var(--accent-muted)' : 'var(--surface-container)', color: remote?.https_ready ? 'var(--accent)' : 'var(--text-tertiary)', border: '1px solid var(--border-default)' }}>
@@ -304,22 +333,49 @@ export default function McpAccessPage() {
                 ))}
               </div>
 
-              <h3 className="text-[13px] font-semibold mt-5 mb-2" style={{ color: 'var(--text-primary)' }}>Connected remote apps</h3>
+              <h3 className="text-[13px] font-semibold mt-5 mb-2" style={{ color: 'var(--text-primary)' }}>App connections</h3>
               {grants.length === 0 ? (
                 <p className="text-[13px]" style={{ color: 'var(--text-secondary)' }}>No ChatGPT or Claude-style OAuth connections yet.</p>
               ) : (
-                <div className="space-y-2">
+                <div className="space-y-3">
                   {grants.map((grant) => (
-                    <div key={grant.id} className="flex items-start justify-between gap-3 rounded-md p-3" style={{ background: 'var(--surface-container)', border: '1px solid var(--border-default)' }}>
-                      <div className="min-w-0">
-                        <div className="text-[13px] font-medium" style={{ color: 'var(--text-primary)' }}>{grant.app_name}</div>
-                        <div className="text-[11px] mt-0.5" style={{ color: 'var(--text-tertiary)' }}>
-                          {grant.connector_profile} · {grant.client_id} · connected {new Date(grant.created_at).toLocaleString()}
+                    <div key={grant.id} className="rounded-md p-3" style={{ background: 'var(--surface-container)', border: '1px solid var(--border-default)' }}>
+                      <div className="flex items-start justify-between gap-3">
+                        <div className="min-w-0">
+                          <div className="text-[13px] font-medium" style={{ color: 'var(--text-primary)' }}>{grant.app_name}</div>
+                          <div className="text-[11px] mt-0.5" style={{ color: 'var(--text-tertiary)' }}>
+                            {grant.connector_profile} / {grant.client_id}
+                          </div>
+                          <div className="text-[11px] mt-1" style={{ color: 'var(--text-tertiary)' }}>
+                            connected {formatDate(grant.created_at)} / last used {formatDate(grant.last_used_at)}
+                          </div>
                         </div>
+                        <button type="button" disabled={busy} onClick={() => revokeGrant(grant.id)} className="p-1.5 rounded-md disabled:opacity-50" style={{ color: 'var(--danger)' }} aria-label={`Revoke ${grant.app_name}`}>
+                          <Trash2 size={14} />
+                        </button>
                       </div>
-                      <button type="button" disabled={busy} onClick={() => revokeGrant(grant.id)} className="p-1.5 rounded-md disabled:opacity-50" style={{ color: 'var(--danger)' }} aria-label={`Revoke ${grant.app_name}`}>
-                        <Trash2 size={14} />
-                      </button>
+                      <div className="flex flex-wrap gap-1 mt-3">
+                        {grant.scopes.map((scope) => (
+                          <span key={scope} className="text-[10px] rounded px-1.5 py-0.5" style={{ color: 'var(--text-secondary)', border: '1px solid var(--border-default)' }}>{scope}</span>
+                        ))}
+                      </div>
+                      <div className="mt-3 pt-3" style={{ borderTop: '1px solid var(--border-default)' }}>
+                        <div className="text-[11px] font-medium uppercase tracking-wide" style={{ color: 'var(--text-tertiary)' }}>Recent actions</div>
+                        {grant.recent_actions?.length ? (
+                          <div className="mt-2 space-y-1.5">
+                            {grant.recent_actions.slice(0, 5).map((action) => (
+                              <div key={action.id} className="grid grid-cols-[1fr_auto] gap-3 text-[11px]">
+                                <span className="min-w-0 truncate" style={{ color: 'var(--text-secondary)' }}>
+                                  {actionTitle(action)} <span style={{ color: 'var(--text-tertiary)' }}>({actionDetail(action)})</span>
+                                </span>
+                                <span style={{ color: 'var(--text-tertiary)' }}>{formatDate(action.created_at)}</span>
+                              </div>
+                            ))}
+                          </div>
+                        ) : (
+                          <div className="mt-2 text-[11px]" style={{ color: 'var(--text-tertiary)' }}>No recent actions recorded.</div>
+                        )}
+                      </div>
                     </div>
                   ))}
                 </div>
@@ -341,7 +397,7 @@ export default function McpAccessPage() {
                   <div className="min-w-0">
                     <div className="text-[13px] font-medium" style={{ color: 'var(--text-primary)' }}>{token.name}</div>
                     <div className="text-[11px] mt-0.5" style={{ color: 'var(--text-tertiary)' }}>
-                      {token.token_prefix}... · created {new Date(token.created_at).toLocaleString()} · last used {token.last_used_at ? new Date(token.last_used_at).toLocaleString() : 'never'}
+                      {token.token_prefix}... / created {formatDate(token.created_at)} / last used {formatDate(token.last_used_at)}
                     </div>
                     <div className="flex flex-wrap gap-1 mt-2">
                       {token.scopes.map((scope) => (

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,6 +71,30 @@ services:
     command: sh -c "pnpm selfhost:doctor"
     profiles: ['tools']
 
+  smoke:
+    build:
+      context: .
+      args:
+        NEXT_PUBLIC_APP_URL: ${NEXT_PUBLIC_APP_URL:-http://localhost:3000}
+        NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://localhost:3001}
+        NEXT_PUBLIC_WS_URL: ${NEXT_PUBLIC_WS_URL:-http://localhost:3001}
+    env_file: .env
+    environment:
+      DATABASE_URL: postgres://postgres:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD required - generate with `openssl rand -hex 32`}@postgres:5432/deft
+      REDIS_URL: redis://redis:6379
+      DEFT_API_URL: http://deft:3001
+      DEFT_WEB_URL: http://deft:3000
+      DEFT_SELFHOST_INTERNAL_CHECK: 1
+    depends_on:
+      deft:
+        condition: service_started
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    command: sh -c "pnpm selfhost:smoke"
+    profiles: ['tools']
+
   postgres:
     # pgvector image ships a standard postgres:16 with the `vector`
     # extension pre-built. Deft's wiki + tasks embeddings columns are

--- a/docs/self-hosting-vps-domain-https.md
+++ b/docs/self-hosting-vps-domain-https.md
@@ -1,0 +1,176 @@
+# VPS + Domain + HTTPS Runbook
+
+This runbook is for a single self-hosted Deft workspace on a VPS. It assumes a
+domain such as `demo.example.com`, one Linux server, Docker Compose, and a
+reverse proxy that terminates HTTPS.
+
+## Target Shape
+
+```text
+https://demo.example.com          -> Deft web container :3000
+https://demo.example.com/api/...  -> Deft API container :3001
+https://demo.example.com/oauth/... and /.well-known/... -> Deft API container :3001
+```
+
+Use one public origin for the web app and API. This is the smoothest shape for
+browser login, OAuth MCP discovery, ChatGPT/Claude/Codex connector setup, and
+cookie/CORS behavior.
+
+## 1. DNS
+
+Create an `A` record:
+
+```text
+demo.example.com -> <your-vps-ip>
+```
+
+Wait until:
+
+```bash
+dig +short demo.example.com
+```
+
+returns the VPS IP.
+
+## 2. Server Prerequisites
+
+Install Docker and the Compose plugin. Then clone Deft:
+
+```bash
+git clone https://github.com/Maneek21/Deft.git
+cd Deft
+cp .env.example .env
+```
+
+Generate required secrets:
+
+```bash
+openssl rand -hex 32   # POSTGRES_PASSWORD
+openssl rand -hex 32   # JWT_SECRET
+openssl rand -hex 32   # JWT_REFRESH_SECRET
+openssl rand -base64 24 | cut -c1-32   # ENCRYPTION_KEY, exactly 32 chars
+```
+
+Set the public URLs in `.env`:
+
+```bash
+NEXT_PUBLIC_APP_URL=https://demo.example.com
+NEXT_PUBLIC_API_URL=https://demo.example.com
+NEXT_PUBLIC_WS_URL=https://demo.example.com
+API_PORT=3001
+
+DEFT_WEB_PORT=3000
+DEFT_API_PORT=3001
+DEFT_BIND_HOST=127.0.0.1
+```
+
+The `DEFT_BIND_HOST=127.0.0.1` default keeps Deft's app ports local to the VPS.
+Only the reverse proxy should be public.
+
+## 3. Reverse Proxy
+
+Example Caddyfile:
+
+```caddyfile
+demo.example.com {
+  encode zstd gzip
+
+  handle /api/* {
+    reverse_proxy 127.0.0.1:3001
+  }
+
+  handle /oauth/* {
+    reverse_proxy 127.0.0.1:3001
+  }
+
+  handle /.well-known/* {
+    reverse_proxy 127.0.0.1:3001
+  }
+
+  handle {
+    reverse_proxy 127.0.0.1:3000
+  }
+}
+```
+
+If you use Nginx, keep the same routing split: `/api`, `/oauth`, and
+`/.well-known` go to the API port; everything else goes to the web port.
+
+## 4. Bootstrap
+
+From the repo:
+
+```bash
+pnpm selfhost:bootstrap --prod --check-only
+pnpm selfhost:bootstrap --prod
+```
+
+If you do not have host-side Node.js/pnpm, run the Docker-only sequence:
+
+```bash
+docker compose -f docker-compose.yml -f compose.prod.yml up -d --build
+docker compose -f docker-compose.yml -f compose.prod.yml run --rm init
+docker compose -f docker-compose.yml -f compose.prod.yml run --rm doctor
+docker compose -f docker-compose.yml -f compose.prod.yml run --rm smoke
+```
+
+For a demo/pilot instance with seeded data:
+
+```bash
+pnpm selfhost:bootstrap --prod --seed-pilot
+```
+
+Do not use `--seed-pilot` for a real customer workspace.
+
+## 5. Verify Browser And OAuth MCP
+
+Open:
+
+```text
+https://demo.example.com
+```
+
+Create the owner account. Then verify public OAuth/MCP metadata:
+
+```bash
+curl https://demo.example.com/.well-known/oauth-protected-resource
+curl https://demo.example.com/.well-known/oauth-authorization-server
+```
+
+The protected resource metadata should name:
+
+```text
+https://demo.example.com/api/mcp/v1
+```
+
+In Deft, go to Settings -> MCP Access, create a personal token, add it to
+`.env` as `DEFT_MCP_BEARER_TOKEN`, and run:
+
+```bash
+docker compose -f docker-compose.yml -f compose.prod.yml run --rm smoke
+```
+
+That confirms an authenticated MCP `tools/list` call works from the running
+deployment.
+
+## 6. Common Failures
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Login shows "Failed to fetch" | `NEXT_PUBLIC_API_URL` was built with the wrong URL | Fix `.env`, rebuild with `docker compose up -d --build` |
+| OAuth connector says metadata missing | Proxy does not route `/.well-known/*` to API | Add the `/.well-known` API route to the proxy |
+| OAuth token exchange fails by resource mismatch | Client uses a different MCP URL than metadata | Use exactly `https://domain/api/mcp/v1` |
+| `doctor` fails CORS | App/API origins do not match expected public URL | Set all `NEXT_PUBLIC_*` URLs to the same HTTPS origin |
+| Smoke fails DCR | API is unreachable through proxy or `/oauth/register` not routed | Route `/oauth/*` to API |
+
+## 7. Upgrade Loop
+
+Before upgrades, take a Postgres backup. Then:
+
+```bash
+git pull
+docker compose -f docker-compose.yml -f compose.prod.yml up -d --build
+docker compose -f docker-compose.yml -f compose.prod.yml run --rm init
+docker compose -f docker-compose.yml -f compose.prod.yml run --rm doctor
+docker compose -f docker-compose.yml -f compose.prod.yml run --rm smoke
+```

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -28,6 +28,38 @@ The stack runs comfortably on 2 vCPU / 4 GB RAM for small pilots.
 
 ## First Boot
 
+### Fast path: one-command bootstrap
+
+If you are working from a cloned repo with Node.js and pnpm available on the
+host, use the bootstrap wrapper:
+
+```bash
+pnpm selfhost:bootstrap
+```
+
+That validates `.env`, builds and starts Compose, runs the database init, runs
+the doctor, and runs the OAuth/MCP smoke test. For a demo/pilot environment
+with seeded Testers Tomatoes data:
+
+```bash
+pnpm selfhost:bootstrap --seed-pilot
+```
+
+For a hardened production overlay:
+
+```bash
+pnpm selfhost:bootstrap --prod
+```
+
+To validate `.env` before starting or rebuilding containers:
+
+```bash
+pnpm selfhost:bootstrap --prod --check-only
+```
+
+The Docker-only path below remains supported and does not require host-side
+Node.js or pnpm.
+
 ### 1. Clone and configure
 
 ```bash
@@ -96,6 +128,17 @@ docker compose run --rm doctor
 The doctor checks API health, web reachability, browser/API origin agreement,
 Postgres schema, Redis, and the platform seed.
 
+Then run the public connector smoke test:
+
+```bash
+docker compose run --rm smoke
+```
+
+The smoke test verifies API health, OAuth discovery metadata, dynamic client
+registration, MCP initialize, and the protected MCP auth challenge. To also
+exercise an authenticated MCP `tools/list` call, set `DEFT_MCP_BEARER_TOKEN` in
+`.env` to a personal MCP token from Settings -> MCP Access and rerun smoke.
+
 ### 5. Open the app
 
 Open `http://localhost:3000`, create the first account, and keep that account as
@@ -110,6 +153,7 @@ ports:
 docker compose -f docker-compose.yml -f compose.prod.yml up -d --build
 docker compose -f docker-compose.yml -f compose.prod.yml run --rm init
 docker compose -f docker-compose.yml -f compose.prod.yml run --rm doctor
+docker compose -f docker-compose.yml -f compose.prod.yml run --rm smoke
 ```
 
 If default local ports are already occupied, change these values in `.env`
@@ -125,6 +169,9 @@ DEFT_REDIS_PORT=6379
 
 The app still listens on ports 3000 and 3001 inside the container. These values
 only control host-side published ports.
+
+For a full VPS, DNS, reverse proxy, and HTTPS runbook, see
+[`docs/self-hosting-vps-domain-https.md`](./self-hosting-vps-domain-https.md).
 
 ## Invites And Password Recovery
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,10 @@
     "pilot:preflight:strict": "tsx scripts/pilot-preflight.ts --strict",
     "pilot:reset": "pnpm db:push-full && pnpm db:seed:pilot && pnpm pilot:preflight",
     "pilot:swarm": "node scripts/pilot-multi-user-swarm.mjs",
+    "selfhost:bootstrap": "tsx scripts/selfhost-bootstrap.ts",
     "selfhost:doctor": "tsx scripts/selfhost-doctor.ts",
+    "selfhost:preflight": "tsx scripts/selfhost-doctor.ts",
+    "selfhost:smoke": "tsx scripts/selfhost-smoke.ts",
     "typecheck": "pnpm -r --parallel typecheck"
   },
   "engines": {

--- a/scripts/selfhost-bootstrap.ts
+++ b/scripts/selfhost-bootstrap.ts
@@ -1,0 +1,130 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { spawn } from 'node:child_process';
+import { URL } from 'node:url';
+
+type EnvMap = Record<string, string>;
+
+const args = new Set(process.argv.slice(2));
+const useProdOverlay = args.has('--prod');
+const seedPilotDemo = args.has('--seed-pilot') || args.has('--demo');
+const skipBuild = args.has('--skip-build');
+const skipSmoke = args.has('--skip-smoke');
+const checkOnly = args.has('--check-only') || args.has('--dry-run');
+const composeFiles = useProdOverlay ? ['-f', 'docker-compose.yml', '-f', 'compose.prod.yml'] : [];
+
+function parseEnvFile(path: string): EnvMap {
+  const env: EnvMap = {};
+  if (!existsSync(path)) return env;
+  const content = readFileSync(path, 'utf8');
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) continue;
+    const equals = line.indexOf('=');
+    if (equals === -1) continue;
+    const key = line.slice(0, equals).trim();
+    let value = line.slice(equals + 1).trim();
+    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+      value = value.slice(1, -1);
+    }
+    env[key] = value;
+  }
+  return env;
+}
+
+function isMissingOrPlaceholder(value: string | undefined) {
+  return !value || value.includes('change-me') || value.includes('CHANGE_ME');
+}
+
+function isLocalUrl(value: string) {
+  try {
+    const url = new URL(value);
+    return ['localhost', '127.0.0.1', '::1'].includes(url.hostname);
+  } catch {
+    return false;
+  }
+}
+
+function validateEnv() {
+  const env = parseEnvFile('.env');
+  const failures: string[] = [];
+  const warnings: string[] = [];
+
+  if (!existsSync('.env')) failures.push('Missing .env. Copy .env.example to .env first.');
+  for (const key of ['POSTGRES_PASSWORD', 'JWT_SECRET', 'JWT_REFRESH_SECRET']) {
+    if (isMissingOrPlaceholder(env[key])) failures.push(`${key} is missing or still uses a placeholder.`);
+  }
+  if (!env.ENCRYPTION_KEY || env.ENCRYPTION_KEY.length !== 32) {
+    failures.push('ENCRYPTION_KEY must be exactly 32 characters.');
+  } else if (env.ENCRYPTION_KEY === 'deft-dev-encryption-key-32ch') {
+    warnings.push('ENCRYPTION_KEY is still the dev value. Rotate it before real production data.');
+  }
+
+  for (const key of ['NEXT_PUBLIC_APP_URL', 'NEXT_PUBLIC_API_URL', 'NEXT_PUBLIC_WS_URL']) {
+    if (!env[key]) warnings.push(`${key} is unset; Compose will use localhost defaults.`);
+  }
+
+  if (useProdOverlay) {
+    for (const key of ['NEXT_PUBLIC_APP_URL', 'NEXT_PUBLIC_API_URL', 'NEXT_PUBLIC_WS_URL']) {
+      const value = env[key];
+      if (value && value.startsWith('http://') && !isLocalUrl(value)) {
+        failures.push(`${key} is ${value}. Production overlay expects HTTPS for non-local domains.`);
+      }
+    }
+  }
+
+  for (const warning of warnings) console.log(`[WARN] ${warning}`);
+  if (failures.length > 0) {
+    for (const failure of failures) console.error(`[FAIL] ${failure}`);
+    process.exit(1);
+  }
+}
+
+function commandLine(command: string, commandArgs: string[]) {
+  return [command, ...commandArgs].map((part) => part.includes(' ') ? `"${part}"` : part).join(' ');
+}
+
+async function run(command: string, commandArgs: string[]) {
+  console.log('');
+  console.log(`[RUN] ${commandLine(command, commandArgs)}`);
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(command, commandArgs, { stdio: 'inherit', shell: process.platform === 'win32' });
+    child.on('error', reject);
+    child.on('exit', (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`${commandLine(command, commandArgs)} exited with ${code}`));
+    });
+  });
+}
+
+async function main() {
+  console.log('Deft self-host bootstrap');
+  console.log(`  overlay: ${useProdOverlay ? 'production' : 'default'}`);
+  console.log(`  seed: ${seedPilotDemo ? 'pilot demo data' : 'platform only'}`);
+  console.log(`  smoke: ${skipSmoke ? 'skipped' : 'enabled'}`);
+  console.log(`  mode: ${checkOnly ? 'check only' : 'execute'}`);
+  validateEnv();
+  if (checkOnly) {
+    console.log('');
+    console.log('[OK] .env validation passed.');
+    return;
+  }
+
+  const compose = ['compose', ...composeFiles];
+  await run('docker', [...compose, 'up', '-d', ...(skipBuild ? [] : ['--build'])]);
+  if (seedPilotDemo) {
+    await run('docker', [...compose, 'run', '--rm', 'init', 'sh', '-c', 'pnpm db:push-full && pnpm db:seed:pilot']);
+  } else {
+    await run('docker', [...compose, 'run', '--rm', 'init']);
+  }
+  await run('docker', [...compose, 'run', '--rm', 'doctor']);
+  if (!skipSmoke) await run('docker', [...compose, 'run', '--rm', 'smoke']);
+
+  console.log('');
+  console.log('[OK] Deft self-host bootstrap completed.');
+}
+
+main().catch((err) => {
+  console.error('');
+  console.error('[FAIL]', err instanceof Error ? err.message : err);
+  process.exit(1);
+});

--- a/scripts/selfhost-smoke.ts
+++ b/scripts/selfhost-smoke.ts
@@ -1,0 +1,184 @@
+import 'dotenv/config';
+
+type Check = {
+  name: string;
+  ok: boolean;
+  detail: string;
+  warn?: boolean;
+};
+
+const API_URL = (process.env.DEFT_API_URL || process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001').replace(/\/$/, '');
+const MCP_URL = `${API_URL}/api/mcp/v1`;
+const CLIENT_NAME = process.env.DEFT_SMOKE_CLIENT_NAME || `Deft self-host smoke ${new Date().toISOString()}`;
+const REDIRECT_URI = process.env.DEFT_SMOKE_REDIRECT_URI || 'http://localhost:3999/callback';
+const REQUESTED_SCOPE = process.env.DEFT_SMOKE_SCOPE || 'read:workspace read:wiki read:tasks read:messages read:calendar';
+const OPTIONAL_BEARER = process.env.DEFT_MCP_BEARER_TOKEN || process.env.DEFT_SMOKE_MCP_TOKEN || '';
+
+function mark(check: Check) {
+  const icon = check.ok ? (check.warn ? 'WARN' : 'OK') : 'FAIL';
+  console.log(`[${icon}] ${check.name}: ${check.detail}`);
+}
+
+async function fetchText(url: string, init?: RequestInit): Promise<{ status: number; text: string; headers: Headers | null }> {
+  try {
+    const res = await fetch(url, { ...init, signal: AbortSignal.timeout(10_000) });
+    return { status: res.status, text: await res.text().catch(() => ''), headers: res.headers };
+  } catch (err) {
+    return { status: 0, text: err instanceof Error ? err.message : String(err), headers: null };
+  }
+}
+
+async function fetchJson<T = any>(url: string, init?: RequestInit): Promise<{ status: number; json: T | null; text: string; headers: Headers | null }> {
+  const res = await fetchText(url, init);
+  try {
+    return { ...res, json: JSON.parse(res.text) as T };
+  } catch {
+    return { ...res, json: null };
+  }
+}
+
+async function checkHealth(): Promise<Check> {
+  const res = await fetchText(`${API_URL}/health`);
+  return {
+    name: 'API health',
+    ok: res.status === 200,
+    detail: res.status === 200 ? `${API_URL}/health returned 200` : `${API_URL}/health returned ${res.status}: ${res.text.slice(0, 160)}`,
+  };
+}
+
+async function checkProtectedResource(): Promise<Check> {
+  const res = await fetchJson(`${API_URL}/.well-known/oauth-protected-resource`);
+  const body = res.json as any;
+  const ok = res.status === 200
+    && body?.resource === MCP_URL
+    && Array.isArray(body?.authorization_servers)
+    && body.authorization_servers.includes(API_URL);
+  return {
+    name: 'OAuth protected resource metadata',
+    ok,
+    detail: ok
+      ? `resource=${body.resource}; issuer=${body.authorization_servers[0]}`
+      : `expected resource ${MCP_URL} and issuer ${API_URL}; got ${res.status}: ${res.text.slice(0, 180)}`,
+  };
+}
+
+async function checkAuthorizationServer(): Promise<Check> {
+  const res = await fetchJson(`${API_URL}/.well-known/oauth-authorization-server`);
+  const body = res.json as any;
+  const ok = res.status === 200
+    && body?.issuer === API_URL
+    && body?.token_endpoint === `${API_URL}/oauth/token`
+    && body?.registration_endpoint === `${API_URL}/oauth/register`
+    && Array.isArray(body?.code_challenge_methods_supported)
+    && body.code_challenge_methods_supported.includes('S256');
+  return {
+    name: 'OAuth authorization-server metadata',
+    ok,
+    detail: ok
+      ? `issuer=${body.issuer}; registration=${body.registration_endpoint}`
+      : `metadata mismatch ${res.status}: ${res.text.slice(0, 180)}`,
+  };
+}
+
+async function checkDynamicClientRegistration(): Promise<Check> {
+  const res = await fetchJson(`${API_URL}/oauth/register`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      client_name: CLIENT_NAME,
+      redirect_uris: [REDIRECT_URI],
+      scope: REQUESTED_SCOPE,
+    }),
+  });
+  const body = res.json as any;
+  const ok = res.status === 201 && typeof body?.client_id === 'string' && body.client_id.startsWith('deft_dcr_');
+  return {
+    name: 'OAuth dynamic client registration',
+    ok,
+    detail: ok
+      ? `registered ${body.client_id} with scope "${body.scope}"`
+      : `registration returned ${res.status}: ${res.text.slice(0, 180)}`,
+  };
+}
+
+async function checkMcpInitialize(): Promise<Check> {
+  const res = await fetchJson(MCP_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 'smoke-init', method: 'initialize', params: {} }),
+  });
+  const body = res.json as any;
+  const ok = res.status === 200 && body?.result?.serverInfo?.name === 'deft-mcp';
+  return {
+    name: 'MCP initialize',
+    ok,
+    detail: ok ? `server=${body.result.serverInfo.name}; protocol=${body.result.protocolVersion}` : `initialize returned ${res.status}: ${res.text.slice(0, 180)}`,
+  };
+}
+
+async function checkProtectedToolsList(): Promise<Check> {
+  const res = await fetchJson(MCP_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 'smoke-tools-denied', method: 'tools/list', params: {} }),
+  });
+  const challenge = res.headers?.get('www-authenticate') ?? '';
+  const metadataUrl = `${API_URL}/.well-known/oauth-protected-resource`;
+  const ok = res.status === 401 && challenge.includes('Bearer') && challenge.includes(metadataUrl);
+  return {
+    name: 'MCP protected tools/list',
+    ok,
+    detail: ok
+      ? 'unauthenticated tools/list is denied with OAuth resource challenge'
+      : `expected 401 with OAuth metadata challenge ${metadataUrl}; got ${res.status}, challenge="${challenge}", body=${res.text.slice(0, 160)}`,
+  };
+}
+
+async function checkOptionalBearerToolsList(): Promise<Check> {
+  if (!OPTIONAL_BEARER) {
+    return {
+      name: 'Optional bearer MCP flow',
+      ok: true,
+      warn: true,
+      detail: 'DEFT_MCP_BEARER_TOKEN not set; skipped authenticated tools/list smoke',
+    };
+  }
+  const res = await fetchJson(MCP_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${OPTIONAL_BEARER}` },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 'smoke-tools-auth', method: 'tools/list', params: {} }),
+  });
+  const body = res.json as any;
+  const tools = body?.result?.tools;
+  const ok = res.status === 200 && Array.isArray(tools) && tools.length > 0;
+  return {
+    name: 'Optional bearer MCP flow',
+    ok,
+    detail: ok ? `authenticated tools/list returned ${tools.length} tool(s)` : `authenticated tools/list returned ${res.status}: ${res.text.slice(0, 180)}`,
+  };
+}
+
+async function main() {
+  console.log('Deft self-host smoke');
+  console.log(`  api: ${API_URL}`);
+  console.log(`  mcp: ${MCP_URL}`);
+  console.log('');
+
+  const checks = [
+    await checkHealth(),
+    await checkProtectedResource(),
+    await checkAuthorizationServer(),
+    await checkDynamicClientRegistration(),
+    await checkMcpInitialize(),
+    await checkProtectedToolsList(),
+    await checkOptionalBearerToolsList(),
+  ];
+
+  for (const check of checks) mark(check);
+  if (!checks.every((check) => check.ok)) process.exitCode = 1;
+}
+
+main().catch((err) => {
+  console.error('[FAIL]', err instanceof Error ? err.message : err);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary

This PR hardens Deft's pilot-facing AI app/MCP and self-host setup paths.

- Adds deterministic human MCP read tools for tasks, projects, spaces, and members, plus `task_transition` for explicit status changes.
- Adds retry-safe idempotency handling for write tools so clients like Codex can safely replay task/message/comment writes without duplicates.
- Keeps `memory_recall` canonical while exposing `wiki_search` as a compatibility alias.
- Expands OAuth MCP audit metadata and the Settings -> MCP Access UI with connected app visibility, recent actions, last-used state, and revoke controls.
- Adds self-host bootstrap/smoke commands, Docker smoke service wiring, and VPS/domain/HTTPS docs.

## Why

The pilot path needs two things to feel trustworthy in week one: AI clients should be able to inspect and update Deft work reliably, and self-host installs should have a repeatable preflight/smoke path. This closes those gaps without adding any dependency on a specific LLM provider.

## Validation

- Live personal MCP workflow as Diego: tools/list, project/space/member reads, task_create, task_get, task_transition to in_progress and done, comment_on_task, message_post.
- Replayed duplicate task/comment/message/transition writes with the same idempotency keys; all returned original objects.
- Revoked temporary MCP token and confirmed it returned 401.
- Verified `memory_recall` and `wiki_search` both return the seeded Farmers Market Pricing Strategy wiki page.
- Browser UI sweep: dashboard, tasks, chat, knowledge, calendar, MCP Access rendered with no console errors or horizontal overflow.
- `pnpm --filter @deft/api typecheck`
- `pnpm --filter @deft/web typecheck`
- `pnpm --filter @deft/api exec tsx --test --test-concurrency=1 --test-force-exit test/oauth-mcp.test.ts` (8/8)
- `pnpm selfhost:smoke`
- `pnpm selfhost:preflight`
- `pnpm selfhost:bootstrap --check-only`
- `pnpm selfhost:bootstrap --prod --check-only`
- `docker compose --profile tools config --services`
- `git diff --check`

## Notes

- `http://localhost:3301/` returning 404 is expected because that is the API root; `/health` is the health endpoint.
- The browser OAuth redirect to a local callback is limited by the in-app browser, but the OAuth/MCP contract path is covered by automated tests.