### PR TITLE
[codex] Harden dense demo certification

### DIFF
--- a/apps/api/src/middleware/rate-limit.ts
+++ b/apps/api/src/middleware/rate-limit.ts
@@ -27,7 +27,11 @@ const UPLOAD_LIMIT_PER_MINUTE = positiveIntFromEnv(
 );
 const DEFAULT_LIMIT_PER_MINUTE = positiveIntFromEnv(
   'DEFT_DEFAULT_RATE_LIMIT_PER_MINUTE',
-  isProduction ? 100 : 2000,
+  // The web app is a chatty SPA: a normal dashboard/chat/task sweep can issue
+  // many protected reads before the user even sends a message. Keep auth,
+  // upload, webhook, and agent-spend surfaces tighter, but give authenticated
+  // app routes enough room for multi-user pilot/demo workflows.
+  isProduction ? 600 : 2000,
 );
 const WEBHOOK_LIMIT_PER_MINUTE = positiveIntFromEnv(
   'DEFT_WEBHOOK_RATE_LIMIT_PER_MINUTE',

--- a/apps/api/test/rate-limit-audit-bypass.test.ts
+++ b/apps/api/test/rate-limit-audit-bypass.test.ts
@@ -55,3 +55,25 @@ test('audit bypass token is ignored in production', async () => {
   if (oldDefaultLimit === undefined) delete process.env.DEFT_DEFAULT_RATE_LIMIT_PER_MINUTE;
   else process.env.DEFT_DEFAULT_RATE_LIMIT_PER_MINUTE = oldDefaultLimit;
 });
+
+test('production default app limiter allows normal chatty UI bursts', async () => {
+  const oldNodeEnv = process.env.NODE_ENV;
+  const oldDefaultLimit = process.env.DEFT_DEFAULT_RATE_LIMIT_PER_MINUTE;
+
+  process.env.NODE_ENV = 'production';
+  delete process.env.DEFT_DEFAULT_RATE_LIMIT_PER_MINUTE;
+
+  const { defaultLimiter } = await import(`../src/middleware/rate-limit.js?default-budget=${Date.now()}`);
+  const app = new Hono();
+  app.use('*', defaultLimiter);
+  app.get('/ok', (c) => c.json({ ok: true }));
+
+  for (let i = 0; i < 120; i += 1) {
+    const res = await app.request('/ok', { headers: { 'x-forwarded-for': '203.0.113.42' } });
+    assert.equal(res.status, 200, `request ${i + 1} should not be rate-limited`);
+  }
+
+  process.env.NODE_ENV = oldNodeEnv;
+  if (oldDefaultLimit === undefined) delete process.env.DEFT_DEFAULT_RATE_LIMIT_PER_MINUTE;
+  else process.env.DEFT_DEFAULT_RATE_LIMIT_PER_MINUTE = oldDefaultLimit;
+});

--- a/scripts/reports/dense-human-workflow-certification.ts
+++ b/scripts/reports/dense-human-workflow-certification.ts
@@ -247,17 +247,24 @@ async function screenshot(page: Page, name: string) {
 
 async function loginUi(page: Page, email: string) {
   await page.goto(`${WEB_URL}/login`, { waitUntil: 'domcontentloaded' });
+  // Public/demo Next builds can show the form before client hydration finishes.
+  // Wait for the login page to go network-quiet so the React submit handler is
+  // attached before we click; otherwise the browser may no-op/reload /login.
+  await page.waitForLoadState('networkidle', { timeout: 30_000 }).catch(() => null);
   await page.locator('#login-email').waitFor({ state: 'visible', timeout: 20_000 });
   await page.locator('#login-email').fill(email);
   await page.locator('#login-password').fill(PASSWORD);
   const responsePromise = page.waitForResponse(
     (response) => response.request().method() === 'POST' && response.url().includes('/api/auth/login'),
-    { timeout: 15_000 },
-  ).catch(() => null);
-  await page.getByRole('button', { name: /^sign in$/i }).click();
-  await page.waitForURL((url) => !url.pathname.includes('/login'), { timeout: 30_000 });
+    { timeout: 30_000 },
+  );
+  await Promise.all([
+    responsePromise,
+    page.getByRole('button', { name: /^sign in$/i }).click(),
+  ]);
   const response = await responsePromise;
-  if (response && response.status() >= 400) throw new Error(`UI login failed for ${email}: ${response.status()}`);
+  if (response.status() >= 400) throw new Error(`UI login failed for ${email}: ${response.status()}`);
+  await page.waitForURL((url) => !url.pathname.includes('/login'), { timeout: 45_000 });
   await page.locator('main').waitFor({ state: 'visible', timeout: 20_000 });
 }
 


### PR DESCRIPTION
## What changed

- Raises the production default protected-app rate limit from 100/min to 600/min.
- Keeps stricter auth, agent, upload, and webhook budgets unchanged.
- Adds a regression test proving production app routes tolerate a chatty UI burst without false 429s.
- Hardens the dense human workflow certification login helper so it waits for public Next.js hydration and requires the login POST before continuing.

## Why

The public dense workflow certification on `demo.deft.ing` proved the Defty work-intent path was correct, but 11/100 human-like UI sends hit false `429` responses. The root cause was the default protected-route limiter being too low for a chatty SPA during multi-user dashboard/chat/task workflows.

## Validation

- `pnpm --filter @deft/api exec tsx --test --test-concurrency=1 --test-force-exit test/rate-limit-audit-bypass.test.ts`
- `pnpm --filter @deft/api typecheck`
- Public demo certification against `https://demo.deft.ing`: 100/100 UI sends, 100/100 observed, 80/80 expected captures, 20/20 explicit no-action messages ignored, 5 approved actions with verified receipts, 0 findings.

Report: `reports/dense-human-workflow-certification-public-demo-2026-06-28T23-53-37-902Z.html`
