### PR TITLE
[codex] Guard MCP message posts by space membership

### DIFF
--- a/apps/api/src/lib/mcp-tools/human.ts
+++ b/apps/api/src/lib/mcp-tools/human.ts
@@ -59,6 +59,20 @@ async function userCanSeeSpace(ctx: HumanToolContext, spaceId: string): Promise<
   return Boolean(member);
 }
 
+async function userIsSpaceMember(ctx: HumanToolContext, spaceId: string): Promise<boolean> {
+  const [member] = await db
+    .select({ id: spaceMembers.id })
+    .from(spaceMembers)
+    .innerJoin(spaces, eq(spaces.id, spaceMembers.space_id))
+    .where(and(
+      eq(spaceMembers.space_id, spaceId),
+      eq(spaceMembers.user_id, ctx.user_id),
+      eq(spaces.org_id, ctx.org_id),
+    ))
+    .limit(1);
+  return Boolean(member);
+}
+
 async function userCanSeeTask(ctx: HumanToolContext, taskId: string): Promise<boolean> {
   const [row] = await db
     .select({ id: tasks.id })
@@ -925,6 +939,7 @@ export async function humanMessagePost(args: { space_id?: string; content?: stri
   if (!content) return errorResult('message_post requires content');
   return withIdempotency('message_post', args, ctx, async () => {
     if (!(await userCanSeeSpace(ctx, spaceId))) return errorResult('message_post: space not found or not visible to user');
+    if (!(await userIsSpaceMember(ctx, spaceId))) return errorResult('message_post: user is not a member of this space');
     if (args.parent_id) {
       const [parent] = await db
         .select({ id: messages.id, space_id: messages.space_id })

--- a/apps/api/test/oauth-mcp.test.ts
+++ b/apps/api/test/oauth-mcp.test.ts
@@ -40,6 +40,7 @@ const RESTRICTED_TASK_ID = `oauth-mcp-restricted-task-${TEST_ID}`;
 const PRIVATE_EVENT_ID = `oauth-mcp-private-event-${TEST_ID}`;
 const SPACE_ID = `oauth-mcp-space-${TEST_ID}`;
 const MESSAGE_ID = `oauth-mcp-message-${TEST_ID}`;
+const PUBLIC_NONMEMBER_SPACE_ID = `oauth-mcp-public-nonmember-space-${TEST_ID}`;
 const PRIVATE_SPACE_ID = `oauth-mcp-private-space-${TEST_ID}`;
 const PRIVATE_MESSAGE_ID = `oauth-mcp-private-message-${TEST_ID}`;
 const PRIVATE_PROOF = `PRIVATE-OAUTH-MCP-PROOF-${TEST_ID}`;
@@ -71,7 +72,7 @@ async function cleanup() {
     await client.query(`DELETE FROM oauth_clients WHERE client_name LIKE 'OAuth MCP Test%'`);
     await client.query(`DELETE FROM events WHERE org_id = $1`, [ORG_ID]);
     await client.query(`DELETE FROM messages WHERE org_id = $1`, [ORG_ID]);
-    await client.query(`DELETE FROM space_members WHERE space_id IN ($1, $2)`, [SPACE_ID, PRIVATE_SPACE_ID]);
+    await client.query(`DELETE FROM space_members WHERE space_id IN ($1, $2, $3)`, [SPACE_ID, PRIVATE_SPACE_ID, PUBLIC_NONMEMBER_SPACE_ID]);
     await client.query(`DELETE FROM spaces WHERE org_id = $1`, [ORG_ID]);
     await client.query(`DELETE FROM task_comments WHERE org_id = $1`, [ORG_ID]);
     await client.query(`DELETE FROM task_activity WHERE org_id = $1`, [ORG_ID]);
@@ -166,9 +167,19 @@ async function seedWorkspace() {
       [SPACE_ID, ORG_ID, USER_ID],
     );
     await client.query(
+      `INSERT INTO space_members (id, space_id, user_id)
+       VALUES ($1, $2, $3)`,
+      [`oauth-mcp-public-space-member-${TEST_ID}`, SPACE_ID, USER_ID],
+    );
+    await client.query(
       `INSERT INTO messages (id, org_id, space_id, user_id, content)
        VALUES ($1, $2, $3, $4, 'Salsa tasting thread for OAuth MCP contract tests')`,
       [MESSAGE_ID, ORG_ID, SPACE_ID, USER_ID],
+    );
+    await client.query(
+      `INSERT INTO spaces (id, org_id, name, type, created_by)
+       VALUES ($1, $2, 'oauth-mcp-public-nonmember', 'public', $3)`,
+      [PUBLIC_NONMEMBER_SPACE_ID, ORG_ID, OTHER_USER_ID],
     );
     await client.query(
       `INSERT INTO spaces (id, org_id, name, type, created_by)
@@ -596,6 +607,24 @@ test('OAuth task-helper profile can comment on and update visible tasks', async 
   assert.equal(duplicateMessageBody.result.isError, false, JSON.stringify(duplicateMessageBody));
   const duplicateMessage = JSON.parse(duplicateMessageBody.result.content[0].text);
   assert.equal(duplicateMessage.id, postedMessage.id, 'same idempotency key should replay the original message result');
+
+  const nonmemberMessageRes = await jsonPost('/api/mcp/v1', {
+    jsonrpc: '2.0',
+    id: 343,
+    method: 'tools/call',
+    params: {
+      name: 'message_post',
+      arguments: {
+        space_id: PUBLIC_NONMEMBER_SPACE_ID,
+        content: 'This should not post because the user has not joined the public space',
+        idempotency_key: `message-nonmember-${TEST_ID}`,
+      },
+    },
+  }, token.access_token);
+  assert.equal(nonmemberMessageRes.status, 200);
+  const nonmemberMessageBody = (await nonmemberMessageRes.json()) as any;
+  assert.equal(nonmemberMessageBody.result.isError, true, JSON.stringify(nonmemberMessageBody));
+  assert.match(nonmemberMessageBody.result.content[0].text, /not a member/i);
 
   const activityRes = await jsonPost('/api/mcp/v1', {
     jsonrpc: '2.0',


### PR DESCRIPTION
## Summary
- Require human MCP `message_post` callers to be actual members of the target space before inserting a message.
- Keep the existing visibility check, but add a membership guard so personal MCP clients cannot post into public/project-linked spaces the user cannot open through the normal chat route.
- Update the OAuth MCP regression fixture to distinguish a joined public space from a public nonmember space.

## Root Cause
The personal MCP `message_post` tool used `userCanSeeSpace`, which treats public spaces as visible even without a `space_members` row. REST chat reads require `space_members`, so Codex could post a message as Diego into `#marketing` and then Diego could not read that space normally.

## Validation
- `pnpm --filter @deft/api exec tsx --test --test-concurrency=1 --test-force-exit test/oauth-mcp.test.ts`
- `pnpm --filter @deft/api typecheck`

## Notes
The real Codex CLI connector workflow succeeded before this patch and exposed the mismatch. After this lands, demo seed/data should ensure pilot users are members of any spaces where MCP-driven workflows are expected to post.
