### PR TITLE
[codex] Fix pilot inbox stabilization

### DIFF
--- a/apps/api/src/routes/agent.ts
+++ b/apps/api/src/routes/agent.ts
@@ -1042,7 +1042,23 @@ agentRoutes.post('/actions/:id/approve', async (c) => {
     });
   }
 
-  return c.json({ ...execResult, executed_at: new Date().toISOString() });
+  const legacyResultBody = {
+    ...execResult,
+    executed_at: new Date().toISOString(),
+  };
+
+  if (!execResult.success) {
+    return c.json(
+      {
+        ...legacyResultBody,
+        error: execResult.error ?? 'Action failed',
+        code: 'EXECUTE_FAILED',
+      },
+      500,
+    );
+  }
+
+  return c.json(legacyResultBody);
 });
 
 agentRoutes.post('/actions/:id/reject', async (c) => {

--- a/apps/api/src/scripts/seed-pilot-workspace.ts
+++ b/apps/api/src/scripts/seed-pilot-workspace.ts
@@ -14,6 +14,8 @@ import bcrypt from 'bcryptjs';
 import { and, eq, gte, inArray, lt } from 'drizzle-orm';
 import { db } from '../lib/db.js';
 import {
+  actionReceipts,
+  agentActions,
   agentEmployees,
   events,
   messages,
@@ -27,6 +29,7 @@ import {
   spaceMembers,
   spaces,
   standups,
+  taskActivity,
   taskComments,
   tasks,
   teamHealthSnapshots,
@@ -38,6 +41,12 @@ import {
 const TOM_TOKEN = process.env.SEED_TOM_MCP_TOKEN ?? 'tom-pilot-mcp-token-2026';
 const MAYA_TOKEN = process.env.SEED_MAYA_MCP_TOKEN ?? 'maya-pilot-mcp-token-2026';
 const PROOF_PHRASE = 'ruby-sunrise-2026';
+const PILOT_ACTION_SOURCES_TO_PRUNE = [
+  'pilot-living',
+  'task_extract',
+  'blocked_classifier',
+  'defty_capture',
+];
 
 type SeedUser = typeof users.$inferSelect;
 type SeedSpace = typeof spaces.$inferSelect;
@@ -1044,6 +1053,26 @@ async function cleanReadState(orgId: string) {
   await db.update(notifications).set({ is_read: true }).where(eq(notifications.org_id, orgId));
 }
 
+async function cleanPilotActionNoise(orgId: string) {
+  const staleActions = await db
+    .select({ id: agentActions.id })
+    .from(agentActions)
+    .where(and(
+      eq(agentActions.org_id, orgId),
+      inArray(agentActions.source, PILOT_ACTION_SOURCES_TO_PRUNE),
+    ));
+  const staleActionIds = staleActions.map((action) => action.id);
+  if (staleActionIds.length === 0) return;
+
+  await db
+    .update(taskActivity)
+    .set({ agent_action_id: null })
+    .where(inArray(taskActivity.agent_action_id, staleActionIds));
+  await db.delete(actionReceipts).where(inArray(actionReceipts.action_id, staleActionIds));
+  await db.delete(agentActions).where(inArray(agentActions.id, staleActionIds));
+  console.log(`[seed-pilot-workspace] pruned ${staleActionIds.length} stale pilot/capture action rows`);
+}
+
 export async function seedPilotWorkspace(): Promise<{
   orgId: string;
   tomToken: string;
@@ -1158,6 +1187,7 @@ export async function seedPilotWorkspace(): Promise<{
     tom,
     maya,
   });
+  await cleanPilotActionNoise(org.id);
   await cleanReadState(org.id);
 
   console.log('[seed-pilot-workspace] done');

--- a/apps/api/test/agent-actions-routes.test.ts
+++ b/apps/api/test/agent-actions-routes.test.ts
@@ -26,6 +26,7 @@ const APPROVER_EMAIL = 'actions-routes-approver@test.local';
 
 let TEST_PROJECT_ID: string | null = null;
 let testApp: Hono | null = null;
+let createdTestOrg = false;
 
 async function withClient<T>(fn: (c: pg.Client) => Promise<T>): Promise<T> {
   const c = new pg.Client({ connectionString: DATABASE_URL });
@@ -39,6 +40,15 @@ async function withClient<T>(fn: (c: pg.Client) => Promise<T>): Promise<T> {
 
 async function seedFixtures() {
   await withClient(async (c) => {
+    const org = await c.query(
+      `INSERT INTO orgs (id, name, slug)
+       VALUES ($1, 'Actions Routes Test Org', 'actions-routes-test-org')
+       ON CONFLICT (id) DO NOTHING
+       RETURNING id`,
+      [ORG_ID],
+    );
+    createdTestOrg = org.rows.length > 0;
+
     await c.query(
       `INSERT INTO users (id, email, name, is_agent)
        VALUES ($1, 'actions-routes-shadow@test.local', 'Actions Shadow', true)
@@ -133,6 +143,12 @@ async function teardownFixtures() {
       `DELETE FROM users WHERE id IN ($1, $2)`,
       [SHADOW_USER_ID, APPROVER_USER_ID],
     );
+    if (createdTestOrg) {
+      await c.query(
+        `DELETE FROM orgs WHERE id = $1 AND slug = 'actions-routes-test-org'`,
+        [ORG_ID],
+      );
+    }
   });
 }
 
@@ -153,6 +169,27 @@ async function insertPendingTaskCreate(title: string): Promise<string> {
           title,
           project_id: TEST_PROJECT_ID,
           priority: 'p2',
+        }),
+      ],
+    );
+    return r.rows[0].id as string;
+  });
+}
+
+async function insertLegacyCreateTaskWithoutProject(title: string): Promise<string> {
+  return withClient(async (c) => {
+    const r = await c.query(
+      `INSERT INTO agent_actions
+        (id, org_id, user_id, source, action, params,
+         approval_tier, approval_status)
+       VALUES (gen_random_uuid()::text, $1, $2, 'blocked_classifier', 'create_task', $3::jsonb, 'quick', 'pending')
+       RETURNING id`,
+      [
+        ORG_ID,
+        SHADOW_USER_ID,
+        JSON.stringify({
+          title,
+          description: 'Legacy create_task rows need a resolvable project_name.',
         }),
       ],
     );
@@ -230,6 +267,33 @@ test('POST /api/agent/actions/:id/approve executes the write', async () => {
 
     const t = await c.query(`SELECT title FROM tasks WHERE title = $1`, [title]);
     assert.equal(t.rows.length, 1);
+  });
+});
+
+test('POST approve on failed legacy action returns non-2xx and leaves it pending', async () => {
+  const title = `routes-legacy-fail-${Date.now()}`;
+  const actionId = await insertLegacyCreateTaskWithoutProject(title);
+
+  const res = await app().request(`/api/agent/actions/${actionId}/approve`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({}),
+  });
+  assert.equal(res.status, 500);
+  const body = await res.json();
+  assert.equal(body.code, 'EXECUTE_FAILED');
+  assert.equal(body.success, false);
+
+  await withClient(async (c) => {
+    const r = await c.query(
+      `SELECT approval_status, error FROM agent_actions WHERE id = $1`,
+      [actionId],
+    );
+    assert.equal(r.rows[0].approval_status, 'pending');
+    assert.equal(r.rows[0].error, 'Project not found');
+
+    const t = await c.query(`SELECT id FROM tasks WHERE title = $1`, [title]);
+    assert.equal(t.rows.length, 0, 'failed legacy approve must not create a task');
   });
 });
 

--- a/apps/web/src/app/(app)/inbox/page.tsx
+++ b/apps/web/src/app/(app)/inbox/page.tsx
@@ -67,8 +67,8 @@ export default function InboxPage() {
   );
 
   return (
-    <div className="flex-1 overflow-y-auto">
-      <div className="max-w-[760px] mx-auto px-6 py-8">
+    <div className="h-full min-h-0 overflow-y-auto overflow-x-hidden">
+      <div className="max-w-[760px] mx-auto px-4 py-6 md:px-6 md:py-8">
         <header className="mb-6 flex items-end justify-between">
           <div>
             <h1


### PR DESCRIPTION
﻿## What changed

- Fixed `/inbox` scroll containment by using the same `h-full min-h-0 overflow-y-auto overflow-x-hidden` pattern as the already-fixed settings pages.
- Added pilot seed cleanup for stale automated agent action rows from `pilot-living`, `task_extract`, `blocked_classifier`, and `defty_capture`.
- Changed legacy agent-action approval failures to return HTTP 500 with `EXECUTE_FAILED` instead of a misleading 200.
- Added regression coverage for failed legacy create-task approvals.

## Why

The local pilot inbox could become visually and operationally noisy after repeated demo/swarm runs, and `/inbox` itself was not becoming the scroll container inside the app shell. Separately, failed legacy approval execution looked successful from the API surface because the route returned 200 even when the executor returned `success: false`.

## Validation

- `corepack pnpm --filter @deft/api typecheck`
- `corepack pnpm --filter @deft/web typecheck`
- `corepack pnpm --filter @deft/api exec tsx src/scripts/seed-pilot-workspace.ts`
- `DATABASE_URL=$(from .env) corepack pnpm --filter @deft/api exec tsx --test --test-concurrency=1 --test-force-exit test/agent-actions-routes.test.ts`
- Browser smoke on `http://localhost:3000/inbox`
- Mobile viewport smoke at 390x844 for `/inbox`
