### PR TITLE
[codex] fix dashboard mobile scrolling

### DIFF
--- a/apps/web/src/app/(app)/dashboard/page.tsx
+++ b/apps/web/src/app/(app)/dashboard/page.tsx
@@ -376,15 +376,6 @@ function DashboardBody() {
   const [standupGenerating, setStandupGenerating] = useState(false);
   const [editMode, setEditMode] = useState(false);
   const [addOpen, setAddOpen] = useState(false);
-  // Mobile-deep P2-8: inner-scroll container breaks iOS Safari URL-bar
-  // auto-hide, pull-to-refresh, and scroll-to-top. Use body scroll on <md.
-  const [isMobile, setIsMobile] = useState(false);
-  useEffect(() => {
-    const check = () => setIsMobile(window.innerWidth < 768);
-    check();
-    window.addEventListener('resize', check);
-    return () => window.removeEventListener('resize', check);
-  }, []);
 
   const isManager = user?.role === 'owner' || user?.role === 'admin';
   const { layout, setLayout, reset } = useLayoutStorage(user?.id, isManager);
@@ -469,9 +460,14 @@ function DashboardBody() {
 
   return (
     <div style={{
-      // On <md: let the body scroll naturally (no height constraint, no overflowY).
-      // On md+: use inner-scroll so the fixed sidebar layout stays intact.
-      ...(isMobile ? {} : { height: '100%', overflowY: 'auto' as const }),
+      // The app shell owns the viewport and clips body overflow, so the
+      // dashboard must provide its own scroll area on mobile and desktop.
+      height: '100%',
+      minHeight: 0,
+      overflowX: 'hidden',
+      overflowY: 'auto',
+      WebkitOverflowScrolling: 'touch',
+      touchAction: 'pan-y',
       background: 'var(--bg-primary)',
       color: 'var(--text-primary)',
     }}>


### PR DESCRIPTION
## What changed
- Makes the dashboard page own its vertical scroll container on mobile and desktop.
- Removes the stale mobile resize workaround that assumed body-level scrolling.

## Why
The app shell uses a fixed viewport with hidden overflow. On mobile Chrome, the dashboard mobile path was relying on body scrolling, so there was no scrollable parent and the lower dashboard content was unreachable.

## Validation
- `pnpm --filter @deft/web typecheck`
- Mobile viewport check at 390x844 against local `/dashboard`: scroll container reports `overflowY: auto`, `scrollHeight > clientHeight`, and scrollTop advances from `0` to `600`.
