### PR TITLE
[codex] fix settings page scroll containers

### DIFF
--- a/apps/web/src/app/(app)/settings/agent-employees/[id]/developer/page.tsx
+++ b/apps/web/src/app/(app)/settings/agent-employees/[id]/developer/page.tsx
@@ -218,6 +218,7 @@ export default function DeveloperPage() {
   );
 
   return (
+    <div className="h-full min-h-0 overflow-y-auto overflow-x-hidden">
     <div className="mx-auto max-w-4xl p-6">
       <div className="mb-4">
         <button
@@ -440,6 +441,7 @@ export default function DeveloperPage() {
           }))}
         />
       </section>
+    </div>
     </div>
   );
 }

--- a/apps/web/src/app/(app)/settings/agent-employees/[id]/webhooks/page.tsx
+++ b/apps/web/src/app/(app)/settings/agent-employees/[id]/webhooks/page.tsx
@@ -96,6 +96,7 @@ export default function WebhooksPage() {
   };
 
   return (
+    <div className="h-full min-h-0 overflow-y-auto overflow-x-hidden">
     <div className="mx-auto max-w-4xl p-6">
       <div className="mb-4">
         <button
@@ -214,6 +215,7 @@ export default function WebhooksPage() {
           </div>
         )}
       </section>
+    </div>
     </div>
   );
 }

--- a/apps/web/src/app/(app)/settings/projects/page.tsx
+++ b/apps/web/src/app/(app)/settings/projects/page.tsx
@@ -63,6 +63,7 @@ export default function ProjectsRecoveryPage() {
   };
 
   return (
+    <div className="h-full min-h-0 overflow-y-auto overflow-x-hidden">
     <div className="max-w-3xl">
       <div className="mb-6">
         <h1 className="text-[20px] font-semibold" style={{ color: 'var(--foreground)', fontFamily: 'var(--font-heading)' }}>
@@ -129,6 +130,7 @@ export default function ProjectsRecoveryPage() {
           ))}
         </div>
       )}
+    </div>
     </div>
   );
 }


### PR DESCRIPTION
## What changed
- Adds explicit full-height scroll containers to long settings leaf pages:
  - Agent employee developer credentials
  - Agent employee webhooks
  - Deleted projects recovery

## Why
The app shell owns the viewport and clips body overflow. Pages that render long content must provide their own `h-full min-h-0 overflow-y-auto` scroll frame. These settings leaves were relying on body scroll, so their lower content could become unreachable on mobile Chrome and other constrained viewports.

## Sweep notes
- Rechecked protected settings pages for scroll ownership.
- Redirect-only routes are false positives.
- Split-pane pages such as settings library already own internal scroll with `h-full overflow-hidden` plus child `overflow-y-auto` panels.

## Validation
- `pnpm --filter @deft/web typecheck`
- Static settings route sweep: no remaining non-redirect settings page without a scroll owner/internal scroll frame.
