### PR TITLE
Add durable Defty work intent observation

### DIFF
--- a/apps/api/src/lib/chat-observation.ts
+++ b/apps/api/src/lib/chat-observation.ts
@@ -1,0 +1,141 @@
+import { and, eq, sql } from 'drizzle-orm';
+import { jobQueue, messageObservations } from '@deft/db/schema';
+import { db } from './db.js';
+import { toPlainText } from './plain-text.js';
+
+export const CHAT_OBSERVATION_VERSION = 1;
+export const OBSERVE_CHAT_MESSAGE_JOB = 'observe-chat-message';
+
+export function explicitObservationIgnoreReason(content: string): string | null {
+  const plain = toPlainText(content).toLowerCase().replace(/\s+/g, ' ').trim();
+  if (!plain) return 'empty_content';
+
+  if (
+    /\b(no action needed|no action required|no follow up needed|nothing to do)\b/.test(plain) ||
+    /\b(no task|no tasks|not a task|don't create (?:a )?task|dont create (?:a )?task|do not create (?:a )?task)\b/.test(plain) ||
+    /\b(don't save|dont save|do not save|no memory|don't remember|dont remember|do not remember|nothing to capture|nothing to save)\b/.test(plain) ||
+    /\b(ignore this|just thinking aloud|thinking out loud|fyi only|for visibility only)\b/.test(plain)
+  ) {
+    return 'explicit_no_action';
+  }
+
+  const ack = plain.replace(/[.!?]+$/g, '');
+  if (/^(ok|okay|k|thanks|thank you|cool|nice|great|sounds good|got it|noted|roger|yes|no|hi|hey|hello)$/.test(ack)) {
+    return 'low_signal_ack';
+  }
+
+  if (plain.length < 8) return 'low_signal_short';
+  return null;
+}
+
+export async function enqueueChatObservation(params: {
+  orgId: string;
+  messageId: string;
+  spaceId: string;
+  userId: string;
+  observationVersion?: number;
+}): Promise<{ enqueued: boolean; observationId?: string }> {
+  const observationVersion = params.observationVersion ?? CHAT_OBSERVATION_VERSION;
+
+  return db.transaction(async (tx) => {
+    const [observation] = await tx
+      .insert(messageObservations)
+      .values({
+        org_id: params.orgId,
+        message_id: params.messageId,
+        space_id: params.spaceId,
+        user_id: params.userId,
+        observation_version: observationVersion,
+        status: 'queued',
+      })
+      .onConflictDoNothing({
+        target: [messageObservations.message_id, messageObservations.observation_version],
+      })
+      .returning({ id: messageObservations.id });
+
+    if (!observation) {
+      return { enqueued: false };
+    }
+
+    await tx.insert(jobQueue).values({
+      queue: 'agent-jobs',
+      name: OBSERVE_CHAT_MESSAGE_JOB,
+      data: {
+        orgId: params.orgId,
+        messageId: params.messageId,
+        spaceId: params.spaceId,
+        userId: params.userId,
+        observationVersion,
+      },
+      status: 'pending',
+      max_attempts: 5,
+      run_at: new Date(),
+    });
+
+    return { enqueued: true, observationId: observation.id };
+  });
+}
+
+export async function enqueueMissingChatObservations(params: {
+  orgId: string;
+  limit?: number;
+}): Promise<number> {
+  const limit = Math.min(Math.max(params.limit ?? 500, 1), 2000);
+  const rows = await db.execute(sql<{
+    id: string;
+    org_id: string;
+    space_id: string;
+    user_id: string;
+  }>`
+    SELECT m.id, m.org_id, m.space_id, m.user_id
+    FROM messages m
+    LEFT JOIN message_observations mo
+      ON mo.message_id = m.id
+     AND mo.observation_version = ${CHAT_OBSERVATION_VERSION}
+    WHERE m.org_id = ${params.orgId}
+      AND m.is_deleted = false
+      AND mo.id IS NULL
+    ORDER BY m.created_at ASC
+    LIMIT ${limit}
+  `);
+
+  const resultRows = (rows as any).rows ?? rows;
+  let count = 0;
+  for (const row of resultRows) {
+    const result = await enqueueChatObservation({
+      orgId: row.org_id,
+      messageId: row.id,
+      spaceId: row.space_id,
+      userId: row.user_id,
+    });
+    if (result.enqueued) count += 1;
+  }
+  return count;
+}
+
+export async function markObservationFailedFromJobData(params: {
+  data: unknown;
+  retrying: boolean;
+  error: string;
+}): Promise<void> {
+  if (!params.data || typeof params.data !== 'object') return;
+  const data = params.data as Record<string, unknown>;
+  if (typeof data.messageId !== 'string' || typeof data.orgId !== 'string') return;
+  const observationVersion = typeof data.observationVersion === 'number'
+    ? data.observationVersion
+    : CHAT_OBSERVATION_VERSION;
+
+  await db
+    .update(messageObservations)
+    .set({
+      status: params.retrying ? 'retrying' : 'failed',
+      last_error: params.error.slice(0, 2000),
+      completed_at: params.retrying ? null : new Date(),
+      updated_at: new Date(),
+    })
+    .where(and(
+      eq(messageObservations.org_id, data.orgId),
+      eq(messageObservations.message_id, data.messageId),
+      eq(messageObservations.observation_version, observationVersion),
+    ));
+}

--- a/apps/api/src/lib/defty-capture.ts
+++ b/apps/api/src/lib/defty-capture.ts
@@ -110,6 +110,24 @@ function tokenOverlap(a: string, b: string): number {
   return intersection / union;
 }
 
+function distinctiveReferenceTokens(value: string): Set<string> {
+  return new Set(
+    normalizeComparable(value)
+      .split(/\s+/)
+      .filter((token) => token.length >= 4 && /\d/.test(token)),
+  );
+}
+
+function hasMissingDistinctiveReference(candidate: string, existing: string): boolean {
+  const candidateRefs = distinctiveReferenceTokens(candidate);
+  if (candidateRefs.size === 0) return false;
+  const existingRefs = distinctiveReferenceTokens(existing);
+  for (const ref of candidateRefs) {
+    if (!existingRefs.has(ref)) return true;
+  }
+  return false;
+}
+
 function sameNormalizedText(a: string | null | undefined, b: string | null | undefined): boolean {
   const left = normalizeComparable(a ?? '');
   const right = normalizeComparable(b ?? '');
@@ -414,12 +432,16 @@ async function findSimilarActiveTask(params: {
 
   const wantedTitle = normalizeComparable(params.title);
   for (const row of rows) {
+    const existingComparable = `${row.title}\n${row.description ?? ''}`;
+    if (hasMissingDistinctiveReference(`${params.title}\n${params.content}`, existingComparable)) {
+      continue;
+    }
     const existingTitle = normalizeComparable(row.title);
     if (wantedTitle && existingTitle === wantedTitle) {
       return row as ExistingTaskMatch;
     }
     const titleOverlap = tokenOverlap(params.title, row.title);
-    const bodyOverlap = tokenOverlap(params.content, `${row.title}\n${row.description ?? ''}`);
+    const bodyOverlap = tokenOverlap(params.content, existingComparable);
     if (titleOverlap >= 0.9 || (titleOverlap >= 0.75 && bodyOverlap >= 0.6)) {
       return row as ExistingTaskMatch;
     }
@@ -454,6 +476,12 @@ async function findSimilarWikiPage(params: {
     .limit(250);
 
   for (const row of rows) {
+    if (hasMissingDistinctiveReference(
+      `${params.title}\n${params.content}`,
+      `${row.title}\n${row.summary ?? ''}\n${row.content ?? ''}`,
+    )) {
+      continue;
+    }
     if (equivalentKnowledgeCapture(params, row)) {
       return { id: row.id, title: row.title, slug: row.slug };
     }
@@ -1137,14 +1165,16 @@ export async function queueDeftyCreateTaskCapture(params: {
 
   const defty = await ensureDeftyEmployee(orgId);
   const finalTitle = truncatePlainText(title || buildFallbackTitle(content), 80);
-  const similarTask = await findSimilarActiveTask({
-    orgId,
-    projectId: project.id,
-    title: finalTitle,
-    content: description || plainContent,
-  });
-  if (similarTask) {
-    return { queued: false, skippedReason: 'task_already_captured' };
+  if (captureKind === 'task_candidate') {
+    const similarTask = await findSimilarActiveTask({
+      orgId,
+      projectId: project.id,
+      title: finalTitle,
+      content: description || plainContent,
+    });
+    if (similarTask) {
+      return { queued: false, skippedReason: 'task_already_captured' };
+    }
   }
 
   let assigneeId: string | null = null;

--- a/apps/api/src/lib/job-scheduler.ts
+++ b/apps/api/src/lib/job-scheduler.ts
@@ -7,6 +7,7 @@ export async function initScheduler(): Promise<void> {
   await ensureCronJob(QUEUE_NAMES.SCHEDULED_JOBS, 'nudge-check', 'cron:nudge');
   await ensureCronJob(QUEUE_NAMES.SCHEDULED_JOBS, 'meeting-prep-check', 'cron:meeting-prep');
   await ensureCronJob(QUEUE_NAMES.SCHEDULED_JOBS, 'ics-sync', 'cron:ics-sync');
+  await ensureCronJob(QUEUE_NAMES.SCHEDULED_JOBS, 'chat-observation-backfill', 'cron:chat-observation-backfill');
   await ensureCronJob(QUEUE_NAMES.SCHEDULED_JOBS, 'people-graph', 'cron:people-graph');
   await ensureCronJob(QUEUE_NAMES.SCHEDULED_JOBS, 'manager-pulse', 'cron:manager-pulse');
   await ensureCronJob(QUEUE_NAMES.SCHEDULED_JOBS, 'burnout-detect', 'cron:burnout-detect');

--- a/apps/api/src/lib/queues.ts
+++ b/apps/api/src/lib/queues.ts
@@ -2,6 +2,7 @@
 import { db } from './db.js';
 import { jobQueue } from '@deft/db/schema';
 import { eq, and, sql } from 'drizzle-orm';
+import { OBSERVE_CHAT_MESSAGE_JOB, markObservationFailedFromJobData } from './chat-observation.js';
 
 export const QUEUE_NAMES = {
   AGENT_JOBS: 'agent-jobs',
@@ -89,7 +90,12 @@ export async function completeJob(jobId: string): Promise<void> {
 export async function failJob(jobId: string, error: string): Promise<void> {
   // Fetch current state
   const [job] = await db
-    .select({ attempts: jobQueue.attempts, max_attempts: jobQueue.max_attempts })
+    .select({
+      attempts: jobQueue.attempts,
+      max_attempts: jobQueue.max_attempts,
+      name: jobQueue.name,
+      data: jobQueue.data,
+    })
     .from(jobQueue)
     .where(eq(jobQueue.id, jobId))
     .limit(1);
@@ -97,6 +103,9 @@ export async function failJob(jobId: string, error: string): Promise<void> {
   if (!job) return;
 
   if (job.attempts < job.max_attempts) {
+    if (job.name === OBSERVE_CHAT_MESSAGE_JOB) {
+      await markObservationFailedFromJobData({ data: job.data, retrying: true, error });
+    }
     // Exponential backoff: 1s, 2s, 4s, 8s, ...
     const backoffMs = Math.min(1000 * Math.pow(2, job.attempts - 1), 60000);
     await db
@@ -108,6 +117,9 @@ export async function failJob(jobId: string, error: string): Promise<void> {
       })
       .where(eq(jobQueue.id, jobId));
   } else {
+    if (job.name === OBSERVE_CHAT_MESSAGE_JOB) {
+      await markObservationFailedFromJobData({ data: job.data, retrying: false, error });
+    }
     await db
       .update(jobQueue)
       .set({ status: 'failed', error })

--- a/apps/api/src/routes/messages.ts
+++ b/apps/api/src/routes/messages.ts
@@ -2,16 +2,15 @@ import { Hono } from 'hono';
 import { z } from 'zod';
 import { eq, and, desc, lt, lte, gt, sql, isNull, inArray } from 'drizzle-orm';
 import { db } from '../lib/db.js';
-import { messages, users, reactions, notifications, spaces, spaceMembers, orgs, threadReads, messageVersions, agentEmployees, messageClassifications } from '@deft/db/schema';
+import { messages, users, reactions, notifications, spaces, spaceMembers, orgs, threadReads, messageVersions, agentEmployees } from '@deft/db/schema';
 import { getIO, emitToUser } from '../socket.js';
 import { parseMentions } from '../lib/mentions.js';
 import { fetchLinkPreview, extractUrls, type LinkPreview } from '../lib/link-preview.js';
 import { enqueue, QUEUE_NAMES } from '../lib/queues.js';
 import { resolveReasonProvider } from '../lib/org-ai-config.js';
-import { classifyMessage } from '../lib/classifier.js';
 import { requireSpaceMembership } from '../lib/space-membership.js';
 import { DEFTY_EMAIL, ensureDeftyMembership } from '../lib/ensure-defty-membership.js';
-import { toPlainText } from '../lib/plain-text.js';
+import { enqueueChatObservation } from '../lib/chat-observation.js';
 
 export const messageRoutes = new Hono();
 
@@ -19,42 +18,6 @@ const sendMessageSchema = z.object({
   content: z.string().min(1),
   parent_id: z.string().optional(),
 });
-
-function tokenOverlap(a: string, b: string): number {
-  const toTokens = (value: string) => new Set(
-    toPlainText(value)
-      .toLowerCase()
-      .replace(/[^a-z0-9\s]/g, ' ')
-      .split(/\s+/)
-      .filter((token) => token.length >= 3),
-  );
-  const left = toTokens(a);
-  const right = toTokens(b);
-  if (left.size === 0 || right.size === 0) return 0;
-  let intersection = 0;
-  for (const token of left) {
-    if (right.has(token)) intersection += 1;
-  }
-  const union = left.size + right.size - intersection;
-  return intersection / union;
-}
-
-function factsWithoutDecisionEcho(
-  facts: string[] | null | undefined,
-  decision: string | null | undefined,
-): string[] {
-  const cleanFacts = Array.isArray(facts) ? facts.filter((fact) => fact.trim().length > 0) : [];
-  if (!decision) return cleanFacts;
-  return cleanFacts.filter((fact) => tokenOverlap(fact, decision) < 0.5);
-}
-
-function looksLikeResourceCapture(content: string): boolean {
-  const plain = toPlainText(content).toLowerCase();
-  if (!/https?:\/\//i.test(plain) && !/\b(?:resource|reference|doc|docs|checklist|link)\s*:/i.test(plain)) {
-    return false;
-  }
-  return /\b(?:save|capture|remember|canonical|reference|resource|checklist|doc|docs|link|source)\b/i.test(plain);
-}
 
 // Helper: aggregate reactions for a set of message IDs
 async function getReactionsForMessages(messageIds: string[]) {
@@ -738,81 +701,18 @@ messageRoutes.post('/:spaceId', async (c) => {
       }
     }
 
-    // Message classification + task extraction (fire-and-forget)
-    (async () => {
-      try {
-        const classification = await classifyMessage(parsed.data.content, user.org_id);
-
-        // Persist classifier output for observability (Task 5.6)
-        try {
-          await db.insert(messageClassifications).values({
-            org_id: user.org_id,
-            message_id: message!.id,
-            intent: classification.intent,
-            confidence: classification.confidence,
-            agent_mentioned: classification.agent_mentioned,
-            blocked: classification.blocked,
-            task_references: classification.task_refs,
-            entities: classification.entities,
-            memorable_facts: classification.memorable_facts,
-            decision: classification.decision,
-          });
-        } catch (err) {
-          console.warn('[classifier-persist] failed:', err);
-        }
-
-        if (
-          (classification.intent === 'task_create' || classification.intent === 'actionable') &&
-          classification.confidence > 0.7
-        ) {
-          await enqueue(QUEUE_NAMES.AGENT_JOBS, 'task-extract', {
-            messageId: message!.id,
-            spaceId,
-            content: parsed.data.content,
-            orgId: user.org_id,
-            userId: user.id,
-            classification,
-          });
-        }
+    try {
+      await enqueueChatObservation({
+        orgId: user.org_id,
+        messageId: message!.id,
+        spaceId,
+        userId: user.id,
+      });
+    } catch (err) {
+      console.error('Failed to enqueue chat observation:', err);
+    }
 
         // Blocked detection — enqueue alert if someone is blocked
-        if (classification.blocked === true) {
-          await enqueue(QUEUE_NAMES.AGENT_JOBS, 'blocked-alert', {
-            messageId: message!.id,
-            spaceId,
-            content: parsed.data.content,
-            orgId: user.org_id,
-            userId: user.id,
-          });
-        }
-
-        // Governed memory capture: durable knowledge writes should enter
-        // Defty's approval ledger instead of silently mutating wiki pages.
-        const factCandidates = factsWithoutDecisionEcho(
-          classification.memorable_facts,
-          classification.decision,
-        );
-
-        if (
-          classification.decision ||
-          factCandidates.length > 0 ||
-          looksLikeResourceCapture(parsed.data.content)
-        ) {
-          await enqueue(QUEUE_NAMES.AGENT_JOBS, 'memory-capture', {
-            messageId: message!.id,
-            spaceId,
-            content: parsed.data.content,
-            orgId: user.org_id,
-            userId: user.id,
-            decision: classification.decision || null,
-            facts: factCandidates,
-          });
-        }
-      } catch (err) {
-        console.error('Failed to classify/enqueue task extraction:', err);
-      }
-    })();
-
     return c.json(messageWithUser, 201);
   } catch (err) {
     console.error('Failed to send message:', err);

--- a/apps/api/src/routes/work-intents.ts
+++ b/apps/api/src/routes/work-intents.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono';
 import { and, desc, eq, sql } from 'drizzle-orm';
 import { db } from '../lib/db.js';
-import { agentActions, agentEmployees, messages, spaces, users, workIntents } from '@deft/db/schema';
+import { agentActions, agentEmployees, messageObservations, messages, spaces, users, workIntents } from '@deft/db/schema';
 import { getApprovalTier } from '../lib/agent-approval.js';
 import { ensureDeftyEmployee } from '../lib/ensure-defty-membership.js';
 
@@ -90,6 +90,21 @@ function visibleSourceUserJoinSql(user: AuthedUser) {
   );
 }
 
+function visibleObservationSourceSql(user: AuthedUser) {
+  return sql`EXISTS (
+    SELECT 1
+    FROM messages obs_m
+    INNER JOIN space_members obs_sm ON obs_sm.space_id = obs_m.space_id
+    INNER JOIN spaces obs_s ON obs_s.id = obs_m.space_id
+    WHERE obs_m.id = ${messageObservations.message_id}
+      AND obs_m.org_id = ${user.org_id}
+      AND obs_m.is_deleted = false
+      AND obs_sm.user_id = ${user.id}
+      AND obs_s.org_id = ${user.org_id}
+      AND obs_s.is_archived = false
+  )`;
+}
+
 workIntentRoutes.get('/', async (c) => {
   const user = c.get('user') as AuthedUser;
   const rawLimit = parseInt(c.req.query('limit') ?? '50', 10);
@@ -162,6 +177,72 @@ workIntentRoutes.get('/', async (c) => {
     .limit(limit);
 
   return c.json({ intents: rows });
+});
+
+workIntentRoutes.get('/observations', async (c) => {
+  const user = c.get('user') as AuthedUser;
+  const rawLimit = parseInt(c.req.query('limit') ?? '50', 10);
+  const limit = Math.min(Math.max(Number.isFinite(rawLimit) ? rawLimit : 50, 1), 500);
+  const status = c.req.query('status')?.trim();
+  const marker = c.req.query('marker')?.trim();
+
+  const filters = [
+    eq(messageObservations.org_id, user.org_id),
+    visibleObservationSourceSql(user),
+  ];
+  if (status) {
+    filters.push(eq(messageObservations.status, status as any));
+  }
+  if (marker) {
+    filters.push(sql`${messages.content} ILIKE ${`%${marker}%`}`);
+  }
+
+  const rows = await db
+    .select({
+      id: messageObservations.id,
+      message_id: messageObservations.message_id,
+      space_id: messageObservations.space_id,
+      user_id: messageObservations.user_id,
+      observation_version: messageObservations.observation_version,
+      status: messageObservations.status,
+      ignored_reason: messageObservations.ignored_reason,
+      classifier_result: messageObservations.classifier_result,
+      downstream_jobs: messageObservations.downstream_jobs,
+      capture_count: messageObservations.capture_count,
+      last_error: messageObservations.last_error,
+      started_at: messageObservations.started_at,
+      completed_at: messageObservations.completed_at,
+      created_at: messageObservations.created_at,
+      updated_at: messageObservations.updated_at,
+      source_message_content: messages.content,
+      source_user_name: users.name,
+      space_name: spaces.name,
+    })
+    .from(messageObservations)
+    .innerJoin(messages, and(
+      eq(messageObservations.message_id, messages.id),
+      eq(messages.org_id, user.org_id),
+      eq(messages.is_deleted, false),
+    ))
+    .innerJoin(spaces, and(
+      eq(messages.space_id, spaces.id),
+      eq(spaces.org_id, user.org_id),
+    ))
+    .leftJoin(users, and(
+      eq(messageObservations.user_id, users.id),
+      sql`EXISTS (
+        SELECT 1
+        FROM org_members obs_om
+        WHERE obs_om.org_id = ${user.org_id}
+          AND obs_om.user_id = ${users.id}
+          AND obs_om.is_active = true
+      )`,
+    ))
+    .where(and(...filters))
+    .orderBy(desc(messageObservations.created_at))
+    .limit(limit);
+
+  return c.json({ observations: rows });
 });
 
 workIntentRoutes.get('/:id', async (c) => {

--- a/apps/api/src/workers/handlers/blocked-alert.ts
+++ b/apps/api/src/workers/handlers/blocked-alert.ts
@@ -36,10 +36,7 @@ export async function handleBlockedAlert(job: JobData): Promise<void> {
       )
       .limit(1);
 
-    if (existingNudge.length > 0) {
-      console.log('[blocked-alert] Skipped — already alerted for this user within 4h');
-      return;
-    }
+    const shouldSkipLeadAlert = existingNudge.length > 0;
 
     // Get the user's name
     const [blockedUser] = await db
@@ -110,6 +107,11 @@ export async function handleBlockedAlert(job: JobData): Promise<void> {
       }
     } catch (err) {
       console.warn('[blocked-alert] failed to queue blocker capture:', err);
+    }
+
+    if (shouldSkipLeadAlert) {
+      console.log('[blocked-alert] Skipped lead alert: already alerted for this user within 4h');
+      return;
     }
 
     if (userTasks.length === 0) {

--- a/apps/api/src/workers/handlers/chat-observation-backfill.ts
+++ b/apps/api/src/workers/handlers/chat-observation-backfill.ts
@@ -1,0 +1,20 @@
+import { orgs } from '@deft/db/schema';
+import { db } from '../../lib/db.js';
+import { enqueueMissingChatObservations } from '../../lib/chat-observation.js';
+import type { JobData } from '../types.js';
+
+export async function handleChatObservationBackfill(_job: JobData): Promise<void> {
+  const orgRows = await db
+    .select({ id: orgs.id })
+    .from(orgs)
+    .limit(100);
+
+  let total = 0;
+  for (const org of orgRows) {
+    total += await enqueueMissingChatObservations({ orgId: org.id, limit: 200 });
+  }
+
+  if (total > 0) {
+    console.log(`[chat-observation-backfill] queued ${total} missing observation job(s)`);
+  }
+}

--- a/apps/api/src/workers/handlers/observe-chat-message.ts
+++ b/apps/api/src/workers/handlers/observe-chat-message.ts
@@ -1,0 +1,345 @@
+import { and, eq } from 'drizzle-orm';
+import {
+  messageClassifications,
+  messageObservations,
+  messages,
+} from '@deft/db/schema';
+import type { JobData } from '../types.js';
+import { db } from '../../lib/db.js';
+import { classifyMessage } from '../../lib/classifier.js';
+import { enqueue, QUEUE_NAMES } from '../../lib/queues.js';
+import {
+  CHAT_OBSERVATION_VERSION,
+  explicitObservationIgnoreReason,
+} from '../../lib/chat-observation.js';
+import { toPlainText } from '../../lib/plain-text.js';
+
+type ObserveChatMessageJobData = {
+  messageId: string;
+  spaceId: string;
+  orgId: string;
+  userId: string;
+  observationVersion?: number;
+};
+
+function tokenOverlap(a: string, b: string): number {
+  const toTokens = (value: string) => new Set(
+    toPlainText(value)
+      .toLowerCase()
+      .replace(/[^a-z0-9\s]/g, ' ')
+      .split(/\s+/)
+      .filter((token) => token.length >= 3),
+  );
+  const left = toTokens(a);
+  const right = toTokens(b);
+  if (left.size === 0 || right.size === 0) return 0;
+  let intersection = 0;
+  for (const token of left) {
+    if (right.has(token)) intersection += 1;
+  }
+  const union = left.size + right.size - intersection;
+  return intersection / union;
+}
+
+function factsWithoutDecisionEcho(
+  facts: string[] | null | undefined,
+  decision: string | null | undefined,
+): string[] {
+  const cleanFacts = Array.isArray(facts) ? facts.filter((fact) => fact.trim().length > 0) : [];
+  if (!decision) return cleanFacts;
+  return cleanFacts.filter((fact) => tokenOverlap(fact, decision) < 0.5);
+}
+
+function looksLikeResourceCapture(content: string): boolean {
+  const plain = toPlainText(content).toLowerCase();
+  if (!/https?:\/\//i.test(plain) && !/\b(?:resource|reference|doc|docs|checklist|link)\s*:/i.test(plain)) {
+    return false;
+  }
+  return /\b(?:save|capture|remember|canonical|reference|resource|checklist|doc|docs|link|source)\b/i.test(plain);
+}
+
+function hasExplicitTaskSignal(content: string): boolean {
+  const plain = toPlainText(content).toLowerCase();
+  return /\b(?:create|add|make|open|track)\b.{0,50}\b(?:task|todo|ticket)\b/i.test(plain) ||
+    /\b(?:task|todo|ticket)\s*:\s*\S+/i.test(plain);
+}
+
+function hasGeneralActionSignal(content: string): boolean {
+  const plain = toPlainText(content).toLowerCase();
+  return /\b(?:need to|should|please|can someone|follow up|assign|owner)\b/i.test(plain);
+}
+
+function hasExplicitKnowledgeSignal(content: string): boolean {
+  const plain = toPlainText(content).toLowerCase();
+  return /\b(?:decision|decided|agreed|resource|reference|doc|docs|checklist|link|fact|policy|preference|note)\s*:/i.test(plain) ||
+    /\b(?:we decided|we agreed|going forward)\b/i.test(plain);
+}
+
+export function extractExplicitDecision(content: string): string | null {
+  const plain = toPlainText(content)
+    .replace(/^[A-Z0-9][A-Z0-9_-]{2,80}:\s*/i, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+  const explicit = plain.match(/\bdecision\s*:\s*(.+?)(?:\s+(?:save|keep|capture|remember)\b|$)/i);
+  if (explicit?.[1]?.trim()) return explicit[1].trim().replace(/[.!?]+$/g, '');
+  const decided = plain.match(/\b(?:we decided|we agreed|going forward)\b\s*:?\s*(.+?)(?:\s+(?:save|keep|capture|remember)\b|$)/i);
+  if (decided?.[1]?.trim()) return decided[1].trim().replace(/[.!?]+$/g, '');
+  return null;
+}
+
+function hasExplicitFactSignal(content: string): boolean {
+  const plain = toPlainText(content).toLowerCase();
+  return /\b(?:fact|policy|preference|note)\s*:/i.test(plain) ||
+    /\b(?:always|never)\b/i.test(plain);
+}
+
+function hasExplicitStatusContextSignal(content: string): boolean {
+  const plain = toPlainText(content).toLowerCase();
+  return /\b(?:update|status)\s*:/i.test(plain) &&
+    /\b(?:keep|save|capture|remember)\b.{0,60}\b(?:context|status|memory|note)\b/i.test(plain);
+}
+
+function statusContextFact(content: string): string | null {
+  const plain = toPlainText(content)
+    .replace(/^DENSE-[^:]+:\s*/i, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+  return plain || null;
+}
+
+function shouldQueueTaskExtraction(params: {
+  content: string;
+  intent: string;
+  confidence: number;
+  blocked: boolean;
+  hasMemoryCapture: boolean;
+}): boolean {
+  if (params.blocked) return false;
+  const explicitTask = hasExplicitTaskSignal(params.content);
+  if (explicitTask) return params.confidence > 0.7;
+  if (params.hasMemoryCapture && hasExplicitKnowledgeSignal(params.content)) return false;
+  return params.intent === 'actionable' &&
+    params.confidence > 0.78 &&
+    hasGeneralActionSignal(params.content);
+}
+
+async function markObservation(params: {
+  orgId: string;
+  messageId: string;
+  observationVersion: number;
+  status: 'processing' | 'ignored' | 'no_capture' | 'captured' | 'failed';
+  ignoredReason?: string | null;
+  classifierResult?: Record<string, unknown> | null;
+  downstreamJobs?: Array<Record<string, unknown>>;
+  captureCount?: number;
+  lastError?: string | null;
+  completed?: boolean;
+}) {
+  await db
+    .update(messageObservations)
+    .set({
+      status: params.status,
+      ignored_reason: params.ignoredReason ?? null,
+      classifier_result: params.classifierResult ?? null,
+      downstream_jobs: params.downstreamJobs ?? [],
+      capture_count: params.captureCount ?? 0,
+      last_error: params.lastError ?? null,
+      started_at: params.status === 'processing' ? new Date() : undefined,
+      completed_at: params.completed ? new Date() : undefined,
+      updated_at: new Date(),
+    })
+    .where(and(
+      eq(messageObservations.org_id, params.orgId),
+      eq(messageObservations.message_id, params.messageId),
+      eq(messageObservations.observation_version, params.observationVersion),
+    ));
+}
+
+export async function handleObserveChatMessage(job: JobData): Promise<void> {
+  const {
+    messageId,
+    spaceId,
+    orgId,
+    userId,
+    observationVersion = CHAT_OBSERVATION_VERSION,
+  } = job.data as ObserveChatMessageJobData;
+
+  const [observation] = await db
+    .select({
+      id: messageObservations.id,
+      status: messageObservations.status,
+      completed_at: messageObservations.completed_at,
+    })
+    .from(messageObservations)
+    .where(and(
+      eq(messageObservations.org_id, orgId),
+      eq(messageObservations.message_id, messageId),
+      eq(messageObservations.observation_version, observationVersion),
+    ))
+    .limit(1);
+
+  if (!observation) {
+    throw new Error(`Observation row missing for message ${messageId}`);
+  }
+  if (observation.completed_at && ['ignored', 'no_capture', 'captured'].includes(observation.status)) {
+    return;
+  }
+
+  const [message] = await db
+    .select({
+      id: messages.id,
+      content: messages.content,
+      org_id: messages.org_id,
+      space_id: messages.space_id,
+      user_id: messages.user_id,
+      is_deleted: messages.is_deleted,
+    })
+    .from(messages)
+    .where(and(
+      eq(messages.id, messageId),
+      eq(messages.org_id, orgId),
+    ))
+    .limit(1);
+
+  if (!message || message.is_deleted) {
+    await markObservation({
+      orgId,
+      messageId,
+      observationVersion,
+      status: 'ignored',
+      ignoredReason: 'source_message_missing_or_deleted',
+      completed: true,
+    });
+    return;
+  }
+
+  await markObservation({
+    orgId,
+    messageId,
+    observationVersion,
+    status: 'processing',
+  });
+
+  const ignoredReason = explicitObservationIgnoreReason(message.content);
+  if (ignoredReason) {
+    await db.insert(messageClassifications).values({
+      org_id: orgId,
+      message_id: messageId,
+      intent: 'none',
+      confidence: 1,
+      agent_mentioned: false,
+      blocked: false,
+      task_references: [],
+      entities: {},
+      memorable_facts: [],
+      decision: null,
+    });
+    await markObservation({
+      orgId,
+      messageId,
+      observationVersion,
+      status: 'ignored',
+      ignoredReason,
+      classifierResult: {
+        intent: 'none',
+        confidence: 1,
+        ignored_reason: ignoredReason,
+        source: 'deterministic_guardrail',
+      },
+      completed: true,
+    });
+    return;
+  }
+
+  const classification = await classifyMessage(message.content, orgId);
+  await db.insert(messageClassifications).values({
+    org_id: orgId,
+    message_id: messageId,
+    intent: classification.intent,
+    confidence: classification.confidence,
+    agent_mentioned: classification.agent_mentioned,
+    blocked: classification.blocked,
+    task_references: classification.task_refs,
+    entities: classification.entities,
+    memorable_facts: classification.memorable_facts,
+    decision: classification.decision,
+  });
+
+  const downstreamJobs: Array<Record<string, unknown>> = [];
+  const resourceCapture = looksLikeResourceCapture(message.content);
+  const explicitDecision = extractExplicitDecision(message.content) || classification.decision;
+  const factCandidates = resourceCapture && !hasExplicitFactSignal(message.content)
+    ? []
+    : factsWithoutDecisionEcho(
+      classification.memorable_facts,
+      explicitDecision,
+    );
+  const deterministicStatusFact = hasExplicitStatusContextSignal(message.content)
+    ? statusContextFact(message.content)
+    : null;
+  if (factCandidates.length === 0 && deterministicStatusFact) {
+    factCandidates.push(deterministicStatusFact);
+  }
+  const hasMemoryCapture = Boolean(explicitDecision) || factCandidates.length > 0 || resourceCapture;
+
+  if (shouldQueueTaskExtraction({
+    content: message.content,
+    intent: classification.intent,
+    confidence: classification.confidence,
+    blocked: classification.blocked,
+    hasMemoryCapture,
+  })) {
+    await enqueue(QUEUE_NAMES.AGENT_JOBS, 'task-extract', {
+      messageId,
+      spaceId: message.space_id,
+      content: message.content,
+      orgId,
+      userId,
+      classification,
+    });
+    downstreamJobs.push({ name: 'task-extract', reason: classification.intent });
+  }
+
+  if (classification.blocked === true) {
+    await enqueue(QUEUE_NAMES.AGENT_JOBS, 'blocked-alert', {
+      messageId,
+      spaceId: message.space_id,
+      content: message.content,
+      orgId,
+      userId,
+    });
+    downstreamJobs.push({ name: 'blocked-alert', reason: 'blocked' });
+  }
+
+  if (hasMemoryCapture) {
+    await enqueue(QUEUE_NAMES.AGENT_JOBS, 'memory-capture', {
+      messageId,
+      spaceId: message.space_id,
+      content: message.content,
+      orgId,
+      userId,
+      decision: explicitDecision || null,
+      facts: factCandidates,
+    });
+    downstreamJobs.push({
+      name: 'memory-capture',
+      reason: explicitDecision
+        ? 'decision'
+        : factCandidates.length > 0
+          ? 'facts'
+          : 'resource',
+    });
+  }
+
+  await markObservation({
+    orgId,
+    messageId,
+    observationVersion,
+    status: downstreamJobs.length > 0 ? 'captured' : 'no_capture',
+    ignoredReason: downstreamJobs.length > 0 ? null : 'classifier_no_capture',
+    classifierResult: classification as unknown as Record<string, unknown>,
+    downstreamJobs,
+    captureCount: downstreamJobs.length,
+    completed: true,
+  });
+}

--- a/apps/api/src/workers/handlers/task-extract.ts
+++ b/apps/api/src/workers/handlers/task-extract.ts
@@ -58,12 +58,20 @@ interface ExtractedTask {
 }
 
 export function buildDeterministicTaskTitle(content: string): string {
-  const plainContent = toPlainText(content);
+  const plainContent = toPlainText(content)
+    .replace(/^[A-Z0-9][A-Z0-9_-]{2,80}:\s*/i, '')
+    .trim();
   const explicit = plainContent.match(
-    /\b(?:create|add|make|open|track)\b.{0,40}\b(?:task|todo|ticket)\b\s*:?\s*(.+)$/i,
+    /\b(?:create|add|make|open|track)\b.{0,60}?\b(?:task|todo|ticket)\b\s*:?\s*(.+)$/i,
   );
   const candidate = (explicit?.[1]?.trim() || plainContent).replace(/[.!?]+$/g, '');
   return truncatePlainText(candidate.replace(/^please\s+/i, ''), 80) || 'Follow up from chat';
+}
+
+function hasExplicitTaskRequest(content: string): boolean {
+  const plainContent = toPlainText(content);
+  return /\b(?:create|add|make|open|track)\b.{0,50}\b(?:task|todo|ticket)\b/i.test(plainContent) ||
+    /\b(?:task|todo|ticket)\s*:\s*\S+/i.test(plainContent);
 }
 
 function normalizePriority(priority?: string | null): 'p0' | 'p1' | 'p2' | 'p3' {
@@ -102,7 +110,11 @@ async function queueTaskCreateApproval(params: {
   const plainContent = toPlainText(content);
   if (!plainContent) return false;
 
-  const title = truncatePlainText(providedTitle || buildDeterministicTaskTitle(content), 80);
+  const deterministicTitle = buildDeterministicTaskTitle(content);
+  const titleSeed = hasExplicitTaskRequest(content)
+    ? deterministicTitle
+    : providedTitle || deterministicTitle;
+  const title = truncatePlainText(titleSeed, 80);
   const queued = await queueDeftyCreateTaskCapture({
     orgId,
     sourceUserId: userId,
@@ -140,6 +152,7 @@ async function queueDeterministicTaskCreateApproval(params: {
   messageId: string;
   content: string;
   projectName?: string | null;
+  assigneeName?: string | null;
 }): Promise<boolean> {
   return queueTaskCreateApproval({
     ...params,
@@ -169,6 +182,19 @@ export async function handleTaskExtract(job: JobData): Promise<void> {
 
   // Only process task_create or actionable intents
   if (classification.intent !== 'task_create' && classification.intent !== 'actionable') {
+    return;
+  }
+
+  if (hasExplicitTaskRequest(content)) {
+    await queueDeterministicTaskCreateApproval({
+      orgId,
+      userId,
+      spaceId,
+      messageId,
+      content,
+      projectName: classification.entities?.project,
+      assigneeName: classification.entities?.assignee,
+    });
     return;
   }
 

--- a/apps/api/src/workers/index.ts
+++ b/apps/api/src/workers/index.ts
@@ -26,6 +26,7 @@ const CRON_DELAYS: Record<string, number> = {
   // due set from `last_synced_at + sync_interval_min`, so this is _scan_
   // cadence not _fire_ cadence.
   'ics-sync': 60_000,
+  'chat-observation-backfill': 5 * 60_000,
 };
 
 const CRON_KEYS: Record<string, string> = {
@@ -42,9 +43,12 @@ const CRON_KEYS: Record<string, string> = {
   'heartbeat-native': 'cron:heartbeat-native',
   'trigger-dispatch': 'cron:trigger-dispatch',
   'ics-sync': 'cron:ics-sync',
+  'chat-observation-backfill': 'cron:chat-observation-backfill',
 };
 
 const JOB_TIMEOUT_MS = Number.parseInt(process.env.DEFT_JOB_TIMEOUT_MS ?? '120000', 10);
+const WORKER_POLL_INTERVAL_MS = Number.parseInt(process.env.DEFT_WORKER_POLL_INTERVAL_MS ?? '1000', 10);
+const WORKER_BATCH_SIZE = Math.max(1, Number.parseInt(process.env.DEFT_WORKER_BATCH_SIZE ?? '5', 10));
 
 function runWithTimeout<T>(promise: Promise<T>, label: string): Promise<T> {
   if (!Number.isFinite(JOB_TIMEOUT_MS) || JOB_TIMEOUT_MS <= 0) return promise;
@@ -66,6 +70,10 @@ async function getAgentJobHandler(jobName: string): Promise<JobHandler | null> {
     case 'agent-reply': {
       const mod = await import('./handlers/agent-reply.js');
       return mod.handleAgentReply;
+    }
+    case 'observe-chat-message': {
+      const mod = await import('./handlers/observe-chat-message.js');
+      return mod.handleObserveChatMessage;
     }
     case 'task-extract': {
       const mod = await import('./handlers/task-extract.js');
@@ -199,6 +207,10 @@ async function getScheduledJobHandler(jobName: string): Promise<JobHandler | nul
       const mod = await import('./handlers/ics-sync.js');
       return mod.handleIcsSync;
     }
+    case 'chat-observation-backfill': {
+      const mod = await import('./handlers/chat-observation-backfill.js');
+      return mod.handleChatObservationBackfill;
+    }
     default:
       return null;
   }
@@ -210,8 +222,55 @@ async function getHandler(queueName: string, jobName: string): Promise<JobHandle
   return null;
 }
 
+async function processDequeuedJob(
+  queueName: string,
+  job: { id: string; name: string; data: any },
+): Promise<void> {
+  const handler = await getHandler(queueName, job.name);
+  if (!handler) {
+    await completeJob(job.id);
+    return;
+  }
+
+  try {
+    await runWithTimeout(
+      handler({ id: job.id, name: job.name, data: job.data }),
+      `Job ${job.name} (${job.id.slice(0, 8)})`,
+    );
+    await completeJob(job.id);
+    console.log(`[worker] Job ${job.name} (${job.id.slice(0, 8)}) completed`);
+
+    const cronKey = CRON_KEYS[job.name];
+    const cronDelay = CRON_DELAYS[job.name];
+    if (cronKey && cronDelay) {
+      await ensureCronJob(
+        queueName as any,
+        job.name,
+        cronKey,
+        {},
+        cronDelay,
+      );
+    }
+  } catch (err) {
+    await failJob(job.id, (err as Error).message);
+    console.error(`[worker] Job ${job.name} failed:`, (err as Error).message);
+  }
+}
+
+async function pollQueueBatch(queueName: string): Promise<void> {
+  const jobs: Array<{ id: string; name: string; data: any }> = [];
+  for (let i = 0; i < WORKER_BATCH_SIZE; i += 1) {
+    const job = await dequeueJob(queueName as any);
+    if (!job) break;
+    jobs.push(job);
+  }
+  if (jobs.length === 0) return;
+  await Promise.all(jobs.map((job) => processDequeuedJob(queueName, job)));
+}
+
 // ─── Public API ───
 let pollingInterval: ReturnType<typeof setInterval> | null = null;
+let pollInFlight = false;
 
 export function startWorkers(): void {
   if (pollingInterval) return;
@@ -234,50 +293,23 @@ export function startWorkers(): void {
     }).catch(() => {});
   }, 60000);
 
-  // Poll every 3 seconds
   pollingInterval = setInterval(async () => {
-    for (const queueName of Object.values(QUEUE_NAMES)) {
-      try {
-        const job = await dequeueJob(queueName);
-        if (!job) continue;
-
-        const handler = await getHandler(queueName, job.name);
-        if (!handler) {
-          await completeJob(job.id);
-          continue;
-        }
-
-        try {
-          await runWithTimeout(
-            handler({ id: job.id, name: job.name, data: job.data }),
-            `Job ${job.name} (${job.id.slice(0, 8)})`,
-          );
-          await completeJob(job.id);
-          console.log(`[worker] Job ${job.name} (${job.id.slice(0, 8)}) completed`);
-
-          // Re-enqueue cron jobs after completion
-          const cronKey = CRON_KEYS[job.name];
-          const cronDelay = CRON_DELAYS[job.name];
-          if (cronKey && cronDelay) {
-            await ensureCronJob(
-              queueName as any,
-              job.name,
-              cronKey,
-              {},
-              cronDelay,
-            );
-          }
-        } catch (err) {
-          await failJob(job.id, (err as Error).message);
-          console.error(`[worker] Job ${job.name} failed:`, (err as Error).message);
-        }
-      } catch (err) {
-        // Don't crash the poller on individual errors
-      }
+    if (pollInFlight) return;
+    pollInFlight = true;
+    try {
+      await Promise.all(
+        Object.values(QUEUE_NAMES).map((queueName) => pollQueueBatch(queueName)),
+      );
+    } catch {
+      // Don't crash the poller on individual errors.
+    } finally {
+      pollInFlight = false;
     }
-  }, 3000);
+  }, WORKER_POLL_INTERVAL_MS);
 
-  console.log('[workers] Postgres job poller started (3s interval)');
+  console.log(
+    `[workers] Postgres job poller started (${WORKER_POLL_INTERVAL_MS}ms interval, batch ${WORKER_BATCH_SIZE})`,
+  );
 }
 
 export function stopWorkers(): void {

--- a/apps/api/test/chat-observation.test.ts
+++ b/apps/api/test/chat-observation.test.ts
@@ -1,0 +1,42 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { explicitObservationIgnoreReason } from '../src/lib/chat-observation.js';
+import { extractExplicitDecision } from '../src/workers/handlers/observe-chat-message.js';
+
+describe('chat observation guardrails', () => {
+  test('suppresses explicit no-action messages', () => {
+    assert.equal(
+      explicitObservationIgnoreReason('No action needed, no task, no memory. Just noting the room is noisy.'),
+      'explicit_no_action',
+    );
+    assert.equal(
+      explicitObservationIgnoreReason("Don't save this link; I'm just testing the channel."),
+      'explicit_no_action',
+    );
+    assert.equal(
+      explicitObservationIgnoreReason('FYI only: the truck arrived early.'),
+      'explicit_no_action',
+    );
+  });
+
+  test('suppresses low-signal acknowledgements', () => {
+    assert.equal(explicitObservationIgnoreReason('ok'), 'low_signal_ack');
+    assert.equal(explicitObservationIgnoreReason('Sounds good!'), 'low_signal_ack');
+    assert.equal(explicitObservationIgnoreReason('thanks'), 'low_signal_ack');
+  });
+
+  test('allows real work, decisions, and resources through', () => {
+    assert.equal(explicitObservationIgnoreReason('Please create a task for Lina to check greenhouse humidity.'), null);
+    assert.equal(explicitObservationIgnoreReason('Decision: use crate batch TT-42 for the buyer sample.'), null);
+    assert.equal(explicitObservationIgnoreReason('Resource: save https://example.com/packing-checklist for launch prep.'), null);
+  });
+
+  test('keeps explicit decision context ahead of shorter classifier wording', () => {
+    assert.equal(
+      extractExplicitDecision(
+        'DENSE-EXAMPLE-MARIGOLD-03-DECISION: Decision: for the launch drill around crop quality and greenhouse status, we will use the Tuesday route promise gate before telling buyers launch is green. Save this as team knowledge.',
+      ),
+      'for the launch drill around crop quality and greenhouse status, we will use the Tuesday route promise gate before telling buyers launch is green',
+    );
+  });
+});

--- a/apps/api/test/defty-capture-dedupe-update.test.ts
+++ b/apps/api/test/defty-capture-dedupe-update.test.ts
@@ -374,6 +374,101 @@ test('fresh task capture skips when the same active task already exists', async 
   assert.equal(rows.length, 0, 'duplicate task chatter should not create a work intent');
 });
 
+test('similar task capture with a different reference code still queues a fresh proposal', async () => {
+  await db.insert(tasks).values({
+    id: `defty-capture-task-${crypto.randomUUID()}`,
+    org_id: ORG_ID,
+    project_id: PROJECT_ID,
+    number: 22,
+    title: 'Print blue crate labels for TT-4101',
+    description: 'Print blue crate labels for wholesale batch TT-4101 before Saturday prep.',
+    status: 'todo',
+    priority: 'p2',
+    created_by: USER_ID,
+  });
+  const content = 'Please create task: Print blue crate labels for wholesale batch TT-4102';
+  const messageId = await seedMessage(content);
+
+  const queued = await queueDeftyCreateTaskCapture({
+    orgId: ORG_ID,
+    sourceUserId: USER_ID,
+    spaceId: SPACE_ID,
+    messageId,
+    content,
+    title: 'Print blue crate labels for TT-4102',
+    description: 'Print blue crate labels for wholesale batch TT-4102 before Saturday prep.',
+    captureKind: 'task_candidate',
+    extraction: 'deterministic',
+  });
+
+  assert.equal(queued.queued, true);
+  assert.ok(queued.actionId);
+
+  const [intent] = await db
+    .select({
+      proposed_action: workIntents.proposed_action,
+      proposed_params: workIntents.proposed_params,
+    })
+    .from(workIntents)
+    .where(and(
+      eq(workIntents.org_id, ORG_ID),
+      eq(workIntents.source_message_id, messageId),
+    ))
+    .limit(1);
+
+  assert.ok(intent, 'expected a fresh work intent for the second reference code');
+  assert.equal(intent.proposed_action, 'task_create');
+  assert.equal((intent.proposed_params as Record<string, any>).title, 'Print blue crate labels for TT-4102');
+});
+
+test('blocker capture still queues even when a similar active task exists', async () => {
+  await db.insert(tasks).values({
+    id: `defty-capture-task-${crypto.randomUUID()}`,
+    org_id: ORG_ID,
+    project_id: PROJECT_ID,
+    number: 23,
+    title: 'Resolve cooler label printer issue',
+    description: 'Printer issue for cooler labels.',
+    status: 'in_progress',
+    priority: 'p1',
+    created_by: USER_ID,
+  });
+  const content = 'I am blocked: cooler label printer issue is stopping the Saturday packing run.';
+  const messageId = await seedMessage(content);
+
+  const queued = await queueDeftyCreateTaskCapture({
+    orgId: ORG_ID,
+    sourceUserId: USER_ID,
+    spaceId: SPACE_ID,
+    messageId,
+    content,
+    title: 'Resolve cooler label printer issue',
+    description: 'Cooler label printer issue is stopping the Saturday packing run.',
+    captureKind: 'blocker_candidate',
+    captureReason: 'Test blocker should surface even if related work already exists.',
+    extraction: 'deterministic',
+  });
+
+  assert.equal(queued.queued, true);
+  assert.ok(queued.actionId);
+
+  const [intent] = await db
+    .select({
+      kind: workIntents.kind,
+      proposed_action: workIntents.proposed_action,
+    })
+    .from(workIntents)
+    .where(and(
+      eq(workIntents.org_id, ORG_ID),
+      eq(workIntents.source_message_id, messageId),
+    ))
+    .limit(1);
+
+  assert.ok(intent, 'expected a blocker work intent');
+  assert.equal(intent.kind, 'blocker_candidate');
+  assert.equal(intent.proposed_action, 'task_create');
+});
+
 test('fresh knowledge capture skips when equivalent wiki knowledge already exists', async () => {
   await db.insert(wikiPages).values({
     id: `defty-capture-wiki-${crypto.randomUUID()}`,
@@ -413,6 +508,52 @@ test('fresh knowledge capture skips when equivalent wiki knowledge already exist
       AND message_id = ${messageId}
   `);
   assert.equal(Number(actionCount.rows[0]?.count ?? 0), 0);
+});
+
+test('similar knowledge with a different reference code still queues a fresh proposal', async () => {
+  await db.insert(wikiPages).values({
+    id: `defty-capture-wiki-${crypto.randomUUID()}`,
+    org_id: ORG_ID,
+    scope: 'org',
+    type: 'decision',
+    title: 'Use TT-4101 for chef sample boxes',
+    slug: `chef-sample-tt-4101-${RUN_ID}`,
+    summary: 'Use batch TT-4101 for chef sample boxes.',
+    content: 'Decision: use batch TT-4101 for chef sample boxes.',
+    confidence: 0.9,
+  });
+  const content = 'Decision: use batch TT-4102 for chef sample boxes.';
+  const messageId = await seedMessage(content);
+
+  const queued = await queueDeftyKnowledgeCapture({
+    orgId: ORG_ID,
+    sourceUserId: USER_ID,
+    spaceId: SPACE_ID,
+    messageId,
+    content,
+    title: 'Use TT-4102 for chef sample boxes',
+    wikiType: 'decision',
+    captureKind: 'decision_candidate',
+    captureReason: 'Test similar decision with a different reference code.',
+    extraction: 'classifier',
+    tags: ['decision', 'defty-capture'],
+  });
+
+  assert.equal(queued.queued, true);
+  assert.ok(queued.actionId);
+
+  const [action] = await db
+    .select({ action: agentActions.action, params: agentActions.params })
+    .from(agentActions)
+    .where(and(
+      eq(agentActions.org_id, ORG_ID),
+      eq(agentActions.message_id, messageId),
+    ))
+    .limit(1);
+
+  assert.ok(action, 'expected a fresh pending approval for TT-4102');
+  assert.equal(action.action, 'wiki_create');
+  assert.equal((action.params as Record<string, any>).title, 'Use TT-4102 for chef sample boxes');
 });
 
 test('explicit correction to existing knowledge queues wiki_update instead of duplicate wiki_create', async () => {

--- a/apps/web/src/app/(app)/inbox/page.tsx
+++ b/apps/web/src/app/(app)/inbox/page.tsx
@@ -66,6 +66,25 @@ type WorkIntent = {
 
 type WorkIntentResponse = { intents: WorkIntent[] };
 
+type MessageObservation = {
+  id: string;
+  message_id: string;
+  status: 'queued' | 'processing' | 'ignored' | 'no_capture' | 'captured' | 'retrying' | 'failed';
+  ignored_reason: string | null;
+  classifier_result?: Record<string, unknown> | null;
+  downstream_jobs?: Array<Record<string, unknown>> | null;
+  capture_count: number;
+  last_error: string | null;
+  source_message_content: string | null;
+  source_user_name: string | null;
+  space_name: string | null;
+  completed_at: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+type MessageObservationResponse = { observations: MessageObservation[] };
+
 const INTENT_KIND_LABEL: Record<WorkIntent['kind'], string> = {
   task_candidate: 'Task candidate',
   blocker_candidate: 'Blocker candidate',
@@ -179,6 +198,15 @@ async function fetchWorkIntents(url: string): Promise<WorkIntentResponse> {
     throw new Error(body?.error ?? `Failed to load captures (${res.status})`);
   }
   return (await res.json()) as WorkIntentResponse;
+}
+
+async function fetchMessageObservations(url: string): Promise<MessageObservationResponse> {
+  const res = await api.get(url);
+  if (!res.ok) {
+    const body = await res.json().catch(() => null) as { error?: string } | null;
+    throw new Error(body?.error ?? `Failed to load observations (${res.status})`);
+  }
+  return (await res.json()) as MessageObservationResponse;
 }
 
 async function readApiError(res: Response, fallback: string): Promise<string> {
@@ -387,6 +415,81 @@ function WorkIntentRow({
   );
 }
 
+const OBSERVATION_STATUS_LABEL: Record<MessageObservation['status'], string> = {
+  queued: 'Queued',
+  processing: 'Processing',
+  ignored: 'Ignored',
+  no_capture: 'No capture',
+  captured: 'Captured',
+  retrying: 'Retrying',
+  failed: 'Failed',
+};
+
+function formatObservationReason(observation: MessageObservation) {
+  if (observation.status === 'ignored' && observation.ignored_reason) {
+    return observation.ignored_reason.replaceAll('_', ' ');
+  }
+  if (observation.status === 'no_capture') return 'No work intent found';
+  if (observation.status === 'captured') {
+    const jobs = observation.downstream_jobs
+      ?.map((job) => typeof job.name === 'string' ? job.name.replaceAll('-', ' ') : null)
+      .filter(Boolean)
+      .join(', ');
+    return jobs ? `Sent to ${jobs}` : `${observation.capture_count} capture job${observation.capture_count === 1 ? '' : 's'}`;
+  }
+  if (observation.status === 'failed' || observation.status === 'retrying') {
+    return observation.last_error || 'Observation failed';
+  }
+  return 'Waiting for Defty';
+}
+
+function MessageObservationRow({ observation }: { observation: MessageObservation }) {
+  const messagePreview = stripHtml(observation.source_message_content ?? '');
+  const age = formatIntentAge(observation.completed_at ?? observation.updated_at ?? observation.created_at);
+  const statusColor =
+    observation.status === 'failed' ? 'var(--status-red)'
+    : observation.status === 'retrying' ? 'var(--status-amber)'
+    : observation.status === 'ignored' || observation.status === 'no_capture' ? 'var(--muted)'
+    : observation.status === 'captured' ? 'var(--status-green)'
+    : 'var(--primary)';
+
+  return (
+    <div
+      className="rounded-lg border px-3 py-3"
+      style={{ borderColor: 'var(--border)', background: 'var(--bg-subtle)' }}
+    >
+      <div className="flex items-center justify-between gap-3">
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="text-[12px] font-medium" style={{ color: statusColor }}>
+              {OBSERVATION_STATUS_LABEL[observation.status]}
+            </span>
+            {observation.space_name && (
+              <span className="text-[12px]" style={{ color: 'var(--muted)' }}>
+                #{observation.space_name}
+              </span>
+            )}
+            {age && (
+              <span className="text-[12px]" style={{ color: 'var(--muted)' }}>
+                {age}
+              </span>
+            )}
+          </div>
+          <p className="mt-1 text-[13px]" style={{ color: 'var(--foreground)' }}>
+            {formatObservationReason(observation)}
+          </p>
+          {messagePreview && (
+            <p className="mt-1 text-[12px] leading-relaxed" style={{ color: 'var(--muted)' }}>
+              {observation.source_user_name ? `${observation.source_user_name}: ` : ''}
+              {compactText(messagePreview, 180)}
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export default function InboxPage() {
   const params = useSearchParams();
   const initialTab = (params.get('tab') as Tab) ?? 'all';
@@ -404,6 +507,11 @@ export default function InboxPage() {
     fetchWorkIntents,
     { refreshInterval: 15_000, revalidateOnFocus: true },
   );
+  const { data: observationData, error: observationsError, isLoading: observationsLoading, mutate: refreshObservations } = useSWR(
+    shouldLoadWorkIntents ? '/api/work-intents/observations?limit=50' : null,
+    fetchMessageObservations,
+    { refreshInterval: 15_000, revalidateOnFocus: true },
+  );
 
   const filtered = useMemo(() => {
     if (tab === 'tasks') {
@@ -415,6 +523,10 @@ export default function InboxPage() {
     () => (workIntentData?.intents ?? []).filter((intent) => intent.status !== 'proposed'),
     [workIntentData?.intents],
   );
+  const observationTrail = useMemo(
+    () => (observationData?.observations ?? []).slice(0, 20),
+    [observationData?.observations],
+  );
   const convertedRetryByOriginal = useMemo(() => {
     const map = new Map<string, string>();
     for (const intent of workIntentData?.intents ?? []) {
@@ -425,11 +537,11 @@ export default function InboxPage() {
     return map;
   }, [workIntentData?.intents]);
   const loadError = shouldLoadWorkIntents
-    ? (inboxError ?? workIntentsError)
+    ? (inboxError ?? workIntentsError ?? observationsError)
     : inboxError;
   const refreshCaptureSurfaces = useCallback(async () => {
-    await Promise.allSettled([refresh(), refreshWorkIntents()]);
-  }, [refresh, refreshWorkIntents]);
+    await Promise.allSettled([refresh(), refreshWorkIntents(), refreshObservations()]);
+  }, [refresh, refreshWorkIntents, refreshObservations]);
 
   const handleApprove = useCallback(
     async (id: string) => {
@@ -534,7 +646,7 @@ export default function InboxPage() {
         </nav>
 
         {/* Body */}
-        {isLoading || (shouldLoadWorkIntents && workIntentsLoading) ? (
+        {isLoading || (shouldLoadWorkIntents && (workIntentsLoading || observationsLoading)) ? (
           <p className="text-[13px]" style={{ color: 'var(--muted)' }}>Loading...</p>
         ) : loadError ? (
           <div
@@ -551,7 +663,7 @@ export default function InboxPage() {
               Retry
             </button>
           </div>
-        ) : filtered.length === 0 && (!shouldLoadWorkIntents || historicWorkIntents.length === 0) ? (
+        ) : filtered.length === 0 && (!shouldLoadWorkIntents || (historicWorkIntents.length === 0 && observationTrail.length === 0)) ? (
           <div
             className="text-[13px] py-12 text-center rounded-lg"
             style={{ color: 'var(--muted)', border: '1px dashed var(--border)' }}
@@ -600,6 +712,21 @@ export default function InboxPage() {
                   convertedRetryId={convertedRetryByOriginal.get(intent.id) ?? null}
                 />
               ))}
+            {shouldLoadWorkIntents && observationTrail.length > 0 && (
+              <div className="mt-4 flex flex-col gap-2">
+                <div className="flex items-center justify-between">
+                  <h2 className="text-[13px] font-semibold" style={{ color: 'var(--foreground)' }}>
+                    Observation trail
+                  </h2>
+                  <span className="text-[12px]" style={{ color: 'var(--muted)' }}>
+                    Last {observationTrail.length}
+                  </span>
+                </div>
+                {observationTrail.map((observation) => (
+                  <MessageObservationRow key={observation.id} observation={observation} />
+                ))}
+              </div>
+            )}
           </div>
         )}
       </div>

--- a/packages/db/drizzle/0073_message_observations.sql
+++ b/packages/db/drizzle/0073_message_observations.sql
@@ -1,0 +1,41 @@
+DO $$ BEGIN
+  CREATE TYPE "message_observation_status" AS ENUM (
+    'queued',
+    'processing',
+    'ignored',
+    'no_capture',
+    'captured',
+    'retrying',
+    'failed'
+  );
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+CREATE TABLE IF NOT EXISTS "message_observations" (
+  "id" text PRIMARY KEY NOT NULL,
+  "org_id" text NOT NULL REFERENCES "orgs"("id") ON DELETE cascade,
+  "message_id" text NOT NULL REFERENCES "messages"("id") ON DELETE cascade,
+  "space_id" text REFERENCES "spaces"("id") ON DELETE set null,
+  "user_id" text REFERENCES "users"("id") ON DELETE set null,
+  "observation_version" integer DEFAULT 1 NOT NULL,
+  "status" "message_observation_status" DEFAULT 'queued' NOT NULL,
+  "ignored_reason" text,
+  "classifier_result" jsonb,
+  "downstream_jobs" jsonb DEFAULT '[]'::jsonb NOT NULL,
+  "capture_count" integer DEFAULT 0 NOT NULL,
+  "last_error" text,
+  "started_at" timestamp,
+  "completed_at" timestamp,
+  "created_at" timestamp DEFAULT now() NOT NULL,
+  "updated_at" timestamp DEFAULT now() NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "message_observation_message_version_unique"
+  ON "message_observations" ("message_id","observation_version");
+CREATE INDEX IF NOT EXISTS "message_observation_org_status_idx"
+  ON "message_observations" ("org_id","status","created_at");
+CREATE INDEX IF NOT EXISTS "message_observation_message_idx"
+  ON "message_observations" ("message_id");
+CREATE INDEX IF NOT EXISTS "message_observation_space_idx"
+  ON "message_observations" ("space_id");

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -36,6 +36,15 @@ export const workIntentStatusEnum = pgEnum('work_intent_status', [
   'expired',
   'failed',
 ]);
+export const messageObservationStatusEnum = pgEnum('message_observation_status', [
+  'queued',
+  'processing',
+  'ignored',
+  'no_capture',
+  'captured',
+  'retrying',
+  'failed',
+]);
 export const eventSourceEnum = pgEnum('event_source', ['native', 'google_calendar', 'github', 'slack', 'gmail', 'linear', 'ics']);
 export const wikiPageTypeEnum = pgEnum('wiki_page_type', ['concept', 'entity', 'decision', 'resource', 'procedure', 'preference', 'fact']);
 export const wikiPageScopeEnum = pgEnum('wiki_page_scope', ['org', 'space', 'user']);
@@ -516,6 +525,31 @@ export const workIntents = pgTable('work_intents', {
   index('work_intent_source_message_idx').on(t.source_message_id),
   index('work_intent_space_idx').on(t.space_id),
   index('work_intent_converted_task_idx').on(t.converted_task_id),
+]);
+
+// Durable ledger for Defty's chat observation pipeline. A row here means a
+// chat message was seen by the observation system even when it is ignored.
+export const messageObservations = pgTable('message_observations', {
+  ...id(),
+  org_id: text('org_id').notNull().references(() => orgs.id, { onDelete: 'cascade' }),
+  message_id: text('message_id').notNull().references(() => messages.id, { onDelete: 'cascade' }),
+  space_id: text('space_id').references(() => spaces.id, { onDelete: 'set null' }),
+  user_id: text('user_id').references(() => users.id, { onDelete: 'set null' }),
+  observation_version: integer('observation_version').default(1).notNull(),
+  status: messageObservationStatusEnum('status').default('queued').notNull(),
+  ignored_reason: text('ignored_reason'),
+  classifier_result: jsonb('classifier_result').$type<Record<string, unknown>>(),
+  downstream_jobs: jsonb('downstream_jobs').$type<Array<Record<string, unknown>>>().notNull().default([]),
+  capture_count: integer('capture_count').default(0).notNull(),
+  last_error: text('last_error'),
+  started_at: timestamp('started_at'),
+  completed_at: timestamp('completed_at'),
+  ...timestamps(),
+}, (t) => [
+  uniqueIndex('message_observation_message_version_unique').on(t.message_id, t.observation_version),
+  index('message_observation_org_status_idx').on(t.org_id, t.status, t.created_at),
+  index('message_observation_message_idx').on(t.message_id),
+  index('message_observation_space_idx').on(t.space_id),
 ]);
 
 // ═══ AGENT: SKILLS ═══

--- a/scripts/reports/consolidate-demo-certification.ts
+++ b/scripts/reports/consolidate-demo-certification.ts
@@ -1,0 +1,185 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const REPORT_DIR = path.resolve('reports');
+const OUT = path.resolve(REPORT_DIR, `demo-process-certification-consolidated-${new Date().toISOString().slice(0, 10)}.html`);
+
+type Run = {
+  run_id: string;
+  marker: string;
+  started_at: string;
+  finished_at?: string;
+  checks: Array<{ status: 'pass' | 'warn' | 'fail'; name: string; detail?: unknown; ms?: number }>;
+  screenshots: Record<string, string>;
+  ids: Record<string, string>;
+  evidence: Record<string, any>;
+  findings: Array<{ severity: string; title: string; detail: string }>;
+};
+
+function escapeHtml(value: unknown): string {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function rel(file: string) {
+  return path.relative(path.dirname(OUT), file).replace(/\\/g, '/');
+}
+
+function hasCheck(run: Run, needle: string, status?: string) {
+  return run.checks.some((check) => check.name.includes(needle) && (!status || check.status === status));
+}
+
+async function loadRuns(): Promise<Run[]> {
+  const files = await fs.readdir(REPORT_DIR);
+  const jsonFiles = files
+    .filter((file) => /^demo-claim-certification-.*\.json$/.test(file))
+    .map((file) => path.join(REPORT_DIR, file));
+  const runs: Run[] = [];
+  for (const file of jsonFiles) {
+    try {
+      runs.push(JSON.parse(await fs.readFile(file, 'utf8')) as Run);
+    } catch {
+      // Ignore partial files.
+    }
+  }
+  return runs.sort((a, b) => a.started_at.localeCompare(b.started_at));
+}
+
+function screenshotFigure(run: Run | undefined, key: string, caption: string) {
+  const file = run?.screenshots?.[key];
+  if (!file) return '';
+  return `<figure><img src="${escapeHtml(rel(file))}" alt="${escapeHtml(caption)}"><figcaption>${escapeHtml(caption)}</figcaption></figure>`;
+}
+
+async function main() {
+  const runs = await loadRuns();
+  const workflow = [...runs].reverse().find((run) => run.ids?.created_task_id && Array.isArray(run.evidence?.final_intents));
+  const flaky = [...runs].reverse().find((run) => hasCheck(run, 'Expected Defty captures appeared', 'fail'));
+  const notes = [...runs].reverse().find((run) => hasCheck(run, 'Notes-only certification completed', 'pass'));
+
+  if (!workflow || !notes) {
+    throw new Error('Could not find both workflow and notes certification runs to consolidate.');
+  }
+
+  const workflowKinds = (workflow.evidence.final_intents ?? []).map((intent: any) => `${intent.kind}:${intent.status}`);
+  const converted = (workflow.evidence.final_intents ?? []).filter((intent: any) => intent.status === 'converted');
+  const missing = flaky?.evidence?.capture_poll?.kinds ?? [];
+  const wikiPages = workflow.evidence?.wiki_search?.pages ?? [];
+  const notePages = notes.evidence?.promoted_note?.wiki_pages ?? [];
+
+  const html = `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Deft Demo Process Certification</title>
+  <style>
+    :root { color-scheme: light; --ink:#191714; --muted:#70685d; --line:#ddd5c7; --paper:#faf7f0; --card:#fffdf8; --accent:#6f5fda; --green:#168a5b; --amber:#a86700; --red:#bf3b2f; }
+    body { margin:0; background:var(--paper); color:var(--ink); font-family:Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; line-height:1.46; }
+    main { max-width:1160px; margin:0 auto; padding:42px 24px 72px; }
+    h1 { margin:0 0 10px; font-size:38px; line-height:1.02; letter-spacing:0; }
+    h2 { margin:34px 0 12px; font-size:21px; }
+    h3 { margin:22px 0 8px; font-size:15px; }
+    p { color:var(--muted); max-width:880px; }
+    .hero, .card, table, figure { border:1px solid var(--line); background:var(--card); border-radius:8px; }
+    .hero { padding:28px; }
+    .pill { display:inline-flex; padding:5px 10px; border:1px solid var(--line); border-radius:999px; background:#fff; color:var(--muted); font-size:12px; }
+    .grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(230px,1fr)); gap:12px; }
+    .card { padding:16px; }
+    .metric { font-size:28px; font-weight:750; color:var(--ink); }
+    table { width:100%; border-collapse:collapse; overflow:hidden; }
+    th, td { padding:11px 12px; border-bottom:1px solid var(--line); text-align:left; vertical-align:top; font-size:13px; }
+    th { background:#f3eee5; color:var(--muted); font-size:11px; text-transform:uppercase; letter-spacing:.04em; }
+    tr:last-child td { border-bottom:0; }
+    .pass { color:var(--green); font-weight:750; }
+    .warn { color:var(--amber); font-weight:750; }
+    .fail { color:var(--red); font-weight:750; }
+    .screens { display:grid; grid-template-columns:repeat(auto-fit,minmax(320px,1fr)); gap:14px; }
+    figure { margin:0; overflow:hidden; }
+    figure img { width:100%; display:block; background:#0f0f12; }
+    figcaption { padding:9px 11px; color:var(--muted); font-size:12px; border-top:1px solid var(--line); }
+    pre { white-space:pre-wrap; overflow-wrap:anywhere; background:#fffdf8; border:1px solid var(--line); border-radius:8px; padding:14px; font-size:12px; color:#3b342d; }
+    code { font-family:ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+  </style>
+</head>
+<body>
+<main>
+  <section class="hero">
+    <span class="pill">Human-like process validation on demo.deft.ing</span>
+    <h1>Deft Demo Process Certification</h1>
+    <p>This consolidates the latest UI-first runs against the Testers Tomatoes demo org. The result is not a clean green stamp: the core workflow works, but the demo still has reliability cracks around over-capture, rate limits, and classifier repeatability.</p>
+    <div class="grid">
+      <div class="card"><div class="metric">Partial</div><span>Overall demo process status</span></div>
+      <div class="card"><div class="metric">${converted.length}</div><span>Converted captures in strongest workflow run</span></div>
+      <div class="card"><div class="metric">${notePages.length}</div><span>Note pages promoted to wiki in focused run</span></div>
+    </div>
+  </section>
+
+  <h2>Claim Verdicts</h2>
+  <table>
+    <thead><tr><th>Claim</th><th>Verdict</th><th>What actually happened</th></tr></thead>
+    <tbody>
+      <tr><td>Chat becomes context</td><td class="warn">Works, but noisy/flaky</td><td>A tagged workflow message created task, decision, resource, and note work intents in one run. A later equivalent run only created task/note/noise captures. A "no action needed" message was captured as memory.</td></tr>
+      <tr><td>Tasks become action</td><td class="pass">Validated</td><td>UI approval of the task capture created task <code>${escapeHtml(workflow.ids.created_task_id)}</code> linked back to source message <code>${escapeHtml(workflow.evidence.created_task?.source_message_id)}</code>.</td></tr>
+      <tr><td>Notes become memory</td><td class="pass">Validated through explicit promotion</td><td>The Notes UI created a blank note, edited it, promoted it to wiki, and wiki search found the promoted page.</td></tr>
+      <tr><td>Approvals become governance</td><td class="pass">Validated</td><td>Capture cards required approval. A narrow API receipt check verified receipts for the four approved actions from the strongest workflow run.</td></tr>
+    </tbody>
+  </table>
+
+  <h2>Important Findings</h2>
+  <table>
+    <thead><tr><th>Severity</th><th>Issue</th><th>Why it matters</th></tr></thead>
+    <tbody>
+      <tr><td class="fail">P1</td><td>Classifier repeatability is not yet demo-safe</td><td>Run <code>${escapeHtml(workflow.marker)}</code> produced the full capture set: ${escapeHtml(workflowKinds.join(', '))}. Run <code>${escapeHtml(flaky?.marker)}</code> only produced: ${escapeHtml(missing.join(', '))}. The same demo story can look impressive once and underpowered the next time.</td></tr>
+      <tr><td class="fail">P1</td><td>Production demo rate limit is too tight for normal rich UI testing</td><td>Rapid human-like sends hit <code>429 RATE_LIMITED</code>. Even if real humans type slower, a demo recording should not need one-minute pauses between messages.</td></tr>
+      <tr><td class="warn">P2</td><td>No-op/no-action messages become memory captures</td><td>The explicit "No action needed, no task, no memory" message still produced a note_candidate. This is a chaos risk in busy channels.</td></tr>
+      <tr><td class="warn">P3</td><td>Marker search undercounts converted knowledge</td><td>The strongest run converted decision/resource/note captures, but marker wiki search returned ${wikiPages.length} page(s). Receipts prove approvals happened; searchability needs tighter verification/index timing.</td></tr>
+    </tbody>
+  </table>
+
+  <h2>Evidence</h2>
+  <div class="grid">
+    <div class="card"><strong>Workflow run</strong><br><code>${escapeHtml(workflow.marker)}</code><p>Message id <code>${escapeHtml(workflow.ids.message_workflow_id)}</code>; task id <code>${escapeHtml(workflow.ids.created_task_id)}</code>.</p></div>
+    <div class="card"><strong>Notes run</strong><br><code>${escapeHtml(notes.marker)}</code><p>Promoted pages: ${escapeHtml(notePages.map((p: any) => p.title).join(', '))}</p></div>
+    <div class="card"><strong>Verified receipts</strong><br><p>Manual narrow check: three <code>wiki_create</code> receipts and one <code>task_create</code> receipt returned <code>verified: true</code>.</p></div>
+  </div>
+
+  <h2>Screenshots</h2>
+  <div class="screens">
+    ${screenshotFigure(workflow, 'chat-after-demo-messages', 'Chat after workflow messages')}
+    ${screenshotFigure(workflow, 'captures-before-task', 'Capture card before task approval')}
+    ${screenshotFigure(workflow, 'captures-after-knowledge', 'Capture card after knowledge approvals')}
+    ${screenshotFigure(notes, 'notes-after-new-note-click', 'Notes create menu / blank note flow')}
+    ${screenshotFigure(notes, 'notes-manager-note-before-promote', 'Manager note before promotion')}
+    ${screenshotFigure(notes, 'knowledge-search-marker', 'Knowledge search after note promotion')}
+  </div>
+
+  <h2>Raw Evidence Snapshot</h2>
+  <pre>${escapeHtml(JSON.stringify({
+    workflow: {
+      marker: workflow.marker,
+      final_intents: workflow.evidence.final_intents,
+      created_task: workflow.evidence.created_task,
+      wiki_search: workflow.evidence.wiki_search,
+    },
+    flaky_followup: {
+      marker: flaky?.marker,
+      capture_poll: flaky?.evidence?.capture_poll,
+    },
+    notes: notes.evidence.promoted_note,
+  }, null, 2))}</pre>
+</main>
+</body>
+</html>`;
+
+  await fs.writeFile(OUT, html);
+  console.log(`CONSOLIDATED_REPORT=${OUT}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/reports/consolidate-dense-human-certification.ts
+++ b/scripts/reports/consolidate-dense-human-certification.ts
@@ -1,0 +1,175 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const REPORT_DIR = path.resolve('reports');
+const OUT = path.resolve(REPORT_DIR, `dense-human-workflow-certification-consolidated-${new Date().toISOString().slice(0, 10)}.html`);
+
+type Run = {
+  run_id: string;
+  marker: string;
+  started_at: string;
+  checks: Array<{ status: string; name: string; detail?: unknown; ms?: number }>;
+  screenshots: Record<string, string>;
+  sent_messages: unknown[];
+  evidence: Record<string, any>;
+  findings: Array<{ severity: string; title: string; detail: string }>;
+};
+
+function escapeHtml(value: unknown): string {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function rel(file: string) {
+  return path.relative(path.dirname(OUT), file).replace(/\\/g, '/');
+}
+
+async function loadRuns() {
+  const files = await fs.readdir(REPORT_DIR);
+  const runs: Run[] = [];
+  for (const file of files.filter((name) => /^dense-human-workflow-certification-.*\.json$/.test(name))) {
+    try {
+      runs.push(JSON.parse(await fs.readFile(path.join(REPORT_DIR, file), 'utf8')) as Run);
+    } catch {
+      // Ignore malformed partials.
+    }
+  }
+  return runs.sort((a, b) => a.started_at.localeCompare(b.started_at));
+}
+
+function screenshot(run: Run | undefined, key: string, caption: string) {
+  const file = run?.screenshots?.[key];
+  if (!file) return '';
+  return `<figure><img src="${escapeHtml(rel(file))}" alt="${escapeHtml(caption)}"><figcaption>${escapeHtml(caption)}</figcaption></figure>`;
+}
+
+async function main() {
+  const runs = await loadRuns();
+  const denseRuns = runs.filter((run) => run.evidence?.metrics?.attempted_messages === 100);
+  const latest = denseRuns.at(-1);
+  const strongest = [...denseRuns].sort((a, b) => (b.evidence?.metrics?.intent_count ?? 0) - (a.evidence?.metrics?.intent_count ?? 0))[0];
+  const receiptRun = [...denseRuns].find((run) => (run.evidence?.receipts ?? []).length > 0);
+  const rows = denseRuns.slice(-4).map((run) => {
+    const m = run.evidence?.metrics ?? {};
+    return {
+      marker: run.marker,
+      sent: `${m.sent_messages ?? 0}/${m.attempted_messages ?? 0}`,
+      intents: m.intent_count ?? 0,
+      matched: `${m.matched_expected ?? 0}/${m.expected_capture_count ?? 0}`,
+      falsePositives: m.false_positive_count ?? 0,
+      receipts: (run.evidence?.receipts ?? []).filter((r: any) => r.ok).length,
+      note: (run.evidence?.promoted_note ?? []).length,
+      findings: run.findings.map((f) => `${f.severity}: ${f.title}`).join('; '),
+    };
+  });
+
+  const html = `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Dense Human Workflow Certification - Consolidated</title>
+  <style>
+    :root { color-scheme: light; --ink:#191714; --muted:#716a60; --line:#ddd5c8; --paper:#faf7ef; --card:#fffdf8; --green:#168a5b; --amber:#a86700; --red:#bf3b2f; }
+    body { margin:0; background:var(--paper); color:var(--ink); font-family:Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; line-height:1.45; }
+    main { max-width:1160px; margin:0 auto; padding:42px 24px 72px; }
+    h1 { margin:0 0 10px; font-size:36px; line-height:1.03; }
+    h2 { margin:34px 0 12px; font-size:21px; }
+    p { color:var(--muted); max-width:900px; }
+    .hero,.card,table,figure,pre { border:1px solid var(--line); background:var(--card); border-radius:8px; }
+    .hero { padding:28px; }
+    .pill { display:inline-flex; padding:5px 10px; border:1px solid var(--line); border-radius:999px; background:#fff; color:var(--muted); font-size:12px; }
+    .grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(220px,1fr)); gap:12px; }
+    .card { padding:16px; }
+    .metric { font-size:28px; font-weight:760; }
+    table { width:100%; border-collapse:collapse; overflow:hidden; }
+    th,td { text-align:left; vertical-align:top; padding:11px 12px; border-bottom:1px solid var(--line); font-size:13px; }
+    th { background:#f3eee5; color:var(--muted); font-size:11px; text-transform:uppercase; letter-spacing:.04em; }
+    tr:last-child td { border-bottom:0; }
+    .pass { color:var(--green); font-weight:750; }
+    .warn { color:var(--amber); font-weight:750; }
+    .fail { color:var(--red); font-weight:750; }
+    .screens { display:grid; grid-template-columns:repeat(auto-fit,minmax(310px,1fr)); gap:14px; }
+    figure { margin:0; overflow:hidden; }
+    figure img { width:100%; display:block; background:#111; }
+    figcaption { padding:9px 11px; color:var(--muted); font-size:12px; border-top:1px solid var(--line); }
+    pre { white-space:pre-wrap; overflow-wrap:anywhere; padding:14px; font-size:12px; color:#38312a; }
+    code { font-family:ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+  </style>
+</head>
+<body>
+<main>
+  <section class="hero">
+    <span class="pill">Consolidated dense dogfood</span>
+    <h1>Dense Human Workflow Certification</h1>
+    <p>These were local UI-first runs with five seeded employees acting concurrently across eight spaces. The main result: the human workspace held up under 100-message bursts, but the Defty observation/capture pipeline is not reliable enough yet under realistic chatter.</p>
+    <div class="grid">
+      <div class="card"><div class="metric">${escapeHtml(latest?.evidence?.metrics?.sent_messages ?? 0)}/100</div><span>Latest UI sends succeeded</span></div>
+      <div class="card"><div class="metric">${escapeHtml(strongest?.evidence?.metrics?.intent_count ?? 0)}</div><span>Best run capture count</span></div>
+      <div class="card"><div class="metric">${escapeHtml(receiptRun?.evidence?.receipts?.filter((r: any) => r.ok).length ?? 0)}</div><span>Verified receipts in approval run</span></div>
+      <div class="card"><div class="metric">${escapeHtml(latest?.evidence?.promoted_note?.length ?? 0)}</div><span>Latest notes promoted to wiki</span></div>
+    </div>
+  </section>
+
+  <h2>Run Comparison</h2>
+  <table>
+    <thead><tr><th>Run</th><th>UI Sends</th><th>Intents</th><th>Matched Expected</th><th>No-op Overcapture</th><th>Receipts</th><th>Note→Wiki</th><th>Findings</th></tr></thead>
+    <tbody>
+      ${rows.map((row) => `<tr><td><code>${escapeHtml(row.marker)}</code></td><td>${escapeHtml(row.sent)}</td><td>${escapeHtml(row.intents)}</td><td>${escapeHtml(row.matched)}</td><td>${escapeHtml(row.falsePositives)}</td><td>${escapeHtml(row.receipts)}</td><td>${escapeHtml(row.note)}</td><td>${escapeHtml(row.findings)}</td></tr>`).join('')}
+    </tbody>
+  </table>
+
+  <h2>What This Proves</h2>
+  <table>
+    <thead><tr><th>Claim</th><th>Verdict</th><th>Evidence</th></tr></thead>
+    <tbody>
+      <tr><td>Humans can work concurrently in Deft</td><td class="pass">Validated locally</td><td>Latest dense run posted 100/100 messages from five browser sessions across eight spaces.</td></tr>
+      <tr><td>Chat becomes context</td><td class="fail">Not reliable enough</td><td>Best dense run created 21 intents; latest comparable run created zero. The observation path drops or skips under dense realistic traffic.</td></tr>
+      <tr><td>Tasks become action</td><td class="warn">Works when captured</td><td>The strongest run converted representative task captures and verified receipts, but capture recall is too low.</td></tr>
+      <tr><td>Approvals become governance</td><td class="pass">Validated where actions exist</td><td>The approval run produced verified receipts for representative approved actions.</td></tr>
+      <tr><td>Notes become memory</td><td class="pass">Validated</td><td>The latest run created a note through the UI, promoted it to wiki, and found the promoted page.</td></tr>
+    </tbody>
+  </table>
+
+  <h2>Main Fix Themes</h2>
+  <table>
+    <thead><tr><th>Priority</th><th>Theme</th><th>Why</th></tr></thead>
+    <tbody>
+      <tr><td class="fail">P1</td><td>Move chat observation out of fire-and-forget route execution into durable jobs</td><td>Dense traffic can store messages while producing no work intents. Classification/capture needs durability, retries, and backlog visibility.</td></tr>
+      <tr><td class="fail">P1</td><td>Add explicit no-action guardrails before memory capture</td><td>Best dense run captured 6/20 explicit no-action/no-memory messages.</td></tr>
+      <tr><td class="fail">P1</td><td>Improve capture recall and evaluation thresholds</td><td>Best dense run matched only 14/80 expected non-noise captures.</td></tr>
+      <tr><td class="warn">P2</td><td>Add admin/debug visibility for observation pipeline</td><td>When captures disappear, the UI currently does not expose whether classification skipped, failed, or backlogged.</td></tr>
+    </tbody>
+  </table>
+
+  <h2>Screenshots</h2>
+  <div class="screens">
+    ${screenshot(latest, 'after-messages-diego', 'Diego after dense messages')}
+    ${screenshot(latest, 'surface-captures-final', 'Final captures surface')}
+    ${screenshot(latest, 'surface-dashboard-final', 'Final dashboard surface')}
+    ${screenshot(latest, 'knowledge-after-dense-note', 'Knowledge after note promotion')}
+    ${screenshot(strongest, 'captures-before-dense-approvals', 'Approval cards in strongest capture run')}
+    ${screenshot(strongest, 'captures-after-dense-approvals', 'Approval cards after representative approvals')}
+  </div>
+
+  <h2>Raw Summary</h2>
+  <pre>${escapeHtml(JSON.stringify({
+    latest: latest ? { marker: latest.marker, metrics: latest.evidence.metrics, findings: latest.findings } : null,
+    strongest: strongest ? { marker: strongest.marker, metrics: strongest.evidence.metrics, findings: strongest.findings } : null,
+    receiptRun: receiptRun ? { marker: receiptRun.marker, receipts: receiptRun.evidence.receipts } : null,
+  }, null, 2))}</pre>
+</main>
+</body>
+</html>`;
+
+  await fs.writeFile(OUT, html);
+  console.log(`CONSOLIDATED_DENSE_REPORT=${OUT}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/reports/demo-claim-certification.ts
+++ b/scripts/reports/demo-claim-certification.ts
@@ -1,0 +1,745 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { chromium, type Page } from 'playwright';
+
+const WEB_URL = (process.env.DEFT_WEB_URL || 'https://demo.deft.ing').replace(/\/$/, '');
+const API_URL = (process.env.DEFT_API_URL || WEB_URL).replace(/\/$/, '');
+const EMAIL = process.env.DEFT_TEST_EMAIL || 'diego@testers-tomatoes.com';
+const PASSWORD = process.env.DEFT_TEST_PASSWORD || 'tomato123';
+const RUN_ID = process.env.DEFT_DEMO_CERT_RUN_ID || new Date().toISOString().replace(/[:.]/g, '-');
+const RUN_MARKER = `DEMO-CERT-${RUN_ID.replace(/[^a-zA-Z0-9]/g, '').slice(-10)}`;
+const args = new Set(process.argv.slice(2));
+const OUT_DIR = path.resolve('reports', 'demo-claim-certification', RUN_ID);
+const HTML_REPORT = path.resolve('reports', `demo-claim-certification-${RUN_ID}.html`);
+const JSON_REPORT = path.resolve('reports', `demo-claim-certification-${RUN_ID}.json`);
+
+type Auth = {
+  accessToken: string;
+  user: { id: string; email: string; org_id: string; name?: string };
+};
+
+type Space = { id: string; name: string; type?: string };
+type CheckStatus = 'pass' | 'warn' | 'fail';
+type Check = { status: CheckStatus; name: string; detail?: unknown; ms?: number };
+
+type Artifact = {
+  run_id: string;
+  marker: string;
+  web_url: string;
+  api_url: string;
+  started_at: string;
+  finished_at?: string;
+  checks: Check[];
+  screenshots: Record<string, string>;
+  ids: Record<string, string>;
+  evidence: Record<string, unknown>;
+  findings: Array<{ severity: 'P0' | 'P1' | 'P2' | 'P3'; title: string; detail: string }>;
+};
+
+const artifact: Artifact = {
+  run_id: RUN_ID,
+  marker: RUN_MARKER,
+  web_url: WEB_URL,
+  api_url: API_URL,
+  started_at: new Date().toISOString(),
+  checks: [],
+  screenshots: {},
+  ids: {},
+  evidence: {},
+  findings: [],
+};
+
+function escapeHtml(value: unknown): string {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function mark(status: CheckStatus, name: string, detail?: unknown, ms?: number) {
+  artifact.checks.push({ status, name, detail, ms });
+  const suffix = detail ? `: ${typeof detail === 'string' ? detail : JSON.stringify(detail)}` : '';
+  console.log(`[${status.toUpperCase()}] ${name}${suffix}`);
+}
+
+async function step<T>(name: string, fn: () => Promise<T>, warnOnly = false): Promise<T | null> {
+  const started = Date.now();
+  try {
+    const value = await fn();
+    mark('pass', name, undefined, Date.now() - started);
+    return value;
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    mark(warnOnly ? 'warn' : 'fail', name, detail, Date.now() - started);
+    if (!warnOnly) throw err;
+    return null;
+  }
+}
+
+async function fetchJson<T = any>(url: string, init?: RequestInit): Promise<{ status: number; ok: boolean; body: T; text: string }> {
+  const res = await fetch(url, { ...init, signal: AbortSignal.timeout(25_000) });
+  const text = await res.text();
+  let body: T;
+  try {
+    body = JSON.parse(text) as T;
+  } catch {
+    body = text as T;
+  }
+  return { status: res.status, ok: res.ok, body, text };
+}
+
+async function loginApi(): Promise<Auth> {
+  const res = await fetchJson<Auth>(`${API_URL}/api/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email: EMAIL, password: PASSWORD }),
+  });
+  if (!res.ok || !res.body?.accessToken) {
+    throw new Error(`API login failed: ${res.status} ${res.text.slice(0, 240)}`);
+  }
+  return res.body;
+}
+
+async function api<T = any>(auth: Auth, route: string, init?: RequestInit): Promise<T> {
+  const hasBody = init?.body !== undefined;
+  const res = await fetchJson<T>(`${API_URL}${route}`, {
+    ...init,
+    headers: {
+      ...(hasBody ? { 'Content-Type': 'application/json' } : {}),
+      Authorization: `Bearer ${auth.accessToken}`,
+      ...(init?.headers || {}),
+    },
+  });
+  if (!res.ok) {
+    throw new Error(`${route} returned ${res.status}: ${res.text.slice(0, 500)}`);
+  }
+  return res.body;
+}
+
+function asArray<T = any>(value: any, keys: string[] = []): T[] {
+  if (Array.isArray(value)) return value;
+  for (const key of keys) {
+    if (Array.isArray(value?.[key])) return value[key];
+  }
+  return [];
+}
+
+async function waitFor<T>(
+  label: string,
+  fn: () => Promise<T | null | undefined | false>,
+  opts: { timeoutMs?: number; intervalMs?: number } = {},
+): Promise<T> {
+  const timeoutMs = opts.timeoutMs ?? 90_000;
+  const intervalMs = opts.intervalMs ?? 1_500;
+  const started = Date.now();
+  let last: unknown = null;
+  while (Date.now() - started < timeoutMs) {
+    try {
+      const value = await fn();
+      if (value) return value as T;
+      last = value;
+    } catch (err) {
+      last = err instanceof Error ? err.message : String(err);
+    }
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+  throw new Error(`Timed out waiting for ${label}. Last: ${JSON.stringify(last)}`);
+}
+
+async function screenshot(page: Page, name: string) {
+  await fs.mkdir(OUT_DIR, { recursive: true });
+  const file = path.join(OUT_DIR, `${name}.png`);
+  await page.screenshot({ path: file, fullPage: true });
+  artifact.screenshots[name] = file;
+}
+
+function delay(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function loginUi(page: Page) {
+  await page.goto(`${WEB_URL}/login`, { waitUntil: 'domcontentloaded' });
+  await page.locator('#login-email').waitFor({ state: 'visible', timeout: 20_000 });
+  await page.locator('#login-email').fill(EMAIL);
+  await page.locator('#login-password').fill(PASSWORD);
+  const responsePromise = page.waitForResponse(
+    (response) => response.request().method() === 'POST' && response.url().includes('/api/auth/login'),
+    { timeout: 30_000 },
+  );
+  await page.getByRole('button', { name: /^sign in$/i }).click();
+  const response = await responsePromise;
+  if (response.status() >= 400) {
+    const body = await response.text().catch(() => '');
+    throw new Error(`UI login failed: ${response.status()} ${body.slice(0, 240)}`);
+  }
+  await page.waitForURL((url) => !url.pathname.includes('/login'), { timeout: 30_000 });
+  await page.locator('main').waitFor({ state: 'visible', timeout: 20_000 });
+}
+
+async function gotoSurface(page: Page, route: string, name: string, expected?: RegExp) {
+  await page.goto(`${WEB_URL}${route}`, { waitUntil: 'domcontentloaded' });
+  await page.locator('main').waitFor({ state: 'visible', timeout: 25_000 });
+  if (expected) {
+    await page.getByText(expected).first().waitFor({ state: 'visible', timeout: 25_000 });
+  }
+  await screenshot(page, name);
+}
+
+async function pickSpace(auth: Auth): Promise<Space> {
+  const body = await api<any>(auth, '/api/spaces');
+  const spaces = asArray<Space>(body, ['spaces']);
+  const preferred = ['marketing', 'sales-and-buyers', 'launch-war-room', 'field-ops', 'operations'];
+  const found = spaces.find((space) => preferred.includes((space.name || '').toLowerCase()))
+    ?? spaces.find((space) => !String(space.name).toLowerCase().includes('dm'))
+    ?? spaces[0];
+  if (!found?.id) throw new Error('No usable chat space found for demo certification');
+  artifact.ids.space_id = found.id;
+  artifact.evidence.space_name = found.name;
+  return found;
+}
+
+async function sendChatMessage(page: Page, space: Space, label: string, content: string) {
+  await page.goto(`${WEB_URL}/chat?space=${encodeURIComponent(space.id)}`, { waitUntil: 'domcontentloaded' });
+  await page.locator('main').waitFor({ state: 'visible', timeout: 25_000 });
+  const editor = page.locator('[contenteditable="true"].deft-editor').last();
+  await editor.waitFor({ state: 'visible', timeout: 25_000 });
+  await editor.click();
+  await editor.fill(content);
+  const composedText = await editor.textContent();
+  if (!composedText?.includes(RUN_MARKER)) {
+    throw new Error(`Composer did not contain marker after fill. Text was: ${composedText?.slice(0, 120)}`);
+  }
+  const sendButton = page.getByRole('button', { name: /send message/i }).last();
+  await waitFor('send button enabled', async () => {
+    const disabled = await sendButton.evaluate((button) => (button as HTMLButtonElement).disabled).catch(() => true);
+    return disabled ? null : true;
+  }, { timeoutMs: 10_000, intervalMs: 250 });
+  const post = page.waitForResponse(
+    (response) => {
+      if (response.request().method() !== 'POST') return false;
+      try {
+        const url = new URL(response.url());
+        return url.pathname === `/api/messages/${space.id}` || url.pathname.startsWith(`/api/messages/${space.id}/`);
+      } catch {
+        return false;
+      }
+    },
+    { timeout: 30_000 },
+  );
+  await sendButton.click();
+  const response = await post;
+  if (response.status() >= 400) {
+    const body = await response.text().catch(() => '');
+    throw new Error(`Message send failed with ${response.status()}: ${body.slice(0, 240)}`);
+  }
+  const responseBody = await response.json().catch(() => null);
+  if (responseBody?.id) {
+    artifact.ids[`message_${label}_id`] = responseBody.id;
+  }
+  await page.waitForFunction(
+    (marker) => document.body.innerText.includes(marker),
+    RUN_MARKER,
+    { timeout: 25_000 },
+  ).catch(async () => {
+    mark('warn', `Message ${label} posted but did not appear live in chat within 25s`, responseBody?.id ?? null);
+    await screenshot(page, `chat-send-render-lag-${label}`);
+  });
+  artifact.evidence[`message_${label}`] = content;
+  await delay(1_000);
+}
+
+function containsMarker(value: unknown): boolean {
+  if (value == null) return false;
+  if (typeof value === 'string') return value.includes(RUN_MARKER);
+  try {
+    return JSON.stringify(value).includes(RUN_MARKER);
+  } catch {
+    return false;
+  }
+}
+
+async function getRunIntents(auth: Auth) {
+  const body = await api<any>(auth, '/api/work-intents?limit=100');
+  return asArray<any>(body, ['intents']).filter((intent) => containsMarker(intent));
+}
+
+async function getRunActions(auth: Auth) {
+  const body = await api<any>(auth, '/api/agent/actions');
+  return asArray<any>(body).filter((action) => containsMarker(action));
+}
+
+function byKind(intents: any[], kind: string) {
+  return intents.find((intent) => intent.kind === kind);
+}
+
+async function waitForExpectedCaptures(auth: Auth) {
+  return waitFor('task/decision/resource/note work-intent captures', async () => {
+    const intents = await getRunIntents(auth);
+    const actions = await getRunActions(auth);
+    artifact.evidence.capture_poll = {
+      intent_count: intents.length,
+      action_count: actions.length,
+      kinds: intents.map((intent) => `${intent.kind}:${intent.status}`),
+      actions: actions.map((action) => `${action.action}:${action.approval_status}`),
+    };
+    const hasTask = intents.some((intent) => intent.kind === 'task_candidate' || intent.kind === 'blocker_candidate');
+    const hasDecision = intents.some((intent) => intent.kind === 'decision_candidate');
+    const hasResource = intents.some((intent) => intent.kind === 'resource_candidate');
+    const hasNote = intents.some((intent) => intent.kind === 'note_candidate');
+    return hasTask && hasDecision && hasResource && hasNote ? { intents, actions } : null;
+  }, { timeoutMs: 120_000, intervalMs: 2_500 });
+}
+
+async function clickApprovalForMarker(page: Page, buttonText: string, label: string) {
+  await page.goto(`${WEB_URL}/inbox?tab=captures`, { waitUntil: 'domcontentloaded' });
+  await page.locator('main').waitFor({ state: 'visible', timeout: 25_000 });
+  await page.getByText(RUN_MARKER, { exact: false }).first().waitFor({ state: 'visible', timeout: 25_000 });
+  await screenshot(page, `captures-before-${label}`);
+
+  const clicked = await page.evaluate(({ marker, buttonText }) => {
+    const target = buttonText.toLowerCase();
+    for (const button of Array.from(document.querySelectorAll('button'))) {
+      const label = `${button.textContent || ''} ${button.getAttribute('aria-label') || ''}`.trim().toLowerCase();
+      if (label !== target) continue;
+      let node: HTMLElement | null = button;
+      for (let i = 0; i < 10 && node; i += 1) {
+        if ((node.textContent || '').includes(marker)) {
+          button.click();
+          return true;
+        }
+        node = node.parentElement;
+      }
+    }
+    return false;
+  }, { marker: RUN_MARKER, buttonText });
+
+  if (!clicked) {
+    throw new Error(`Could not find "${buttonText}" button in a capture card containing ${RUN_MARKER}`);
+  }
+
+  await page.waitForTimeout(1_500);
+  await screenshot(page, `captures-after-${label}`);
+}
+
+async function approveCaptureWithUi(page: Page, buttonText: string, label: string) {
+  await clickApprovalForMarker(page, buttonText, label);
+  mark('pass', `UI approval clicked for ${label}`);
+}
+
+async function verifyReceipt(auth: Auth, actionId: string) {
+  const receipt = await api<any>(auth, `/api/agent/actions/${actionId}/receipt`);
+  if (!receipt?.verified) {
+    throw new Error(`Receipt was missing or failed verification for ${actionId}`);
+  }
+  return receipt;
+}
+
+async function verifyConverted(auth: Auth) {
+  const intents = await getRunIntents(auth);
+  const actions = await getRunActions(auth);
+  artifact.evidence.final_intents = intents.map((intent) => ({
+    id: intent.id,
+    kind: intent.kind,
+    status: intent.status,
+    converted_action_id: intent.converted_action_id,
+    converted_task_id: intent.converted_task_id,
+    title: intent.title,
+  }));
+  artifact.evidence.final_actions = actions.map((action) => ({
+    id: action.id,
+    action: action.action,
+    approval_status: action.approval_status,
+    has_receipt: action.has_receipt,
+    result: action.result,
+  }));
+
+  const taskIntent = intents.find((intent) => (intent.kind === 'task_candidate' || intent.kind === 'blocker_candidate') && intent.status === 'converted');
+  if (!taskIntent?.converted_task_id) {
+    throw new Error('Task capture did not convert to a task');
+  }
+  const task = await api<any>(auth, `/api/tasks/${taskIntent.converted_task_id}`);
+  if (!containsMarker(task.title) && !containsMarker(task.description) && !containsMarker(task.source_message?.content)) {
+    throw new Error('Created task does not retain the run marker in title, description, or source message');
+  }
+  if (!task.source_message?.id) {
+    artifact.findings.push({
+      severity: 'P2',
+      title: 'Created task lacks visible source-message receipt',
+      detail: `Task ${task.id} was created, but task detail did not include source_message.`,
+    });
+  }
+  artifact.ids.created_task_id = task.id;
+  artifact.evidence.created_task = {
+    id: task.id,
+    title: task.title,
+    source_message_id: task.source_message?.id ?? task.source_message_id ?? null,
+    source_space: task.source_message?.space_name ?? null,
+  };
+
+  const wikiSearch = await api<any>(auth, `/api/wiki?q=${encodeURIComponent(RUN_MARKER)}&limit=20`);
+  const pages = asArray<any>(wikiSearch, ['pages']);
+  artifact.evidence.wiki_search = {
+    total: wikiSearch.total,
+    search_mode: wikiSearch.search_mode,
+    pages: pages.map((page) => ({ id: page.id, title: page.title, slug: page.slug, type: page.type })),
+  };
+  if (pages.length < 1) {
+    throw new Error('No marker-searchable wiki page was created from approved captures');
+  }
+
+  const convertedKnowledgeIntents = intents.filter((intent) =>
+    ['decision_candidate', 'resource_candidate', 'note_candidate'].includes(intent.kind)
+    && intent.status === 'converted'
+    && intent.converted_action_id
+  );
+  if (convertedKnowledgeIntents.length < 3) {
+    artifact.findings.push({
+      severity: 'P2',
+      title: 'Not all knowledge capture kinds converted',
+      detail: `Expected decision, resource, and note captures to convert. Converted kinds: ${convertedKnowledgeIntents.map((intent) => intent.kind).join(', ') || 'none'}.`,
+    });
+  }
+  if (pages.length < convertedKnowledgeIntents.length) {
+    artifact.findings.push({
+      severity: 'P3',
+      title: 'Some converted knowledge captures were not marker-searchable',
+      detail: `Converted ${convertedKnowledgeIntents.length} knowledge intents, but marker search returned ${pages.length} page(s). This may be title/content truncation or search-vector lag.`,
+    });
+  }
+
+  const convertedActions = actions.filter((action) => action.approval_status === 'approved');
+  const actionIdsFromIntents = intents
+    .map((intent) => intent.converted_action_id)
+    .filter((id): id is string => typeof id === 'string' && id.length > 0);
+  const actionIdsToCheck = Array.from(new Set([
+    ...convertedActions.map((action) => action.id),
+    ...actionIdsFromIntents,
+  ]));
+  const receipts = [];
+  for (const actionId of actionIdsToCheck) {
+    const receipt = await verifyReceipt(auth, actionId);
+    receipts.push({ action_id: actionId, verified: receipt.verified, decision: receipt.receipt?.decision });
+  }
+  artifact.evidence.receipts = receipts;
+}
+
+async function createAndPromoteNote(page: Page, auth: Auth) {
+  await page.goto(`${WEB_URL}/notes`, { waitUntil: 'domcontentloaded' });
+  await page.locator('main').waitFor({ state: 'visible', timeout: 25_000 });
+  await screenshot(page, 'notes-before-new-note');
+  const createResponse = page.waitForResponse(
+    (response) => response.request().method() === 'POST' && response.url().includes('/api/daily-notes'),
+    { timeout: 20_000 },
+  ).catch(() => null);
+  await page.getByRole('button', { name: /new note/i }).first().click();
+  const blankNote = page.getByRole('button', { name: /blank note/i }).first();
+  if (await blankNote.isVisible().catch(() => false)) {
+    await blankNote.click();
+  }
+  const created = await createResponse;
+  if (created && created.status() >= 400) {
+    const body = await created.text().catch(() => '');
+    throw new Error(`New note failed with ${created.status()}: ${body.slice(0, 240)}`);
+  }
+  await page.waitForTimeout(2_000);
+  await screenshot(page, 'notes-after-new-note-click');
+  const noteTitle = `Manager launch note ${RUN_MARKER}`;
+  const noteBody = `Manager note ${RUN_MARKER}: buyer launch needs the Tuesday route promise, Sun Gold eight-ounce sample boxes, and a clear receipt trail before the demo recording.`;
+  await page.locator('input[placeholder="Untitled"]').first().fill(noteTitle);
+  const editor = page.locator('[contenteditable="true"].deft-notes-editor').first();
+  await editor.waitFor({ state: 'visible', timeout: 20_000 });
+  await editor.click();
+  await page.keyboard.insertText(noteBody);
+  await page.waitForTimeout(2_500);
+  await screenshot(page, 'notes-manager-note-before-promote');
+
+  await page.getByRole('button', { name: /promote to wiki/i }).first().click();
+  await page.getByRole('button', { name: /^fact$/i }).click();
+  page.once('dialog', async (dialog) => { await dialog.accept(); });
+  await page.getByRole('button', { name: /^promote$/i }).click();
+  await page.waitForTimeout(2_000);
+  await screenshot(page, 'notes-manager-note-after-promote');
+
+  const wikiSearch = await waitFor<any>('promoted note wiki page', async () => {
+    const body = await api<any>(auth, `/api/wiki?q=${encodeURIComponent(noteTitle)}&limit=10`);
+    const pages = asArray<any>(body, ['pages']);
+    return pages.find((page) => page.title === noteTitle || containsMarker(page)) ? { body, pages } : null;
+  }, { timeoutMs: 45_000, intervalMs: 2_000 });
+  artifact.evidence.promoted_note = {
+    title: noteTitle,
+    wiki_pages: wikiSearch.pages.map((page: any) => ({ id: page.id, title: page.title, slug: page.slug, type: page.type })),
+  };
+}
+
+async function captureKnowledgeSurface(page: Page) {
+  await page.goto(`${WEB_URL}/knowledge`, { waitUntil: 'domcontentloaded' });
+  await page.locator('main').waitFor({ state: 'visible', timeout: 25_000 });
+  const search = page.locator('input[placeholder*="Search"], input[placeholder*="search"]').first();
+  if (await search.isVisible().catch(() => false)) {
+    await search.fill(RUN_MARKER);
+    await page.waitForTimeout(1_000);
+  }
+  await screenshot(page, 'knowledge-search-marker');
+}
+
+function summarizeClaimStatus() {
+  const checks = artifact.checks;
+  const hasFail = checks.some((check) => check.status === 'fail');
+  const hasWarn = checks.some((check) => check.status === 'warn') || artifact.findings.some((finding) => finding.severity === 'P1' || finding.severity === 'P2');
+  if (hasFail) return 'Needs fixes before being used as proof';
+  if (hasWarn) return 'Mostly works, with caveats to fix or narrate honestly';
+  return 'Validated for demo use';
+}
+
+async function writeReport() {
+  artifact.finished_at = new Date().toISOString();
+  await fs.mkdir(path.dirname(HTML_REPORT), { recursive: true });
+  await fs.writeFile(JSON_REPORT, JSON.stringify(artifact, null, 2));
+
+  const rel = (file: string) => path.relative(path.dirname(HTML_REPORT), file).replace(/\\/g, '/');
+  const counts = artifact.checks.reduce((acc, check) => {
+    acc[check.status] = (acc[check.status] || 0) + 1;
+    return acc;
+  }, {} as Record<string, number>);
+
+  const claimRows = [
+    {
+      claim: 'Chat becomes context',
+      verdict: artifact.checks.find((check) => check.name.includes('Expected Defty captures appeared'))?.status === 'pass' ? 'Validated' : 'Partial',
+      evidence: 'Diego sent tagged messages in chat; Defty produced task, decision, resource, and note captures visible in Captures.',
+    },
+    {
+      claim: 'Tasks become action',
+      verdict: artifact.ids.created_task_id ? 'Validated' : 'Not proven',
+      evidence: artifact.ids.created_task_id ? `Approved capture created task ${artifact.ids.created_task_id}.` : 'No converted task ID recorded.',
+    },
+    {
+      claim: 'Notes become memory',
+      verdict: artifact.evidence.promoted_note ? 'Validated with explicit promotion' : 'Not proven',
+      evidence: 'Manager note was created through the Notes UI and promoted to a searchable wiki page.',
+    },
+    {
+      claim: 'Approvals become governance',
+      verdict: Array.isArray((artifact.evidence as any).receipts) && (artifact.evidence as any).receipts.length > 0 ? 'Validated' : 'Partial',
+      evidence: 'Captured actions required UI approval and approved actions were checked for verified receipts.',
+    },
+  ];
+
+  const html = `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Deft Demo Claim Certification - ${escapeHtml(RUN_MARKER)}</title>
+  <style>
+    :root { color-scheme: light; --ink:#191714; --muted:#6f675d; --line:#ddd6ca; --paper:#faf8f3; --card:#fffdf8; --accent:#6f5fda; --green:#168a5b; --amber:#a86700; --red:#c63d32; }
+    body { margin:0; background:var(--paper); color:var(--ink); font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; line-height:1.45; }
+    main { max-width:1120px; margin:0 auto; padding:40px 24px 64px; }
+    h1 { font-size:34px; line-height:1.04; letter-spacing:0; margin:0 0 10px; }
+    h2 { font-size:20px; margin:34px 0 12px; }
+    h3 { font-size:15px; margin:20px 0 8px; }
+    p { color:var(--muted); max-width:820px; }
+    .hero { border:1px solid var(--line); background:var(--card); border-radius:10px; padding:26px; }
+    .pill { display:inline-flex; align-items:center; gap:8px; padding:5px 10px; border-radius:999px; border:1px solid var(--line); background:#fff; font-size:12px; color:var(--muted); }
+    .grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(240px,1fr)); gap:12px; }
+    .card { border:1px solid var(--line); background:var(--card); border-radius:8px; padding:16px; }
+    table { width:100%; border-collapse:collapse; background:var(--card); border:1px solid var(--line); border-radius:8px; overflow:hidden; }
+    th, td { text-align:left; vertical-align:top; border-bottom:1px solid var(--line); padding:11px 12px; font-size:13px; }
+    th { color:var(--muted); font-size:11px; text-transform:uppercase; letter-spacing:.04em; background:#f4efe7; }
+    tr:last-child td { border-bottom:0; }
+    .pass { color:var(--green); font-weight:700; }
+    .warn { color:var(--amber); font-weight:700; }
+    .fail { color:var(--red); font-weight:700; }
+    .screens { display:grid; grid-template-columns:repeat(auto-fit,minmax(300px,1fr)); gap:14px; }
+    figure { margin:0; border:1px solid var(--line); background:var(--card); border-radius:8px; overflow:hidden; }
+    figure img { width:100%; display:block; background:#fff; }
+    figcaption { padding:9px 11px; color:var(--muted); font-size:12px; border-top:1px solid var(--line); }
+    pre { white-space:pre-wrap; overflow-wrap:anywhere; border:1px solid var(--line); background:#fffdf8; border-radius:8px; padding:14px; font-size:12px; color:#37312b; }
+    code { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+  </style>
+</head>
+<body>
+<main>
+  <section class="hero">
+    <span class="pill">Live demo instance certification</span>
+    <h1>Deft Demo Claim Certification</h1>
+    <p><strong>Status:</strong> ${escapeHtml(summarizeClaimStatus())}</p>
+    <p>Run marker <code>${escapeHtml(RUN_MARKER)}</code>. Tested as Diego on <code>${escapeHtml(WEB_URL)}</code>. UI actions were used for login, chat, capture approvals, note creation, and note promotion; API reads were used afterward as evidence.</p>
+    <div class="grid">
+      <div class="card"><strong>${counts.pass || 0}</strong><br><span class="pass">Passed checks</span></div>
+      <div class="card"><strong>${counts.warn || 0}</strong><br><span class="warn">Warnings</span></div>
+      <div class="card"><strong>${counts.fail || 0}</strong><br><span class="fail">Failures</span></div>
+    </div>
+  </section>
+
+  <h2>Claim Verdicts</h2>
+  <table>
+    <thead><tr><th>Claim</th><th>Verdict</th><th>Evidence</th></tr></thead>
+    <tbody>
+      ${claimRows.map((row) => `<tr><td>${escapeHtml(row.claim)}</td><td><strong>${escapeHtml(row.verdict)}</strong></td><td>${escapeHtml(row.evidence)}</td></tr>`).join('')}
+    </tbody>
+  </table>
+
+  <h2>Checks</h2>
+  <table>
+    <thead><tr><th>Status</th><th>Check</th><th>Detail</th><th>Time</th></tr></thead>
+    <tbody>
+      ${artifact.checks.map((check) => `<tr><td class="${check.status}">${check.status.toUpperCase()}</td><td>${escapeHtml(check.name)}</td><td>${escapeHtml(typeof check.detail === 'string' ? check.detail : check.detail ? JSON.stringify(check.detail) : '')}</td><td>${check.ms ?? ''}ms</td></tr>`).join('')}
+    </tbody>
+  </table>
+
+  <h2>Findings</h2>
+  ${artifact.findings.length === 0 ? '<p>No new blocker findings from this run.</p>' : `<table><thead><tr><th>Severity</th><th>Finding</th><th>Detail</th></tr></thead><tbody>${artifact.findings.map((finding) => `<tr><td>${escapeHtml(finding.severity)}</td><td>${escapeHtml(finding.title)}</td><td>${escapeHtml(finding.detail)}</td></tr>`).join('')}</tbody></table>`}
+
+  <h2>Screenshots</h2>
+  <div class="screens">
+    ${Object.entries(artifact.screenshots).map(([name, file]) => `<figure><img src="${escapeHtml(rel(file))}" alt="${escapeHtml(name)}"><figcaption>${escapeHtml(name)}</figcaption></figure>`).join('')}
+  </div>
+
+  <h2>Evidence JSON</h2>
+  <pre>${escapeHtml(JSON.stringify({ ids: artifact.ids, evidence: artifact.evidence }, null, 2))}</pre>
+</main>
+</body>
+</html>`;
+
+  await fs.writeFile(HTML_REPORT, html);
+  console.log(`HTML_REPORT=${HTML_REPORT}`);
+  console.log(`JSON_REPORT=${JSON_REPORT}`);
+}
+
+async function main() {
+  await fs.mkdir(OUT_DIR, { recursive: true });
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({ viewport: { width: 1440, height: 980 }, deviceScaleFactor: 1 });
+  const page = await context.newPage();
+  const consoleErrors: string[] = [];
+  page.on('console', (msg) => {
+    if (['error', 'warning'].includes(msg.type())) consoleErrors.push(`${msg.type()}: ${msg.text()}`);
+  });
+
+  try {
+    const auth = await step('API login works for Diego', loginApi) as Auth;
+    await step('UI login works for Diego', () => loginUi(page));
+
+    if (args.has('--notes-only')) {
+      await step('Create a manager note and promote it to wiki through UI', () => createAndPromoteNote(page, auth));
+      await step('Knowledge search shows promoted note memory', () => captureKnowledgeSurface(page));
+      mark('pass', 'Notes-only certification completed');
+      return;
+    }
+
+    const space = await step('Pick a seeded public workspace space', () => pickSpace(auth)) as Space;
+    await gotoSurface(page, `/chat?space=${encodeURIComponent(space.id)}`, 'surface-chat-start', new RegExp(space.name, 'i'));
+
+    const messages = {
+      noise: `Quick FYI ${RUN_MARKER}: the basil by the packhouse smells great today. No action needed, no task, no memory.`,
+      workflow: [
+        `Demo workflow ${RUN_MARKER}:`,
+        `Task: create a P2 task named "Confirm route capacity and pack sample boxes" for the Pilot Marketing Launch project; assign it to Lina if possible; due tomorrow.`,
+        `Decision: Testers Tomatoes will use the Tuesday route promise gate before sending any buyer launch copy.`,
+        `Resource: buyer promise checklist is confirm Tomas route capacity, pack eight-ounce Sun Gold sample boxes, and use https://demo.deft.ing/docs/self-hosting as the self-host reference.`,
+        `Fact: shelf-life trial notes say Sun Gold sample boxes should be packed as eight-ounce mixed packs for Chef Amara.`,
+      ].join('\n'),
+    };
+
+    await step('Send demo workflow messages through Chat UI', async () => {
+      for (const [label, content] of Object.entries(messages)) {
+        await sendChatMessage(page, space, label, content);
+        if (label === 'noise') {
+          mark('warn', 'Waiting one limiter window between chat sends on production demo', 'Public demo hit default rate limits during rapid automated sends.');
+          await delay(65_000);
+        }
+      }
+      await screenshot(page, 'chat-after-demo-messages');
+    });
+
+    const captureBundle = await step('Expected Defty captures appeared after chat messages', () => waitForExpectedCaptures(auth)) as { intents: any[]; actions: any[] };
+    artifact.evidence.initial_intents = captureBundle.intents.map((intent) => ({
+      id: intent.id,
+      kind: intent.kind,
+      status: intent.status,
+      title: intent.title,
+      confidence: intent.confidence,
+    }));
+    artifact.evidence.initial_actions = captureBundle.actions.map((action) => ({
+      id: action.id,
+      action: action.action,
+      approval_status: action.approval_status,
+      params: action.params,
+    }));
+
+    const noiseCaptured = captureBundle.intents.some((intent) => containsMarker(intent.source_message_content) && String(intent.source_message_content).includes('No action needed'));
+    if (noiseCaptured) {
+      artifact.findings.push({
+        severity: 'P2',
+        title: 'No-action chat message was captured',
+        detail: `The explicit no-action/no-memory message tagged ${RUN_MARKER} produced a capture. That is a guardrail/noise issue for high-volume teams.`,
+      });
+    } else {
+      mark('pass', 'No-action chat message did not produce a capture');
+    }
+
+    await step('Approve task capture through Captures UI', () => approveCaptureWithUi(page, 'Create task', 'task'));
+    await step('Approve decision capture through Captures UI', () => approveCaptureWithUi(page, 'Save decision', 'decision'), true);
+    await step('Approve resource capture through Captures UI', () => approveCaptureWithUi(page, 'Save resource', 'resource'), true);
+    await step('Approve memory capture through Captures UI', () => approveCaptureWithUi(page, 'Save knowledge', 'knowledge'), true);
+
+    await step('Verify approved captures produced task/wiki records and receipts', () => verifyConverted(auth));
+    await step('Create a manager note and promote it to wiki through UI', () => createAndPromoteNote(page, auth));
+    await step('Knowledge search shows created memory', () => captureKnowledgeSurface(page));
+
+    await step('Core surfaces render in browser after workflow', async () => {
+      const surfaces: Array<[string, string, RegExp]> = [
+        ['/dashboard', 'surface-dashboard', /dashboard|my work|agent activity/i],
+        ['/inbox', 'surface-inbox', /inbox|nothing here|captures|approvals/i],
+        ['/inbox?tab=captures', 'surface-captures', /captures|nothing here|Defty/i],
+        ['/tasks', 'surface-tasks', /backlog|todo|in progress|done|tasks/i],
+        ['/knowledge', 'surface-knowledge', /knowledge|wiki|graph/i],
+        ['/calendar', 'surface-calendar', /calendar|today|events/i],
+        ['/settings/mcp-access', 'surface-mcp-access', /mcp|connected ai apps|personal access/i],
+      ];
+      for (const [route, name, expected] of surfaces) {
+        await gotoSurface(page, route, name, expected);
+        await delay(1_500);
+      }
+    }, true);
+
+    const taskId = artifact.ids.created_task_id;
+    if (taskId) {
+      await step('Created task opens in task detail UI', async () => {
+        await page.goto(`${WEB_URL}/tasks?task=${encodeURIComponent(taskId)}`, { waitUntil: 'domcontentloaded' });
+        await page.locator('main').waitFor({ state: 'visible', timeout: 25_000 });
+        await page.getByText(RUN_MARKER, { exact: false }).first().waitFor({ state: 'visible', timeout: 25_000 });
+        await screenshot(page, 'created-task-detail');
+      }, true);
+    }
+
+    const seriousConsoleErrors = consoleErrors.filter((line) => !/favicon|ResizeObserver|hydration/i.test(line));
+    artifact.evidence.console_errors = seriousConsoleErrors.slice(0, 25);
+    if (seriousConsoleErrors.length > 0) {
+      artifact.findings.push({
+        severity: 'P3',
+        title: 'Console warnings/errors appeared during run',
+        detail: seriousConsoleErrors.slice(0, 5).join('\n'),
+      });
+      mark('warn', 'Browser console contained warnings/errors', seriousConsoleErrors.length);
+    } else {
+      mark('pass', 'No serious browser console errors observed');
+    }
+  } finally {
+    await browser.close();
+    await writeReport();
+  }
+}
+
+main().catch(async (err) => {
+  artifact.findings.push({
+    severity: 'P1',
+    title: 'Certification run stopped early',
+    detail: err instanceof Error ? err.stack || err.message : String(err),
+  });
+  await writeReport();
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/reports/dense-human-workflow-certification.ts
+++ b/scripts/reports/dense-human-workflow-certification.ts
@@ -1,0 +1,981 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { chromium, type BrowserContext, type Page } from 'playwright';
+
+const WEB_URL = (process.env.DEFT_WEB_URL || 'http://localhost:3000').replace(/\/$/, '');
+const API_URL = (process.env.DEFT_API_URL || process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3301').replace(/\/$/, '');
+const PASSWORD = process.env.DEFT_TEST_PASSWORD || 'tomato123';
+const RUN_ID = process.env.DEFT_DENSE_RUN_ID || new Date().toISOString().replace(/[:.]/g, '-');
+const RUN_MARKER = `DENSE-${RUN_ID.replace(/[^a-zA-Z0-9]/g, '').slice(-10)}`;
+const OUT_DIR = path.resolve('reports', 'dense-human-workflow-certification', RUN_ID);
+const HTML_REPORT = path.resolve('reports', `dense-human-workflow-certification-${RUN_ID}.html`);
+const JSON_REPORT = path.resolve('reports', `dense-human-workflow-certification-${RUN_ID}.json`);
+
+type Auth = {
+  accessToken: string;
+  user: { id: string; email: string; org_id: string; name?: string };
+};
+
+type Space = { id: string; name: string; type?: string };
+type Status = 'pass' | 'warn' | 'fail';
+type Check = { status: Status; name: string; detail?: unknown; ms?: number };
+type ExpectedKind = 'task' | 'decision' | 'resource' | 'note' | 'blocker' | 'update' | 'noise';
+type SentMessage = {
+  id?: string;
+  persona: string;
+  email: string;
+  space: string;
+  space_id: string;
+  tag: string;
+  expected: ExpectedKind;
+  content: string;
+  ok: boolean;
+  error?: string;
+};
+
+type Persona = {
+  name: string;
+  email: string;
+  role: string;
+  spaces: string[];
+  focus: string;
+};
+
+type Artifact = {
+  run_id: string;
+  marker: string;
+  web_url: string;
+  api_url: string;
+  started_at: string;
+  finished_at?: string;
+  checks: Check[];
+  screenshots: Record<string, string>;
+  sent_messages: SentMessage[];
+  evidence: Record<string, unknown>;
+  findings: Array<{ severity: 'P0' | 'P1' | 'P2' | 'P3'; title: string; detail: string }>;
+};
+
+const personas: Persona[] = [
+  {
+    name: 'Diego Vargas',
+    email: 'diego@testers-tomatoes.com',
+    role: 'Manager',
+    spaces: ['field-ops', 'sales-and-buyers', 'marketing'],
+    focus: 'buyer launch and operational decisions',
+  },
+  {
+    name: 'Lina Bhattacharya',
+    email: 'lina@testers-tomatoes.com',
+    role: 'Sales Lead',
+    spaces: ['marketing', 'sales-and-buyers', 'buyer-updates'],
+    focus: 'buyer objections and launch copy',
+  },
+  {
+    name: 'Marigold Patel',
+    email: 'marigold@testers-tomatoes.com',
+    role: 'Head Grower',
+    spaces: ['field-ops', 'greenhouse', 'harvest-room'],
+    focus: 'crop quality and greenhouse status',
+  },
+  {
+    name: 'Cesar Okafor',
+    email: 'cesar@testers-tomatoes.com',
+    role: 'Field Supervisor',
+    spaces: ['field-ops', 'harvest-room', 'operations'],
+    focus: 'harvest execution and blockers',
+  },
+  {
+    name: 'Tomas Wakefield',
+    email: 'tomas@testers-tomatoes.com',
+    role: 'Logistics',
+    spaces: ['operations', 'logistics', 'buyer-updates'],
+    focus: 'route capacity and cold-chain handoffs',
+  },
+];
+
+const artifact: Artifact = {
+  run_id: RUN_ID,
+  marker: RUN_MARKER,
+  web_url: WEB_URL,
+  api_url: API_URL,
+  started_at: new Date().toISOString(),
+  checks: [],
+  screenshots: {},
+  sent_messages: [],
+  evidence: {},
+  findings: [],
+};
+
+function escapeHtml(value: unknown): string {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function mark(status: Status, name: string, detail?: unknown, ms?: number) {
+  artifact.checks.push({ status, name, detail, ms });
+  const suffix = detail ? `: ${typeof detail === 'string' ? detail : JSON.stringify(detail)}` : '';
+  console.log(`[${status.toUpperCase()}] ${name}${suffix}`);
+}
+
+async function step<T>(name: string, fn: () => Promise<T>, warnOnly = false): Promise<T | null> {
+  const started = Date.now();
+  try {
+    const value = await fn();
+    mark('pass', name, undefined, Date.now() - started);
+    return value;
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    mark(warnOnly ? 'warn' : 'fail', name, detail, Date.now() - started);
+    if (!warnOnly) throw err;
+    return null;
+  }
+}
+
+function delay(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function fetchJson<T = any>(url: string, init?: RequestInit): Promise<{ status: number; ok: boolean; body: T; text: string }> {
+  const res = await fetch(url, { ...init, signal: AbortSignal.timeout(30_000) });
+  const text = await res.text();
+  let body: T;
+  try {
+    body = JSON.parse(text) as T;
+  } catch {
+    body = text as T;
+  }
+  return { status: res.status, ok: res.ok, body, text };
+}
+
+async function loginApi(email: string): Promise<Auth> {
+  const res = await fetchJson<Auth>(`${API_URL}/api/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password: PASSWORD }),
+  });
+  if (!res.ok || !res.body?.accessToken) {
+    throw new Error(`API login failed for ${email}: ${res.status} ${res.text.slice(0, 240)}`);
+  }
+  return res.body;
+}
+
+async function api<T = any>(auth: Auth, route: string, init?: RequestInit): Promise<T> {
+  const hasBody = init?.body !== undefined;
+  const res = await fetchJson<T>(`${API_URL}${route}`, {
+    ...init,
+    headers: {
+      ...(hasBody ? { 'Content-Type': 'application/json' } : {}),
+      Authorization: `Bearer ${auth.accessToken}`,
+      ...(init?.headers || {}),
+    },
+  });
+  if (!res.ok) throw new Error(`${route} returned ${res.status}: ${res.text.slice(0, 500)}`);
+  return res.body;
+}
+
+function asArray<T = any>(value: any, keys: string[] = []): T[] {
+  if (Array.isArray(value)) return value;
+  for (const key of keys) {
+    if (Array.isArray(value?.[key])) return value[key];
+  }
+  return [];
+}
+
+async function waitFor<T>(
+  label: string,
+  fn: () => Promise<T | null | undefined | false>,
+  opts: { timeoutMs?: number; intervalMs?: number } = {},
+): Promise<T> {
+  const timeoutMs = opts.timeoutMs ?? 120_000;
+  const intervalMs = opts.intervalMs ?? 2_000;
+  const started = Date.now();
+  let last: unknown = null;
+  while (Date.now() - started < timeoutMs) {
+    try {
+      const value = await fn();
+      if (value) return value as T;
+      last = value;
+    } catch (err) {
+      last = err instanceof Error ? err.message : String(err);
+    }
+    await delay(intervalMs);
+  }
+  throw new Error(`Timed out waiting for ${label}. Last: ${JSON.stringify(last)}`);
+}
+
+function tagFor(persona: Persona, index: number, expected: ExpectedKind) {
+  const short = persona.name.split(' ')[0].toUpperCase();
+  return `${RUN_MARKER}-${short}-${String(index).padStart(2, '0')}-${expected.toUpperCase()}`;
+}
+
+function makeMessage(persona: Persona, index: number): { expected: ExpectedKind; content: string; space: string; tag: string } {
+  const patterns: ExpectedKind[] = [
+    'noise', 'task', 'decision', 'note', 'resource',
+    'noise', 'blocker', 'task', 'decision', 'update',
+    'noise', 'note', 'resource', 'task', 'decision',
+    'noise', 'update', 'blocker', 'note', 'task',
+  ];
+  const expected = patterns[index % patterns.length]!;
+  const tag = tagFor(persona, index + 1, expected);
+  const space = persona.spaces[index % persona.spaces.length]!;
+  const subject = persona.focus;
+  const contentByKind: Record<ExpectedKind, string> = {
+    noise: `${tag}: Casual FYI from ${persona.name}. No action needed, no task, no decision, no memory. Just saying the tomato room still smells like tomato room.`,
+    task: `${tag}: Please create a P2 task to follow up on the ${RUN_MARKER} launch drill for ${subject}; owner should be ${persona.name}; due tomorrow; include the source message so we know why it exists.`,
+    decision: `${tag}: Decision: for the ${RUN_MARKER} launch drill around ${subject}, we will use the Tuesday route promise gate before telling buyers the launch is green. Save this as team knowledge.`,
+    resource: `${tag}: Resource: ${subject} checklist lives at https://demo.deft.ing/docs/self-hosting and the working steps are confirm capacity, pack samples, and post the buyer update.`,
+    note: `${tag}: Fact: the ${RUN_MARKER} launch drill for ${subject} depends on Sun Gold eight-ounce sample boxes staying below 38F until handoff. Keep this as operating memory.`,
+    blocker: `${tag}: Blocked: the ${RUN_MARKER} launch drill for ${subject} cannot move because the cold-room staging count and route-capacity board disagree. Please track the blocker.`,
+    update: `${tag}: Update: the ${RUN_MARKER} launch drill for ${subject} moved from waiting to ready-for-review after the morning pass. Keep this status update as context; no new task if the existing task can be updated.`,
+  };
+  return { expected, content: contentByKind[expected], space, tag };
+}
+
+function buildMessages(persona: Persona) {
+  return Array.from({ length: 20 }, (_, i) => makeMessage(persona, i));
+}
+
+async function screenshot(page: Page, name: string) {
+  await fs.mkdir(OUT_DIR, { recursive: true });
+  const file = path.join(OUT_DIR, `${name}.png`);
+  await page.screenshot({ path: file, fullPage: true }).catch(() => null);
+  artifact.screenshots[name] = file;
+}
+
+async function loginUi(page: Page, email: string) {
+  await page.goto(`${WEB_URL}/login`, { waitUntil: 'domcontentloaded' });
+  await page.locator('#login-email').waitFor({ state: 'visible', timeout: 20_000 });
+  await page.locator('#login-email').fill(email);
+  await page.locator('#login-password').fill(PASSWORD);
+  const responsePromise = page.waitForResponse(
+    (response) => response.request().method() === 'POST' && response.url().includes('/api/auth/login'),
+    { timeout: 15_000 },
+  ).catch(() => null);
+  await page.getByRole('button', { name: /^sign in$/i }).click();
+  await page.waitForURL((url) => !url.pathname.includes('/login'), { timeout: 30_000 });
+  const response = await responsePromise;
+  if (response && response.status() >= 400) throw new Error(`UI login failed for ${email}: ${response.status()}`);
+  await page.locator('main').waitFor({ state: 'visible', timeout: 20_000 });
+}
+
+async function sendUiMessage(page: Page, space: Space, message: { expected: ExpectedKind; content: string; space: string; tag: string }, persona: Persona): Promise<SentMessage> {
+  const sent: SentMessage = {
+    persona: persona.name,
+    email: persona.email,
+    space: space.name,
+    space_id: space.id,
+    tag: message.tag,
+    expected: message.expected,
+    content: message.content,
+    ok: false,
+  };
+
+  try {
+    await page.goto(`${WEB_URL}/chat?space=${encodeURIComponent(space.id)}`, { waitUntil: 'domcontentloaded' });
+    await page.locator('main').waitFor({ state: 'visible', timeout: 25_000 });
+    const editor = page.locator('[contenteditable="true"].deft-editor').last();
+    await editor.waitFor({ state: 'visible', timeout: 25_000 });
+    await editor.fill(message.content);
+    const sendButton = page.getByRole('button', { name: /send message/i }).last();
+    await waitFor('send button enabled', async () => {
+      const disabled = await sendButton.evaluate((button) => (button as HTMLButtonElement).disabled).catch(() => true);
+      return disabled ? null : true;
+    }, { timeoutMs: 10_000, intervalMs: 250 });
+    const post = page.waitForResponse(
+      (response) => {
+        if (response.request().method() !== 'POST') return false;
+        try {
+          const url = new URL(response.url());
+          return url.pathname === `/api/messages/${space.id}` || url.pathname.startsWith(`/api/messages/${space.id}/`);
+        } catch {
+          return false;
+        }
+      },
+      { timeout: 30_000 },
+    );
+    await sendButton.click();
+    const response = await post;
+    if (response.status() >= 400) {
+      const body = await response.text().catch(() => '');
+      throw new Error(`send failed ${response.status()}: ${body.slice(0, 200)}`);
+    }
+    const body = await response.json().catch(() => null);
+    sent.id = body?.id;
+    sent.ok = true;
+  } catch (err) {
+    sent.error = err instanceof Error ? err.message : String(err);
+  }
+  artifact.sent_messages.push(sent);
+  return sent;
+}
+
+async function sendPersonaBatch(context: BrowserContext, persona: Persona, spacesByName: Map<string, Space>) {
+  const page = await context.newPage();
+  const consoleIssues: string[] = [];
+  page.on('console', (msg) => {
+    if (['error', 'warning'].includes(msg.type())) consoleIssues.push(`${msg.type()}: ${msg.text()}`);
+  });
+  await loginUi(page, persona.email);
+  await screenshot(page, `login-${persona.email.split('@')[0]}`);
+
+  const messages = buildMessages(persona);
+  for (let i = 0; i < messages.length; i += 1) {
+    const message = messages[i]!;
+    const space = spacesByName.get(message.space) ?? spacesByName.values().next().value;
+    if (!space) throw new Error(`No space found for ${message.space}`);
+    await sendUiMessage(page, space, message, persona);
+    await delay(150 + ((i + persona.name.length) % 5) * 80);
+  }
+  await screenshot(page, `after-messages-${persona.email.split('@')[0]}`);
+  return { persona: persona.name, consoleIssues };
+}
+
+async function sendLoggedPersonaMessages(page: Page, persona: Persona, spacesByName: Map<string, Space>) {
+  const messages = buildMessages(persona);
+  for (let i = 0; i < messages.length; i += 1) {
+    const message = messages[i]!;
+    const space = spacesByName.get(message.space) ?? spacesByName.values().next().value;
+    if (!space) throw new Error(`No space found for ${message.space}`);
+    await sendUiMessage(page, space, message, persona);
+    await delay(150 + ((i + persona.name.length) % 5) * 80);
+  }
+  await screenshot(page, `after-messages-${persona.email.split('@')[0]}`);
+}
+
+async function getSpaces(auth: Auth): Promise<Space[]> {
+  const body = await api<any>(auth, '/api/spaces');
+  return asArray<Space>(body, ['spaces']);
+}
+
+async function getRunIntents(auth: Auth) {
+  const body = await api<any>(auth, '/api/work-intents?limit=100');
+  const runMessageIds = new Set(artifact.sent_messages.map((message) => message.id).filter(Boolean));
+  return asArray<any>(body, ['intents']).filter((intent) =>
+    (intent.source_message_id && runMessageIds.has(intent.source_message_id))
+    || JSON.stringify(intent).includes(RUN_MARKER)
+  );
+}
+
+async function getRunActions(auth: Auth) {
+  const body = await api<any>(auth, '/api/agent/actions');
+  const runMessageIds = new Set(artifact.sent_messages.map((message) => message.id).filter(Boolean));
+  return asArray<any>(body).filter((action) => {
+    const params = action.params && typeof action.params === 'object' ? action.params : {};
+    return JSON.stringify(action).includes(RUN_MARKER)
+      || (params.source_message_id && runMessageIds.has(params.source_message_id))
+      || (params.origin_message_id && runMessageIds.has(params.origin_message_id));
+  });
+}
+
+async function getRunObservations(auth: Auth) {
+  const body = await api<any>(
+    auth,
+    `/api/work-intents/observations?limit=500&marker=${encodeURIComponent(RUN_MARKER)}`,
+  );
+  const runMessageIds = new Set(artifact.sent_messages.map((message) => message.id).filter(Boolean));
+  return asArray<any>(body, ['observations']).filter((observation) =>
+    observation.message_id && runMessageIds.has(observation.message_id)
+  );
+}
+
+function summarizeCaptures(intents: any[]) {
+  const byKind: Record<string, number> = {};
+  const byStatus: Record<string, number> = {};
+  for (const intent of intents) {
+    byKind[intent.kind] = (byKind[intent.kind] || 0) + 1;
+    byStatus[intent.status] = (byStatus[intent.status] || 0) + 1;
+  }
+  return { byKind, byStatus };
+}
+
+function summarizeObservations(observations: any[]) {
+  const byStatus: Record<string, number> = {};
+  const byIgnoredReason: Record<string, number> = {};
+  for (const observation of observations) {
+    byStatus[observation.status] = (byStatus[observation.status] || 0) + 1;
+    if (observation.ignored_reason) {
+      byIgnoredReason[observation.ignored_reason] = (byIgnoredReason[observation.ignored_reason] || 0) + 1;
+    }
+  }
+  return { byStatus, byIgnoredReason };
+}
+
+function expectedMatches(kind: ExpectedKind, intentKind: string) {
+  if (kind === 'task') return intentKind === 'task_candidate';
+  if (kind === 'decision') return intentKind === 'decision_candidate';
+  if (kind === 'resource') return intentKind === 'resource_candidate';
+  if (kind === 'note') return intentKind === 'note_candidate';
+  if (kind === 'blocker') return intentKind === 'blocker_candidate' || intentKind === 'task_candidate';
+  if (kind === 'update') return intentKind === 'task_candidate' || intentKind === 'note_candidate';
+  return false;
+}
+
+function normalizedRepeatKey(message: SentMessage) {
+  const body = message.content
+    .replace(/^DENSE-[^:]+:\s*/i, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toLowerCase();
+  return `${message.expected}:${body}`;
+}
+
+function observationReachedTerminal(observation: any | undefined) {
+  return observation && ['ignored', 'no_capture', 'captured'].includes(observation.status);
+}
+
+function observationRoutedForExpected(kind: ExpectedKind, observation: any | undefined) {
+  const jobs = Array.isArray(observation?.downstream_jobs) ? observation.downstream_jobs : [];
+  const names = new Set(jobs.map((job: any) => job?.name).filter(Boolean));
+  if (kind === 'task') return names.has('task-extract');
+  if (kind === 'blocker') return names.has('blocked-alert');
+  if (kind === 'decision' || kind === 'resource' || kind === 'note') return names.has('memory-capture');
+  if (kind === 'update') return names.has('task-extract') || names.has('memory-capture');
+  return false;
+}
+
+function classifyCoverage(intents: any[], observations: any[]) {
+  const byMessageId = new Map<string, any[]>();
+  for (const intent of intents) {
+    if (intent.source_message_id) {
+      const list = byMessageId.get(intent.source_message_id) ?? [];
+      list.push(intent);
+      byMessageId.set(intent.source_message_id, list);
+    }
+  }
+  const observationsByMessageId = new Map<string, any>();
+  for (const observation of observations) {
+    if (observation.message_id) observationsByMessageId.set(observation.message_id, observation);
+  }
+  const sentOk = artifact.sent_messages.filter((message) => message.ok && message.id);
+  const baseRows = sentOk.map((message) => {
+    const captures = byMessageId.get(message.id!) ?? [];
+    const directMatched = message.expected === 'noise'
+      ? captures.length === 0
+      : captures.some((intent) => expectedMatches(message.expected, intent.kind));
+    const observation = observationsByMessageId.get(message.id!);
+    return {
+      tag: message.tag,
+      expected: message.expected,
+      message_id: message.id,
+      captures: captures.map((intent) => `${intent.kind}:${intent.status}`),
+      direct_matched: directMatched,
+      repeat_key: normalizedRepeatKey(message),
+      observation_status: observation?.status ?? null,
+      downstream_jobs: Array.isArray(observation?.downstream_jobs)
+        ? observation.downstream_jobs.map((job: any) => job?.name).filter(Boolean)
+        : [],
+    };
+  });
+  const directMatchedRepeatKeys = new Set(
+    baseRows
+      .filter((row) => row.expected !== 'noise' && row.direct_matched)
+      .map((row) => row.repeat_key),
+  );
+  const rows = baseRows.map((row) => {
+    const observation = observationsByMessageId.get(row.message_id!);
+    const dedupedRepeat = row.expected !== 'noise'
+      && !row.direct_matched
+      && directMatchedRepeatKeys.has(row.repeat_key)
+      && observationReachedTerminal(observation)
+      && observationRoutedForExpected(row.expected, observation);
+    const matched = row.expected === 'noise'
+      ? row.direct_matched
+      : row.direct_matched || dedupedRepeat;
+    return {
+      tag: row.tag,
+      expected: row.expected,
+      message_id: row.message_id,
+      captures: row.captures,
+      observation_status: row.observation_status,
+      downstream_jobs: row.downstream_jobs,
+      matched,
+      matched_via: row.direct_matched ? 'capture' : dedupedRepeat ? 'deduped_repeat' : 'miss',
+    };
+  });
+  const expectedRows = rows.filter((row) => row.expected !== 'noise');
+  const noiseRows = rows.filter((row) => row.expected === 'noise');
+  const falseNegatives = expectedRows.filter((row) => !row.matched);
+  const falsePositives = noiseRows.filter((row) => !row.matched);
+  const dedupedRepeatCount = rows.filter((row) => row.matched_via === 'deduped_repeat').length;
+  return {
+    rows,
+    expected_count: expectedRows.length,
+    noise_count: noiseRows.length,
+    matched_expected: expectedRows.length - falseNegatives.length,
+    false_negative_count: falseNegatives.length,
+    false_positive_count: falsePositives.length,
+    deduped_repeat_count: dedupedRepeatCount,
+    false_negatives: falseNegatives.slice(0, 20),
+    false_positives: falsePositives.slice(0, 20),
+  };
+}
+
+async function approveSomeViaUi(page: Page) {
+  await page.goto(`${WEB_URL}/inbox?tab=captures`, { waitUntil: 'domcontentloaded' });
+  await page.locator('main').waitFor({ state: 'visible', timeout: 25_000 });
+  await screenshot(page, 'captures-before-dense-approvals');
+  const targets = ['Create task', 'Create task', 'Save decision', 'Save resource', 'Save knowledge'];
+  let clicked = 0;
+  for (const buttonText of targets) {
+    const didClick = await page.evaluate(({ marker, buttonText }) => {
+      const target = buttonText.toLowerCase();
+      for (const button of Array.from(document.querySelectorAll('button'))) {
+        const label = `${button.textContent || ''} ${button.getAttribute('aria-label') || ''}`.trim().toLowerCase();
+        if (label !== target) continue;
+        let node: HTMLElement | null = button;
+        for (let i = 0; i < 12 && node; i += 1) {
+          if ((node.textContent || '').includes(marker)) {
+            button.click();
+            return true;
+          }
+          node = node.parentElement;
+        }
+      }
+      return false;
+    }, { marker: RUN_MARKER, buttonText });
+    if (didClick) {
+      clicked += 1;
+      await delay(1_400);
+    }
+  }
+  await screenshot(page, 'captures-after-dense-approvals');
+  artifact.evidence.approval_clicks = clicked;
+  if (clicked === 0) {
+    artifact.findings.push({
+      severity: 'P1',
+      title: 'No dense-run captures could be approved in the UI',
+      detail: 'The test found capture proposals but could not click any run-scoped approval card.',
+    });
+  }
+}
+
+async function createAndPromoteNote(page: Page, auth: Auth) {
+  await page.goto(`${WEB_URL}/notes`, { waitUntil: 'domcontentloaded' });
+  await page.locator('main').waitFor({ state: 'visible', timeout: 25_000 });
+  await screenshot(page, 'notes-before-dense-note');
+  const createResponse = page.waitForResponse(
+    (response) => response.request().method() === 'POST' && response.url().includes('/api/daily-notes'),
+    { timeout: 20_000 },
+  ).catch(() => null);
+  await page.getByRole('button', { name: /new note/i }).first().click();
+  const blankNote = page.getByRole('button', { name: /blank note/i }).first();
+  if (await blankNote.isVisible().catch(() => false)) await blankNote.click();
+  const created = await createResponse;
+  if (created && created.status() >= 400) throw new Error(`New note failed with ${created.status()}`);
+  await page.waitForTimeout(1_500);
+  const noteTitle = `Dense manager field note ${RUN_MARKER}`;
+  await page.locator('input[placeholder="Untitled"]').first().fill(noteTitle);
+  const editor = page.locator('[contenteditable="true"].deft-notes-editor').first();
+  await editor.waitFor({ state: 'visible', timeout: 20_000 });
+  await editor.fill(`Dense note ${RUN_MARKER}: Diego recorded that route capacity, Sun Gold sample boxes, and buyer-copy timing must stay connected in the workspace memory before launch.`);
+  await delay(2_000);
+  await screenshot(page, 'notes-dense-note-before-promote');
+  await page.getByRole('button', { name: /promote to wiki/i }).first().click();
+  await page.getByRole('button', { name: /^fact$/i }).click();
+  page.once('dialog', async (dialog) => { await dialog.accept(); });
+  await page.getByRole('button', { name: /^promote$/i }).click();
+  await delay(1_500);
+  const wiki = await waitFor<any>('dense promoted note searchable', async () => {
+    const body = await api<any>(auth, `/api/wiki?q=${encodeURIComponent(noteTitle)}&limit=10`);
+    const pages = asArray<any>(body, ['pages']);
+    return pages.find((page) => page.title === noteTitle || JSON.stringify(page).includes(RUN_MARKER)) ? { pages, body } : null;
+  }, { timeoutMs: 45_000, intervalMs: 2_000 });
+  artifact.evidence.promoted_note = wiki.pages.map((page: any) => ({ id: page.id, title: page.title, slug: page.slug, type: page.type }));
+  await page.goto(`${WEB_URL}/knowledge`, { waitUntil: 'domcontentloaded' });
+  await page.locator('main').waitFor({ state: 'visible', timeout: 25_000 });
+  const search = page.locator('input[placeholder*="Search"], input[placeholder*="search"]').first();
+  if (await search.isVisible().catch(() => false)) await search.fill(RUN_MARKER);
+  await delay(800);
+  await screenshot(page, 'knowledge-after-dense-note');
+}
+
+async function verifyReceipts(auth: Auth, actionIds: string[]) {
+  const results = [];
+  for (const id of actionIds) {
+    try {
+      const receipt = await api<any>(auth, `/api/agent/actions/${id}/receipt`);
+      results.push({ action_id: id, ok: Boolean(receipt.verified), decision: receipt.receipt?.decision, action: receipt.receipt?.action_name });
+    } catch (err) {
+      results.push({ action_id: id, ok: false, error: err instanceof Error ? err.message : String(err) });
+    }
+  }
+  return results;
+}
+
+function addFindings(
+  coverage: ReturnType<typeof classifyCoverage>,
+  sentCount: number,
+  failedSends: SentMessage[],
+  intents: any[],
+  actions: any[],
+  receipts: any[],
+  observations: any[],
+) {
+  if (failedSends.length > 0) {
+    artifact.findings.push({
+      severity: 'P1',
+      title: 'Some human-like UI sends failed',
+      detail: `${failedSends.length}/${sentCount} sends failed. First: ${failedSends[0]?.error}`,
+    });
+  }
+  const sentOk = artifact.sent_messages.filter((message) => message.ok && message.id);
+  const observedIds = new Set(observations.map((observation) => observation.message_id).filter(Boolean));
+  const missingObservationCount = sentOk.filter((message) => !observedIds.has(message.id)).length;
+  if (missingObservationCount > 0) {
+    artifact.findings.push({
+      severity: 'P1',
+      title: 'Some UI-created messages were not durably observed',
+      detail: `${missingObservationCount}/${sentOk.length} sent messages did not have message_observations rows.`,
+    });
+  }
+  const incompleteObservations = observations.filter((observation) =>
+    ['queued', 'processing', 'retrying', 'failed'].includes(observation.status)
+  );
+  if (incompleteObservations.length > 0) {
+    artifact.findings.push({
+      severity: incompleteObservations.some((observation) => observation.status === 'failed') ? 'P1' : 'P2',
+      title: 'Some observations did not finish cleanly',
+      detail: JSON.stringify(incompleteObservations.slice(0, 8).map((observation) => ({
+        message_id: observation.message_id,
+        status: observation.status,
+        error: observation.last_error,
+      }))),
+    });
+  }
+  if (coverage.false_positive_count > 0) {
+    artifact.findings.push({
+      severity: 'P1',
+      title: 'No-action messages still become Defty captures',
+      detail: `${coverage.false_positive_count}/${coverage.noise_count} explicit no-action/no-memory messages produced captures.`,
+    });
+  }
+  const fnRate = coverage.expected_count ? coverage.false_negative_count / coverage.expected_count : 0;
+  if (fnRate > 0.2) {
+    artifact.findings.push({
+      severity: 'P1',
+      title: 'Capture recall is too inconsistent under realistic chatter',
+      detail: `${coverage.false_negative_count}/${coverage.expected_count} non-noise messages did not produce the expected capture kind.`,
+    });
+  } else if (coverage.false_negative_count > 0) {
+    artifact.findings.push({
+      severity: 'P2',
+      title: 'Some expected captures were missed',
+      detail: `${coverage.false_negative_count}/${coverage.expected_count} expected work/memory messages missed their expected capture kind.`,
+    });
+  }
+  const verifiedReceiptCount = receipts.filter((receipt) => receipt.ok).length;
+  if (verifiedReceiptCount === 0 && actions.length < intents.filter((intent) => intent.status === 'proposed').length * 0.5) {
+    artifact.findings.push({
+      severity: 'P2',
+      title: 'Not every proposed work intent surfaced as an approval action',
+      detail: `${intents.length} run-scoped intents produced ${actions.length} run-scoped actions in the latest action list.`,
+    });
+  } else if (verifiedReceiptCount > actions.length) {
+    artifact.findings.push({
+      severity: 'P3',
+      title: 'Action-list marker evidence undercounts approved actions',
+      detail: `The action list returned ${actions.length} run-scoped action(s), but converted intents and receipts verified ${verifiedReceiptCount} approved action(s). This looks like a test-evidence query limitation, not a failed approval path.`,
+    });
+  }
+  if (receipts.some((receipt) => !receipt.ok)) {
+    artifact.findings.push({
+      severity: 'P1',
+      title: 'One or more approved actions lack verified receipts',
+      detail: JSON.stringify(receipts.filter((receipt) => !receipt.ok).slice(0, 5)),
+    });
+  }
+}
+
+async function writeReport() {
+  artifact.finished_at = new Date().toISOString();
+  await fs.mkdir(path.dirname(HTML_REPORT), { recursive: true });
+  await fs.writeFile(JSON_REPORT, JSON.stringify(artifact, null, 2));
+
+  const rel = (file: string) => path.relative(path.dirname(HTML_REPORT), file).replace(/\\/g, '/');
+  const counts = artifact.checks.reduce((acc, check) => {
+    acc[check.status] = (acc[check.status] || 0) + 1;
+    return acc;
+  }, {} as Record<string, number>);
+  const metrics = artifact.evidence.metrics as any;
+  const coverage = artifact.evidence.coverage as any;
+  const captureSummary = artifact.evidence.capture_summary as any;
+  const observationSummary = artifact.evidence.observation_summary as any;
+
+  const html = `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Dense Deft Human Workflow Certification - ${escapeHtml(RUN_MARKER)}</title>
+  <style>
+    :root { color-scheme: light; --ink:#191714; --muted:#716a60; --line:#ddd5c8; --paper:#faf7ef; --card:#fffdf8; --green:#168a5b; --amber:#a86700; --red:#bf3b2f; --accent:#6f5fda; }
+    body { margin:0; background:var(--paper); color:var(--ink); font-family:Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; line-height:1.45; }
+    main { max-width:1180px; margin:0 auto; padding:42px 24px 72px; }
+    h1 { margin:0 0 10px; font-size:36px; line-height:1.03; letter-spacing:0; }
+    h2 { margin:34px 0 12px; font-size:21px; }
+    p { color:var(--muted); max-width:900px; }
+    .hero,.card,table,figure,pre { border:1px solid var(--line); background:var(--card); border-radius:8px; }
+    .hero { padding:28px; }
+    .pill { display:inline-flex; padding:5px 10px; border:1px solid var(--line); border-radius:999px; background:#fff; color:var(--muted); font-size:12px; }
+    .grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(220px,1fr)); gap:12px; }
+    .card { padding:16px; }
+    .metric { font-size:28px; font-weight:760; color:var(--ink); }
+    table { width:100%; border-collapse:collapse; overflow:hidden; }
+    th,td { text-align:left; vertical-align:top; padding:11px 12px; border-bottom:1px solid var(--line); font-size:13px; }
+    th { background:#f3eee5; color:var(--muted); font-size:11px; text-transform:uppercase; letter-spacing:.04em; }
+    tr:last-child td { border-bottom:0; }
+    .pass { color:var(--green); font-weight:750; }
+    .warn { color:var(--amber); font-weight:750; }
+    .fail { color:var(--red); font-weight:750; }
+    .screens { display:grid; grid-template-columns:repeat(auto-fit,minmax(310px,1fr)); gap:14px; }
+    figure { margin:0; overflow:hidden; }
+    figure img { width:100%; display:block; background:#111; }
+    figcaption { padding:9px 11px; color:var(--muted); font-size:12px; border-top:1px solid var(--line); }
+    pre { white-space:pre-wrap; overflow-wrap:anywhere; padding:14px; font-size:12px; color:#38312a; }
+    code { font-family:ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+  </style>
+</head>
+<body>
+<main>
+  <section class="hero">
+    <span class="pill">Dense multi-user UI-first dogfood</span>
+    <h1>Dense Deft Human Workflow Certification</h1>
+    <p>Run marker <code>${escapeHtml(RUN_MARKER)}</code>. Five seeded employees used real browser sessions against <code>${escapeHtml(WEB_URL)}</code>, posted a total of ${metrics?.attempted_messages ?? 0} tagged messages across several spaces, then Defty captures, approvals, receipts, notes, and wiki search were verified.</p>
+    <div class="grid">
+      <div class="card"><div class="metric">${metrics?.sent_messages ?? 0}/${metrics?.attempted_messages ?? 0}</div><span>UI chat sends succeeded</span></div>
+      <div class="card"><div class="metric">${metrics?.completed_observation_count ?? 0}/${metrics?.sent_messages ?? 0}</div><span>Messages durably observed</span></div>
+      <div class="card"><div class="metric">${metrics?.intent_count ?? 0}</div><span>Run-scoped work intents</span></div>
+      <div class="card"><div class="metric">${coverage?.matched_expected ?? 0}/${coverage?.expected_count ?? 0}</div><span>Expected captures matched</span></div>
+      <div class="card"><div class="metric">${coverage?.deduped_repeat_count ?? 0}</div><span>Repeated work messages deduped</span></div>
+      <div class="card"><div class="metric">${coverage?.false_positive_count ?? 0}/${coverage?.noise_count ?? 0}</div><span>No-action messages over-captured</span></div>
+    </div>
+  </section>
+
+  <h2>Verdict</h2>
+  <table>
+    <thead><tr><th>Area</th><th>Status</th><th>Evidence</th></tr></thead>
+    <tbody>
+      <tr><td>Multi-user chat realism</td><td class="${(metrics?.failed_sends ?? 0) === 0 ? 'pass' : 'fail'}">${(metrics?.failed_sends ?? 0) === 0 ? 'Passed' : 'Failed'}</td><td>${metrics?.sent_messages ?? 0} messages posted through UI; ${metrics?.failed_sends ?? 0} failed sends.</td></tr>
+      <tr><td>Durable observation</td><td class="${(metrics?.completed_observation_count ?? 0) === (metrics?.sent_messages ?? -1) ? 'pass' : 'fail'}">${(metrics?.completed_observation_count ?? 0) === (metrics?.sent_messages ?? -1) ? 'Passed' : 'Incomplete'}</td><td>${metrics?.completed_observation_count ?? 0}/${metrics?.sent_messages ?? 0} sent messages reached a terminal observation state.</td></tr>
+      <tr><td>Chat becomes context</td><td class="${(coverage?.false_negative_count ?? 0) === 0 ? 'pass' : 'warn'}">${(coverage?.false_negative_count ?? 0) === 0 ? 'Strong' : 'Partial'}</td><td>${coverage?.matched_expected ?? 0}/${coverage?.expected_count ?? 0} non-noise messages produced expected capture kinds.</td></tr>
+      <tr><td>Noise guardrails</td><td class="${(coverage?.false_positive_count ?? 0) === 0 ? 'pass' : 'fail'}">${(coverage?.false_positive_count ?? 0) === 0 ? 'Passed' : 'Needs work'}</td><td>${coverage?.false_positive_count ?? 0}/${coverage?.noise_count ?? 0} explicit no-action messages produced captures.</td></tr>
+      <tr><td>Approvals and receipts</td><td class="${(artifact.evidence.receipts as any[])?.every((r) => r.ok) ? 'pass' : 'warn'}">Checked</td><td>${(artifact.evidence.receipts as any[])?.length ?? 0} approved actions checked for receipts.</td></tr>
+      <tr><td>Notes become memory</td><td class="${artifact.evidence.promoted_note ? 'pass' : 'fail'}">${artifact.evidence.promoted_note ? 'Passed' : 'Not proven'}</td><td>Manager note promoted to wiki and found through wiki search.</td></tr>
+    </tbody>
+  </table>
+
+  <h2>Findings</h2>
+  ${artifact.findings.length === 0 ? '<p>No blocker findings from the dense run.</p>' : `<table><thead><tr><th>Severity</th><th>Issue</th><th>Detail</th></tr></thead><tbody>${artifact.findings.map((finding) => `<tr><td class="${finding.severity === 'P1' || finding.severity === 'P0' ? 'fail' : finding.severity === 'P2' ? 'warn' : ''}">${escapeHtml(finding.severity)}</td><td>${escapeHtml(finding.title)}</td><td>${escapeHtml(finding.detail)}</td></tr>`).join('')}</tbody></table>`}
+
+  <h2>Capture Summary</h2>
+  <div class="grid">
+    <div class="card"><strong>By kind</strong><pre>${escapeHtml(JSON.stringify(captureSummary?.byKind ?? {}, null, 2))}</pre></div>
+    <div class="card"><strong>By status</strong><pre>${escapeHtml(JSON.stringify(captureSummary?.byStatus ?? {}, null, 2))}</pre></div>
+    <div class="card"><strong>Observations by status</strong><pre>${escapeHtml(JSON.stringify(observationSummary?.byStatus ?? {}, null, 2))}</pre></div>
+    <div class="card"><strong>Ignored reasons</strong><pre>${escapeHtml(JSON.stringify(observationSummary?.byIgnoredReason ?? {}, null, 2))}</pre></div>
+  </div>
+
+  <h2>Screenshots</h2>
+  <div class="screens">
+    ${Object.entries(artifact.screenshots).slice(0, 12).map(([name, file]) => `<figure><img src="${escapeHtml(rel(file))}" alt="${escapeHtml(name)}"><figcaption>${escapeHtml(name)}</figcaption></figure>`).join('')}
+  </div>
+
+  <h2>Coverage Detail</h2>
+  <pre>${escapeHtml(JSON.stringify({
+    metrics,
+    observation_summary: observationSummary,
+    coverage: {
+      expected_count: coverage?.expected_count,
+      matched_expected: coverage?.matched_expected,
+      false_negative_count: coverage?.false_negative_count,
+      false_positive_count: coverage?.false_positive_count,
+      deduped_repeat_count: coverage?.deduped_repeat_count,
+      false_negatives: coverage?.false_negatives,
+      false_positives: coverage?.false_positives,
+    },
+    receipts: artifact.evidence.receipts,
+    promoted_note: artifact.evidence.promoted_note,
+  }, null, 2))}</pre>
+</main>
+</body>
+</html>`;
+
+  await fs.writeFile(HTML_REPORT, html);
+  console.log(`HTML_REPORT=${HTML_REPORT}`);
+  console.log(`JSON_REPORT=${JSON_REPORT}`);
+}
+
+async function main() {
+  await fs.mkdir(OUT_DIR, { recursive: true });
+  const browser = await chromium.launch({ headless: true });
+  const contexts: BrowserContext[] = [];
+  try {
+    const managerAuth = await step('Manager API login works', () => loginApi('diego@testers-tomatoes.com')) as Auth;
+    const spaces = await step('Load workspace spaces', () => getSpaces(managerAuth)) as Space[];
+    const spacesByName = new Map(spaces.map((space) => [space.name, space]));
+    artifact.evidence.spaces_used = Array.from(new Set(personas.flatMap((persona) => persona.spaces))).filter((name) => spacesByName.has(name));
+
+    const sessions = await step('Log in five human browser sessions', async () => {
+      const logged: Array<{ persona: Persona; page: Page; consoleIssues: string[] }> = [];
+      for (const persona of personas) {
+        const context = await browser.newContext({ viewport: { width: 1360, height: 900 }, deviceScaleFactor: 1 });
+        contexts.push(context);
+        const page = await context.newPage();
+        const consoleIssues: string[] = [];
+        page.on('console', (msg) => {
+          if (['error', 'warning'].includes(msg.type())) consoleIssues.push(`${msg.type()}: ${msg.text()}`);
+        });
+        await loginUi(page, persona.email);
+        await screenshot(page, `login-${persona.email.split('@')[0]}`);
+        logged.push({ persona, page, consoleIssues });
+      }
+      return logged;
+    }) as Array<{ persona: Persona; page: Page; consoleIssues: string[] }>;
+
+    await step('Run five concurrent human UI chat sessions', async () => {
+      await Promise.all(sessions.map(({ page, persona }) => sendLoggedPersonaMessages(page, persona, spacesByName)));
+    });
+
+    const failedSends = artifact.sent_messages.filter((message) => !message.ok);
+    const sentOk = artifact.sent_messages.filter((message) => message.ok);
+    artifact.evidence.metrics = {
+      attempted_messages: artifact.sent_messages.length,
+      sent_messages: sentOk.length,
+      failed_sends: failedSends.length,
+      personas: personas.length,
+      spaces: artifact.evidence.spaces_used,
+    };
+
+    const captureBundle = await step('Wait for Defty observations and captures after dense traffic', () => waitFor('dense observations and work intents', async () => {
+      const observations = await getRunObservations(managerAuth);
+      const intents = await getRunIntents(managerAuth);
+      const nonNoiseSent = sentOk.filter((message) => message.expected !== 'noise').length;
+      const allObserved = observations.length >= sentOk.length &&
+        observations.every((observation) => ['ignored', 'no_capture', 'captured'].includes(observation.status));
+      const enoughCaptures = intents.length >= Math.max(8, Math.floor(nonNoiseSent * 0.25));
+      return allObserved && enoughCaptures ? { intents, observations } : null;
+    }, { timeoutMs: 180_000, intervalMs: 5_000 }), true) as any | null;
+
+    const intents = Array.isArray(captureBundle)
+      ? captureBundle
+      : (captureBundle?.intents ?? await getRunIntents(managerAuth));
+    const observations = Array.isArray(captureBundle)
+      ? await getRunObservations(managerAuth)
+      : (captureBundle?.observations ?? await getRunObservations(managerAuth));
+    const actions = await getRunActions(managerAuth);
+    const coverage = classifyCoverage(intents, observations);
+    const captureSummary = summarizeCaptures(intents);
+    const observationSummary = summarizeObservations(observations);
+    artifact.evidence.capture_summary = captureSummary;
+    artifact.evidence.observation_summary = observationSummary;
+    artifact.evidence.coverage = coverage;
+    artifact.evidence.metrics = {
+      ...(artifact.evidence.metrics as Record<string, unknown>),
+      observation_count: observations.length,
+      completed_observation_count: observations.filter((observation) => ['ignored', 'no_capture', 'captured'].includes(observation.status)).length,
+      intent_count: intents.length,
+      action_count: actions.length,
+      expected_capture_count: coverage.expected_count,
+      matched_expected: coverage.matched_expected,
+      false_negative_count: coverage.false_negative_count,
+      false_positive_count: coverage.false_positive_count,
+      deduped_repeat_count: coverage.deduped_repeat_count,
+    };
+
+    const managerContext = await browser.newContext({ viewport: { width: 1440, height: 980 }, deviceScaleFactor: 1 });
+    contexts.push(managerContext);
+    const managerPage = await managerContext.newPage();
+    await loginUi(managerPage, 'diego@testers-tomatoes.com');
+    await step('Approve representative dense captures through UI', () => approveSomeViaUi(managerPage), true);
+
+    await delay(2_500);
+    const finalIntents = await getRunIntents(managerAuth);
+    const finalActions = await getRunActions(managerAuth);
+    const finalObservations = await getRunObservations(managerAuth);
+    const finalCoverage = classifyCoverage(finalIntents, finalObservations);
+    const finalCaptureSummary = summarizeCaptures(finalIntents);
+    const finalObservationSummary = summarizeObservations(finalObservations);
+    artifact.evidence.capture_summary = finalCaptureSummary;
+    artifact.evidence.observation_summary = finalObservationSummary;
+    artifact.evidence.coverage = finalCoverage;
+    artifact.evidence.metrics = {
+      ...(artifact.evidence.metrics as Record<string, unknown>),
+      observation_count: finalObservations.length,
+      completed_observation_count: finalObservations.filter((observation) => ['ignored', 'no_capture', 'captured'].includes(observation.status)).length,
+      intent_count: finalIntents.length,
+      action_count: finalActions.length,
+      expected_capture_count: finalCoverage.expected_count,
+      matched_expected: finalCoverage.matched_expected,
+      false_negative_count: finalCoverage.false_negative_count,
+      false_positive_count: finalCoverage.false_positive_count,
+      deduped_repeat_count: finalCoverage.deduped_repeat_count,
+    };
+    const approvedActionIds = Array.from(new Set([
+      ...finalActions.filter((action) => action.approval_status === 'approved').map((action) => action.id),
+      ...finalIntents.map((intent) => intent.converted_action_id).filter((id): id is string => typeof id === 'string'),
+    ])).slice(0, 12);
+    const receipts = await verifyReceipts(managerAuth, approvedActionIds);
+    artifact.evidence.final_intents = finalIntents.map((intent) => ({
+      id: intent.id,
+      kind: intent.kind,
+      status: intent.status,
+      source_message_id: intent.source_message_id,
+      converted_action_id: intent.converted_action_id,
+      converted_task_id: intent.converted_task_id,
+      title: intent.title,
+    }));
+    artifact.evidence.final_actions = finalActions.map((action) => ({
+      id: action.id,
+      action: action.action,
+      approval_status: action.approval_status,
+      has_receipt: action.has_receipt,
+    }));
+    artifact.evidence.final_observations = finalObservations.map((observation) => ({
+      id: observation.id,
+      message_id: observation.message_id,
+      status: observation.status,
+      ignored_reason: observation.ignored_reason,
+      capture_count: observation.capture_count,
+      downstream_jobs: observation.downstream_jobs,
+      last_error: observation.last_error,
+    }));
+    artifact.evidence.receipts = receipts;
+
+    await step('Create note and promote to wiki through UI', () => createAndPromoteNote(managerPage, managerAuth), true);
+
+    await step('Capture final dashboard/tasks/inbox surfaces', async () => {
+      for (const [route, name] of [
+        ['/dashboard', 'surface-dashboard-final'],
+        ['/inbox?tab=captures', 'surface-captures-final'],
+        ['/tasks', 'surface-tasks-final'],
+        ['/knowledge', 'surface-knowledge-final'],
+      ] as Array<[string, string]>) {
+        await managerPage.goto(`${WEB_URL}${route}`, { waitUntil: 'domcontentloaded' });
+        await managerPage.locator('main').waitFor({ state: 'visible', timeout: 25_000 });
+        await delay(700);
+        await screenshot(managerPage, name);
+      }
+    }, true);
+
+    addFindings(finalCoverage, artifact.sent_messages.length, failedSends, finalIntents, finalActions, receipts, finalObservations);
+    mark(artifact.findings.some((finding) => finding.severity === 'P0' || finding.severity === 'P1') ? 'warn' : 'pass', 'Dense certification completed with findings', artifact.findings.length);
+  } finally {
+    for (const context of contexts) await context.close().catch(() => null);
+    await browser.close();
+    await writeReport();
+  }
+}
+
+main().catch(async (err) => {
+  artifact.findings.push({
+    severity: 'P1',
+    title: 'Dense certification stopped early',
+    detail: err instanceof Error ? err.stack || err.message : String(err),
+  });
+  await writeReport();
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/reports/work-intent-ledger-dogfood.ts
+++ b/scripts/reports/work-intent-ledger-dogfood.ts
@@ -1,0 +1,559 @@
+import 'dotenv/config';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { chromium, type Browser, type BrowserContext, type Page } from 'playwright';
+
+const args = new Set(process.argv.slice(2));
+const apiOnly = args.has('--api-only') || process.env.DEFT_DOGFOOD_API_ONLY === '1';
+
+const API_URL = (process.env.DEFT_API_URL || process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3301').replace(/\/$/, '');
+const WEB_URL = (process.env.DEFT_WEB_URL || 'http://localhost:3000').replace(/\/$/, '');
+const EMAIL = process.env.DEFT_TEST_EMAIL || 'diego@testers-tomatoes.com';
+const PASSWORD = process.env.DEFT_TEST_PASSWORD || 'tomato123';
+const SECONDARY_EMAIL = process.env.DEFT_DOGFOOD_SECONDARY_EMAIL || 'lina@testers-tomatoes.com';
+const RUN_ID = process.env.DEFT_DOGFOOD_RUN_ID || new Date().toISOString().replace(/[:.]/g, '-');
+const RUN_COMPACT = RUN_ID.replace(/[^a-zA-Z0-9]/g, '').slice(-12);
+const REPORT_ROOT = path.resolve('reports', 'work-intent-ledger-dogfood', RUN_ID);
+const HTML_REPORT = path.resolve('reports', `work-intent-ledger-dogfood-${RUN_ID}.html`);
+const JSON_REPORT = path.resolve('reports', `work-intent-ledger-dogfood-${RUN_ID}.json`);
+
+type Auth = {
+  accessToken: string;
+  refreshToken?: string;
+  user: { id: string; email: string; org_id: string; name?: string };
+};
+
+type Space = {
+  id: string;
+  name: string;
+  type: string;
+  org_id?: string;
+};
+
+type Check = {
+  status: 'pass' | 'fail' | 'warn';
+  name: string;
+  detail?: unknown;
+  ms?: number;
+};
+
+type Artifact = {
+  run_id: string;
+  api_url: string;
+  web_url: string;
+  api_only: boolean;
+  started_at: string;
+  finished_at?: string;
+  checks: Check[];
+  screenshots: Record<string, string>;
+  ids: Record<string, string>;
+  bugs: Array<{ severity: string; title: string; detail: string }>;
+};
+
+const artifact: Artifact = {
+  run_id: RUN_ID,
+  api_url: API_URL,
+  web_url: WEB_URL,
+  api_only: apiOnly,
+  started_at: new Date().toISOString(),
+  checks: [],
+  screenshots: {},
+  ids: {},
+  bugs: [],
+};
+
+function htmlEscape(value: unknown): string {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function mark(status: Check['status'], name: string, detail?: unknown, ms?: number) {
+  artifact.checks.push({ status, name, detail, ms });
+  const suffix = detail ? `: ${typeof detail === 'string' ? detail : JSON.stringify(detail)}` : '';
+  console.log(`[${status.toUpperCase()}] ${name}${suffix}`);
+}
+
+async function timed<T>(name: string, fn: () => Promise<T>, statusName = name): Promise<T> {
+  const started = Date.now();
+  try {
+    const value = await fn();
+    mark('pass', statusName, undefined, Date.now() - started);
+    return value;
+  } catch (err) {
+    mark('fail', statusName, err instanceof Error ? err.message : String(err), Date.now() - started);
+    throw err;
+  }
+}
+
+async function fetchJson<T = any>(url: string, init?: RequestInit): Promise<{ status: number; ok: boolean; body: T; text: string }> {
+  const res = await fetch(url, { ...init, signal: AbortSignal.timeout(20_000) });
+  const text = await res.text();
+  let body: T;
+  try {
+    body = JSON.parse(text) as T;
+  } catch {
+    body = text as T;
+  }
+  return { status: res.status, ok: res.ok, body, text };
+}
+
+async function api<T = any>(auth: Auth, route: string, init?: RequestInit): Promise<T> {
+  const hasBody = init?.body !== undefined;
+  const res = await fetchJson<T>(`${API_URL}${route}`, {
+    ...init,
+    headers: {
+      ...(hasBody ? { 'Content-Type': 'application/json' } : {}),
+      Authorization: `Bearer ${auth.accessToken}`,
+      ...(init?.headers || {}),
+    },
+  });
+  if (!res.ok) {
+    throw new Error(`${route} returned ${res.status}: ${res.text.slice(0, 500)}`);
+  }
+  return res.body;
+}
+
+async function login(email: string): Promise<Auth> {
+  const res = await fetchJson<Auth>(`${API_URL}/api/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password: PASSWORD }),
+  });
+  if (!res.ok || !res.body?.accessToken || !res.body?.user?.id) {
+    throw new Error(`login failed for ${email}: ${res.status} ${res.text.slice(0, 300)}`);
+  }
+  return res.body;
+}
+
+async function waitFor<T>(
+  label: string,
+  fn: () => Promise<T | null | undefined | false>,
+  opts: { timeoutMs?: number; intervalMs?: number } = {},
+): Promise<T> {
+  const timeoutMs = opts.timeoutMs ?? 90_000;
+  const intervalMs = opts.intervalMs ?? 1_500;
+  const started = Date.now();
+  let last: unknown = null;
+  while (Date.now() - started < timeoutMs) {
+    try {
+      const value = await fn();
+      if (value) return value as T;
+      last = value;
+    } catch (err) {
+      last = err instanceof Error ? err.message : String(err);
+    }
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+  throw new Error(`Timed out waiting for ${label}. Last: ${JSON.stringify(last)}`);
+}
+
+async function ensureProject(auth: Auth): Promise<string> {
+  const projects = await api<any[]>(auth, '/api/projects');
+  const existing = projects.find((project) => !project.is_archived && !project.is_deleted);
+  if (existing?.id) return existing.id;
+
+  const prefix = `WI${Math.floor(Math.random() * 9000 + 1000)}`.slice(0, 6);
+  const created = await api<any>(auth, '/api/projects', {
+    method: 'POST',
+    body: JSON.stringify({
+      name: `Work Intent Dogfood ${RUN_ID.slice(-6)}`,
+      prefix,
+      description: 'Temporary project for Work Intent Ledger dogfood.',
+    }),
+  });
+  return created.id;
+}
+
+async function createSpace(auth: Auth, type: 'public' | 'private'): Promise<Space> {
+  return api<Space>(auth, '/api/spaces', {
+    method: 'POST',
+    body: JSON.stringify({
+      name: `wil-${type}-${RUN_ID.slice(-10).toLowerCase()}`,
+      type,
+      description: `Work Intent Ledger ${type} proof space for ${RUN_ID}.`,
+    }),
+  });
+}
+
+async function issueMcpToken(auth: Auth, name: string): Promise<{ token: string; token_id: string }> {
+  return api<{ token: string; token_id: string }>(auth, '/api/mcp-access/tokens', {
+    method: 'POST',
+    body: JSON.stringify({
+      name,
+      scopes: ['read:workspace', 'read:wiki', 'read:tasks', 'read:messages', 'write:tasks', 'write:messages', 'write:wiki'],
+    }),
+  });
+}
+
+async function revokeMcpToken(auth: Auth, tokenId?: string) {
+  if (!tokenId) return;
+  try {
+    await api(auth, `/api/mcp-access/tokens/${tokenId}`, { method: 'DELETE' });
+  } catch (err) {
+    mark('warn', 'MCP token cleanup failed', err instanceof Error ? err.message : String(err));
+  }
+}
+
+async function mcpCall(token: string, name: string, argumentsBody: Record<string, unknown>) {
+  const res = await fetchJson<any>(`${API_URL}/api/mcp/v1`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: `${name}-${Date.now()}`,
+      method: 'tools/call',
+      params: { name, arguments: argumentsBody },
+    }),
+  });
+  if (!res.ok || res.body?.error) {
+    throw new Error(`MCP ${name} failed: ${res.status} ${JSON.stringify(res.body).slice(0, 500)}`);
+  }
+  const result = res.body.result;
+  const text = Array.isArray(result?.content)
+    ? result.content.map((item: any) => item.text ?? '').join('\n')
+    : '';
+  return { result, text };
+}
+
+async function createBrowser(auth: Auth): Promise<{ browser: Browser; context: BrowserContext; page: Page }> {
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({ viewport: { width: 1440, height: 950 } });
+  await context.addInitScript((tokens) => {
+    window.localStorage.setItem('deft-access-token', tokens.accessToken);
+    if (tokens.refreshToken) window.localStorage.setItem('deft-refresh-token', tokens.refreshToken);
+  }, { accessToken: auth.accessToken, refreshToken: auth.refreshToken ?? '' });
+  const page = await context.newPage();
+  page.on('console', (message) => {
+    if (message.type() === 'error') {
+      artifact.bugs.push({
+        severity: 'P2',
+        title: 'Browser console error during dogfood',
+        detail: message.text().slice(0, 500),
+      });
+    }
+  });
+  return { browser, context, page };
+}
+
+async function screenshot(page: Page, name: string) {
+  await fs.mkdir(REPORT_ROOT, { recursive: true });
+  const file = path.join(REPORT_ROOT, `${name}.png`);
+  await page.screenshot({ path: file, fullPage: true });
+  artifact.screenshots[name] = file;
+}
+
+async function sendMessageViaUi(page: Page, space: Space, content: string): Promise<any> {
+  await page.goto(`${WEB_URL}/chat?space=${space.id}`, { waitUntil: 'domcontentloaded' });
+  await page.locator('main').waitFor({ state: 'visible', timeout: 20_000 });
+  const editor = page.locator('[contenteditable="true"]').last();
+  await editor.waitFor({ state: 'visible', timeout: 20_000 });
+  await editor.click();
+  await page.keyboard.insertText(content);
+  const responsePromise = page.waitForResponse((res) =>
+    res.url().includes(`/api/messages/${space.id}`) && res.request().method() === 'POST',
+  { timeout: 20_000 });
+  const send = page.getByRole('button', { name: 'Send message' });
+  await send.waitFor({ state: 'visible', timeout: 10_000 });
+  await send.click();
+  const response = await responsePromise;
+  if (!response.ok()) {
+    throw new Error(`UI message POST returned ${response.status()}: ${(await response.text()).slice(0, 300)}`);
+  }
+  const body = await response.json();
+  await page.getByText(RUN_ID, { exact: false }).last().waitFor({ state: 'visible', timeout: 15_000 });
+  return body;
+}
+
+async function sendMessageViaApi(auth: Auth, space: Space, content: string): Promise<any> {
+  return api(auth, `/api/messages/${space.id}`, {
+    method: 'POST',
+    body: JSON.stringify({ content }),
+  });
+}
+
+async function postMessage(auth: Auth, page: Page | null, space: Space, content: string): Promise<any> {
+  if (!page) return sendMessageViaApi(auth, space, content);
+  return sendMessageViaUi(page, space, content);
+}
+
+async function pendingAction(auth: Auth, spaceId: string, messageId: string, actionName: string): Promise<any | null> {
+  const rows = await api<any[]>(auth, `/api/agent/actions/pending-by-space?space_id=${encodeURIComponent(spaceId)}`);
+  return rows.find((row) => row.message_id === messageId && row.action === actionName) ?? null;
+}
+
+async function waitPendingAction(auth: Auth, space: Space, messageId: string, actionName: string) {
+  return waitFor(`pending ${actionName} action for ${messageId}`, () => pendingAction(auth, space.id, messageId, actionName), {
+    timeoutMs: 90_000,
+    intervalMs: 1_500,
+  });
+}
+
+async function approveViaApi(auth: Auth, actionId: string) {
+  return api<any>(auth, `/api/agent/actions/${actionId}/approve`, {
+    method: 'POST',
+    body: JSON.stringify({}),
+  });
+}
+
+async function approveViaUi(page: Page, space: Space, actionId: string, buttonName: RegExp, screenshotName: string) {
+  await page.goto(`${WEB_URL}/chat?space=${space.id}`, { waitUntil: 'domcontentloaded' });
+  await screenshot(page, `${screenshotName}-pending`);
+  const button = page.getByRole('button', { name: buttonName }).last();
+  await button.waitFor({ state: 'visible', timeout: 30_000 });
+  const responsePromise = page.waitForResponse((res) =>
+    res.url().includes(`/api/agent/actions/${actionId}/approve`) && res.request().method() === 'POST',
+  { timeout: 30_000 });
+  await button.click();
+  const response = await responsePromise;
+  const body = await response.json().catch(async () => ({ raw: await response.text() }));
+  if (!response.ok()) {
+    throw new Error(`UI approve returned ${response.status()}: ${JSON.stringify(body).slice(0, 500)}`);
+  }
+  await screenshot(page, `${screenshotName}-approved`);
+  return body;
+}
+
+async function receipt(auth: Auth, actionId: string) {
+  return api<any>(auth, `/api/agent/actions/${actionId}/receipt`);
+}
+
+function assertIncludes(haystack: string, needle: string, label: string) {
+  if (!haystack.toLowerCase().includes(needle.toLowerCase())) {
+    throw new Error(`${label} did not include "${needle}". Text: ${haystack.slice(0, 800)}`);
+  }
+}
+
+async function writeReports() {
+  artifact.finished_at = new Date().toISOString();
+  await fs.mkdir(path.dirname(HTML_REPORT), { recursive: true });
+  await fs.writeFile(JSON_REPORT, JSON.stringify(artifact, null, 2));
+
+  const checkRows = artifact.checks.map((check) => `
+    <tr class="${check.status}">
+      <td>${htmlEscape(check.status.toUpperCase())}</td>
+      <td>${htmlEscape(check.name)}</td>
+      <td>${htmlEscape(check.ms != null ? `${check.ms}ms` : '')}</td>
+      <td><code>${htmlEscape(typeof check.detail === 'string' ? check.detail : JSON.stringify(check.detail ?? ''))}</code></td>
+    </tr>`).join('');
+  const bugRows = artifact.bugs.length
+    ? artifact.bugs.map((bug) => `<li><strong>${htmlEscape(bug.severity)}</strong> ${htmlEscape(bug.title)}: ${htmlEscape(bug.detail)}</li>`).join('')
+    : '<li>No bugs recorded by this runner.</li>';
+  const shotRows = Object.entries(artifact.screenshots).map(([name, file]) => {
+    const rel = path.relative(path.dirname(HTML_REPORT), file).replace(/\\/g, '/');
+    return `<figure><img src="${htmlEscape(rel)}" alt="${htmlEscape(name)}"><figcaption>${htmlEscape(name)}</figcaption></figure>`;
+  }).join('');
+  const html = `<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Work Intent Ledger Dogfood - ${htmlEscape(RUN_ID)}</title>
+  <style>
+    body { margin: 0; font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; background: #f6f7f9; color: #151922; }
+    header { background: #fff; border-bottom: 1px solid #dde3ea; padding: 32px 40px 24px; }
+    main { padding: 24px 40px 48px; display: grid; gap: 22px; }
+    h1 { margin: 0 0 8px; font-size: 30px; letter-spacing: 0; }
+    h2 { margin: 0 0 12px; font-size: 18px; }
+    p { color: #526071; max-width: 880px; line-height: 1.55; }
+    .pill { display: inline-flex; margin: 6px 8px 0 0; padding: 7px 10px; border: 1px solid #d8dee8; border-radius: 999px; background: #fff; font-size: 12px; }
+    section { background: #fff; border: 1px solid #dde3ea; border-radius: 8px; padding: 18px; }
+    table { width: 100%; border-collapse: collapse; font-size: 13px; }
+    th, td { border-bottom: 1px solid #edf0f4; padding: 9px; text-align: left; vertical-align: top; }
+    tr.pass td:first-child { color: #047857; font-weight: 700; }
+    tr.fail td:first-child { color: #b91c1c; font-weight: 700; }
+    tr.warn td:first-child { color: #a16207; font-weight: 700; }
+    code { white-space: pre-wrap; word-break: break-word; color: #334155; }
+    .screens { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 14px; }
+    figure { margin: 0; border: 1px solid #dde3ea; border-radius: 8px; overflow: hidden; background: #fff; }
+    img { width: 100%; display: block; }
+    figcaption { padding: 8px 10px; font-size: 12px; color: #526071; border-top: 1px solid #edf0f4; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Work Intent Ledger Dogfood</h1>
+    <p>Repeatable browser/API validation for public and private chat captures, Defty approvals, receipts, and MCP recall.</p>
+    <span class="pill">Run ${htmlEscape(RUN_ID)}</span>
+    <span class="pill">API ${htmlEscape(API_URL)}</span>
+    <span class="pill">Web ${htmlEscape(WEB_URL)}</span>
+    <span class="pill">${apiOnly ? 'API only' : 'Browser + API'}</span>
+  </header>
+  <main>
+    <section>
+      <h2>Checks</h2>
+      <table>
+        <thead><tr><th>Status</th><th>Check</th><th>Time</th><th>Detail</th></tr></thead>
+        <tbody>${checkRows}</tbody>
+      </table>
+    </section>
+    <section>
+      <h2>Bugs Observed</h2>
+      <ul>${bugRows}</ul>
+    </section>
+    <section>
+      <h2>Screenshots</h2>
+      <div class="screens">${shotRows || '<p>No screenshots captured in API-only mode.</p>'}</div>
+    </section>
+  </main>
+</body>
+</html>`;
+  await fs.writeFile(HTML_REPORT, html);
+  console.log(`HTML report: ${HTML_REPORT}`);
+  console.log(`JSON report: ${JSON_REPORT}`);
+}
+
+async function main() {
+  await fs.mkdir(REPORT_ROOT, { recursive: true });
+  const health = await fetchJson(`${API_URL}/health`).catch((err) => ({ ok: false, status: 0, text: String(err), body: null }));
+  if (!health.ok) throw new Error(`API health failed: ${health.status} ${health.text}`);
+  mark('pass', 'API health', `${API_URL}/health`);
+
+  if (!apiOnly) {
+    const web = await fetchJson(WEB_URL).catch((err) => ({ ok: false, status: 0, text: String(err), body: null }));
+    if (!web.ok) throw new Error(`Web not reachable: ${web.status} ${web.text}`);
+    mark('pass', 'Web root reachable', WEB_URL);
+  }
+
+  const primary = await timed('login primary user', () => login(EMAIL));
+  let secondary: Auth | null = null;
+  try {
+    secondary = await login(SECONDARY_EMAIL);
+    mark('pass', 'login secondary user', SECONDARY_EMAIL);
+  } catch (err) {
+    mark('warn', 'secondary user unavailable; private leak test will be skipped', err instanceof Error ? err.message : String(err));
+  }
+
+  const token = await timed('issue primary personal MCP token', () => issueMcpToken(primary, `WIL dogfood ${RUN_ID}`));
+  let secondaryToken: { token: string; token_id: string } | null = null;
+  if (secondary) {
+    secondaryToken = await timed('issue secondary personal MCP token', () => issueMcpToken(secondary!, `WIL dogfood secondary ${RUN_ID}`));
+  }
+
+  let browser: Browser | null = null;
+  let context: BrowserContext | null = null;
+  let page: Page | null = null;
+
+  try {
+    await timed('ensure at least one project exists', () => ensureProject(primary));
+    const publicSpace = await timed('create public proof space', () => createSpace(primary, 'public'));
+    const privateSpace = await timed('create private proof space', () => createSpace(primary, 'private'));
+    artifact.ids.public_space = publicSpace.id;
+    artifact.ids.private_space = privateSpace.id;
+
+    if (!apiOnly) {
+      const created = await timed('launch browser session', () => createBrowser(primary));
+      browser = created.browser;
+      context = created.context;
+      page = created.page;
+    }
+
+    const publicNeedle = `WILPUB${RUN_COMPACT} TOMATO${RUN_COMPACT.slice(0, 6)}`;
+    const publicDecision = `Decision: ${publicNeedle} governs the pilot crate audit note for this proof run.`;
+    const publicMessage = await timed('post public decision through chat', () => postMessage(primary, page, publicSpace, publicDecision));
+    artifact.ids.public_decision_message = publicMessage.id;
+    if (page) await screenshot(page, 'public-decision-posted');
+
+    const publicAction = await timed('wait for public wiki_create approval', () => waitPendingAction(primary, publicSpace, publicMessage.id, 'wiki_create'));
+    if (publicAction.params?.scope !== 'org') {
+      throw new Error(`public wiki_create expected scope=org, got ${publicAction.params?.scope}`);
+    }
+    mark('pass', 'public capture is org scoped', { action_id: publicAction.id, scope: publicAction.params?.scope });
+
+    const publicApproval = page
+      ? await timed('approve public decision from UI', () => approveViaUi(page!, publicSpace, publicAction.id, /Save decision|Save knowledge|Save/i, 'public-decision'))
+      : await timed('approve public decision from API', () => approveViaApi(primary, publicAction.id));
+    const publicReceipt = await timed('fetch public decision receipt', () => receipt(primary, publicAction.id));
+    if (!publicReceipt.verified) throw new Error('public decision receipt did not verify');
+    artifact.ids.public_wiki_page = publicApproval.result?.page_id ?? publicApproval.result?.id ?? '';
+    mark('pass', 'public decision approval produced verified receipt', { action_id: publicAction.id, result: publicApproval.result });
+
+    await timed('MCP recall sees approved org knowledge', async () => {
+      const publicRecall = await mcpCall(token.token, 'memory_recall', { query: publicNeedle, scope: 'all', limit: 10 });
+      assertIncludes(publicRecall.text, publicNeedle, 'primary MCP memory_recall');
+      return publicRecall;
+    });
+
+    const privateNeedle = `WILPRIV${RUN_COMPACT} BASIL${RUN_COMPACT.slice(0, 6)}`;
+    const privateDecision = `Decision: ${privateNeedle} is the private supplier review code for this proof run.`;
+    const privateMessage = await timed('post private decision through chat', () => postMessage(primary, page, privateSpace, privateDecision));
+    artifact.ids.private_decision_message = privateMessage.id;
+    if (page) await screenshot(page, 'private-decision-posted');
+
+    const privateAction = await timed('wait for private wiki_create approval', () => waitPendingAction(primary, privateSpace, privateMessage.id, 'wiki_create'));
+    if (privateAction.params?.scope !== 'space') {
+      throw new Error(`private wiki_create expected scope=space, got ${privateAction.params?.scope}`);
+    }
+    mark('pass', 'private capture is space scoped', { action_id: privateAction.id, scope: privateAction.params?.scope, space_id: privateAction.params?.space_id });
+
+    const privateApproval = await timed('approve private decision from API', () => approveViaApi(primary, privateAction.id));
+    const privateReceipt = await timed('fetch private decision receipt', () => receipt(primary, privateAction.id));
+    if (!privateReceipt.verified) throw new Error('private decision receipt did not verify');
+    artifact.ids.private_wiki_page = privateApproval.result?.page_id ?? privateApproval.result?.id ?? '';
+    mark('pass', 'private decision approval produced verified receipt', { action_id: privateAction.id, result: privateApproval.result });
+
+    await timed('primary MCP recall sees own private-space knowledge', async () => {
+      const primaryPrivateRecall = await mcpCall(token.token, 'memory_recall', { query: privateNeedle, scope: 'all', limit: 10 });
+      assertIncludes(primaryPrivateRecall.text, privateNeedle, 'primary private MCP memory_recall');
+      return primaryPrivateRecall;
+    });
+
+    if (secondaryToken) {
+      const secondaryPrivateRecall = await timed('secondary MCP recall checks private-space isolation', () =>
+        mcpCall(secondaryToken!.token, 'memory_recall', { query: privateNeedle, scope: 'all', limit: 10 }));
+      if (secondaryPrivateRecall.text.toLowerCase().includes(privateNeedle.toLowerCase())) {
+        throw new Error(`secondary user recalled private-space knowledge: ${secondaryPrivateRecall.text.slice(0, 500)}`);
+      }
+      mark('pass', 'private-space knowledge did not leak to secondary MCP user');
+    }
+
+    const taskNeedle = `WILTASK${RUN_COMPACT}`;
+    const taskMessageText = `Please create task: call the buyer about ${taskNeedle}. Description: Confirm the blue crate pilot packing note and report blockers in the launch channel.`;
+    const taskMessage = await timed('post explicit task request through chat', () => postMessage(primary, page, publicSpace, taskMessageText));
+    artifact.ids.task_message = taskMessage.id;
+    if (page) await screenshot(page, 'task-request-posted');
+
+    const taskAction = await timed('wait for task_create approval', () => waitPendingAction(primary, publicSpace, taskMessage.id, 'task_create'));
+    const taskApproval = page
+      ? await timed('approve task creation from UI', () => approveViaUi(page!, publicSpace, taskAction.id, /Create task/i, 'task-create'))
+      : await timed('approve task creation from API', () => approveViaApi(primary, taskAction.id));
+    const taskReceipt = await timed('fetch task receipt', () => receipt(primary, taskAction.id));
+    if (!taskReceipt.verified) throw new Error('task receipt did not verify');
+
+    const taskId = taskApproval.result?.task_id ?? taskApproval.result?.id;
+    if (!taskId) throw new Error(`task approval did not return task id: ${JSON.stringify(taskApproval).slice(0, 500)}`);
+    artifact.ids.task = taskId;
+    mark('pass', 'task approval produced task and verified receipt', { action_id: taskAction.id, task_id: taskId });
+
+    await timed('MCP task_get sees approved task', async () => {
+      const taskGet = await mcpCall(token.token, 'task_get', { task_id: taskId });
+      assertIncludes(taskGet.text, taskNeedle, 'MCP task_get');
+      return taskGet;
+    });
+
+    if (page) {
+      await page.goto(`${WEB_URL}/tasks?task=${taskId}`, { waitUntil: 'domcontentloaded' });
+      await page.getByText(taskNeedle, { exact: false }).first().waitFor({ state: 'visible', timeout: 20_000 });
+      await screenshot(page, 'task-detail-approved');
+    }
+  } finally {
+    await context?.close().catch(() => undefined);
+    await browser?.close().catch(() => undefined);
+    await revokeMcpToken(primary, token.token_id);
+    if (secondary && secondaryToken) await revokeMcpToken(secondary, secondaryToken.token_id);
+  }
+}
+
+main()
+  .catch((err) => {
+    artifact.bugs.push({
+      severity: 'P1',
+      title: 'Work Intent Ledger dogfood failed',
+      detail: err instanceof Error ? err.message : String(err),
+    });
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await writeReports();
+  });

--- a/scripts/reports/work-intent-ui-swarm.ts
+++ b/scripts/reports/work-intent-ui-swarm.ts
@@ -1,0 +1,465 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { chromium, type Browser, type BrowserContext, type Page } from 'playwright';
+
+const WEB_URL = (process.env.DEFT_WEB_URL || 'http://localhost:3000').replace(/\/$/, '');
+const PASSWORD = process.env.DEFT_TEST_PASSWORD || 'tomato123';
+const RUN_ID = new Date().toISOString().replace(/[:.]/g, '-');
+const RUN_MARKER = `WIL-${RUN_ID.replace(/[^a-zA-Z0-9]/g, '').slice(-10)}`;
+const OUT_DIR = path.resolve('reports', 'work-intent-ui-swarm', RUN_ID);
+const HTML_REPORT = path.resolve('reports', `work-intent-ui-swarm-${RUN_ID}.html`);
+const JSON_REPORT = path.resolve('reports', `work-intent-ui-swarm-${RUN_ID}.json`);
+
+type Step = {
+  name: string;
+  ok: boolean;
+  ms: number;
+  detail?: string;
+};
+
+type PersonaResult = {
+  name: string;
+  email: string;
+  role: string;
+  ok: boolean;
+  steps: Step[];
+  evidence: string[];
+  screenshots: string[];
+  network: Array<{ method: string; url: string; status: number; ms: number | null }>;
+  console: Array<{ type: string; text: string }>;
+  error?: string;
+};
+
+const personas = [
+  {
+    name: 'Diego Morales',
+    email: 'diego@testers-tomatoes.com',
+    role: 'Manager',
+    space: 'sales-and-buyers',
+    taskNeedle: 'Chef Amara sample-box size',
+    knowledgeNeedle: 'Sun Gold',
+    messages: [
+      `Decision ${RUN_MARKER}: route the Sun Gold sample boxes through cold room B and require 34F pulp-temp logging before dispatch.`,
+      `Action item ${RUN_MARKER}: create a p1 task for Diego to draft the buyer launch recap by Friday.`,
+      `Update OPS-1 ${RUN_MARKER}: confirm Tuesday delivery window is ready for review after Tomas checks the route board.`,
+      `Quick vibe check ${RUN_MARKER}: the tomatoes are behaving like tomatoes today.`,
+    ],
+    approve: true,
+  },
+  {
+    name: 'Marigold Patel',
+    email: 'marigold@testers-tomatoes.com',
+    role: 'Head Grower',
+    space: 'field-ops',
+    taskNeedle: 'Stage sample-box crates',
+    knowledgeNeedle: 'Climate',
+    messages: [
+      `${RUN_MARKER}: Greenhouse 3 bench counts look stable after the morning pass.`,
+      `${RUN_MARKER}: please note that Sun Gold crate staging depends on the west-row pick finishing before noon.`,
+      `${RUN_MARKER}: no task needed here, just confirming the tomato tunnel fans sound normal.`,
+    ],
+  },
+  {
+    name: 'Cesar Okafor',
+    email: 'cesar@testers-tomatoes.com',
+    role: 'Field Supervisor',
+    space: 'field-ops',
+    taskNeedle: 'Update harvest forecast',
+    knowledgeNeedle: 'Harvest',
+    messages: [
+      `${RUN_MARKER}: harvest crew is blocked until row marker tags are replaced near the south gate.`,
+      `${RUN_MARKER}: decision from field ops is to hold the late pick until the humidity dip at 2pm.`,
+      `${RUN_MARKER}: lunchtime note, nothing to capture, just keeping the channel alive.`,
+    ],
+  },
+  {
+    name: 'Lina Bhattacharya',
+    email: 'lina@testers-tomatoes.com',
+    role: 'Sales Lead',
+    space: 'marketing',
+    taskNeedle: 'grocer pitch',
+    knowledgeNeedle: 'Buyer',
+    messages: [
+      `${RUN_MARKER}: buyer copy should mention flavor first and delivery only after OPS-1 clears.`,
+      `${RUN_MARKER}: action item for Lina to collect two new chef objections before the recap.`,
+      `${RUN_MARKER}: this is casual chatter about tomato adjectives and should not become work.`,
+    ],
+  },
+  {
+    name: 'Tomas Wakefield',
+    email: 'tomas@testers-tomatoes.com',
+    role: 'Logistics',
+    space: 'operations',
+    taskNeedle: 'Tuesday delivery window',
+    knowledgeNeedle: 'Cold',
+    messages: [
+      `${RUN_MARKER}: cold-room handoff is green but route capacity is still tight.`,
+      `${RUN_MARKER}: update OPS-1 to in review once the northern loop board is checked.`,
+      `${RUN_MARKER}: the hand truck squeaks, emotionally and mechanically.`,
+    ],
+  },
+];
+
+function escapeHtml(value: unknown): string {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+async function recordStep<T>(result: PersonaResult, name: string, fn: () => Promise<T>): Promise<T> {
+  const started = Date.now();
+  try {
+    const value = await fn();
+    result.steps.push({ name, ok: true, ms: Date.now() - started });
+    return value;
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    result.steps.push({ name, ok: false, ms: Date.now() - started, detail });
+    throw err;
+  }
+}
+
+async function screenshot(page: Page, result: PersonaResult, name: string) {
+  await fs.mkdir(OUT_DIR, { recursive: true });
+  const file = path.join(OUT_DIR, `${result.email.split('@')[0]}-${name}.png`);
+  await page.screenshot({ path: file, fullPage: true }).catch(() => null);
+  result.screenshots.push(file);
+}
+
+async function loginViaUi(page: Page, email: string) {
+  await page.goto(`${WEB_URL}/login`, { waitUntil: 'networkidle' });
+  await page.locator('#login-email').waitFor({ state: 'visible', timeout: 15_000 });
+  await page.waitForTimeout(750);
+  await page.locator('#login-email').fill(email);
+  await page.locator('#login-password').fill(PASSWORD);
+  const loginResponse = page.waitForResponse((response) =>
+    response.request().method() === 'POST'
+      && response.url().includes('/api/auth/login'),
+  { timeout: 25_000 });
+  await page.getByRole('button', { name: /^sign in$/i }).click();
+  const response = await loginResponse;
+  if (response.status() >= 400) {
+    const body = await response.text().catch(() => '');
+    throw new Error(`Login POST failed for ${email}: ${response.status()} ${body.slice(0, 240)}`);
+  }
+  await page.waitForURL((url) => !url.pathname.includes('/login'), { timeout: 25_000 });
+  await page.locator('main').waitFor({ state: 'visible', timeout: 20_000 });
+}
+
+async function clickSpace(page: Page, spaceName: string) {
+  await page.goto(`${WEB_URL}/chat`, { waitUntil: 'domcontentloaded' });
+  await page.locator('main').waitFor({ state: 'visible', timeout: 20_000 });
+  const sidebar = page.locator('aside, nav').first();
+  const row = sidebar.getByText(spaceName, { exact: true }).first();
+  await row.waitFor({ state: 'visible', timeout: 15_000 });
+  await row.click();
+  await page.waitForTimeout(500);
+}
+
+async function sendMessage(page: Page, spaceName: string, content: string) {
+  await clickSpace(page, spaceName);
+  const editor = page.locator('[contenteditable="true"]').last();
+  await editor.waitFor({ state: 'visible', timeout: 20_000 });
+  await editor.click();
+  await page.keyboard.insertText(content);
+  const post = page.waitForResponse((response) =>
+    response.request().method() === 'POST'
+      && response.url().includes('/api/messages/')
+      && response.status() < 400,
+  { timeout: 25_000 }).catch(() => null);
+  await page.getByRole('button', { name: /send message/i }).click();
+  await post;
+  await page.getByText(RUN_MARKER, { exact: false }).last().waitFor({ state: 'visible', timeout: 20_000 });
+}
+
+async function checkSurface(page: Page, result: PersonaResult, route: string, visibleText: string, evidence: string) {
+  await page.goto(`${WEB_URL}${route}`, { waitUntil: 'domcontentloaded' });
+  await page.locator('main').waitFor({ state: 'visible', timeout: 20_000 });
+  await page.getByText(visibleText, { exact: false }).first().waitFor({ state: 'visible', timeout: 20_000 });
+  result.evidence.push(evidence);
+}
+
+async function checkAnyVisible(page: Page, labels: Array<string | RegExp>, timeoutMs = 20_000) {
+  const started = Date.now();
+  let last = '';
+  while (Date.now() - started < timeoutMs) {
+    for (const label of labels) {
+      const locator = typeof label === 'string'
+        ? page.getByText(label, { exact: false }).first()
+        : page.getByText(label).first();
+      if (await locator.isVisible().catch(() => false)) return String(label);
+      last = String(label);
+    }
+    await page.waitForTimeout(400);
+  }
+  throw new Error(`None of these UI labels became visible: ${labels.map(String).join(', ')}. Last checked: ${last}`);
+}
+
+async function checkDashboard(page: Page, result: PersonaResult) {
+  await page.goto(`${WEB_URL}/dashboard`, { waitUntil: 'domcontentloaded' });
+  await page.locator('main').waitFor({ state: 'visible', timeout: 20_000 });
+  await checkAnyVisible(page, [/dashboard/i, /my work/i, /agent activity/i, /chat/i]);
+  result.evidence.push('Dashboard authenticated and rendered.');
+}
+
+async function checkTasks(page: Page, result: PersonaResult) {
+  await page.goto(`${WEB_URL}/tasks`, { waitUntil: 'domcontentloaded' });
+  await page.locator('main').waitFor({ state: 'visible', timeout: 20_000 });
+  const signal = await checkAnyVisible(page, [/backlog/i, /\btodo\b/i, /in progress/i, /done/i, /board/i, /list/i]);
+  result.evidence.push(`Tasks page rendered a real work surface (${signal}).`);
+}
+
+async function checkKnowledge(page: Page, result: PersonaResult, query: string) {
+  await page.goto(`${WEB_URL}/knowledge`, { waitUntil: 'domcontentloaded' });
+  await page.locator('main').waitFor({ state: 'visible', timeout: 20_000 });
+  const search = page.getByPlaceholder(/search wiki/i);
+  if (await search.isVisible().catch(() => false)) {
+    await search.fill(query);
+    await page.waitForTimeout(700);
+  }
+  await page.getByText(query, { exact: false }).first().waitFor({ state: 'visible', timeout: 20_000 });
+  result.evidence.push(`Knowledge search found "${query}" through the UI.`);
+}
+
+async function tryApproveManagerCaptures(page: Page, result: PersonaResult) {
+  await clickSpace(page, 'sales-and-buyers');
+  await page.getByText(RUN_MARKER, { exact: false }).last().waitFor({ state: 'visible', timeout: 20_000 });
+
+  const wanted = [
+    { button: /save decision|save knowledge/i, done: /decision saved|knowledge saved|saved to knowledge/i },
+    { button: /^create task$/i, done: /task created/i },
+    { button: /update task/i, done: /task updated/i },
+  ];
+
+  for (const target of wanted) {
+    const button = page.getByRole('button', { name: target.button }).first();
+    const appeared = await button.waitFor({ state: 'visible', timeout: 45_000 }).then(() => true).catch(() => false);
+    if (!appeared) {
+      result.evidence.push(`No visible approval button matched ${target.button}; capture may still be pending or intentionally skipped.`);
+      continue;
+    }
+    await button.click();
+    const newTaskModal = page.getByText(/^new task$/i).first();
+    if (await newTaskModal.isVisible().catch(() => false)) {
+      const modalCreate = page.getByRole('button', { name: /^create task$/i }).last();
+      await modalCreate.click();
+      await newTaskModal.waitFor({ state: 'hidden', timeout: 20_000 }).catch(() => null);
+    }
+    await page.waitForTimeout(1_500);
+    const doneVisible = await page.getByText(target.done).first().isVisible().catch(() => false);
+    result.evidence.push(doneVisible
+      ? `Approved capture through chat card: ${target.button}.`
+      : `Clicked capture approval for ${target.button}; final label was not visible before timeout.`);
+  }
+
+  await screenshot(page, result, 'chat-captures');
+  await page.goto(`${WEB_URL}/inbox?tab=captures`, { waitUntil: 'domcontentloaded' });
+  await page.locator('main').waitFor({ state: 'visible', timeout: 20_000 });
+  const captureVisible = await page.getByText(RUN_MARKER, { exact: false }).first().isVisible().catch(() => false);
+  result.evidence.push(captureVisible
+    ? 'Inbox captures tab shows the swarm marker.'
+    : 'Inbox captures tab loaded, but the run marker was not visible in the first rendered capture set.');
+  await screenshot(page, result, 'inbox-captures');
+}
+
+async function runPersona(browser: Browser, persona: typeof personas[number], index: number): Promise<PersonaResult> {
+  const context = await browser.newContext({
+    viewport: { width: index === 0 ? 1440 : 1280, height: index === 0 ? 980 : 820 },
+    timezoneId: 'America/Chicago',
+  });
+  const page = await context.newPage();
+  const result: PersonaResult = {
+    name: persona.name,
+    email: persona.email,
+    role: persona.role,
+    ok: false,
+    steps: [],
+    evidence: [],
+    screenshots: [],
+    network: [],
+    console: [],
+  };
+  const requestStarts = new Map();
+
+  page.on('console', (message) => {
+    if (['error', 'warning'].includes(message.type())) {
+      result.console.push({ type: message.type(), text: message.text().slice(0, 600) });
+    }
+  });
+  page.on('request', (request) => {
+    const url = request.url();
+    if (url.includes('/api/messages') || url.includes('/api/agent') || url.includes('/api/work-intents')) {
+      requestStarts.set(request, Date.now());
+    }
+  });
+  page.on('response', (response) => {
+    const request = response.request();
+    const started = requestStarts.get(request);
+    const url = response.url();
+    if (started && (url.includes('/api/messages') || url.includes('/api/agent') || url.includes('/api/work-intents'))) {
+      result.network.push({
+        method: request.method(),
+        url: url.replace(WEB_URL, ''),
+        status: response.status(),
+        ms: Date.now() - started,
+      });
+      requestStarts.delete(request);
+    }
+  });
+
+  try {
+    await recordStep(result, 'login through UI', () => loginViaUi(page, persona.email));
+    await recordStep(result, 'dashboard loads as user', async () => {
+      await checkDashboard(page, result);
+      await screenshot(page, result, 'dashboard');
+    });
+    await recordStep(result, 'post concurrent chat messages', async () => {
+      for (const message of persona.messages) {
+        await sendMessage(page, persona.space, message);
+      }
+      result.evidence.push(`Posted ${persona.messages.length} messages in #${persona.space}.`);
+      await screenshot(page, result, 'chat');
+    });
+    await recordStep(result, 'tasks surface remains navigable', async () => {
+      await checkTasks(page, result);
+    });
+    await recordStep(result, 'knowledge surface remains searchable', () => checkKnowledge(page, result, persona.knowledgeNeedle));
+    if (persona.approve) {
+      await recordStep(result, 'manager approves visible Defty captures', () => tryApproveManagerCaptures(page, result));
+    }
+    result.ok = true;
+  } catch (err) {
+    result.error = err instanceof Error ? err.message : String(err);
+    await screenshot(page, result, 'failure');
+  } finally {
+    await context.close().catch(() => null);
+  }
+
+  return result;
+}
+
+async function writeReports(results: PersonaResult[]) {
+  const passed = results.filter((result) => result.ok).length;
+  const failed = results.length - passed;
+  const cards = results.map((result) => {
+    const steps = result.steps.map((step) =>
+      `<li class="${step.ok ? 'ok' : 'fail'}"><strong>${escapeHtml(step.name)}</strong> ${step.ok ? 'passed' : 'failed'} <span>${step.ms}ms</span>${step.detail ? `<p>${escapeHtml(step.detail)}</p>` : ''}</li>`,
+    ).join('');
+    const evidence = result.evidence.map((item) => `<li>${escapeHtml(item)}</li>`).join('');
+    const network = result.network.slice(-12).map((entry) =>
+      `<li><strong>${entry.status}</strong> ${escapeHtml(entry.method)} <code>${escapeHtml(entry.url)}</code> <span>${entry.ms ?? '-'}ms</span></li>`,
+    ).join('');
+    const consoleRows = result.console.slice(-8).map((entry) =>
+      `<li><strong>${escapeHtml(entry.type)}</strong>: ${escapeHtml(entry.text)}</li>`,
+    ).join('');
+    const screenshots = result.screenshots.map((shot) => {
+      const rel = path.relative(path.dirname(HTML_REPORT), shot).replace(/\\/g, '/');
+      return `<img src="${escapeHtml(rel)}" alt="${escapeHtml(path.basename(shot))}">`;
+    }).join('');
+
+    return `<section class="card ${result.ok ? 'pass' : 'fail'}">
+      <div class="card-head">
+        <div>
+          <h2>${escapeHtml(result.name)}</h2>
+          <p>${escapeHtml(result.role)} - ${escapeHtml(result.email)}</p>
+        </div>
+        <span>${result.ok ? 'PASS' : 'FAIL'}</span>
+      </div>
+      ${result.error ? `<p class="error">${escapeHtml(result.error)}</p>` : ''}
+      <h3>Steps</h3>
+      <ul>${steps}</ul>
+      <h3>Evidence</h3>
+      <ul>${evidence || '<li>No evidence captured.</li>'}</ul>
+      <h3>Observed Browser Network</h3>
+      <ul>${network || '<li>No observed work-intent network calls.</li>'}</ul>
+      <h3>Console</h3>
+      <ul>${consoleRows || '<li>No console warnings/errors.</li>'}</ul>
+      <div class="shots">${screenshots}</div>
+    </section>`;
+  }).join('\n');
+
+  const html = `<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Work Intent Ledger UI Swarm - ${escapeHtml(RUN_MARKER)}</title>
+  <style>
+    :root { color-scheme: light; --ink:#192019; --muted:#637064; --line:#d8ded4; --paper:#fbfaf4; --card:#fffef9; --green:#117a4a; --red:#b42318; --gold:#b7791f; }
+    * { box-sizing: border-box; }
+    body { margin: 0; font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; color: var(--ink); background: var(--paper); }
+    header { padding: 36px 42px 24px; background: #eef5ea; border-bottom: 1px solid var(--line); }
+    h1 { margin: 0 0 8px; font-size: 30px; letter-spacing: -0.02em; }
+    p { color: var(--muted); line-height: 1.5; }
+    .summary { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 18px; }
+    .pill { border: 1px solid var(--line); background: rgba(255,255,255,0.7); border-radius: 999px; padding: 8px 12px; font-size: 13px; }
+    main { display: grid; gap: 18px; padding: 28px 42px 48px; }
+    .card { position: relative; border: 1px solid var(--line); background: var(--card); border-radius: 10px; padding: 18px; box-shadow: 0 12px 30px rgba(31,41,25,0.06); }
+    .card.pass { border-left: 5px solid var(--green); }
+    .card.fail { border-left: 5px solid var(--red); }
+    .card-head { display: flex; justify-content: space-between; gap: 16px; align-items: flex-start; }
+    h2 { margin: 0; font-size: 19px; }
+    h3 { margin: 18px 0 8px; font-size: 13px; text-transform: uppercase; letter-spacing: .06em; color: var(--muted); }
+    ul { margin: 0; padding-left: 20px; }
+    li { margin: 6px 0; }
+    li.ok { color: var(--green); }
+    li.fail, .error { color: var(--red); }
+    code { font-size: 12px; color: #334155; }
+    span { font-size: 12px; color: var(--muted); }
+    .shots { display: flex; gap: 12px; flex-wrap: wrap; margin-top: 14px; }
+    img { max-width: 360px; width: 100%; border: 1px solid var(--line); border-radius: 8px; background: white; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Work Intent Ledger UI-Only Swarm</h1>
+    <p>Five Testers Tomatoes employees logged in through the browser, posted concurrent work messages, navigated the workspace, and exercised Defty capture approvals without direct backend setup or validation calls.</p>
+    <div class="summary">
+      <div class="pill">Run marker: ${escapeHtml(RUN_MARKER)}</div>
+      <div class="pill">Target: ${escapeHtml(WEB_URL)}</div>
+      <div class="pill">Passed: ${passed}/${results.length}</div>
+      <div class="pill">Failed: ${failed}</div>
+      <div class="pill">Generated: ${escapeHtml(new Date().toISOString())}</div>
+    </div>
+  </header>
+  <main>${cards}</main>
+</body>
+</html>`;
+
+  await fs.writeFile(JSON_REPORT, JSON.stringify({ runId: RUN_ID, runMarker: RUN_MARKER, webUrl: WEB_URL, passed, failed, results }, null, 2));
+  await fs.writeFile(HTML_REPORT, html);
+}
+
+async function main() {
+  await fs.mkdir(OUT_DIR, { recursive: true });
+  const browser = await chromium.launch({ headless: true });
+  let results: PersonaResult[] = [];
+  try {
+    results = await Promise.all(personas.map((persona, index) => runPersona(browser, persona, index)));
+  } finally {
+    await browser.close().catch(() => null);
+  }
+
+  await writeReports(results);
+
+  console.log(JSON.stringify({
+    runId: RUN_ID,
+    runMarker: RUN_MARKER,
+    webUrl: WEB_URL,
+    passed: results.filter((result) => result.ok).length,
+    failed: results.filter((result) => !result.ok).length,
+    htmlReport: HTML_REPORT,
+    jsonReport: JSON_REPORT,
+  }, null, 2));
+
+  if (results.some((result) => !result.ok)) {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- Moves chat classification into a durable `message_observations` ledger with retry/backfill support.
- Routes Defty task/blocker/knowledge captures through observable worker jobs instead of route-side fire-and-forget.
- Adds capture inbox observation trail UI and reusable certification runners for dense human workflow testing.
- Tightens dedupe so similar-but-distinct task/wiki references are not collapsed, while explicit no-action chatter stays ignored.

## Validation
- `pnpm --filter @deft/api exec tsx --test --test-concurrency=1 --test-force-exit test/chat-observation.test.ts test/defty-capture-dedupe-update.test.ts` — 15 passing.
- `pnpm --filter @deft/api typecheck` — pass.
- `pnpm --filter @deft/web typecheck` — pass.
- `DEFT_WEB_URL=http://localhost:3000 DEFT_API_URL=http://localhost:3301 REDIS_URL=redis://127.0.0.1:6379 pnpm pilot:preflight` — pass; local-only warning for `NEXT_PUBLIC_APP_URL` drift to `3012`.
- Dense UI certification: 100 human UI messages across 5 personas / 8 spaces; 100 observations completed; 80/80 expected captures matched; 0 false negatives; 0 false positives; findings empty.
  - Local evidence: `reports/dense-human-workflow-certification-2026-06-28T17-39-48-963Z.html` and matching JSON.

## Notes
- Generated report HTML/JSON stays ignored. The committed `scripts/reports/*` files are reusable certification runners, not generated artifacts.