### PR TITLE
[codex] Improve self-host reset workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ migration-*.sql
 
 # Ad-hoc scratch test reports
 deft-human-test-results.md
+backups/
 
 # Playwright MCP internal browser state
 .playwright-mcp/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,8 @@ services:
       REDIS_URL: redis://redis:6379
       API_PORT: 3001
       NEXT_PUBLIC_APP_URL: ${NEXT_PUBLIC_APP_URL:-http://localhost:3000}
+      NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://localhost:3001}
+      NEXT_PUBLIC_WS_URL: ${NEXT_PUBLIC_WS_URL:-http://localhost:3001}
     depends_on:
       postgres:
         condition: service_healthy

--- a/docs/self-hosting-vps-domain-https.md
+++ b/docs/self-hosting-vps-domain-https.md
@@ -122,6 +122,54 @@ pnpm selfhost:bootstrap --prod --seed-pilot
 
 Do not use `--seed-pilot` for a real customer workspace.
 
+## 4.1 Fresh Reset On An Existing VPS
+
+If the VPS already has a Deft stack and you want a clean first-signup workspace,
+use the reset command instead of manually dropping schemas or deleting Docker
+volumes. It takes a Postgres backup first, preserves reverse-proxy state, and
+validates the rebuilt app before returning.
+The command rebuilds the Deft, init, doctor, and smoke images before it drops
+the schema, so validation uses the checked-out code instead of a stale image.
+
+Clean internal workspace:
+
+```bash
+pnpm selfhost:reset --prod --platform-only --force --force-production-reset
+```
+
+Clean demo workspace:
+
+```bash
+pnpm selfhost:reset --prod --seed-pilot --force --force-production-reset
+```
+
+If this VPS has an additional local Compose overlay, include it explicitly:
+
+```bash
+pnpm selfhost:reset --prod --compose-file compose.demo.yml --platform-only --force --force-production-reset
+```
+
+Dry-run first when you are unsure which stack will be touched:
+
+```bash
+pnpm selfhost:reset --prod --compose-file compose.demo.yml --platform-only --dry-run
+```
+
+Expected post-reset shape for `--platform-only`:
+
+```text
+orgs=0
+org_members=0
+spaces=0
+projects=0
+tasks=0
+messages=0
+```
+
+`users` may be `1` because the platform seed creates Defty, the internal system
+user. `skills` and `employee_templates` should be non-zero because platform
+bundles are seeded.
+
 ## 5. Verify Browser And OAuth MCP
 
 Open:

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -144,6 +144,64 @@ exercise an authenticated MCP `tools/list` call, set `DEFT_MCP_BEARER_TOKEN` in
 Open `http://localhost:3000`, create the first account, and keep that account as
 the owner/admin seat.
 
+## Fresh Reset For A Pilot Or Internal Workspace
+
+Use `selfhost:reset` when the stack already exists and you want to return it to
+a clean first-user experience. The command takes a Postgres backup by default,
+stops only the app container, drops and recreates the application schema, flushes
+Redis, clears the local uploads volume, runs the supported `init` path, restarts
+the app, and then runs doctor + smoke. It rebuilds the app and tool images before
+the destructive reset so the validation containers match the checked-out code.
+
+Empty internal workspace, ready for the first owner signup:
+
+```bash
+pnpm selfhost:reset --platform-only --force
+```
+
+Fresh Testers Tomatoes/demo workspace:
+
+```bash
+pnpm selfhost:reset --seed-pilot --force
+```
+
+For a public or production-overlay deployment, the command intentionally needs a
+second confirmation flag:
+
+```bash
+pnpm selfhost:reset --prod --platform-only --force --force-production-reset
+```
+
+If your server uses a site-specific Compose overlay, append it after the base
+and production files:
+
+```bash
+pnpm selfhost:reset --prod --compose-file compose.demo.yml --platform-only --force --force-production-reset
+```
+
+Preview the exact plan without touching data:
+
+```bash
+pnpm selfhost:reset --prod --platform-only --dry-run
+```
+
+Take only a backup:
+
+```bash
+pnpm selfhost:backup --prod
+```
+
+Reset safety notes:
+
+- `--force` is required for any real reset.
+- `--force-production-reset` is also required when URLs or overlays look public.
+- Backups are written to `./backups` unless `--backup-dir` is supplied.
+- Use `--skip-build` only when you intentionally want to reuse the existing
+  Docker images.
+- The command never deletes Docker volumes or reverse-proxy state.
+- Use `--keep-redis` or `--keep-uploads` only when you intentionally want stale
+  runtime state or files to survive.
+
 ## Production Overlay
 
 For production, use the overlay that does not publish Postgres or Redis to host
@@ -282,13 +340,32 @@ Persistent data lives in Docker volumes:
 Postgres backup:
 
 ```bash
+pnpm selfhost:backup
+```
+
+The backup command writes a gzip-compressed SQL dump to `./backups`. For the
+production overlay:
+
+```bash
+pnpm selfhost:backup --prod
+```
+
+Raw Docker equivalent:
+
+```bash
 docker compose exec postgres pg_dump -U postgres deft > deft-backup-$(date +%Y%m%d).sql
 ```
 
-Restore:
+Restore from an uncompressed SQL dump:
 
 ```bash
 docker compose exec -T postgres psql -U postgres deft < deft-backup-20260101.sql
+```
+
+Restore from a `.sql.gz` backup:
+
+```bash
+gunzip -c backups/deft-backup-20260101T120000Z.sql.gz | docker compose exec -T postgres psql -U postgres deft
 ```
 
 ## Upgrading

--- a/package.json
+++ b/package.json
@@ -39,9 +39,11 @@
     "pilot:preflight:strict": "tsx scripts/pilot-preflight.ts --strict",
     "pilot:reset": "pnpm db:push-full && pnpm db:seed:pilot && pnpm pilot:preflight",
     "pilot:swarm": "node scripts/pilot-multi-user-swarm.mjs",
+    "selfhost:backup": "tsx scripts/selfhost-backup.ts",
     "selfhost:bootstrap": "tsx scripts/selfhost-bootstrap.ts",
     "selfhost:doctor": "tsx scripts/selfhost-doctor.ts",
     "selfhost:preflight": "tsx scripts/selfhost-doctor.ts",
+    "selfhost:reset": "tsx scripts/selfhost-reset.ts",
     "selfhost:smoke": "tsx scripts/selfhost-smoke.ts",
     "typecheck": "pnpm -r --parallel typecheck"
   },

--- a/scripts/selfhost-backup.ts
+++ b/scripts/selfhost-backup.ts
@@ -1,0 +1,7 @@
+import { main } from './selfhost-reset.ts';
+
+main(['--backup-only', ...process.argv.slice(2)]).catch((err) => {
+  console.error('');
+  console.error('[FAIL]', err instanceof Error ? err.message : err);
+  process.exit(1);
+});

--- a/scripts/selfhost-doctor.ts
+++ b/scripts/selfhost-doctor.ts
@@ -21,6 +21,7 @@ const APP_URL = (
   || (explicitApiUrl && explicitWebUrl ? WEB_URL : process.env.NEXT_PUBLIC_APP_URL)
   || WEB_URL
 ).replace(/\/$/, '');
+const BROWSER_ORIGIN = (process.env.NEXT_PUBLIC_APP_URL || APP_URL).replace(/\/$/, '');
 
 function maskDatabaseUrl(url: string): string {
   return url.replace(/:\/\/([^:]+):([^@]+)@/, '://$1:***@');
@@ -81,7 +82,7 @@ async function checkCors(): Promise<Check> {
   const res = await fetchStatus(`${API_URL}/api/auth/login`, {
     method: 'OPTIONS',
     headers: {
-      Origin: APP_URL,
+      Origin: BROWSER_ORIGIN,
       'Access-Control-Request-Method': 'POST',
       'Access-Control-Request-Headers': 'Content-Type',
     },
@@ -89,9 +90,9 @@ async function checkCors(): Promise<Check> {
   const allowOrigin = res.headers?.get('access-control-allow-origin') ?? '';
   return {
     name: 'Browser API origin',
-    ok: res.status === 204 && allowOrigin === APP_URL,
+    ok: res.status === 204 && allowOrigin === BROWSER_ORIGIN,
     detail: res.status === 204
-      ? `CORS allows ${allowOrigin || '(empty)'}; expected ${APP_URL}`
+      ? `CORS allows ${allowOrigin || '(empty)'}; expected ${BROWSER_ORIGIN}`
       : `OPTIONS returned ${res.status}: ${res.text.slice(0, 160)}`,
   };
 }
@@ -214,6 +215,7 @@ async function main() {
   console.log(`  web: ${WEB_URL}`);
   console.log(`  api: ${API_URL}`);
   console.log(`  app origin: ${APP_URL}`);
+  console.log(`  browser origin: ${BROWSER_ORIGIN}`);
   console.log('');
 
   const checks = [

--- a/scripts/selfhost-reset.test.ts
+++ b/scripts/selfhost-reset.test.ts
@@ -1,0 +1,124 @@
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+
+import {
+  buildResetPlan,
+  composeArgs,
+  isPublicUrl,
+  parseResetArgs,
+  validateResetSafety,
+} from './selfhost-reset.ts';
+
+test('compose args include base, prod, and extra overlays in order', () => {
+  const options = parseResetArgs(['--prod', '--compose-file', 'compose.demo.yml']);
+
+  assert.deepEqual(composeArgs(options), [
+    'compose',
+    '-f',
+    'docker-compose.yml',
+    '-f',
+    'compose.prod.yml',
+    '-f',
+    'compose.demo.yml',
+  ]);
+});
+
+test('reset refuses destructive execution without force', () => {
+  const options = parseResetArgs(['--platform-only']);
+
+  assert.throws(
+    () => validateResetSafety(options, { NEXT_PUBLIC_APP_URL: 'http://localhost:3000' }),
+    /without --force/
+  );
+});
+
+test('public or production-looking targets need explicit production reset confirmation', () => {
+  const options = parseResetArgs(['--prod', '--force']);
+
+  assert.throws(
+    () => validateResetSafety(options, { NEXT_PUBLIC_APP_URL: 'https://demo.deft.ing' }),
+    /--force-production-reset/
+  );
+});
+
+test('dry run can print a public reset plan without force flags', () => {
+  const options = parseResetArgs(['--prod', '--dry-run']);
+
+  assert.doesNotThrow(() => validateResetSafety(options, { NEXT_PUBLIC_APP_URL: 'https://demo.deft.ing' }));
+});
+
+test('platform-only reset uses platform init and skips demo seed', () => {
+  const options = parseResetArgs(['--force']);
+  const plan = buildResetPlan(options);
+  const init = plan.find((step) => step.label.includes('platform seed'));
+
+  assert.ok(init);
+  assert.equal(init?.args.includes('pnpm db:seed:pilot'), false);
+});
+
+test('reset builds current images before destructive steps by default', () => {
+  const options = parseResetArgs(['--force']);
+  const plan = buildResetPlan(options);
+
+  assert.equal(plan[0]?.label, 'Build current app and tool images');
+  assert.deepEqual(plan[0]?.args.slice(-4), ['deft', 'init', 'doctor', 'smoke']);
+});
+
+test('skip-build omits the image build step', () => {
+  const options = parseResetArgs(['--force', '--skip-build']);
+  const plan = buildResetPlan(options);
+
+  assert.notEqual(plan[0]?.label, 'Build current app and tool images');
+});
+
+test('seed-pilot reset uses the pilot seed command', () => {
+  const options = parseResetArgs(['--seed-pilot', '--force']);
+  const plan = buildResetPlan(options);
+  const init = plan.find((step) => step.label.includes('pilot demo'));
+
+  assert.ok(init);
+  assert.ok(init?.args.includes('pnpm db:push-full && pnpm db:seed:pilot'));
+});
+
+test('reset recreates the app container so current env takes effect', () => {
+  const options = parseResetArgs(['--force']);
+  const plan = buildResetPlan(options);
+  const start = plan.find((step) => step.label.includes('Start app'));
+
+  assert.ok(start?.args.includes('--force-recreate'));
+});
+
+test('keep flags omit Redis flush and upload clear steps', () => {
+  const options = parseResetArgs(['--force', '--keep-redis', '--keep-uploads']);
+  const labels = buildResetPlan(options).map((step) => step.label);
+
+  assert.equal(labels.some((label) => label.includes('Redis')), false);
+  assert.equal(labels.some((label) => label.includes('uploads')), false);
+});
+
+test('backup-only has no reset plan', () => {
+  const options = parseResetArgs(['--backup-only']);
+
+  assert.deepEqual(buildResetPlan(options), []);
+});
+
+test('doctor and smoke receive runtime public URL overrides', () => {
+  const options = parseResetArgs(['--force']);
+  const plan = buildResetPlan(options, {
+    NEXT_PUBLIC_APP_URL: 'http://localhost:3090',
+    NEXT_PUBLIC_API_URL: 'http://localhost:3091',
+    NEXT_PUBLIC_WS_URL: 'http://localhost:3091',
+  });
+  const doctor = plan.find((step) => step.label.includes('doctor'));
+  const smoke = plan.find((step) => step.label.includes('smoke'));
+
+  assert.ok(doctor?.args.includes('NEXT_PUBLIC_APP_URL=http://localhost:3090'));
+  assert.ok(doctor?.args.includes('NEXT_PUBLIC_API_URL=http://localhost:3091'));
+  assert.ok(smoke?.args.includes('NEXT_PUBLIC_WS_URL=http://localhost:3091'));
+});
+
+test('public URL detection ignores localhost', () => {
+  assert.equal(isPublicUrl('http://localhost:3000'), false);
+  assert.equal(isPublicUrl('http://127.0.0.1:3000'), false);
+  assert.equal(isPublicUrl('https://demo.deft.ing'), true);
+});

--- a/scripts/selfhost-reset.ts
+++ b/scripts/selfhost-reset.ts
@@ -1,0 +1,450 @@
+import { spawn } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync } from 'node:fs';
+import { createWriteStream } from 'node:fs';
+import { basename, resolve } from 'node:path';
+import { pipeline } from 'node:stream/promises';
+import { fileURLToPath, URL } from 'node:url';
+import { createGzip } from 'node:zlib';
+
+type EnvMap = Record<string, string>;
+
+export type ResetMode = 'platform-only' | 'seed-pilot';
+
+export type ResetOptions = {
+  prod: boolean;
+  composeFiles: string[];
+  mode: ResetMode;
+  backup: boolean;
+  backupOnly: boolean;
+  backupDir: string;
+  keepRedis: boolean;
+  keepUploads: boolean;
+  skipBuild: boolean;
+  skipDoctor: boolean;
+  skipSmoke: boolean;
+  dryRun: boolean;
+  force: boolean;
+  forceProductionReset: boolean;
+};
+
+type CommandStep = {
+  label: string;
+  command: string;
+  args: string[];
+};
+
+const DEFAULT_BACKUP_DIR = 'backups';
+const ROW_COUNT_SQL = `
+SELECT 'orgs=' || count(*) FROM orgs
+UNION ALL SELECT 'users=' || count(*) FROM users
+UNION ALL SELECT 'org_members=' || count(*) FROM org_members
+UNION ALL SELECT 'spaces=' || count(*) FROM spaces
+UNION ALL SELECT 'projects=' || count(*) FROM projects
+UNION ALL SELECT 'tasks=' || count(*) FROM tasks
+UNION ALL SELECT 'messages=' || count(*) FROM messages
+UNION ALL SELECT 'skills=' || count(*) FROM skills
+UNION ALL SELECT 'employee_templates=' || count(*) FROM agent_employee_templates;
+`.trim();
+
+export function parseResetArgs(argv: string[]): ResetOptions {
+  const options: ResetOptions = {
+    prod: false,
+    composeFiles: [],
+    mode: 'platform-only',
+    backup: true,
+    backupOnly: false,
+    backupDir: DEFAULT_BACKUP_DIR,
+    keepRedis: false,
+    keepUploads: false,
+    skipBuild: false,
+    skipDoctor: false,
+    skipSmoke: false,
+    dryRun: false,
+    force: false,
+    forceProductionReset: false,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    switch (arg) {
+      case '--prod':
+        options.prod = true;
+        break;
+      case '--compose-file':
+      case '-f': {
+        const value = argv[i + 1];
+        if (!value) throw new Error(`${arg} requires a file path.`);
+        options.composeFiles.push(value);
+        i += 1;
+        break;
+      }
+      case '--seed-pilot':
+      case '--demo':
+        options.mode = 'seed-pilot';
+        break;
+      case '--platform-only':
+        options.mode = 'platform-only';
+        break;
+      case '--backup':
+        options.backup = true;
+        break;
+      case '--no-backup':
+        options.backup = false;
+        break;
+      case '--backup-only':
+        options.backupOnly = true;
+        options.backup = true;
+        break;
+      case '--backup-dir': {
+        const value = argv[i + 1];
+        if (!value) throw new Error('--backup-dir requires a directory path.');
+        options.backupDir = value;
+        i += 1;
+        break;
+      }
+      case '--keep-redis':
+        options.keepRedis = true;
+        break;
+      case '--keep-uploads':
+        options.keepUploads = true;
+        break;
+      case '--skip-build':
+        options.skipBuild = true;
+        break;
+      case '--skip-doctor':
+        options.skipDoctor = true;
+        break;
+      case '--skip-smoke':
+        options.skipSmoke = true;
+        break;
+      case '--dry-run':
+      case '--check-only':
+        options.dryRun = true;
+        break;
+      case '--force':
+        options.force = true;
+        break;
+      case '--force-production-reset':
+        options.forceProductionReset = true;
+        break;
+      case '--help':
+      case '-h':
+        printHelp();
+        process.exit(0);
+      default:
+        throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+
+  return options;
+}
+
+export function parseEnvFile(path = '.env'): EnvMap {
+  const env: EnvMap = {};
+  if (!existsSync(path)) return env;
+  const content = readFileSync(path, 'utf8');
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) continue;
+    const equals = line.indexOf('=');
+    if (equals === -1) continue;
+    const key = line.slice(0, equals).trim();
+    let value = line.slice(equals + 1).trim();
+    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+      value = value.slice(1, -1);
+    }
+    env[key] = value;
+  }
+  return env;
+}
+
+export function loadRuntimeEnv(path = '.env'): EnvMap {
+  return { ...parseEnvFile(path), ...(process.env as EnvMap) };
+}
+
+export function composeArgs(options: ResetOptions): string[] {
+  const files = ['docker-compose.yml'];
+  if (options.prod) files.push('compose.prod.yml');
+  files.push(...options.composeFiles);
+  return ['compose', ...files.flatMap((file) => ['-f', file])];
+}
+
+export function isPublicUrl(value: string | undefined): boolean {
+  if (!value) return false;
+  try {
+    const url = new URL(value);
+    return !['localhost', '127.0.0.1', '::1'].includes(url.hostname);
+  } catch {
+    return false;
+  }
+}
+
+export function validateResetSafety(options: ResetOptions, env: EnvMap) {
+  if (options.backupOnly || options.dryRun) return;
+  if (!options.force) {
+    throw new Error('Refusing to reset without --force. This drops the public schema and clears runtime data.');
+  }
+
+  const looksProduction =
+    options.prod ||
+    env.NODE_ENV === 'production' ||
+    isPublicUrl(env.NEXT_PUBLIC_APP_URL) ||
+    isPublicUrl(env.NEXT_PUBLIC_API_URL) ||
+    isPublicUrl(env.DEFT_PUBLIC_URL);
+
+  if (looksProduction && !options.forceProductionReset) {
+    throw new Error(
+      'This looks like a production or public deployment. Add --force-production-reset after taking a backup and confirming the target.'
+    );
+  }
+}
+
+function toolEnvArgs(env: EnvMap): string[] {
+  const keys = ['NEXT_PUBLIC_APP_URL', 'NEXT_PUBLIC_API_URL', 'NEXT_PUBLIC_WS_URL', 'DEFT_PUBLIC_URL'];
+  return keys.flatMap((key) => (env[key] ? ['-e', `${key}=${env[key]}`] : []));
+}
+
+export function buildResetPlan(options: ResetOptions, env: EnvMap = {}): CommandStep[] {
+  const compose = composeArgs(options);
+  const toolEnv = toolEnvArgs(env);
+  const steps: CommandStep[] = [];
+
+  if (options.backupOnly) return steps;
+
+  if (!options.skipBuild) {
+    steps.push({
+      label: 'Build current app and tool images',
+      command: 'docker',
+      args: [...compose, 'build', 'deft', 'init', 'doctor', 'smoke'],
+    });
+  }
+
+  steps.push({
+    label: 'Stop app container',
+    command: 'docker',
+    args: [...compose, 'stop', 'deft'],
+  });
+  steps.push({
+    label: 'Drop and recreate public schema',
+    command: 'docker',
+    args: [
+      ...compose,
+      'exec',
+      '-T',
+      'postgres',
+      'psql',
+      '-U',
+      'postgres',
+      '-d',
+      'deft',
+      '-v',
+      'ON_ERROR_STOP=1',
+      '-c',
+      'DROP SCHEMA IF EXISTS public CASCADE; CREATE SCHEMA public; GRANT ALL ON SCHEMA public TO postgres; GRANT ALL ON SCHEMA public TO public; CREATE EXTENSION IF NOT EXISTS vector;',
+    ],
+  });
+
+  if (!options.keepRedis) {
+    steps.push({
+      label: 'Flush Redis runtime state',
+      command: 'docker',
+      args: [...compose, 'exec', '-T', 'redis', 'redis-cli', 'FLUSHALL'],
+    });
+  }
+
+  if (!options.keepUploads) {
+    steps.push({
+      label: 'Clear local uploads volume',
+      command: 'docker',
+      args: [
+        ...compose,
+        'run',
+        '--rm',
+        '--entrypoint',
+        'sh',
+        'deft',
+        '-lc',
+        'rm -rf /app/uploads/* /app/uploads/.[!.]* /app/uploads/..?* 2>/dev/null || true',
+      ],
+    });
+  }
+
+  if (options.mode === 'seed-pilot') {
+    steps.push({
+      label: 'Initialize schema and seed pilot demo workspace',
+      command: 'docker',
+      args: [...compose, 'run', '--rm', 'init', 'sh', '-c', 'pnpm db:push-full && pnpm db:seed:pilot'],
+    });
+  } else {
+    steps.push({
+      label: 'Initialize schema and platform seed only',
+      command: 'docker',
+      args: [...compose, 'run', '--rm', 'init'],
+    });
+  }
+
+  steps.push({
+    label: 'Start app container with current environment',
+    command: 'docker',
+    args: [...compose, 'up', '-d', '--force-recreate', 'deft'],
+  });
+
+  if (!options.skipDoctor) {
+    steps.push({
+      label: 'Run self-host doctor',
+      command: 'docker',
+      args: [...compose, 'run', '--rm', ...toolEnv, 'doctor'],
+    });
+  }
+
+  if (!options.skipSmoke) {
+    steps.push({
+      label: 'Run self-host smoke test',
+      command: 'docker',
+      args: [...compose, 'run', '--rm', ...toolEnv, 'smoke'],
+    });
+  }
+
+  steps.push({
+    label: 'Print post-reset row counts',
+    command: 'docker',
+    args: [...compose, 'exec', '-T', 'postgres', 'psql', '-U', 'postgres', '-d', 'deft', '-At', '-c', ROW_COUNT_SQL],
+  });
+
+  return steps;
+}
+
+function printHelp() {
+  console.log(`Deft self-host reset
+
+Usage:
+  pnpm selfhost:reset --platform-only --force
+  pnpm selfhost:reset --prod --compose-file compose.demo.yml --platform-only --force --force-production-reset
+  pnpm selfhost:reset --seed-pilot --force
+  pnpm selfhost:backup --prod
+
+Options:
+  --platform-only              Fresh empty workspace plus platform bundles (default)
+  --seed-pilot, --demo          Fresh Testers Tomatoes/demo workspace
+  --prod                       Include compose.prod.yml
+  --compose-file, -f <file>     Append an additional Compose overlay
+  --backup / --no-backup        Take or skip pg_dump before reset (default: backup)
+  --backup-only                 Only write a backup; do not reset
+  --backup-dir <dir>            Backup output directory (default: backups)
+  --keep-redis                  Do not flush Redis
+  --keep-uploads                Do not clear local uploads
+  --skip-build                  Do not rebuild app/tool images before reset
+  --skip-doctor                 Skip docker compose run --rm doctor
+  --skip-smoke                  Skip docker compose run --rm smoke
+  --dry-run, --check-only       Print the plan without executing
+  --force                      Required for any real reset
+  --force-production-reset      Required when target looks public/production
+`);
+}
+
+function commandLine(command: string, args: string[]) {
+  return [command, ...args].map((part) => (part.includes(' ') ? `"${part}"` : part)).join(' ');
+}
+
+async function runStep(step: CommandStep, dryRun: boolean) {
+  console.log('');
+  console.log(`[STEP] ${step.label}`);
+  console.log(`[RUN] ${commandLine(step.command, step.args)}`);
+  if (dryRun) return;
+  await new Promise<void>((resolveStep, reject) => {
+    const child = spawn(step.command, step.args, { stdio: 'inherit' });
+    child.on('error', reject);
+    child.on('exit', (code) => {
+      if (code === 0) resolveStep();
+      else reject(new Error(`${commandLine(step.command, step.args)} exited with ${code}`));
+    });
+  });
+}
+
+async function writeBackup(options: ResetOptions) {
+  const backupDir = resolve(options.backupDir);
+  const stamp = new Date().toISOString().replace(/[-:]/g, '').replace(/\.\d+Z$/, 'Z');
+  const backupPath = resolve(backupDir, `deft-backup-${stamp}.sql.gz`);
+  const args = [...composeArgs(options), 'exec', '-T', 'postgres', 'pg_dump', '-U', 'postgres', 'deft'];
+
+  console.log('');
+  console.log('[STEP] Backup Postgres');
+  console.log(`[OUT] ${backupPath}`);
+  console.log(`[RUN] ${commandLine('docker', args)} | gzip > ${backupPath}`);
+  if (options.dryRun) return backupPath;
+
+  mkdirSync(backupDir, { recursive: true });
+  await new Promise<void>((resolveBackup, reject) => {
+    const child = spawn('docker', args, { stdio: ['ignore', 'pipe', 'inherit'] });
+    const gzip = createGzip({ level: 9 });
+    const out = createWriteStream(backupPath);
+    const streamDone = pipeline(child.stdout, gzip, out);
+    const processDone = new Promise<void>((resolveProcess, rejectProcess) => {
+      child.on('error', rejectProcess);
+      child.on('exit', (code) => {
+        if (code === 0) resolveProcess();
+        else rejectProcess(new Error(`Backup command exited with ${code}`));
+      });
+    });
+    Promise.all([streamDone, processDone]).then(() => resolveBackup(), reject);
+  });
+
+  return backupPath;
+}
+
+function printTarget(options: ResetOptions, env: EnvMap) {
+  const urls = [env.NEXT_PUBLIC_APP_URL, env.NEXT_PUBLIC_API_URL, env.NEXT_PUBLIC_WS_URL].filter(Boolean);
+  console.log(options.backupOnly ? 'Deft self-host backup' : 'Deft self-host reset');
+  console.log(`  compose: ${composeArgs(options).slice(1).join(' ')}`);
+  console.log(`  mode: ${options.backupOnly ? 'backup only' : options.mode}`);
+  console.log(`  backup: ${options.backup ? options.backupDir : 'disabled'}`);
+  if (!options.backupOnly) {
+    console.log(`  build: ${options.skipBuild ? 'skipped' : 'current images before reset'}`);
+    console.log(`  redis: ${options.keepRedis ? 'kept' : 'flushed'}`);
+    console.log(`  uploads: ${options.keepUploads ? 'kept' : 'cleared'}`);
+    console.log(`  validation: doctor=${options.skipDoctor ? 'skipped' : 'on'}, smoke=${options.skipSmoke ? 'skipped' : 'on'}`);
+  }
+  console.log(`  execute: ${options.dryRun ? 'dry run' : 'yes'}`);
+  if (urls.length > 0) console.log(`  urls: ${urls.join(', ')}`);
+}
+
+export async function main(argv = process.argv.slice(2)) {
+  const options = parseResetArgs(argv);
+  const env = loadRuntimeEnv('.env');
+  printTarget(options, env);
+  validateResetSafety(options, env);
+
+  if (options.backup) {
+    const backupPath = await writeBackup(options);
+    console.log(`[OK] Backup ${options.dryRun ? 'planned' : 'written'}: ${backupPath}`);
+  }
+
+  for (const step of buildResetPlan(options, env)) {
+    await runStep(step, options.dryRun);
+  }
+
+  if (options.backupOnly) {
+    console.log('');
+    console.log('[OK] Backup complete.');
+    return;
+  }
+
+  const appUrl = env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
+  console.log('');
+  console.log(`[OK] Reset complete. Open ${appUrl}/signup to create the owner account.`);
+}
+
+const invokedPath = process.argv[1] ? resolve(process.argv[1]) : '';
+if (invokedPath && fileURLToPath(import.meta.url) === invokedPath) {
+  main().catch((err) => {
+    console.error('');
+    console.error('[FAIL]', err instanceof Error ? err.message : err);
+    process.exit(1);
+  });
+}
+
+export const __test = {
+  ROW_COUNT_SQL,
+  commandLine,
+  backupBasename: (path: string) => basename(path),
+};

--- a/scripts/selfhost-smoke.ts
+++ b/scripts/selfhost-smoke.ts
@@ -10,7 +10,9 @@ type Check = {
 };
 
 const API_URL = (process.env.DEFT_API_URL || process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001').replace(/\/$/, '');
+const PUBLIC_API_URL = (process.env.DEFT_PUBLIC_URL || process.env.NEXT_PUBLIC_API_URL || API_URL).replace(/\/$/, '');
 const MCP_URL = `${API_URL}/api/mcp/v1`;
+const PUBLIC_MCP_URL = `${PUBLIC_API_URL}/api/mcp/v1`;
 const CLIENT_NAME = process.env.DEFT_SMOKE_CLIENT_NAME || `Deft self-host smoke ${new Date().toISOString()}`;
 const REDIRECT_URI = process.env.DEFT_SMOKE_REDIRECT_URI || 'http://localhost:3999/callback';
 const REQUESTED_SCOPE = process.env.DEFT_SMOKE_SCOPE || 'read:workspace read:wiki read:tasks read:messages read:calendar';
@@ -53,15 +55,15 @@ async function checkProtectedResource(): Promise<Check> {
   const res = await fetchJson(`${API_URL}/.well-known/oauth-protected-resource`);
   const body = res.json as any;
   const ok = res.status === 200
-    && body?.resource === MCP_URL
+    && body?.resource === PUBLIC_MCP_URL
     && Array.isArray(body?.authorization_servers)
-    && body.authorization_servers.includes(API_URL);
+    && body.authorization_servers.includes(PUBLIC_API_URL);
   return {
     name: 'OAuth protected resource metadata',
     ok,
     detail: ok
       ? `resource=${body.resource}; issuer=${body.authorization_servers[0]}`
-      : `expected resource ${MCP_URL} and issuer ${API_URL}; got ${res.status}: ${res.text.slice(0, 180)}`,
+      : `expected resource ${PUBLIC_MCP_URL} and issuer ${PUBLIC_API_URL}; got ${res.status}: ${res.text.slice(0, 180)}`,
   };
 }
 
@@ -69,9 +71,9 @@ async function checkAuthorizationServer(): Promise<Check> {
   const res = await fetchJson(`${API_URL}/.well-known/oauth-authorization-server`);
   const body = res.json as any;
   const ok = res.status === 200
-    && body?.issuer === API_URL
-    && body?.token_endpoint === `${API_URL}/oauth/token`
-    && body?.registration_endpoint === `${API_URL}/oauth/register`
+    && body?.issuer === PUBLIC_API_URL
+    && body?.token_endpoint === `${PUBLIC_API_URL}/oauth/token`
+    && body?.registration_endpoint === `${PUBLIC_API_URL}/oauth/register`
     && Array.isArray(body?.code_challenge_methods_supported)
     && body.code_challenge_methods_supported.includes('S256');
   return {
@@ -126,7 +128,7 @@ async function checkProtectedToolsList(): Promise<Check> {
     body: JSON.stringify({ jsonrpc: '2.0', id: 'smoke-tools-denied', method: 'tools/list', params: {} }),
   });
   const challenge = res.headers?.get('www-authenticate') ?? '';
-  const metadataUrl = `${API_URL}/.well-known/oauth-protected-resource`;
+  const metadataUrl = `${PUBLIC_API_URL}/.well-known/oauth-protected-resource`;
   const ok = res.status === 401 && challenge.includes('Bearer') && challenge.includes(metadataUrl);
   return {
     name: 'MCP protected tools/list',
@@ -166,6 +168,7 @@ async function checkOptionalBearerToolsList(): Promise<Check> {
 async function main() {
   console.log('Deft self-host smoke');
   console.log(`  api: ${API_URL}`);
+  console.log(`  public api: ${PUBLIC_API_URL}`);
   console.log(`  mcp: ${MCP_URL}`);
   console.log(`  authenticated tools/list: ${REQUIRE_AUTH ? 'required' : 'optional'}`);
   console.log('');


### PR DESCRIPTION
﻿## Summary

Adds a first-class self-host reset/backup operator flow for fresh internal pilots and demo installs.

## What changed

- Added `pnpm selfhost:reset` with guarded destructive reset flow:
  - backup first by default
  - builds current app/tool images before touching data
  - requires `--force`, plus `--force-production-reset` for public/prod-looking targets
  - supports `--platform-only` and `--seed-pilot`
  - clears Redis and local uploads unless explicitly kept
  - runs init, doctor, smoke, and row-count proof after reset
- Added `pnpm selfhost:backup` for compressed Postgres dumps.
- Fixed Docker runtime env passthrough for `NEXT_PUBLIC_API_URL` and `NEXT_PUBLIC_WS_URL`.
- Fixed self-host doctor/smoke to distinguish internal container targets from public browser/OAuth metadata URLs.
- Updated self-host and VPS docs with reset/backup recipes.

## Validation

- `pnpm exec tsx --test scripts/selfhost-reset.test.ts` -> 13/13 passing.
- Created disposable Compose stack with isolated project/ports:
  - `COMPOSE_PROJECT_NAME=deft_reset_pr`
  - web `3090`, api `3091`, postgres `55433`, redis `56380`
- Seeded the disposable stack with pilot/demo data.
- Ran real backup with `pnpm selfhost:backup` against populated data.
- Ran real destructive reset:
  - `pnpm selfhost:reset --platform-only --force --backup-dir backups/reset-pr-reset-proof-final-3`
- Reset proof passed:
  - backup written
  - images rebuilt
  - schema reset
  - Redis flushed
  - uploads cleared
  - platform init succeeded
  - doctor passed
  - smoke passed
  - post-reset row counts: `orgs=0`, `users=1`, `org_members=0`, `spaces=0`, `projects=0`, `tasks=0`, `messages=0`, `skills=4`, `employee_templates=9`
- Cleaned up disposable Compose stack with `docker compose down -v --remove-orphans`.

## Notes

Opened as draft because this is an operational workflow PR, but the local validation is complete.
