### PR TITLE
[codex] Improve MCP reliability followups

### DIFF
--- a/apps/api/src/lib/mcp-tools/human.ts
+++ b/apps/api/src/lib/mcp-tools/human.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import { and, desc, eq, isNull, sql } from 'drizzle-orm';
 import { db } from '../db.js';
 import {
@@ -144,6 +144,7 @@ export const HUMAN_READ_TOOLS = new Set([
   'thread_fetch',
   'member_list',
   'member_get',
+  'activity_query',
   'events_query',
   'messages_search',
   'project_progress',
@@ -182,6 +183,7 @@ export const HUMAN_TOOLS: Record<string, HumanToolHandler> = {
   thread_fetch: humanThreadFetch,
   member_list: humanMemberList,
   member_get: humanMemberGet,
+  activity_query: humanActivityQuery,
   messages_search: humanMessagesSearch,
   project_progress: humanProjectProgress,
   team_workload: humanTeamWorkload,
@@ -211,34 +213,81 @@ function storedToolResult(value: unknown): ToolResult | null {
   return { content: maybe.content, isError: maybe.isError };
 }
 
+function normalizedText(value: unknown): string | null {
+  return typeof value === 'string' ? value.trim().replace(/\s+/g, ' ').toLowerCase() : null;
+}
+
+function stableJson(value: unknown): string {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map((item) => stableJson(item)).join(',')}]`;
+  const record = value as Record<string, unknown>;
+  return `{${Object.keys(record)
+    .filter((key) => record[key] !== undefined && key !== 'idempotency_key')
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${stableJson(record[key])}`)
+    .join(',')}}`;
+}
+
+function fallbackDedupeInput(toolName: string, args: Record<string, unknown>): Record<string, unknown> | null {
+  switch (toolName) {
+    case 'task_create':
+      return {
+        title: normalizedText(args.title),
+        project_id: args.project_id ?? null,
+        assignee_id: args.assignee_id ?? null,
+        priority: args.priority ?? null,
+      };
+    case 'task_update':
+      return { task_id: args.task_id ?? null, patch: args.patch ?? null };
+    case 'task_transition':
+      return { task_id: args.task_id ?? null, status: args.status ?? null };
+    case 'comment_on_task':
+      return { task_id: args.task_id ?? null, content: normalizedText(args.content) };
+    case 'message_post':
+      return { space_id: args.space_id ?? null, parent_id: args.parent_id ?? null, content: normalizedText(args.content) };
+    default:
+      return null;
+  }
+}
+
+function fallbackDedupeSignature(toolName: string, args: Record<string, unknown>): string | null {
+  const input = fallbackDedupeInput(toolName, args);
+  if (!input) return null;
+  return createHash('sha256').update(`${toolName}:${stableJson(input)}`).digest('hex');
+}
+
 async function withIdempotency(
   toolName: string,
-  args: { idempotency_key?: unknown },
+  args: { idempotency_key?: unknown } & Record<string, unknown>,
   ctx: HumanToolContext,
   execute: () => Promise<ToolResult>,
 ): Promise<ToolResult> {
   const idempotencyKey = normalizeIdempotencyKey(args.idempotency_key);
-  if (!idempotencyKey) return execute();
+  const fallbackSignature = idempotencyKey ? null : fallbackDedupeSignature(toolName, args);
 
   const clientId = ctx.client_id ?? `personal-token:${ctx.token_id ?? 'unknown'}`;
-  const [existing] = await db
-    .select({ metadata: oauthAuditEvents.metadata })
-    .from(oauthAuditEvents)
-    .where(and(
-      eq(oauthAuditEvents.org_id, ctx.org_id),
-      eq(oauthAuditEvents.user_id, ctx.user_id),
-      eq(oauthAuditEvents.client_id, clientId),
-      eq(oauthAuditEvents.event, 'mcp_idempotency_result'),
-      sql`${oauthAuditEvents.metadata}->>'tool_name' = ${toolName}`,
-      sql`${oauthAuditEvents.metadata}->>'idempotency_key' = ${idempotencyKey}`,
-    ))
-    .orderBy(desc(oauthAuditEvents.created_at))
-    .limit(1);
-  const replay = storedToolResult(existing?.metadata?.result);
-  if (replay) return replay;
+  if (idempotencyKey || fallbackSignature) {
+    const [existing] = await db
+      .select({ metadata: oauthAuditEvents.metadata })
+      .from(oauthAuditEvents)
+      .where(and(
+        eq(oauthAuditEvents.org_id, ctx.org_id),
+        eq(oauthAuditEvents.user_id, ctx.user_id),
+        eq(oauthAuditEvents.client_id, clientId),
+        eq(oauthAuditEvents.event, 'mcp_idempotency_result'),
+        sql`${oauthAuditEvents.metadata}->>'tool_name' = ${toolName}`,
+        idempotencyKey
+          ? sql`${oauthAuditEvents.metadata}->>'idempotency_key' = ${idempotencyKey}`
+          : sql`${oauthAuditEvents.metadata}->>'fallback_signature' = ${fallbackSignature} AND ${oauthAuditEvents.created_at} >= now() - interval '2 minutes'`,
+      ))
+      .orderBy(desc(oauthAuditEvents.created_at))
+      .limit(1);
+    const replay = storedToolResult(existing?.metadata?.result);
+    if (replay) return replay;
+  }
 
   const result = await execute();
-  if (!result.isError) {
+  if (!result.isError && (idempotencyKey || fallbackSignature)) {
     await db.insert(oauthAuditEvents).values({
       org_id: ctx.org_id,
       user_id: ctx.user_id,
@@ -246,7 +295,9 @@ async function withIdempotency(
       event: 'mcp_idempotency_result',
       metadata: {
         tool_name: toolName,
-        idempotency_key: idempotencyKey,
+        idempotency_key: idempotencyKey ?? null,
+        fallback_signature: fallbackSignature,
+        fallback_window_seconds: fallbackSignature ? 120 : null,
         grant_id: ctx.grant_id ?? null,
         principal_kind: ctx.principal_kind ?? 'human',
         result,
@@ -960,16 +1011,37 @@ export async function humanMessagesSearch(args: { query?: string; limit?: number
   return textResult((rows as any).rows ?? []);
 }
 
-export async function humanProjectProgress(args: { project_id?: string; project_name?: string }, ctx: HumanToolContext): Promise<ToolResult> {
+type ProjectProgressArgs = {
+  project_id?: string;
+  project_identifier?: string;
+  project_name?: string;
+};
+
+export async function humanProjectProgress(args: ProjectProgressArgs, ctx: HumanToolContext): Promise<ToolResult> {
   const scopeError = requireScope(ctx, 'read:tasks');
   if (scopeError) return scopeError;
-  const projectWhere = args.project_id
-    ? sql`p.id = ${args.project_id}`
-    : args.project_name
-      ? sql`lower(p.name) = ${args.project_name.toLowerCase()}`
-      : sql`true`;
+  const projectId = args.project_id?.trim();
+  const projectIdentifier = args.project_identifier?.trim();
+  const projectName = args.project_name?.trim();
+  const identifier = projectIdentifier ? projectIdentifier.toLowerCase() : '';
+  const prefixIdentifier = identifier.includes('-') ? identifier.split('-')[0] : identifier;
+  const hasSpecificProject = Boolean(projectId || projectIdentifier || projectName);
+  const projectWhere = projectId
+    ? sql`p.id = ${projectId}`
+    : projectIdentifier
+      ? sql`(lower(p.prefix) = ${prefixIdentifier} OR lower(p.name) = ${identifier} OR p.id = ${projectIdentifier})`
+      : projectName
+        ? sql`lower(p.name) = ${projectName.toLowerCase()}`
+        : sql`true`;
   const rows = await db.execute(sql`
-    SELECT p.id, p.name, p.prefix, t.status, count(t.id)::int AS count
+    SELECT
+      p.id,
+      p.name,
+      p.prefix,
+      p.updated_at,
+      t.status,
+      count(t.id)::int AS count,
+      count(t.id) FILTER (WHERE t.status = 'done' AND t.updated_at >= now() - interval '7 days')::int AS done_last_7_days
     FROM projects p
     LEFT JOIN tasks t ON t.project_id = p.id
       AND t.org_id = p.org_id
@@ -986,9 +1058,75 @@ export async function humanProjectProgress(args: { project_id?: string; project_
     WHERE p.org_id = ${ctx.org_id}
       AND p.is_deleted = false
       AND ${projectWhere}
-    GROUP BY p.id, p.name, p.prefix, t.status
+    GROUP BY p.id, p.name, p.prefix, p.updated_at, t.status
     ORDER BY p.updated_at DESC
-    LIMIT 30
+    LIMIT ${hasSpecificProject ? 20 : 200}
+  `);
+  const summaries = new Map<string, {
+    project: { id: string; name: string; prefix: string | null };
+    status_counts: Record<string, number>;
+    total_tasks: number;
+    open_tasks: number;
+    done_tasks: number;
+    cancelled_tasks: number;
+    completion_rate: number;
+    recent_velocity: { done_last_7_days: number };
+  }>();
+
+  for (const row of ((rows as any).rows ?? []) as Array<Record<string, unknown>>) {
+    const id = String(row.id);
+    const summary = summaries.get(id) ?? {
+      project: { id, name: String(row.name), prefix: row.prefix == null ? null : String(row.prefix) },
+      status_counts: {},
+      total_tasks: 0,
+      open_tasks: 0,
+      done_tasks: 0,
+      cancelled_tasks: 0,
+      completion_rate: 0,
+      recent_velocity: { done_last_7_days: 0 },
+    };
+    const status = row.status == null ? null : String(row.status);
+    const count = Number(row.count ?? 0);
+    if (status && count > 0) {
+      summary.status_counts[status] = count;
+      summary.total_tasks += count;
+      if (status === 'done') summary.done_tasks += count;
+      else if (status === 'cancelled') summary.cancelled_tasks += count;
+      else summary.open_tasks += count;
+    }
+    summary.recent_velocity.done_last_7_days += Number(row.done_last_7_days ?? 0);
+    summaries.set(id, summary);
+  }
+
+  const result = Array.from(summaries.values()).map((summary) => ({
+    ...summary,
+    completion_rate: summary.total_tasks > 0 ? Number((summary.done_tasks / summary.total_tasks).toFixed(2)) : 0,
+  }));
+
+  if (hasSpecificProject) {
+    if (!result[0]) return errorResult('project_progress: project not found');
+    return textResult(result[0]);
+  }
+
+  return textResult({ projects: result });
+}
+
+export async function humanActivityQuery(args: { limit?: number; tool_name?: string; since?: string }, ctx: HumanToolContext): Promise<ToolResult> {
+  const scopeError = requireScope(ctx, 'read:workspace');
+  if (scopeError) return scopeError;
+  const limit = Math.min(Math.max(1, args.limit ?? 25), 100);
+  const toolName = args.tool_name?.trim();
+  const since = args.since && !Number.isNaN(Date.parse(args.since)) ? new Date(args.since) : null;
+  const rows = await db.execute(sql`
+    SELECT id, client_id, event, metadata, created_at
+    FROM oauth_audit_events
+    WHERE org_id = ${ctx.org_id}
+      AND user_id = ${ctx.user_id}
+      AND event IN ('mcp_tool_call', 'mcp_idempotency_result', 'token_issued', 'grant_revoked', 'token_revoked')
+      AND (${toolName ? sql`metadata->>'tool_name' = ${toolName}` : sql`true`})
+      AND (${since ? sql`created_at >= ${since}` : sql`true`})
+    ORDER BY created_at DESC
+    LIMIT ${limit}
   `);
   return textResult((rows as any).rows ?? []);
 }
@@ -1174,9 +1312,23 @@ export function buildHumanToolSchemas(agentSchemas: Array<Record<string, unknown
       },
     },
     {
+      name: 'activity_query',
+      title: 'Query Deft MCP Activity',
+      description: 'Query recent OAuth/Codex MCP activity for the connected human user: tool calls, idempotency results, token events, and grant revocations. Use this to answer "what did my connected AI app do?" Human personal-MCP read: requires read:workspace.',
+      annotations: { readOnlyHint: true },
+      inputSchema: {
+        type: 'object',
+        properties: {
+          tool_name: { type: 'string', description: 'Optional tool name filter such as task_create, task_update, message_post, or search.' },
+          since: { type: 'string', description: 'Optional ISO timestamp lower bound.' },
+          limit: { type: 'integer', minimum: 1, maximum: 100 },
+        },
+      },
+    },
+    {
       name: 'task_transition',
       title: 'Transition Deft Task',
-      description: 'Change one visible task status as the connected human user. Prefer this over task_update for status-only changes. Human personal-MCP write: requires write:tasks.',
+      description: 'Change one visible task status as the connected human user. Prefer this over task_update for status-only changes. Always include idempotency_key for retry-safe writes. Human personal-MCP write: requires write:tasks.',
       annotations: { readOnlyHint: false, destructiveHint: false },
       inputSchema: {
         type: 'object',
@@ -1192,7 +1344,7 @@ export function buildHumanToolSchemas(agentSchemas: Array<Record<string, unknown
     {
       name: 'comment_on_task',
       title: 'Comment On Deft Task',
-      description: 'Add a comment to a visible task as the connected human user. Human personal-MCP write: requires write:tasks.',
+      description: 'Add a comment to a visible task as the connected human user. Always include idempotency_key for retry-safe writes. Human personal-MCP write: requires write:tasks.',
       annotations: { readOnlyHint: false, destructiveHint: false },
       inputSchema: {
         type: 'object',
@@ -1213,7 +1365,7 @@ export function buildHumanToolSchemas(agentSchemas: Array<Record<string, unknown
     .map((schema) => {
       const next = withoutCallerSlug(schema);
       if (HUMAN_WRITE_TOOLS.has(String(next.name))) {
-        next.description = `${next.description ?? ''} Human personal-MCP write: executes as the token owner and requires a matching write scope.`;
+        next.description = `${next.description ?? ''} Human personal-MCP write: executes as the token owner and requires a matching write scope. Always include idempotency_key for retry-safe writes; if you retry the same user intent, reuse the same key.`;
         next.annotations = { ...(next.annotations as Record<string, unknown> | undefined), readOnlyHint: false, destructiveHint: false };
         const inputSchema = next.inputSchema as { properties?: Record<string, unknown> } | undefined;
         if (inputSchema?.properties && !inputSchema.properties.idempotency_key) {

--- a/apps/api/src/lib/mcp-tools/index.ts
+++ b/apps/api/src/lib/mcp-tools/index.ts
@@ -552,6 +552,7 @@ export const toolSchemas: ToolSchema[] = [
       type: 'object',
       properties: {
         ...CALLER_SLUG_PROP,
+        project_id: { type: 'string', description: 'Exact Deft project id. Prefer this when known.' },
         project_identifier: { type: 'string' },
         project_name: { type: 'string' },
       },

--- a/apps/api/src/routes/mcp-server-v1.ts
+++ b/apps/api/src/routes/mcp-server-v1.ts
@@ -204,6 +204,7 @@ const HUMAN_TOOL_SCOPE: Record<string, string> = {
   platform_context: 'read:workspace',
   member_list: 'read:workspace',
   member_get: 'read:workspace',
+  activity_query: 'read:workspace',
   events_query: 'read:calendar',
   memory_recall: 'read:wiki',
   wiki_search: 'read:wiki',

--- a/apps/api/test/oauth-mcp.test.ts
+++ b/apps/api/test/oauth-mcp.test.ts
@@ -380,6 +380,7 @@ test('OAuth task-helper profile can comment on and update visible tasks', async 
   assert.ok(names.has('task_transition'));
   assert.ok(names.has('comment_on_task'));
   assert.ok(names.has('message_post'));
+  assert.ok(names.has('activity_query'));
 
   const createArgs = {
     title: `Retry-safe OAuth follow-up ${TEST_ID}`,
@@ -424,6 +425,57 @@ test('OAuth task-helper profile can comment on and update visible tasks', async 
       [ORG_ID, createArgs.title],
     );
     assert.equal(count.rows[0].count, 1, 'idempotent task_create must not create duplicates');
+  });
+
+  const fallbackCreateArgs = {
+    title: `Fallback duplicate-safe OAuth follow-up ${TEST_ID}`,
+    project_id: PROJECT_ID,
+    assignee_id: USER_ID,
+    priority: 'p3',
+    description: 'first no-key create call',
+  };
+  const fallbackCreateRes = await jsonPost('/api/mcp/v1', {
+    jsonrpc: '2.0',
+    id: 292,
+    method: 'tools/call',
+    params: {
+      name: 'task_create',
+      arguments: fallbackCreateArgs,
+    },
+  }, token.access_token);
+  assert.equal(fallbackCreateRes.status, 200);
+  const fallbackCreateBody = (await fallbackCreateRes.json()) as any;
+  assert.equal(fallbackCreateBody.result.isError, false, JSON.stringify(fallbackCreateBody));
+  const fallbackCreatedTask = JSON.parse(fallbackCreateBody.result.content[0].text);
+
+  const fallbackDuplicateCreateRes = await jsonPost('/api/mcp/v1', {
+    jsonrpc: '2.0',
+    id: 293,
+    method: 'tools/call',
+    params: {
+      name: 'task_create',
+      arguments: {
+        ...fallbackCreateArgs,
+        description: 'second no-key create call from the same user intent',
+      },
+    },
+  }, token.access_token);
+  assert.equal(fallbackDuplicateCreateRes.status, 200);
+  const fallbackDuplicateCreateBody = (await fallbackDuplicateCreateRes.json()) as any;
+  assert.equal(fallbackDuplicateCreateBody.result.isError, false, JSON.stringify(fallbackDuplicateCreateBody));
+  const fallbackDuplicateTask = JSON.parse(fallbackDuplicateCreateBody.result.content[0].text);
+  assert.equal(
+    fallbackDuplicateTask.id,
+    fallbackCreatedTask.id,
+    'fallback duplicate detection should replay the original task_create result even without idempotency_key',
+  );
+
+  await withClient(async (pgClient) => {
+    const count = await pgClient.query(
+      `SELECT count(*)::int AS count FROM tasks WHERE org_id = $1 AND title = $2`,
+      [ORG_ID, fallbackCreateArgs.title],
+    );
+    assert.equal(count.rows[0].count, 1, 'fallback duplicate detection must not create duplicate task rows');
   });
 
   const commentRes = await jsonPost('/api/mcp/v1', {
@@ -545,6 +597,27 @@ test('OAuth task-helper profile can comment on and update visible tasks', async 
   const duplicateMessage = JSON.parse(duplicateMessageBody.result.content[0].text);
   assert.equal(duplicateMessage.id, postedMessage.id, 'same idempotency key should replay the original message result');
 
+  const activityRes = await jsonPost('/api/mcp/v1', {
+    jsonrpc: '2.0',
+    id: 342,
+    method: 'tools/call',
+    params: {
+      name: 'activity_query',
+      arguments: {
+        tool_name: 'task_create',
+        limit: 10,
+      },
+    },
+  }, token.access_token);
+  assert.equal(activityRes.status, 200);
+  const activityBody = (await activityRes.json()) as any;
+  assert.equal(activityBody.result.isError, false, JSON.stringify(activityBody));
+  const activity = JSON.parse(activityBody.result.content[0].text);
+  assert.ok(
+    activity.some((event: any) => event.event === 'mcp_tool_call' && event.metadata?.tool_name === 'task_create'),
+    'activity_query should expose recent task_create audit activity',
+  );
+
   const blockedRes = await jsonPost('/api/mcp/v1', {
     jsonrpc: '2.0',
     id: 33,
@@ -612,6 +685,16 @@ test('OAuth human MCP read tools match user-scoped wiki task and calendar visibi
   const primarySpaces = await callTool(primaryToken.access_token, 131, 'space_list', { limit: 50 });
   assert.ok(!primarySpaces.some((space: any) => space.id === PRIVATE_SPACE_ID));
 
+  const projectProgress = await callTool(primaryToken.access_token, 132, 'project_progress', { project_identifier: 'OMCP' });
+  assert.equal(projectProgress.project.id, PROJECT_ID);
+  assert.equal(projectProgress.project.prefix, 'OMCP');
+  assert.ok(projectProgress.total_tasks >= 1);
+  assert.ok(typeof projectProgress.status_counts === 'object');
+  assert.ok(!Array.isArray(projectProgress), 'filtered project_progress should return one project summary, not an org-wide list');
+
+  const projectProgressById = await callTool(primaryToken.access_token, 133, 'project_progress', { project_id: PROJECT_ID });
+  assert.equal(projectProgressById.project.id, PROJECT_ID);
+
   await callToolError(primaryToken.access_token, 14, 'fetch', { id: `wiki:${PRIVATE_WIKI_SLUG}` });
   await callToolError(primaryToken.access_token, 15, 'fetch', { id: `task:${RESTRICTED_TASK_ID}` });
   await callToolError(primaryToken.access_token, 16, 'fetch', { id: `event:${PRIVATE_EVENT_ID}` });
@@ -663,6 +746,7 @@ test('OAuth tools/list read catalog only advertises callable tools', async () =>
     thread_fetch: { parent_message_id: MESSAGE_ID, limit: 5 },
     member_list: { limit: 5 },
     member_get: { user_id: USER_ID },
+    activity_query: { limit: 5 },
     events_query: { limit: 5 },
     messages_search: { query: 'salsa', limit: 5 },
     project_progress: { project_id: PROJECT_ID },

--- a/apps/web/src/app/(app)/settings/mcp-access/page.tsx
+++ b/apps/web/src/app/(app)/settings/mcp-access/page.tsx
@@ -71,6 +71,11 @@ function actionDetail(action: OAuthAuditAction) {
   return pieces.length > 0 ? pieces.join(' / ') : 'recorded';
 }
 
+function isStale(value: string | null | undefined) {
+  if (!value) return true;
+  return Date.now() - new Date(value).getTime() > 1000 * 60 * 60 * 24 * 14;
+}
+
 export default function McpAccessPage() {
   const [tokens, setTokens] = useState<McpToken[]>([]);
   const [remote, setRemote] = useState<RemoteReadiness | null>(null);
@@ -350,11 +355,16 @@ export default function McpAccessPage() {
                             connected {formatDate(grant.created_at)} / last used {formatDate(grant.last_used_at)}
                           </div>
                         </div>
-                        <button type="button" disabled={busy} onClick={() => revokeGrant(grant.id)} className="p-1.5 rounded-md disabled:opacity-50" style={{ color: 'var(--danger)' }} aria-label={`Revoke ${grant.app_name}`}>
-                          <Trash2 size={14} />
+                        <button type="button" disabled={busy} onClick={() => revokeGrant(grant.id)} className="inline-flex items-center gap-1.5 rounded-md px-2 py-1.5 text-[12px] disabled:opacity-50" style={{ color: 'var(--danger)', border: '1px solid color-mix(in srgb, var(--danger) 35%, transparent)' }} aria-label={`Revoke ${grant.app_name}`}>
+                          <Trash2 size={13} /> Revoke
                         </button>
                       </div>
                       <div className="flex flex-wrap gap-1 mt-3">
+                        {isStale(grant.last_used_at) && (
+                          <span className="text-[10px] rounded px-1.5 py-0.5" style={{ color: 'var(--warning, #f59e0b)', border: '1px solid color-mix(in srgb, var(--warning, #f59e0b) 45%, transparent)' }}>
+                            {grant.last_used_at ? 'stale' : 'unused'}
+                          </span>
+                        )}
                         {grant.scopes.map((scope) => (
                           <span key={scope} className="text-[10px] rounded px-1.5 py-0.5" style={{ color: 'var(--text-secondary)', border: '1px solid var(--border-default)' }}>{scope}</span>
                         ))}
@@ -405,8 +415,8 @@ export default function McpAccessPage() {
                       ))}
                     </div>
                   </div>
-                  <button type="button" disabled={busy} onClick={() => revoke(token.id)} className="p-1.5 rounded-md disabled:opacity-50" style={{ color: 'var(--danger)' }} aria-label={`Revoke ${token.name}`}>
-                    <Trash2 size={14} />
+                  <button type="button" disabled={busy} onClick={() => revoke(token.id)} className="inline-flex items-center gap-1.5 rounded-md px-2 py-1.5 text-[12px] disabled:opacity-50 shrink-0" style={{ color: 'var(--danger)', border: '1px solid color-mix(in srgb, var(--danger) 35%, transparent)' }} aria-label={`Revoke ${token.name}`}>
+                    <Trash2 size={13} /> Revoke
                   </button>
                 </div>
               ))}

--- a/scripts/selfhost-doctor.ts
+++ b/scripts/selfhost-doctor.ts
@@ -11,9 +11,16 @@ type Check = {
   warn?: boolean;
 };
 
-const API_URL = (process.env.DEFT_API_URL || process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001').replace(/\/$/, '');
-const WEB_URL = (process.env.DEFT_WEB_URL || process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000').replace(/\/$/, '');
-const APP_URL = (process.env.NEXT_PUBLIC_APP_URL || WEB_URL).replace(/\/$/, '');
+const explicitApiUrl = process.env.DEFT_API_URL;
+const explicitWebUrl = process.env.DEFT_WEB_URL;
+const API_URL = (explicitApiUrl || process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001').replace(/\/$/, '');
+const WEB_URL = (explicitWebUrl || process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000').replace(/\/$/, '');
+const APP_URL = (
+  process.env.DEFT_APP_URL
+  || process.env.DEFT_APP_ORIGIN
+  || (explicitApiUrl && explicitWebUrl ? WEB_URL : process.env.NEXT_PUBLIC_APP_URL)
+  || WEB_URL
+).replace(/\/$/, '');
 
 function maskDatabaseUrl(url: string): string {
   return url.replace(/:\/\/([^:]+):([^@]+)@/, '://$1:***@');
@@ -180,6 +187,13 @@ async function checkUrlAgreement(): Promise<Check> {
   const apiUrl = process.env.NEXT_PUBLIC_API_URL || '';
   const wsUrl = process.env.NEXT_PUBLIC_WS_URL || '';
   const appUrl = process.env.NEXT_PUBLIC_APP_URL || '';
+  if (explicitApiUrl || explicitWebUrl || process.env.DEFT_APP_URL || process.env.DEFT_APP_ORIGIN) {
+    return {
+      name: 'Public URL config',
+      ok: true,
+      detail: `target app=${APP_URL}, api=${API_URL}; configured env app=${appUrl || '(unset)'}, api=${apiUrl || '(unset)'}, ws=${wsUrl || '(unset)'}`,
+    };
+  }
   const missing = [
     apiUrl ? null : 'NEXT_PUBLIC_API_URL',
     wsUrl ? null : 'NEXT_PUBLIC_WS_URL',

--- a/scripts/selfhost-smoke.ts
+++ b/scripts/selfhost-smoke.ts
@@ -1,5 +1,7 @@
 import 'dotenv/config';
 
+const args = new Set(process.argv.slice(2));
+
 type Check = {
   name: string;
   ok: boolean;
@@ -13,6 +15,7 @@ const CLIENT_NAME = process.env.DEFT_SMOKE_CLIENT_NAME || `Deft self-host smoke 
 const REDIRECT_URI = process.env.DEFT_SMOKE_REDIRECT_URI || 'http://localhost:3999/callback';
 const REQUESTED_SCOPE = process.env.DEFT_SMOKE_SCOPE || 'read:workspace read:wiki read:tasks read:messages read:calendar';
 const OPTIONAL_BEARER = process.env.DEFT_MCP_BEARER_TOKEN || process.env.DEFT_SMOKE_MCP_TOKEN || '';
+const REQUIRE_AUTH = args.has('--require-auth') || process.env.DEFT_REQUIRE_AUTH_SMOKE === '1';
 
 function mark(check: Check) {
   const icon = check.ok ? (check.warn ? 'WARN' : 'OK') : 'FAIL';
@@ -138,9 +141,11 @@ async function checkOptionalBearerToolsList(): Promise<Check> {
   if (!OPTIONAL_BEARER) {
     return {
       name: 'Optional bearer MCP flow',
-      ok: true,
-      warn: true,
-      detail: 'DEFT_MCP_BEARER_TOKEN not set; skipped authenticated tools/list smoke',
+      ok: !REQUIRE_AUTH,
+      warn: !REQUIRE_AUTH,
+      detail: REQUIRE_AUTH
+        ? 'DEFT_MCP_BEARER_TOKEN not set; authenticated tools/list smoke is required'
+        : 'DEFT_MCP_BEARER_TOKEN not set; skipped authenticated tools/list smoke. Set DEFT_REQUIRE_AUTH_SMOKE=1 or pass --require-auth to make this a failure.',
     };
   }
   const res = await fetchJson(MCP_URL, {
@@ -162,6 +167,7 @@ async function main() {
   console.log('Deft self-host smoke');
   console.log(`  api: ${API_URL}`);
   console.log(`  mcp: ${MCP_URL}`);
+  console.log(`  authenticated tools/list: ${REQUIRE_AUTH ? 'required' : 'optional'}`);
   console.log('');
 
   const checks = [


### PR DESCRIPTION
## Summary
- add fallback duplicate protection for MCP write tools when clients omit idempotency keys
- add activity_query and tighten project_progress filtering for human OAuth MCP clients
- clarify self-host preflight/smoke output and strict auth smoke mode
- make MCP Access revocation clearer and flag stale/unused AI app grants

## Validation
- pnpm --filter @deft/api exec tsx --test --test-concurrency=1 --test-force-exit test/oauth-mcp.test.ts
- pnpm --filter @deft/api typecheck
- pnpm --filter @deft/web typecheck
- pnpm selfhost:preflight against local stack
- pnpm selfhost:smoke against local stack
- pnpm selfhost:preflight against https://demo.deft.ing target
- browser check of local /settings/mcp-access desktop/mobile layout