### PR TITLE
[codex] Add channel-aware knowledge context routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ docker compose run --rm init
 docker compose run --rm doctor
 ```
 
-> **Note:** Use `pnpm db:push-full`, not `pnpm db:migrate`. `push-full` is the supported path for fresh installs — it diffs the live schema against `packages/db/src/schema.ts`, then applies two orphan SQL files (`0020_wiki_search_vector.sql` and `0033_tasks_embedding.sql`) that create generated tsvector columns and GIN indexes Drizzle's pushed schema can't express. Plain `pnpm db:push` skips the orphans and leaves wiki/task FTS broken. Versioned `db:migrate` upgrade paths are not yet supported and will arrive post-alpha.
+> **Note:** Use `pnpm db:push-full`, not `pnpm db:migrate`. `push-full` is the supported path for fresh installs — it diffs the live schema against `packages/db/src/schema.ts`, then applies supplemental SQL files for generated search columns, GIN/vector indexes, and safe metadata backfills that Drizzle's pushed schema can't fully express. Plain `pnpm db:push` skips those extras and leaves search/backfill behavior incomplete. Versioned `db:migrate` upgrade paths are not yet supported and will arrive post-alpha.
 
 > **`pnpm db:seed` is prod-safe and idempotent** — re-running on a populated workspace is a no-op. It inserts only platform bundles (Defty system user, internal agent/tool bundles, bundled task templates, first-party employee templates). It never inserts test accounts.
 

--- a/apps/api/src/lib/mcp-tools/context.ts
+++ b/apps/api/src/lib/mcp-tools/context.ts
@@ -28,7 +28,7 @@ import {
 } from '@deft/db/schema';
 import type { ToolContext, ToolResult } from './types.js';
 import { errorResult, textResult } from './types.js';
-import { retrieveContext } from '../retrieve-context.js';
+import { retrieveContext, type ContextResult } from '../retrieve-context.js';
 
 type TriggerDescriptor = {
   kind: string;
@@ -41,6 +41,188 @@ type PlatformContextArgs = {
   caller_employee_slug: string;
   trigger?: TriggerDescriptor;
 };
+
+type WikiSnippet = {
+  source_id?: string;
+  slug: string;
+  title: string;
+  summary: string | null;
+  type: string;
+  confidence: number;
+  scope?: string | null;
+  tier?: string | null;
+  space_id?: string | null;
+  origin_space_id?: string | null;
+  origin_message_id?: string | null;
+  created_via?: string | null;
+  matched_space_id?: string | null;
+  agent_employee_id?: string | null;
+};
+
+type ContextPacket = {
+  id: string;
+  scope: 'org' | 'space' | 'employee';
+  label: string;
+  description: string;
+  space_id?: string | null;
+  employee_id?: string | null;
+  retrieval_hint: {
+    tool: 'memory_recall';
+    args_template: Record<string, unknown>;
+  };
+  item_count: number;
+  items: WikiSnippet[];
+};
+
+function snippetFromContextResult(result: ContextResult): WikiSnippet {
+  return {
+    source_id: result.source_id,
+    slug: String(result.metadata?.slug ?? ''),
+    title: result.title,
+    summary: (result.metadata?.summary as string | null) ?? null,
+    type: String(result.metadata?.type ?? 'fact'),
+    confidence: result.confidence ?? 0,
+    scope: result.scope ?? null,
+    tier: (result.metadata?.tier as string | null) ?? null,
+    space_id: (result.metadata?.space_id as string | null) ?? null,
+    origin_space_id: (result.metadata?.origin_space_id as string | null) ?? null,
+    origin_message_id: (result.metadata?.origin_message_id as string | null) ?? null,
+    created_via: (result.metadata?.created_via as string | null) ?? null,
+    matched_space_id: (result.metadata?.matched_space_id as string | null) ?? null,
+    agent_employee_id: (result.metadata?.agent_employee_id as string | null) ?? null,
+  };
+}
+
+function isEmployeeSnippet(snippet: WikiSnippet, employeeId: string): boolean {
+  return (
+    snippet.tier === 'employee' ||
+    (snippet.agent_employee_id === employeeId && snippet.scope !== 'org')
+  );
+}
+
+function isChannelSnippet(snippet: WikiSnippet, spaceId: string | null | undefined): boolean {
+  if (!spaceId) return false;
+  return (
+    snippet.space_id === spaceId ||
+    snippet.origin_space_id === spaceId ||
+    snippet.matched_space_id === spaceId ||
+    (snippet.scope === 'space' && snippet.space_id === spaceId)
+  );
+}
+
+function buildContextPackets(
+  snippets: WikiSnippet[],
+  trigger: TriggerDescriptor | undefined,
+  ctx: ToolContext,
+): ContextPacket[] {
+  const spaceId = trigger?.space_id ?? null;
+  const channelItems = spaceId
+    ? snippets.filter((snippet) => isChannelSnippet(snippet, spaceId))
+    : [];
+  const employeeItems = snippets.filter((snippet) => isEmployeeSnippet(snippet, ctx.employee_id));
+  const companyItems = snippets.filter((snippet) => {
+    if (isEmployeeSnippet(snippet, ctx.employee_id)) return false;
+    if (isChannelSnippet(snippet, spaceId)) return false;
+    return snippet.scope === 'org' || snippet.tier === 'org' || !snippet.scope;
+  });
+
+  const packets: ContextPacket[] = [
+    {
+      id: 'company_memory',
+      scope: 'org',
+      label: 'Company memory',
+      description: 'Org-wide knowledge that is useful across channels and teams.',
+      retrieval_hint: {
+        tool: 'memory_recall',
+        args_template: {
+          caller_employee_slug: ctx.employee_slug,
+          query: '<query>',
+          scope: 'org',
+        },
+      },
+      item_count: companyItems.length,
+      items: companyItems,
+    },
+    {
+      id: 'employee_memory',
+      scope: 'employee',
+      label: 'Employee memory',
+      description: 'Memory owned by or scoped to the calling employee.',
+      employee_id: ctx.employee_id,
+      retrieval_hint: {
+        tool: 'memory_recall',
+        args_template: {
+          caller_employee_slug: ctx.employee_slug,
+          query: '<query>',
+          scope: 'own',
+        },
+      },
+      item_count: employeeItems.length,
+      items: employeeItems,
+    },
+  ];
+
+  if (spaceId) {
+    packets.splice(1, 0, {
+      id: `space:${spaceId}:memory`,
+      scope: 'space',
+      label: 'Channel memory',
+      description:
+        'Knowledge created in, scoped to, or cited from the current channel. Use this before broad company memory when answering channel-specific questions.',
+      space_id: spaceId,
+      retrieval_hint: {
+        tool: 'memory_recall',
+        args_template: {
+          caller_employee_slug: ctx.employee_slug,
+          query: '<query>',
+          space_id: spaceId,
+          include_org: false,
+          scope: 'all',
+        },
+      },
+      item_count: channelItems.length,
+      items: channelItems,
+    });
+  }
+
+  return packets;
+}
+
+function mergeWikiSnippets(existing: WikiSnippet[], additions: WikiSnippet[]): WikiSnippet[] {
+  const seen = new Set(existing.map((snippet) => snippet.source_id ?? snippet.slug));
+  const merged = [...existing];
+  for (const snippet of additions) {
+    const key = snippet.source_id ?? snippet.slug;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    merged.push(snippet);
+  }
+  return merged;
+}
+
+function wikiPageMatchesSpaceExpr(orgId: string, spaceId: string) {
+  return sql<boolean>`(
+    ${wikiPages.space_id} = ${spaceId}
+    OR ${wikiPages.origin_space_id} = ${spaceId}
+    OR EXISTS (
+      SELECT 1
+      FROM wiki_citations wc
+      LEFT JOIN messages m
+        ON m.id = wc.source_id
+       AND wc.source_type = 'message'
+      WHERE wc.page_id = ${wikiPages.id}
+        AND (
+          wc.source_space_id = ${spaceId}
+          OR (m.space_id = ${spaceId} AND m.org_id = ${orgId})
+        )
+    )
+  )`;
+}
+
+function wikiMatchedSpaceIdExpr(orgId: string, spaceId: string | null | undefined) {
+  if (!spaceId) return sql<string | null>`NULL`;
+  return sql<string | null>`CASE WHEN ${wikiPageMatchesSpaceExpr(orgId, spaceId)} THEN ${spaceId} ELSE NULL END`;
+}
 
 // ─── 60s LRU cache ────────────────────────────────────────────────────────
 
@@ -182,30 +364,42 @@ export async function platformContext(
     // When there is no query text, fall back to top-confidence pages
     // (the gateway requires a non-empty query string, so we keep the
     // direct DB read for the no-query case).
-    let wikiSnippets: Array<{
-      slug: string;
-      title: string;
-      summary: string | null;
-      type: string;
-      confidence: number;
-    }> = [];
+    let wikiSnippets: WikiSnippet[] = [];
     try {
       if (queryText.trim().length > 0) {
         const results = await retrieveContext({
           query: queryText,
           org_id: ctx.org_id,
           agent_employee_id: ctx.employee_id,
+          space_id: trigger?.space_id ?? undefined,
+          include_org: true,
           types: ['wiki'],
           limit: 5,
         });
-        wikiSnippets = results.map((r) => ({
-          slug: String(r.metadata?.slug ?? ''),
-          title: r.title,
-          summary: (r.metadata?.summary as string | null) ?? null,
-          type: String(r.metadata?.type ?? 'fact'),
-          confidence: r.confidence ?? 0,
-        }));
+        wikiSnippets = results.map(snippetFromContextResult);
+        if (trigger?.space_id) {
+          const employeeResults = await retrieveContext({
+            query: queryText,
+            org_id: ctx.org_id,
+            agent_employee_id: ctx.employee_id,
+            types: ['wiki'],
+            limit: 2,
+          });
+          wikiSnippets = mergeWikiSnippets(
+            wikiSnippets,
+            employeeResults
+              .map(snippetFromContextResult)
+              .filter((snippet) => isEmployeeSnippet(snippet, ctx.employee_id)),
+          );
+        }
       } else {
+        const noQueryOrderBy = trigger?.space_id
+          ? [
+              desc(sql<number>`CASE WHEN ${wikiPageMatchesSpaceExpr(ctx.org_id, trigger.space_id)} THEN 1 ELSE 0 END`),
+              desc(wikiPages.confidence),
+              desc(wikiPages.updated_at),
+            ]
+          : [desc(wikiPages.confidence), desc(wikiPages.updated_at)];
         const rows = await db
           .select({
             slug: wikiPages.slug,
@@ -213,6 +407,13 @@ export async function platformContext(
             summary: wikiPages.summary,
             type: wikiPages.type,
             confidence: wikiPages.confidence,
+            scope: wikiPages.scope,
+            space_id: wikiPages.space_id,
+            origin_space_id: wikiPages.origin_space_id,
+            origin_message_id: wikiPages.origin_message_id,
+            created_via: wikiPages.created_via,
+            matched_space_id: wikiMatchedSpaceIdExpr(ctx.org_id, trigger?.space_id),
+            agent_employee_id: wikiPages.agent_employee_id,
           })
           .from(wikiPages)
           .where(
@@ -221,6 +422,15 @@ export async function platformContext(
               eq(wikiPages.is_deleted, false),
               or(
                 eq(wikiPages.scope, 'org'),
+                trigger?.space_id
+                  ? or(
+                      and(
+                        eq(wikiPages.scope, 'space'),
+                        eq(wikiPages.space_id, trigger.space_id),
+                      ),
+                      eq(wikiPages.origin_space_id, trigger.space_id),
+                    )
+                  : undefined,
                 and(
                   eq(wikiPages.agent_employee_id, ctx.employee_id),
                   sql`${wikiPages.scope} != 'org'`,
@@ -228,7 +438,7 @@ export async function platformContext(
               ),
             ),
           )
-          .orderBy(desc(wikiPages.confidence), desc(wikiPages.updated_at))
+          .orderBy(...noQueryOrderBy)
           .limit(5);
         wikiSnippets = rows.map((r) => ({
           slug: r.slug,
@@ -236,6 +446,14 @@ export async function platformContext(
           summary: r.summary,
           type: r.type as string,
           confidence: r.confidence,
+          scope: r.scope,
+          tier: r.scope === 'org' ? 'org' : r.agent_employee_id === ctx.employee_id ? 'employee' : null,
+          space_id: r.space_id,
+          origin_space_id: r.origin_space_id,
+          origin_message_id: r.origin_message_id,
+          created_via: r.created_via,
+          matched_space_id: r.matched_space_id,
+          agent_employee_id: r.agent_employee_id,
         }));
       }
     } catch {
@@ -265,6 +483,7 @@ export async function platformContext(
       })),
       active_projects: activeProjects,
       relevant_wiki_snippets: wikiSnippets,
+      context_packets: buildContextPackets(wikiSnippets, trigger, ctx),
       trigger_context: trigger ?? null,
       _cache_hit: false,
     };

--- a/apps/api/src/lib/mcp-tools/human.ts
+++ b/apps/api/src/lib/mcp-tools/human.ts
@@ -492,40 +492,52 @@ export async function humanFetch(args: { id?: string }, ctx: HumanToolContext): 
   return errorResult(`fetch: unsupported id type ${kind}`);
 }
 
-export async function humanMemoryRecall(args: { query?: string; limit?: number }, ctx: HumanToolContext): Promise<ToolResult> {
+export async function humanMemoryRecall(
+  args: { query?: string; limit?: number; space_id?: string; include_org?: boolean },
+  ctx: HumanToolContext,
+): Promise<ToolResult> {
   const scopeError = requireScope(ctx, 'read:wiki');
   if (scopeError) return scopeError;
   const query = (args.query ?? '').trim();
   if (!query) return errorResult('memory_recall requires query');
-  const terms = query.toLowerCase().split(/[^a-z0-9]+/).filter((t) => t.length >= 3).slice(0, 8);
   const limit = Math.min(Math.max(1, args.limit ?? 10), 25);
-  const rows = await db
-    .select({
-      slug: wikiPages.slug,
-      title: wikiPages.title,
-      summary: wikiPages.summary,
-      content: wikiPages.content,
-      type: wikiPages.type,
-      confidence: wikiPages.confidence,
-      updated_at: wikiPages.updated_at,
-    })
-    .from(wikiPages)
-    .where(and(
-      eq(wikiPages.org_id, ctx.org_id),
-      eq(wikiPages.is_deleted, false),
-      visibleWikiPageCondition(ctx.user_id),
-      ...terms.map((term) => {
-        const pattern = `%${term}%`;
-        return sql`(lower(${wikiPages.title}) like ${pattern} or lower(${wikiPages.summary}) like ${pattern} or lower(${wikiPages.content}) like ${pattern})`;
-      }),
-    ))
-    .orderBy(desc(wikiPages.updated_at))
-    .limit(limit);
-  return textResult(rows.map((row) => ({
-    ...row,
-    content: row.content.length > 2000 ? row.content.slice(0, 2000) : row.content,
-    truncated: row.content.length > 2000,
-  })));
+  const spaceId = args.space_id?.trim() || undefined;
+  const includeOrg = args.include_org !== false;
+  if (spaceId && !(await userCanSeeSpace(ctx, spaceId))) {
+    return errorResult(`memory_recall: user cannot access space ${spaceId}`);
+  }
+
+  const rows = await retrieveContext({
+    query,
+    org_id: ctx.org_id,
+    user_id: ctx.user_id,
+    space_id: spaceId,
+    include_org: includeOrg,
+    types: ['wiki'],
+    limit,
+    hybrid: false,
+  });
+
+  return textResult(rows
+    .filter((row) => row.source_type === 'wiki_page')
+    .map((row) => {
+      const content = row.content ?? '';
+      const truncated = content.length > 2000;
+      return {
+        slug: row.metadata?.slug ?? '',
+        title: row.title,
+        summary: row.metadata?.summary ?? null,
+        content: truncated ? content.slice(0, 2000) : content,
+        truncated,
+        type: row.metadata?.type ?? '',
+        confidence: row.confidence ?? 1.0,
+        space_id: row.metadata?.space_id ?? null,
+        origin_space_id: row.metadata?.origin_space_id ?? null,
+        origin_message_id: row.metadata?.origin_message_id ?? null,
+        created_via: row.metadata?.created_via ?? null,
+        matched_space_id: row.metadata?.matched_space_id ?? null,
+      };
+    }));
 }
 
 export async function humanMemoryList(args: { type?: string; limit?: number }, ctx: HumanToolContext): Promise<ToolResult> {

--- a/apps/api/src/lib/mcp-tools/index.ts
+++ b/apps/api/src/lib/mcp-tools/index.ts
@@ -116,7 +116,8 @@ export const toolSchemas: ToolSchema[] = [
       'Returns the dynamic platform context for the calling employee: today\'s ' +
       'date, org + role info, teammates, active projects, and relevant wiki ' +
       'snippets. Call this first on every turn — it is the source of truth for ' +
-      'who you are, what day it is, and what you know.',
+      'who you are, what day it is, and what you know. ' +
+      'The response also includes context_packets that separate company, channel, and employee memory.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -142,6 +143,16 @@ export const toolSchemas: ToolSchema[] = [
         ...CALLER_SLUG_PROP,
         query: { type: 'string', description: 'Natural language query text' },
         limit: { type: 'integer', minimum: 1, maximum: 25 },
+        space_id: {
+          type: 'string',
+          description:
+            'Optional channel/space id. When provided, recall is scoped to memory relevant to that space.',
+        },
+        include_org: {
+          type: 'boolean',
+          description:
+            'When space_id is provided, include org/company memory alongside channel-specific memory. Default true. Set false for channel-only recall.',
+        },
         scope: {
           type: 'string',
           enum: ['own', 'org', 'all'],
@@ -161,6 +172,16 @@ export const toolSchemas: ToolSchema[] = [
         ...CALLER_SLUG_PROP,
         query: { type: 'string', description: 'Natural language query text' },
         limit: { type: 'integer', minimum: 1, maximum: 25 },
+        space_id: {
+          type: 'string',
+          description:
+            'Optional channel/space id. When provided, recall is scoped to memory relevant to that space.',
+        },
+        include_org: {
+          type: 'boolean',
+          description:
+            'When space_id is provided, include org/company memory alongside channel-specific memory. Default true. Set false for channel-only recall.',
+        },
         scope: {
           type: 'string',
           enum: ['own', 'org', 'all'],

--- a/apps/api/src/lib/mcp-tools/memory.ts
+++ b/apps/api/src/lib/mcp-tools/memory.ts
@@ -9,7 +9,7 @@
 import { sql, and, eq, or, desc } from 'drizzle-orm';
 import { randomUUID } from 'node:crypto';
 import { db } from '../db.js';
-import { wikiPages } from '@deft/db/schema';
+import { agentEmployees, spaceMembers, spaces, wikiPages } from '@deft/db/schema';
 import type { ToolContext, ToolResult } from './types.js';
 import { errorResult, textResult } from './types.js';
 import { invalidatePlatformContextCacheFor } from './context.js';
@@ -49,6 +49,65 @@ function contextResultMatchesMemoryScope(
   return isOrgScope || isOwnScope;
 }
 
+function wikiPageRelevantToSpaceCondition(spaceId: string, orgId: string) {
+  return or(
+    and(eq(wikiPages.scope, 'space'), eq(wikiPages.space_id, spaceId)),
+    eq(wikiPages.origin_space_id, spaceId),
+    sql`EXISTS (
+      SELECT 1
+      FROM wiki_citations wc
+      LEFT JOIN messages m
+        ON m.id = wc.source_id
+       AND wc.source_type = 'message'
+      WHERE wc.page_id = ${wikiPages.id}
+        AND (
+          wc.source_space_id = ${spaceId}
+          OR (m.space_id = ${spaceId} AND m.org_id = ${orgId})
+        )
+    )`,
+  );
+}
+
+function wikiRetrievalScopeCondition(orgId: string, spaceId: string | undefined, includeOrg: boolean) {
+  if (!spaceId) return undefined;
+  const spaceRelevant = wikiPageRelevantToSpaceCondition(spaceId, orgId);
+  return includeOrg ? or(eq(wikiPages.scope, 'org'), spaceRelevant) : spaceRelevant;
+}
+
+function wikiMatchedSpaceIdExpr(orgId: string, spaceId: string | undefined) {
+  if (!spaceId) return sql<string | null>`NULL`;
+  const spaceRelevant = wikiPageRelevantToSpaceCondition(spaceId, orgId) ?? sql`FALSE`;
+  return sql<string | null>`CASE WHEN ${spaceRelevant} THEN ${spaceId} ELSE NULL END`;
+}
+
+async function canEmployeeSeeSpace(
+  spaceId: string,
+  orgId: string,
+  employeeId: string,
+): Promise<boolean> {
+  const [space] = await db
+    .select({ id: spaces.id, type: spaces.type })
+    .from(spaces)
+    .where(and(eq(spaces.id, spaceId), eq(spaces.org_id, orgId)))
+    .limit(1);
+  if (!space) return false;
+  if (space.type === 'public') return true;
+
+  const [employee] = await db
+    .select({ user_id: agentEmployees.user_id })
+    .from(agentEmployees)
+    .where(and(eq(agentEmployees.id, employeeId), eq(agentEmployees.org_id, orgId)))
+    .limit(1);
+  if (!employee?.user_id) return false;
+
+  const [member] = await db
+    .select({ id: spaceMembers.id })
+    .from(spaceMembers)
+    .where(and(eq(spaceMembers.space_id, spaceId), eq(spaceMembers.user_id, employee.user_id)))
+    .limit(1);
+  return !!member;
+}
+
 // ─── memory_recall ────────────────────────────────────────────────────────
 
 export type MemoryRecallArgs = {
@@ -56,6 +115,8 @@ export type MemoryRecallArgs = {
   query: string;
   limit?: number;
   scope?: 'own' | 'org' | 'all';
+  space_id?: string;
+  include_org?: boolean;
 };
 
 export async function memoryRecall(
@@ -68,8 +129,14 @@ export async function memoryRecall(
   }
   const limit = Math.min(Math.max(1, args.limit ?? 5), 25);
   const scope = args.scope ?? 'all';
+  const spaceId = args.space_id?.trim() || undefined;
+  const includeOrg = args.include_org !== false;
 
   try {
+    if (spaceId && !(await canEmployeeSeeSpace(spaceId, ctx.org_id, ctx.employee_id))) {
+      return errorResult(`memory_recall: employee cannot access space ${spaceId}`);
+    }
+    const retrievalScope = wikiRetrievalScopeCondition(ctx.org_id, spaceId, includeOrg);
     const terms = query
       .toLowerCase()
       .split(/[^a-z0-9]+/)
@@ -84,6 +151,11 @@ export async function memoryRecall(
             content: wikiPages.content,
             type: wikiPages.type,
             agent_employee_id: wikiPages.agent_employee_id,
+            space_id: wikiPages.space_id,
+            origin_space_id: wikiPages.origin_space_id,
+            origin_message_id: wikiPages.origin_message_id,
+            created_via: wikiPages.created_via,
+            matched_space_id: wikiMatchedSpaceIdExpr(ctx.org_id, spaceId),
             updated_at: wikiPages.updated_at,
           })
           .from(wikiPages)
@@ -91,6 +163,7 @@ export async function memoryRecall(
             eq(wikiPages.org_id, ctx.org_id),
             eq(wikiPages.is_deleted, false),
             wikiScopeCondition(scope, ctx.employee_id),
+            ...(retrievalScope ? [retrievalScope] : []),
             ...terms.map((term) => {
               const pattern = `%${term}%`;
               return sql`(
@@ -109,6 +182,8 @@ export async function memoryRecall(
       query,
       org_id: ctx.org_id,
       agent_employee_id: ctx.employee_id,
+      space_id: spaceId,
+      include_org: includeOrg,
       types: ['wiki'],
       limit,
       hybrid: false, // FTS-only; pgvector is a separate phase
@@ -140,6 +215,11 @@ export async function memoryRecall(
         truncated,
         type: row.type ?? '',
         confidence: 1.0,
+        space_id: row.space_id ?? null,
+        origin_space_id: row.origin_space_id ?? null,
+        origin_message_id: row.origin_message_id ?? null,
+        created_via: row.created_via ?? null,
+        matched_space_id: row.matched_space_id ?? null,
       };
     });
     const result = [...exactResults, ...filtered.filter((r) => {
@@ -158,6 +238,11 @@ export async function memoryRecall(
         truncated,
         type: (r.metadata?.type as string) ?? '',
         confidence: r.confidence ?? 1.0,
+        space_id: r.metadata?.space_id ?? null,
+        origin_space_id: r.metadata?.origin_space_id ?? null,
+        origin_message_id: r.metadata?.origin_message_id ?? null,
+        created_via: r.metadata?.created_via ?? null,
+        matched_space_id: r.metadata?.matched_space_id ?? null,
       };
     })].slice(0, limit);
 

--- a/apps/api/src/lib/mcp-tools/wiki-create.ts
+++ b/apps/api/src/lib/mcp-tools/wiki-create.ts
@@ -77,11 +77,12 @@ async function verifyMessageVisibleToUser(
   userId: string,
   orgId: string,
   expectedSpaceId?: string | null,
-): Promise<{ id: string; space_id: string; content: string } | null> {
+): Promise<{ id: string; space_id: string; user_id: string; content: string } | null> {
   const [row] = await db
     .select({
       id: messages.id,
       space_id: messages.space_id,
+      user_id: messages.user_id,
       content: messages.content,
     })
     .from(messages)
@@ -208,8 +209,12 @@ export async function executeWikiCreate(
 
     let sourceMessageExcerpt: string | null = null;
     let sourceSpaceId = args.source_space_id ?? args.space_id ?? null;
+    let sourceUserId: string | null = null;
     if (sourceSpaceId && !(await verifySpaceInOrg(sourceSpaceId, ctx.org_id))) {
       return errorResult(`wiki_create: source space ${sourceSpaceId} not found in caller's org`);
+    }
+    if (scope === 'space' && !sourceSpaceId) {
+      return errorResult('wiki_create: space_id or source_space_id is required when scope is space');
     }
     if (args.source_message_id?.trim()) {
       const readerIds = [
@@ -219,7 +224,7 @@ export async function executeWikiCreate(
       ].filter((value, index, values): value is string =>
         typeof value === 'string' && value.length > 0 && values.indexOf(value) === index,
       );
-      let source: { id: string; space_id: string; content: string } | null = null;
+      let source: { id: string; space_id: string; user_id: string; content: string } | null = null;
       for (const readerId of readerIds) {
         source = await verifyMessageVisibleToUser(
           args.source_message_id,
@@ -235,8 +240,10 @@ export async function executeWikiCreate(
         );
       }
       sourceSpaceId = source.space_id;
+      sourceUserId = source.user_id;
       sourceMessageExcerpt = stripHtml(source.content).slice(0, 200);
     }
+    sourceUserId = sourceUserId ?? shadowUserId;
 
     const slug = await uniqueSlug(ctx.org_id, title);
     const tags = Array.isArray(args.tags)
@@ -247,6 +254,7 @@ export async function executeWikiCreate(
       created_via: 'wiki_create',
       source_message_id: args.source_message_id ?? null,
       source_space_id: sourceSpaceId,
+      source_user_id: sourceUserId,
       capture_kind: args.capture_kind ?? null,
       capture_reason: args.capture_reason ?? null,
     };
@@ -257,7 +265,11 @@ export async function executeWikiCreate(
         .values({
           org_id: ctx.org_id,
           scope,
-          space_id: sourceSpaceId,
+          space_id: scope === 'space' ? sourceSpaceId : null,
+          origin_space_id: sourceSpaceId,
+          origin_message_id: args.source_message_id ?? null,
+          origin_user_id: sourceUserId,
+          created_via: 'wiki_create',
           user_id: shadowUserId,
           agent_employee_id: ctx.employee_id,
           type: wikiType,
@@ -275,9 +287,12 @@ export async function executeWikiCreate(
 
       if (args.source_message_id) {
         await tx.insert(wikiCitations).values({
+          org_id: ctx.org_id,
           page_id: insertedPage.id,
           source_type: 'message',
           source_id: args.source_message_id,
+          source_space_id: sourceSpaceId,
+          source_user_id: sourceUserId,
           excerpt: sourceMessageExcerpt ?? stripHtml(content).slice(0, 200),
         });
       }
@@ -318,6 +333,10 @@ export async function executeWikiCreate(
           metadata: page.metadata ?? null,
           source_message_id: args.source_message_id ?? null,
           source_space_id: sourceSpaceId,
+          origin_space_id: page.origin_space_id ?? null,
+          origin_message_id: page.origin_message_id ?? null,
+          origin_user_id: page.origin_user_id ?? null,
+          created_via: page.created_via ?? null,
           space_id: page.space_id,
           created_by: page.user_id,
           created_at: page.created_at,
@@ -564,7 +583,8 @@ export async function executeWikiUpdate(
     }
 
     let sourceMessageExcerpt: string | null = null;
-    let sourceSpaceId = args.source_space_id ?? existingPage.space_id ?? null;
+    let sourceSpaceId = args.source_space_id ?? existingPage.origin_space_id ?? existingPage.space_id ?? null;
+    let sourceUserId: string | null = null;
     if (sourceSpaceId && !(await verifySpaceInOrg(sourceSpaceId, ctx.org_id))) {
       return errorResult(`wiki_update: source space ${sourceSpaceId} not found in caller's org`);
     }
@@ -576,7 +596,7 @@ export async function executeWikiUpdate(
       ].filter((value, index, values): value is string =>
         typeof value === 'string' && value.length > 0 && values.indexOf(value) === index,
       );
-      let source: { id: string; space_id: string; content: string } | null = null;
+      let source: { id: string; space_id: string; user_id: string; content: string } | null = null;
       for (const readerId of readerIds) {
         source = await verifyMessageVisibleToUser(
           args.source_message_id,
@@ -592,7 +612,22 @@ export async function executeWikiUpdate(
         );
       }
       sourceSpaceId = source.space_id;
+      sourceUserId = source.user_id;
       sourceMessageExcerpt = stripHtml(source.content).slice(0, 200);
+    }
+    sourceUserId = sourceUserId ?? shadowUserId;
+
+    if (!existingPage.origin_space_id && sourceSpaceId) {
+      update.origin_space_id = sourceSpaceId;
+      changedFields.push('origin_space_id');
+    }
+    if (!existingPage.origin_message_id && args.source_message_id) {
+      update.origin_message_id = args.source_message_id;
+      changedFields.push('origin_message_id');
+    }
+    if (!existingPage.origin_user_id && sourceUserId) {
+      update.origin_user_id = sourceUserId;
+      changedFields.push('origin_user_id');
     }
 
     const nextVersion = (existingPage.version ?? 1) + 1;
@@ -619,9 +654,12 @@ export async function executeWikiUpdate(
 
       if (args.source_message_id) {
         await tx.insert(wikiCitations).values({
+          org_id: ctx.org_id,
           page_id: updatedPage.id,
           source_type: 'message',
           source_id: args.source_message_id,
+          source_space_id: sourceSpaceId,
+          source_user_id: sourceUserId,
           excerpt: sourceMessageExcerpt ?? stripHtml(updatedPage.content).slice(0, 200),
         });
       }

--- a/apps/api/src/lib/retrieve-context.ts
+++ b/apps/api/src/lib/retrieve-context.ts
@@ -37,6 +37,8 @@ export interface RetrieveContextParams {
   user_id?: string;
   conversation_id?: string;
   agent_employee_id?: string;
+  space_id?: string;
+  include_org?: boolean;
   types?: Array<'wiki' | 'memory' | 'notes' | 'decisions' | 'tasks'>;
   limit?: number;
   /**
@@ -115,6 +117,37 @@ function employeeWikiCondition(agentEmployeeId: string) {
   );
 }
 
+function wikiPageRelevantToSpaceCondition(spaceId: string, orgId: string) {
+  return or(
+    and(eq(wikiPages.scope, 'space'), eq(wikiPages.space_id, spaceId)),
+    eq(wikiPages.origin_space_id, spaceId),
+    sql`EXISTS (
+      SELECT 1
+      FROM wiki_citations wc
+      LEFT JOIN messages m
+        ON m.id = wc.source_id
+       AND wc.source_type = 'message'
+      WHERE wc.page_id = ${wikiPages.id}
+        AND (
+          wc.source_space_id = ${spaceId}
+          OR (m.space_id = ${spaceId} AND m.org_id = ${orgId})
+        )
+    )`,
+  );
+}
+
+function wikiRetrievalScopeCondition(orgId: string, spaceId: string | undefined, includeOrg: boolean) {
+  if (!spaceId) return undefined;
+  const spaceRelevant = wikiPageRelevantToSpaceCondition(spaceId, orgId);
+  return includeOrg ? or(eq(wikiPages.scope, 'org'), spaceRelevant) : spaceRelevant;
+}
+
+function wikiMatchedSpaceIdExpr(orgId: string, spaceId: string | undefined) {
+  if (!spaceId) return sql<string | null>`NULL`;
+  const spaceRelevant = wikiPageRelevantToSpaceCondition(spaceId, orgId) ?? sql`FALSE`;
+  return sql<string | null>`CASE WHEN ${spaceRelevant} THEN ${spaceId} ELSE NULL END`;
+}
+
 // ─── Hybrid vector helpers ────────────────────────────────────────────────────
 
 // Warn only once per process when the <=> operator is unavailable (BYTEA env).
@@ -183,10 +216,14 @@ async function runWikiQuery(
   user_id: string | undefined,
   forFTS: string,
   agent_employee_id: string | undefined,
+  space_id: string | undefined,
+  include_org: boolean,
   limit: number,
   scoreExpr: ReturnType<typeof hybridScoreExpr> | ReturnType<typeof ftsScoreExpr>,
   orderExpr: ReturnType<typeof hybridScoreExpr> | ReturnType<typeof ftsScoreExpr>,
 ) {
+  const retrievalScope = wikiRetrievalScopeCondition(org_id, space_id, include_org);
+
   if (agent_employee_id) {
     const [tier1Rows, tier2Rows] = await Promise.all([
       db
@@ -199,6 +236,11 @@ async function runWikiQuery(
           scope: wikiPages.scope,
           confidence: wikiPages.confidence,
           type: wikiPages.type,
+          space_id: wikiPages.space_id,
+          origin_space_id: wikiPages.origin_space_id,
+          origin_message_id: wikiPages.origin_message_id,
+          created_via: wikiPages.created_via,
+          matched_space_id: wikiMatchedSpaceIdExpr(org_id, space_id),
           agent_employee_id: wikiPages.agent_employee_id,
           rawScore: scoreExpr,
         })
@@ -210,6 +252,7 @@ async function runWikiQuery(
             sql`${wikiPages.type} != 'decision'`,
             ...(user_id ? [visibleWikiPageCondition(user_id)] : []),
             employeeWikiCondition(agent_employee_id),
+            ...(retrievalScope ? [retrievalScope] : []),
             sql`search_vector @@ plainto_tsquery('english', ${forFTS})`,
           ),
         )
@@ -226,6 +269,11 @@ async function runWikiQuery(
           scope: wikiPages.scope,
           confidence: wikiPages.confidence,
           type: wikiPages.type,
+          space_id: wikiPages.space_id,
+          origin_space_id: wikiPages.origin_space_id,
+          origin_message_id: wikiPages.origin_message_id,
+          created_via: wikiPages.created_via,
+          matched_space_id: wikiMatchedSpaceIdExpr(org_id, space_id),
           agent_employee_id: wikiPages.agent_employee_id,
           rawScore: scoreExpr,
         })
@@ -236,7 +284,7 @@ async function runWikiQuery(
             eq(wikiPages.is_deleted, false),
             sql`${wikiPages.type} != 'decision'`,
             ...(user_id ? [visibleWikiPageCondition(user_id)] : []),
-            eq(wikiPages.scope, 'org'),
+            retrievalScope ?? eq(wikiPages.scope, 'org'),
             sql`search_vector @@ plainto_tsquery('english', ${forFTS})`,
           ),
         )
@@ -256,6 +304,11 @@ async function runWikiQuery(
       scope: wikiPages.scope,
       confidence: wikiPages.confidence,
       type: wikiPages.type,
+      space_id: wikiPages.space_id,
+      origin_space_id: wikiPages.origin_space_id,
+      origin_message_id: wikiPages.origin_message_id,
+      created_via: wikiPages.created_via,
+      matched_space_id: wikiMatchedSpaceIdExpr(org_id, space_id),
       agent_employee_id: wikiPages.agent_employee_id,
       rawScore: scoreExpr,
     })
@@ -266,6 +319,7 @@ async function runWikiQuery(
         eq(wikiPages.is_deleted, false),
         sql`${wikiPages.type} != 'decision'`,
         ...(user_id ? [visibleWikiPageCondition(user_id)] : []),
+        ...(retrievalScope ? [retrievalScope] : []),
         sql`search_vector @@ plainto_tsquery('english', ${forFTS})`,
       ),
     )
@@ -283,6 +337,11 @@ type WikiRow = {
   scope: string | null;
   confidence: number;
   type: string;
+  space_id: string | null;
+  origin_space_id: string | null;
+  origin_message_id: string | null;
+  created_via: string | null;
+  matched_space_id: string | null;
   agent_employee_id: string | null;
   rawScore: number;
 };
@@ -308,6 +367,11 @@ function mapWikiRows(
           tier: 'employee',
           slug: row.slug,
           summary: row.summary ?? null,
+          space_id: row.space_id ?? null,
+          origin_space_id: row.origin_space_id ?? null,
+          origin_message_id: row.origin_message_id ?? null,
+          created_via: row.created_via ?? null,
+          matched_space_id: row.matched_space_id ?? null,
           agent_employee_id: row.agent_employee_id ?? null,
         },
       });
@@ -326,6 +390,11 @@ function mapWikiRows(
           tier: 'org',
           slug: row.slug,
           summary: row.summary ?? null,
+          space_id: row.space_id ?? null,
+          origin_space_id: row.origin_space_id ?? null,
+          origin_message_id: row.origin_message_id ?? null,
+          created_via: row.created_via ?? null,
+          matched_space_id: row.matched_space_id ?? null,
           agent_employee_id: row.agent_employee_id ?? null,
         },
       });
@@ -344,6 +413,11 @@ function mapWikiRows(
           type: row.type,
           slug: row.slug,
           summary: row.summary ?? null,
+          space_id: row.space_id ?? null,
+          origin_space_id: row.origin_space_id ?? null,
+          origin_message_id: row.origin_message_id ?? null,
+          created_via: row.created_via ?? null,
+          matched_space_id: row.matched_space_id ?? null,
           agent_employee_id: row.agent_employee_id ?? null,
         },
       });
@@ -359,6 +433,8 @@ async function fetchWiki(
   forIlike: string,
   words: string[],
   agent_employee_id: string | undefined,
+  space_id: string | undefined,
+  include_org: boolean,
   limit: number,
   queryEmbedding: number[] | null,
   hybrid: boolean,
@@ -372,19 +448,21 @@ async function fetchWiki(
 
   try {
     const { tier1Rows, tier2Rows, singleRows } = await runWikiQuery(
-      org_id, user_id, forFTS, agent_employee_id, limit, scoreExpr, orderExpr,
+      org_id, user_id, forFTS, agent_employee_id, space_id, include_org, limit, scoreExpr, orderExpr,
     );
     const mapped = mapWikiRows(tier1Rows, tier2Rows, singleRows);
     if (mapped.length >= limit) {
       return mapped;
     }
     const fallback = await fetchWikiIlike(
-      org_id,
-      user_id,
-      forIlike,
-      words,
-      agent_employee_id,
-      limit - mapped.length,
+        org_id,
+        user_id,
+        forIlike,
+        words,
+        agent_employee_id,
+        space_id,
+        include_org,
+        limit - mapped.length,
       new Set(mapped.map((r) => r.source_id)),
     );
     return [...mapped, ...fallback];
@@ -398,7 +476,7 @@ async function fetchWiki(
       try {
         const ftsSE = ftsScoreExpr(forFTS);
         const { tier1Rows: t1, tier2Rows: t2, singleRows: sr } = await runWikiQuery(
-          org_id, user_id, forFTS, agent_employee_id, limit, ftsSE, ftsSE,
+          org_id, user_id, forFTS, agent_employee_id, space_id, include_org, limit, ftsSE, ftsSE,
         );
         const mapped = mapWikiRows(t1, t2, sr);
         if (mapped.length >= limit) {
@@ -410,6 +488,8 @@ async function fetchWiki(
           forIlike,
           words,
           agent_employee_id,
+          space_id,
+          include_org,
           limit - mapped.length,
           new Set(mapped.map((r) => r.source_id)),
         );
@@ -431,6 +511,8 @@ async function fetchWikiIlike(
   forIlike: string,
   words: string[],
   agent_employee_id: string | undefined,
+  space_id: string | undefined,
+  include_org: boolean,
   limit: number,
   excludeIds = new Set<string>(),
 ): Promise<ContextResult[]> {
@@ -466,8 +548,14 @@ async function fetchWikiIlike(
     scope: wikiPages.scope,
     confidence: wikiPages.confidence,
     type: wikiPages.type,
+    space_id: wikiPages.space_id,
+    origin_space_id: wikiPages.origin_space_id,
+    origin_message_id: wikiPages.origin_message_id,
+    created_via: wikiPages.created_via,
+    matched_space_id: wikiMatchedSpaceIdExpr(org_id, space_id),
     agent_employee_id: wikiPages.agent_employee_id,
   };
+  const retrievalScope = wikiRetrievalScopeCondition(org_id, space_id, include_org);
 
   const rows: Array<Omit<WikiRow, 'rawScore'>> = [];
   if (agent_employee_id) {
@@ -475,13 +563,13 @@ async function fetchWikiIlike(
       db
         .select(selectColumns)
         .from(wikiPages)
-        .where(and(...baseConditions, employeeWikiCondition(agent_employee_id)))
+        .where(and(...baseConditions, employeeWikiCondition(agent_employee_id), ...(retrievalScope ? [retrievalScope] : [])))
         .orderBy(sql`${wikiPages.confidence} DESC`, sql`${wikiPages.updated_at} DESC`)
         .limit(Math.min(2, limit)),
       db
         .select(selectColumns)
         .from(wikiPages)
-        .where(and(...baseConditions, eq(wikiPages.scope, 'org')))
+        .where(and(...baseConditions, retrievalScope ?? eq(wikiPages.scope, 'org')))
         .orderBy(sql`${wikiPages.confidence} DESC`, sql`${wikiPages.updated_at} DESC`)
         .limit(limit),
     ]);
@@ -490,7 +578,7 @@ async function fetchWikiIlike(
     const singleRows = await db
       .select(selectColumns)
       .from(wikiPages)
-      .where(and(...baseConditions))
+      .where(and(...baseConditions, ...(retrievalScope ? [retrievalScope] : [])))
       .orderBy(sql`${wikiPages.confidence} DESC`, sql`${wikiPages.updated_at} DESC`)
       .limit(limit);
     rows.push(...singleRows);
@@ -519,6 +607,11 @@ async function fetchWikiIlike(
         ...(tier ? { tier } : {}),
         slug: row.slug,
         summary: row.summary ?? null,
+        space_id: row.space_id ?? null,
+        origin_space_id: row.origin_space_id ?? null,
+        origin_message_id: row.origin_message_id ?? null,
+        created_via: row.created_via ?? null,
+        matched_space_id: row.matched_space_id ?? null,
         agent_employee_id: row.agent_employee_id ?? null,
         retrieval: 'text_fallback',
       },
@@ -860,6 +953,8 @@ export async function retrieveContext(
     user_id,
     conversation_id,
     agent_employee_id,
+    space_id,
+    include_org = true,
     types = ['wiki', 'memory', 'notes', 'decisions', 'tasks'],
     limit = 10,
     hybrid = true,
@@ -886,7 +981,7 @@ export async function retrieveContext(
   // 4. Run all requested branches concurrently; each returns its own array.
   const [wikiRows, decisionRows, memRows, noteRows, taskRows] = await Promise.all([
     types.includes('wiki')
-      ? fetchWiki(org_id, user_id, forFTS, forIlike, words, agent_employee_id, limit, queryEmbedding, hybrid)
+      ? fetchWiki(org_id, user_id, forFTS, forIlike, words, agent_employee_id, space_id, include_org, limit, queryEmbedding, hybrid)
       : Promise.resolve([]),
 
     // 5. Decisions branch: queries wikiPages WHERE type='decision'. Forward-

--- a/apps/api/src/routes/knowledge.ts
+++ b/apps/api/src/routes/knowledge.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { eq, and, desc, ilike, or, sql, inArray } from 'drizzle-orm';
+import { eq, and, desc, ilike, or, sql } from 'drizzle-orm';
 import { db } from '../lib/db.js';
 import { wikiPages, wikiCitations, messages, users, spaces } from '@deft/db/schema';
 import { getIO } from '../socket.js';
@@ -41,6 +41,10 @@ function toKnowledgeEntry(row: any) {
     metadata: row.metadata ?? null,
     source_message_id: row.source_message_id ?? null,
     source_space_id: row.source_space_id ?? null,
+    origin_space_id: row.origin_space_id ?? null,
+    origin_message_id: row.origin_message_id ?? null,
+    origin_user_id: row.origin_user_id ?? null,
+    created_via: row.created_via ?? null,
     space_id: row.space_id,
     created_by: row.user_id,
     created_at: row.created_at,
@@ -65,14 +69,33 @@ function sourceMessageIdSql() {
 
 function sourceSpaceIdSql() {
   return sql<string | null>`(
-    SELECT m.space_id
+    SELECT COALESCE(wc.source_space_id, m.space_id)
     FROM wiki_citations wc
-    JOIN messages m ON m.id = wc.source_id
+    LEFT JOIN messages m ON m.id = wc.source_id
     WHERE wc.page_id = ${wikiPages.id}
       AND wc.source_type = 'message'
     ORDER BY wc.created_at DESC
     LIMIT 1
   )`;
+}
+
+function pageRelevantToSpaceCondition(spaceId: string, orgId: string) {
+  return or(
+    eq(wikiPages.space_id, spaceId),
+    eq(wikiPages.origin_space_id, spaceId),
+    sql`EXISTS (
+      SELECT 1
+      FROM wiki_citations wc
+      LEFT JOIN messages m
+        ON m.id = wc.source_id
+       AND wc.source_type = 'message'
+      WHERE wc.page_id = ${wikiPages.id}
+        AND (
+          wc.source_space_id = ${spaceId}
+          OR (m.space_id = ${spaceId} AND m.org_id = ${orgId})
+        )
+    )`,
+  );
 }
 
 function cleanMetadata(value: unknown): Record<string, unknown> | null {
@@ -90,10 +113,10 @@ function stripHtml(value: string): string {
 async function latestMessageCitation(pageId: string): Promise<{ source_message_id: string | null; source_space_id: string | null }> {
   const [row] = await db.select({
     source_message_id: wikiCitations.source_id,
-    source_space_id: messages.space_id,
+    source_space_id: sql<string | null>`COALESCE(${wikiCitations.source_space_id}, ${messages.space_id})`,
   })
     .from(wikiCitations)
-    .innerJoin(messages, and(
+    .leftJoin(messages, and(
       eq(wikiCitations.source_id, messages.id),
       eq(wikiCitations.source_type, 'message'),
     ))
@@ -136,6 +159,10 @@ knowledgeAggRoutes.get('/', async (c) => {
       title: wikiPages.title,
       content: wikiPages.content,
       space_id: wikiPages.space_id,
+      origin_space_id: wikiPages.origin_space_id,
+      origin_message_id: wikiPages.origin_message_id,
+      origin_user_id: wikiPages.origin_user_id,
+      created_via: wikiPages.created_via,
       user_id: wikiPages.user_id,
       slug: wikiPages.slug,
       scope: wikiPages.scope,
@@ -174,8 +201,9 @@ knowledgeAggRoutes.get('/', async (c) => {
 
 // GET /api/spaces/:spaceId/knowledge — list entries for a space
 // Returns wiki pages where:
-//   1. space_id matches exactly (org-scoped pages written from this space, or manually scoped)
-//   2. OR a wiki citation exists linking the page to a message sent in this space
+//   1. space_id matches exactly (space-scoped pages)
+//   2. OR origin_space_id matches (org memory that originated in this space)
+//   3. OR a wiki citation links the page to a message sent in this space
 knowledgeRoutes.get('/:spaceId/knowledge', async (c) => {
   try {
     const user = c.get('user');
@@ -188,30 +216,11 @@ knowledgeRoutes.get('/:spaceId/knowledge', async (c) => {
       return c.json({ error: 'Not a member of this space', code: 'FORBIDDEN' }, 403);
     }
 
-    // Find page IDs that have a citation from a message in this space
-    const citedPageIds = await db.select({ page_id: wikiCitations.page_id })
-      .from(wikiCitations)
-      .innerJoin(messages, and(
-        eq(wikiCitations.source_id, messages.id),
-        eq(wikiCitations.source_type, 'message'),
-      ))
-      .where(and(
-        eq(messages.space_id, spaceId),
-        eq(messages.org_id, user.org_id),
-      ));
-
-    const citedIds = [...new Set(citedPageIds.map(r => r.page_id))];
-
-    // Build conditions: space_id match OR cited from this space
-    const spaceCondition = citedIds.length > 0
-      ? or(eq(wikiPages.space_id, spaceId), inArray(wikiPages.id, citedIds))
-      : eq(wikiPages.space_id, spaceId);
-
     const conditions: any[] = [
       eq(wikiPages.org_id, user.org_id),
       eq(wikiPages.is_deleted, false),
       visibleWikiPageCondition(user.id),
-      spaceCondition!,
+      pageRelevantToSpaceCondition(spaceId, user.org_id)!,
     ];
 
     if (typeFilter) {
@@ -228,6 +237,10 @@ knowledgeRoutes.get('/:spaceId/knowledge', async (c) => {
         title: wikiPages.title,
         content: wikiPages.content,
         space_id: wikiPages.space_id,
+        origin_space_id: wikiPages.origin_space_id,
+        origin_message_id: wikiPages.origin_message_id,
+        origin_user_id: wikiPages.origin_user_id,
+        created_via: wikiPages.created_via,
         user_id: wikiPages.user_id,
         slug: wikiPages.slug,
         scope: wikiPages.scope,
@@ -320,6 +333,10 @@ knowledgeRoutes.post('/:spaceId/knowledge', async (c) => {
     const [entry] = await db.insert(wikiPages).values({
       org_id: user.org_id,
       space_id: spaceId,
+      origin_space_id: sourceSpaceId ?? spaceId,
+      origin_message_id: sourceMessageId,
+      origin_user_id: user.id,
+      created_via: 'space_knowledge_panel',
       user_id: user.id,
       scope: 'space',
       type: wikiType,
@@ -336,9 +353,12 @@ knowledgeRoutes.post('/:spaceId/knowledge', async (c) => {
 
     if (sourceMessageId) {
       await db.insert(wikiCitations).values({
+        org_id: user.org_id,
         page_id: entry.id,
         source_type: 'message',
         source_id: sourceMessageId,
+        source_space_id: sourceSpaceId,
+        source_user_id: user.id,
         excerpt: sourceMessageExcerpt,
       });
     }
@@ -357,6 +377,10 @@ knowledgeRoutes.post('/:spaceId/knowledge', async (c) => {
       metadata,
       source_message_id: sourceMessageId,
       source_space_id: sourceSpaceId,
+      origin_space_id: entry.origin_space_id,
+      origin_message_id: entry.origin_message_id,
+      origin_user_id: entry.origin_user_id,
+      created_via: entry.created_via,
     });
 
     const io = getIO();
@@ -492,6 +516,7 @@ knowledgeRoutes.get('/knowledge/search', async (c) => {
     const conditions: any[] = [
       eq(wikiPages.org_id, user.org_id),
       eq(wikiPages.is_deleted, false),
+      visibleWikiPageCondition(user.id),
       or(ilike(wikiPages.title, pattern), ilike(wikiPages.content, pattern)),
     ];
 
@@ -509,6 +534,10 @@ knowledgeRoutes.get('/knowledge/search', async (c) => {
         title: wikiPages.title,
         content: wikiPages.content,
         space_id: wikiPages.space_id,
+        origin_space_id: wikiPages.origin_space_id,
+        origin_message_id: wikiPages.origin_message_id,
+        origin_user_id: wikiPages.origin_user_id,
+        created_via: wikiPages.created_via,
         user_id: wikiPages.user_id,
         slug: wikiPages.slug,
         scope: wikiPages.scope,

--- a/apps/api/src/routes/wiki.ts
+++ b/apps/api/src/routes/wiki.ts
@@ -44,6 +44,28 @@ function slugify(title: string): string {
     .slice(0, 80);
 }
 
+function wikiPageRelevantToSpaceCondition(spaceId: string, orgId: string, includeOrg: boolean) {
+  const relevant = or(
+    and(eq(wikiPages.scope, 'space'), eq(wikiPages.space_id, spaceId)),
+    ...(includeOrg ? [
+      eq(wikiPages.origin_space_id, spaceId),
+      sql`EXISTS (
+        SELECT 1
+        FROM wiki_citations wc
+        LEFT JOIN messages m
+          ON m.id = wc.source_id
+         AND wc.source_type = 'message'
+        WHERE wc.page_id = ${wikiPages.id}
+          AND (
+            wc.source_space_id = ${spaceId}
+            OR (m.space_id = ${spaceId} AND m.org_id = ${orgId})
+          )
+      )`,
+    ] : []),
+  );
+  return relevant;
+}
+
 // GET /api/wiki — list/search wiki pages
 wikiRoutes.get('/', async (c) => {
   try {
@@ -84,29 +106,33 @@ wikiRoutes.get('/', async (c) => {
       : null;
 
     const fetchPageBatch = async (conditions: any[], useFullText: boolean) => db.select({
-        id: wikiPages.id,
-        type: wikiPages.type,
-        scope: wikiPages.scope,
-        title: wikiPages.title,
-        slug: wikiPages.slug,
-        summary: wikiPages.summary,
-        metadata: wikiPages.metadata,
-        confidence: wikiPages.confidence,
-        version: wikiPages.version,
-        space_id: wikiPages.space_id,
-        created_at: wikiPages.created_at,
-        updated_at: wikiPages.updated_at,
-        ...(useFullText && query ? { rank: sql<number>`ts_rank(search_vector, websearch_to_tsquery('english', ${query}))` } : {}),
-      })
-        .from(wikiPages)
-        .where(and(...conditions))
-        .orderBy(
-          ...(useFullText && query
-            ? [sql`ts_rank(search_vector, websearch_to_tsquery('english', ${query})) DESC`, desc(wikiPages.confidence)]
-            : [desc(wikiPages.confidence), desc(wikiPages.updated_at)])
-        )
-        .limit(limit)
-        .offset(offset);
+      id: wikiPages.id,
+      type: wikiPages.type,
+      scope: wikiPages.scope,
+      title: wikiPages.title,
+      slug: wikiPages.slug,
+      summary: wikiPages.summary,
+      metadata: wikiPages.metadata,
+      confidence: wikiPages.confidence,
+      version: wikiPages.version,
+      space_id: wikiPages.space_id,
+      origin_space_id: wikiPages.origin_space_id,
+      origin_message_id: wikiPages.origin_message_id,
+      origin_user_id: wikiPages.origin_user_id,
+      created_via: wikiPages.created_via,
+      created_at: wikiPages.created_at,
+      updated_at: wikiPages.updated_at,
+      ...(useFullText && query ? { rank: sql<number>`ts_rank(search_vector, websearch_to_tsquery('english', ${query}))` } : {}),
+    })
+      .from(wikiPages)
+      .where(and(...conditions))
+      .orderBy(
+        ...(useFullText && query
+          ? [sql`ts_rank(search_vector, websearch_to_tsquery('english', ${query})) DESC`, desc(wikiPages.confidence)]
+          : [desc(wikiPages.confidence), desc(wikiPages.updated_at)])
+      )
+      .limit(limit)
+      .offset(offset);
 
     let conditions = ftsCondition ? [...baseConditions, ftsCondition] : baseConditions;
     let pages = await fetchPageBatch(conditions, !!ftsCondition);
@@ -168,18 +194,62 @@ wikiRoutes.get('/', async (c) => {
 wikiRoutes.get('/graph', async (c) => {
   try {
     const user = c.get('user');
+    const mode = c.req.query('mode') === 'space' ? 'space' : 'org';
+    const spaceId = c.req.query('space_id') || c.req.query('spaceId') || null;
+    const includeOrg = c.req.query('include_org') !== 'false';
+    const limit = Math.min(Math.max(parseInt(c.req.query('limit') || '200'), 25), 500);
+
+    const conditions: any[] = [
+      eq(wikiPages.org_id, user.org_id),
+      eq(wikiPages.is_deleted, false),
+      visibleWikiPageCondition(user.id),
+    ];
+
+    let scopeLabel = 'Company';
+    if (mode === 'space') {
+      if (!spaceId) {
+        return c.json({ error: 'space_id is required for space graph mode', code: 'VALIDATION_ERROR' }, 400);
+      }
+      const isMember = await requireSpaceMembership(spaceId, user.id);
+      if (!isMember) {
+        return c.json({ error: 'Not a member of this space', code: 'FORBIDDEN' }, 403);
+      }
+      const [space] = await db.select({ name: spaces.name })
+        .from(spaces)
+        .where(and(eq(spaces.id, spaceId), eq(spaces.org_id, user.org_id)))
+        .limit(1);
+      if (!space) {
+        return c.json({ error: 'Space not found', code: 'NOT_FOUND' }, 404);
+      }
+      scopeLabel = space.name;
+      conditions.push(wikiPageRelevantToSpaceCondition(spaceId, user.org_id, includeOrg)!);
+    } else {
+      conditions.push(eq(wikiPages.scope, 'org'));
+    }
 
     const nodes = await db.select({
       id: wikiPages.id,
       slug: wikiPages.slug,
       title: wikiPages.title,
       type: wikiPages.type,
+      scope: wikiPages.scope,
+      space_id: wikiPages.space_id,
+      origin_space_id: wikiPages.origin_space_id,
+      origin_message_id: wikiPages.origin_message_id,
+      created_via: wikiPages.created_via,
       confidence: wikiPages.confidence,
+      origin_space_name: spaces.name,
+      citation_count: sql<number>`(
+        SELECT count(*)
+        FROM wiki_citations wc
+        WHERE wc.page_id = ${wikiPages.id}
+      )`,
     })
       .from(wikiPages)
-      .where(and(eq(wikiPages.org_id, user.org_id), eq(wikiPages.is_deleted, false), visibleWikiPageCondition(user.id)))
+      .leftJoin(spaces, eq(spaces.id, wikiPages.origin_space_id))
+      .where(and(...conditions))
       .orderBy(desc(wikiPages.confidence))
-      .limit(200);
+      .limit(limit);
 
     const nodeIds = nodes.map(n => n.id);
     let edges: { source: string; target: string; context: string | null }[] = [];
@@ -198,7 +268,14 @@ wikiRoutes.get('/graph', async (c) => {
         ));
     }
 
-    return c.json({ nodes, edges });
+    return c.json({
+      mode,
+      space_id: mode === 'space' ? spaceId : null,
+      scope_label: scopeLabel,
+      include_org: includeOrg,
+      nodes,
+      edges,
+    });
   } catch (err) {
     console.error('Failed to fetch wiki graph:', err);
     return c.json({ error: 'Failed to fetch graph', code: 'INTERNAL_ERROR' }, 500);
@@ -434,7 +511,8 @@ wikiRoutes.get('/:slug', async (c) => {
       source_id: wikiCitations.source_id,
       excerpt: wikiCitations.excerpt,
       created_at: wikiCitations.created_at,
-      source_space_id: messages.space_id,
+      source_space_id: sql<string | null>`COALESCE(${wikiCitations.source_space_id}, ${messages.space_id})`,
+      source_user_id: sql<string | null>`COALESCE(${wikiCitations.source_user_id}, ${messages.user_id})`,
     })
       .from(wikiCitations)
       .leftJoin(messages, and(
@@ -516,6 +594,9 @@ wikiRoutes.post('/', async (c) => {
       org_id: user.org_id,
       scope,
       space_id: scope === 'space' ? space_id : null,
+      origin_space_id: scope === 'space' ? space_id : null,
+      origin_user_id: user.id,
+      created_via: 'manual',
       user_id: scope === 'user' ? user.id : null,
       type,
       title,

--- a/apps/api/src/workers/handlers/memory-extract.ts
+++ b/apps/api/src/workers/handlers/memory-extract.ts
@@ -29,6 +29,63 @@ interface WikiIngestResult {
   related_slugs?: string[];
 }
 
+async function readMockWikiAction(): Promise<WikiIngestResult | null> {
+  const testGlobal = globalThis as typeof globalThis & {
+    __mockMemoryExtractResult?: unknown;
+    __mockAnthropicResponse?: unknown;
+    __mockAnthropicResponseNoAgMem?: unknown;
+  };
+  const factory =
+    typeof testGlobal.__mockMemoryExtractResult === 'function'
+      ? testGlobal.__mockMemoryExtractResult
+      : typeof testGlobal.__mockAnthropicResponse === 'function'
+        ? testGlobal.__mockAnthropicResponse
+        : typeof testGlobal.__mockAnthropicResponseNoAgMem === 'function'
+          ? testGlobal.__mockAnthropicResponseNoAgMem
+          : null;
+
+  if (!factory) return null;
+
+  const raw = await (factory as () => unknown | Promise<unknown>)();
+  if (raw && typeof raw === 'object' && 'action' in raw) {
+    return raw as WikiIngestResult;
+  }
+
+  let text = '';
+  if (typeof raw === 'string') {
+    text = raw;
+  } else if (raw && typeof raw === 'object') {
+    const response = raw as {
+      text?: () => Promise<string>;
+      json?: () => Promise<unknown>;
+    };
+    if (typeof response.json === 'function') {
+      const body = await response.json();
+      const content = (body as any)?.content;
+      if (Array.isArray(content)) {
+        text = content.map((block) => block?.text).filter(Boolean).join('\n');
+      } else {
+        text = JSON.stringify(body);
+      }
+    } else if (typeof response.text === 'function') {
+      const body = await response.text();
+      try {
+        const parsed = JSON.parse(body);
+        const content = parsed?.content;
+        text = Array.isArray(content)
+          ? content.map((block) => block?.text).filter(Boolean).join('\n')
+          : body;
+      } catch {
+        text = body;
+      }
+    }
+  }
+
+  const jsonMatch = text.match(/\{[\s\S]*\}/);
+  if (!jsonMatch) return null;
+  return JSON.parse(jsonMatch[0]) as WikiIngestResult;
+}
+
 function emitKnowledgeChange(
   event: 'knowledge:created' | 'knowledge:updated',
   page: typeof wikiPages.$inferSelect,
@@ -130,6 +187,9 @@ async function decideWikiAction(
   existingPages: { title: string; slug: string; summary: string | null; type: string }[],
   orgConfig: OrgAIConfigRuntime,
 ): Promise<WikiIngestResult> {
+  const mockedAction = await readMockWikiAction();
+  if (mockedAction) return mockedAction;
+
   const pageList = existingPages.length > 0
     ? existingPages.map(p => `- "${p.title}" (slug: ${p.slug}, type: ${p.type})${p.summary ? ': ' + p.summary : ''}`).join('\n')
     : '(no existing pages)';
@@ -210,6 +270,26 @@ function fallbackCreate(fact: string, isDecision: boolean): WikiIngestResult {
  * knowledge panel can surface pages extracted from that space's conversation.
  * scope stays 'org' for memory-extracted facts (they are org-wide knowledge).
  */
+function isForeignKeyViolation(err: unknown): boolean {
+  const anyErr = err as any;
+  const cause = anyErr?.cause ?? anyErr;
+  return cause?.code === '23503'
+    || (typeof anyErr?.message === 'string' && anyErr.message.includes('23503'));
+}
+
+async function insertCitationWithProvenanceFallback(values: typeof wikiCitations.$inferInsert): Promise<void> {
+  try {
+    await db.insert(wikiCitations).values(values);
+  } catch (err) {
+    if (!isForeignKeyViolation(err)) throw err;
+    await db.insert(wikiCitations).values({
+      ...values,
+      source_space_id: null,
+      source_user_id: null,
+    });
+  }
+}
+
 async function executeWikiIngest(
   result: WikiIngestResult,
   orgId: string,
@@ -236,17 +316,35 @@ async function executeWikiIngest(
     } else {
       // Append new content to existing page
       const updatedContent = existing.content + '\n\n' + result.content;
-      await db.update(wikiPages).set({
+      const updateValues = {
         content: updatedContent,
         previous_content: existing.content,
+        origin_space_id: existing.origin_space_id ?? spaceId ?? null,
+        origin_message_id: existing.origin_message_id ?? messageId,
+        origin_user_id: existing.origin_user_id ?? userId,
+        created_via: existing.created_via ?? 'memory_extract',
         version: existing.version + 1,
-      }).where(eq(wikiPages.id, existing.id));
+      };
+      try {
+        await db.update(wikiPages).set(updateValues).where(eq(wikiPages.id, existing.id));
+      } catch (err) {
+        if (!isForeignKeyViolation(err)) throw err;
+        await db.update(wikiPages).set({
+          ...updateValues,
+          origin_space_id: existing.origin_space_id ?? null,
+          origin_message_id: existing.origin_message_id ?? null,
+          origin_user_id: existing.origin_user_id ?? null,
+        }).where(eq(wikiPages.id, existing.id));
+      }
 
       // Add citation
-      await db.insert(wikiCitations).values({
+      await insertCitationWithProvenanceFallback({
+        org_id: orgId,
         page_id: existing.id,
         source_type: 'message',
         source_id: messageId,
+        source_space_id: spaceId ?? null,
+        source_user_id: userId,
         excerpt: result.content!.slice(0, 200),
       });
 
@@ -306,7 +404,11 @@ async function executeWikiIngest(
     const insertValues = {
       org_id: orgId,
       scope: 'org' as const, // memory-extracted facts are org-wide knowledge
-      space_id: spaceId || null,
+      space_id: null,
+      origin_space_id: spaceId || null,
+      origin_message_id: messageId,
+      origin_user_id: userId,
+      created_via: 'memory_extract',
       type: pageType,
       title: result.title || slug.replace(/-/g, ' '),
       slug,
@@ -323,13 +425,14 @@ async function executeWikiIngest(
     } catch (err: any) {
       // FK violation on space_id (e.g. space deleted, test fixture, or non-existent space)
       // Drizzle wraps the pg error — check original cause or message for FK code 23503.
-      const cause = err?.cause ?? err;
-      const isFkViolation = cause?.code === '23503'
-        || (typeof err?.message === 'string' && err.message.includes('23503'))
-        || (typeof err?.message === 'string' && err.message.includes('space_id'));
-      if (isFkViolation && spaceId) {
-        console.warn(`[memory-extract] space_id "${spaceId}" not found (FK violation), creating page without space hint`);
-        [pageResult] = await db.insert(wikiPages).values({ ...insertValues, space_id: null }).returning();
+      if (isForeignKeyViolation(err)) {
+        console.warn(`[memory-extract] provenance reference missing, creating page without invalid origin FK`);
+        [pageResult] = await db.insert(wikiPages).values({
+          ...insertValues,
+          origin_space_id: null,
+          origin_message_id: null,
+          origin_user_id: null,
+        }).returning();
       } else {
         throw err;
       }
@@ -337,10 +440,13 @@ async function executeWikiIngest(
     const page = pageResult;
 
     // Add citation
-    await db.insert(wikiCitations).values({
+    await insertCitationWithProvenanceFallback({
+      org_id: orgId,
       page_id: page!.id,
       source_type: 'message',
       source_id: messageId,
+      source_space_id: spaceId ?? null,
+      source_user_id: userId,
       excerpt: result.content!.slice(0, 200),
     });
 

--- a/apps/api/test/agent-approval-resolver.test.ts
+++ b/apps/api/test/agent-approval-resolver.test.ts
@@ -295,6 +295,15 @@ async function teardownFixtures() {
       `DELETE FROM messages WHERE user_id = $1`,
       [SHADOW_USER_ID],
     );
+    await c.query(
+      `DELETE FROM messages
+       WHERE space_id IN (
+         SELECT id FROM spaces
+         WHERE org_id = $1
+           AND created_by IN ($2, $3, $4)
+       )`,
+      [ORG_ID, APPROVER_USER_ID, SHADOW_USER_ID, DEFTY_USER_ID],
+    );
     if (TEST_SPACE_ID) {
       await c.query(
         `DELETE FROM space_members
@@ -303,12 +312,36 @@ async function teardownFixtures() {
         [TEST_SPACE_ID, APPROVER_USER_ID, SHADOW_USER_ID, DEFTY_USER_ID],
       );
     }
+    await c.query(
+      `DELETE FROM space_members
+       WHERE space_id IN (
+         SELECT id FROM spaces
+         WHERE org_id = $1
+           AND created_by IN ($2, $3, $4)
+       )`,
+      [ORG_ID, APPROVER_USER_ID, SHADOW_USER_ID, DEFTY_USER_ID],
+    );
+    await c.query(
+      `DELETE FROM space_memory
+       WHERE space_id IN (
+         SELECT id FROM spaces
+         WHERE org_id = $1
+           AND created_by IN ($2, $3, $4)
+       )`,
+      [ORG_ID, APPROVER_USER_ID, SHADOW_USER_ID, DEFTY_USER_ID],
+    );
     if (CREATED_TEST_SPACE_ID) {
       await c.query(
         `DELETE FROM spaces WHERE id = $1`,
         [CREATED_TEST_SPACE_ID],
       );
     }
+    await c.query(
+      `DELETE FROM spaces
+       WHERE org_id = $1
+         AND created_by IN ($2, $3, $4)`,
+      [ORG_ID, APPROVER_USER_ID, SHADOW_USER_ID, DEFTY_USER_ID],
+    );
     if (CREATED_TEST_PROJECT_ID) {
       await c.query(
         `DELETE FROM projects WHERE id = $1`,
@@ -804,19 +837,29 @@ test('1f. approving Defty wiki_create saves knowledge with source citation', asy
 
   await withClient(async (c) => {
     const page = await c.query(
-      `SELECT id, title, type, user_id, agent_employee_id, metadata
+      `SELECT id, title, type, scope, space_id, origin_space_id,
+              origin_message_id, origin_user_id, created_via,
+              user_id, agent_employee_id, metadata
        FROM wiki_pages
        WHERE title = $1 AND org_id = $2`,
       [title, ORG_ID],
     );
     assert.equal(page.rows.length, 1, 'wiki page should have been created');
     assert.equal(page.rows[0].type, 'decision');
+    assert.equal(page.rows[0].scope, 'org');
+    assert.equal(page.rows[0].space_id, null, 'approved org memory should not become space-private memory');
+    assert.equal(page.rows[0].origin_space_id, TEST_SPACE_ID);
+    assert.equal(page.rows[0].origin_message_id, sourceMessageId);
+    assert.equal(page.rows[0].origin_user_id, APPROVER_USER_ID);
+    assert.equal(page.rows[0].created_via, 'wiki_create');
     assert.equal(page.rows[0].user_id, DEFTY_USER_ID);
     assert.equal(page.rows[0].agent_employee_id, DEFTY_EMP_ID);
     assert.equal(page.rows[0].metadata.source_message_id, sourceMessageId);
+    assert.equal(page.rows[0].metadata.source_space_id, TEST_SPACE_ID);
+    assert.equal(page.rows[0].metadata.source_user_id, APPROVER_USER_ID);
 
     const citation = await c.query(
-      `SELECT source_type, source_id, excerpt
+      `SELECT source_type, source_id, source_space_id, source_user_id, excerpt
        FROM wiki_citations
        WHERE page_id = $1`,
       [page.rows[0].id],
@@ -824,6 +867,8 @@ test('1f. approving Defty wiki_create saves knowledge with source citation', asy
     assert.equal(citation.rows.length, 1, 'wiki page should cite the source message');
     assert.equal(citation.rows[0].source_type, 'message');
     assert.equal(citation.rows[0].source_id, sourceMessageId);
+    assert.equal(citation.rows[0].source_space_id, TEST_SPACE_ID);
+    assert.equal(citation.rows[0].source_user_id, APPROVER_USER_ID);
     assert.match(citation.rows[0].excerpt, /chef sample boxes/i);
 
     const op = await c.query(
@@ -895,7 +940,13 @@ test('1g. approving Defty wiki_update updates page with version history and ops 
   // @ts-expect-error narrow
   assert.equal(result.result?.page_id, pageId);
   // @ts-expect-error narrow
-  assert.deepEqual(result.result?.changed_fields, ['content', 'summary']);
+  assert.deepEqual(result.result?.changed_fields, [
+    'content',
+    'summary',
+    'origin_space_id',
+    'origin_message_id',
+    'origin_user_id',
+  ]);
 
   await withClient(async (c) => {
     const page = await c.query(
@@ -925,7 +976,13 @@ test('1g. approving Defty wiki_update updates page with version history and ops 
       [pageId],
     );
     assert.equal(op.rows.length, 1, 'wiki update should have an ops log row');
-    assert.deepEqual(op.rows[0].details.changed_fields, ['content', 'summary']);
+    assert.deepEqual(op.rows[0].details.changed_fields, [
+      'content',
+      'summary',
+      'origin_space_id',
+      'origin_message_id',
+      'origin_user_id',
+    ]);
     assert.equal(op.rows[0].performed_by, DEFTY_USER_ID);
 
     const citation = await c.query(

--- a/apps/api/test/in-chat-knowledge-panel.test.ts
+++ b/apps/api/test/in-chat-knowledge-panel.test.ts
@@ -122,13 +122,18 @@ async function insertWikiPage(overrides: Record<string, unknown> = {}): Promise<
   await withClient(async (c) => {
     await c.query(
       `INSERT INTO wiki_pages
-         (id, org_id, scope, space_id, type, title, slug, content, confidence, is_deleted)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, false)`,
+         (id, org_id, scope, space_id, origin_space_id, origin_message_id, origin_user_id, created_via,
+          type, title, slug, content, confidence, is_deleted)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, false)`,
       [
         id,
         overrides.org_id ?? ORG_ID,
         overrides.scope ?? 'org',
         overrides.space_id ?? null,
+        overrides.origin_space_id ?? null,
+        overrides.origin_message_id ?? null,
+        overrides.origin_user_id ?? null,
+        overrides.created_via ?? null,
         overrides.type ?? 'fact',
         overrides.title ?? 'Test Page',
         overrides.slug ?? `test-page-${id}`,
@@ -241,6 +246,25 @@ test('2. GET returns org-scoped page that has a citation from a message in the s
   assert.ok(found, `Cited page ${pageId} should appear via citation join`);
   assert.equal(found.source_message_id, messageId);
   assert.equal(found.source_space_id, SPACE_ID);
+});
+
+test('2b. GET returns org-scoped page that originated in the space even without citation', async () => {
+  const pageId = await insertWikiPage({
+    scope: 'org',
+    space_id: null,
+    origin_space_id: SPACE_ID,
+    type: 'fact',
+    title: 'Origin Space Org Page',
+  });
+
+  const res = await callRoute('GET', `/${SPACE_ID}/knowledge`);
+  assert.equal(res.status, 200);
+
+  const data = await res.json() as any;
+  const found = data.entries.find((e: any) => e.id === pageId);
+  assert.ok(found, `Origin-space page ${pageId} should appear via origin_space_id`);
+  assert.equal(found.origin_space_id, SPACE_ID);
+  assert.equal(found.space_id, null);
 });
 
 // ─── Test 3: GET does NOT return page from a different space ─────────────────

--- a/apps/api/test/mcp-memory-recall.test.ts
+++ b/apps/api/test/mcp-memory-recall.test.ts
@@ -23,6 +23,8 @@ const ORG_ID = '1d7d869a-5e68-48d5-832e-11d8f3bb1dd6';
 const TEST_USER_ID = 'mcp-recall-test-user';
 const AGENT_EMPLOYEE_ID = `mcp-recall-test-emp-${Date.now()}`;
 const OTHER_AGENT_EMPLOYEE_ID = `mcp-recall-other-emp-${Date.now()}`;
+const SPACE_ID = `mcp-recall-space-${Date.now()}`;
+const PRIVATE_SPACE_ID = `mcp-recall-private-space-${Date.now()}`;
 
 // Unique query term so only our seeded pages match — avoids interference with
 // other wiki_pages rows in the dev database.
@@ -89,6 +91,20 @@ before(async () => {
       [OTHER_AGENT_EMPLOYEE_ID, ORG_ID, TEST_USER_ID, `mcp-recall-other-${Date.now()}`],
     );
     seededIds.push({ table: 'agent_employees', id: OTHER_AGENT_EMPLOYEE_ID });
+
+    await c.query(
+      `INSERT INTO spaces (id, org_id, name, type, is_archived)
+       VALUES ($1, $2, 'MCP Recall Public Space', 'public', false)`,
+      [SPACE_ID, ORG_ID],
+    );
+    seededIds.push({ table: 'spaces', id: SPACE_ID });
+
+    await c.query(
+      `INSERT INTO spaces (id, org_id, name, type, is_archived)
+       VALUES ($1, $2, 'MCP Recall Private Space', 'private', false)`,
+      [PRIVATE_SPACE_ID, ORG_ID],
+    );
+    seededIds.push({ table: 'spaces', id: PRIVATE_SPACE_ID });
 
     // Employee-tagged wiki page (tier 1 — "own").
     const empPageId = `mcp-recall-emp-page-${Date.now()}`;
@@ -172,6 +188,35 @@ before(async () => {
       [attributedOrgPageId],
     );
     seededIds.push({ table: 'wiki_pages', id: attributedOrgPageId });
+
+    // Org-wide page that originated in one specific channel. Channel-only
+    // recall should include this page while excluding unrelated org memory.
+    const channelOriginPageId = `mcp-recall-channel-origin-page-${Date.now()}`;
+    await c.query(
+      `INSERT INTO wiki_pages
+         (id, org_id, type, scope, title, slug, summary, content, confidence,
+          origin_space_id, created_via, is_deleted, created_at, updated_at)
+       VALUES ($1, $2, 'procedure', 'org', $3, $4, $5, $6, 0.95, $7, 'test_channel_origin',
+          false, NOW(), NOW())`,
+      [
+        channelOriginPageId,
+        ORG_ID,
+        `Channel ${QUERY_TERM} Procedure`,
+        `channel-procedure-${Date.now()}`,
+        `Summary about ${QUERY_TERM} from a specific channel.`,
+        `The ${QUERY_TERM} channel procedure belongs to the public test channel.`,
+        SPACE_ID,
+      ],
+    );
+    await c.query(
+      `UPDATE wiki_pages SET search_vector =
+         setweight(to_tsvector('english', COALESCE(title, '')), 'A') ||
+         setweight(to_tsvector('english', COALESCE(summary, '')), 'B') ||
+         setweight(to_tsvector('english', COALESCE(content, '')), 'C')
+       WHERE id = $1`,
+      [channelOriginPageId],
+    );
+    seededIds.push({ table: 'wiki_pages', id: channelOriginPageId });
   });
 });
 
@@ -222,11 +267,12 @@ describe('memoryRecall', () => {
     const rows = JSON.parse(result.content[0].text) as Array<Record<string, unknown>>;
     assert.ok(rows.length >= 1, `Expected at least 1 org-scope result, got ${rows.length}`);
 
-    // All returned pages should be the org-wide one (title includes 'Org').
+    // Org scope returns company memory, including pages that originated from a
+    // channel but were promoted to org-level knowledge.
     for (const row of rows) {
       assert.ok(
-        String(row.title).includes('Org'),
-        `Expected only org-wide page in org scope, got title: ${row.title}`,
+        !String(row.title).includes('Employee'),
+        `Expected no employee-private page in org scope, got title: ${row.title}`,
       );
     }
     // Employee-tagged page must not appear.
@@ -236,6 +282,10 @@ describe('memoryRecall', () => {
     assert.ok(
       rows.some((r) => String(r.title).includes('Defty Org')),
       'Org scope should include org pages that retain agent_employee_id for audit attribution',
+    );
+    assert.ok(
+      rows.some((r) => String(r.title).includes('Channel')),
+      'Org scope should include promoted channel-origin company memory',
     );
   });
 
@@ -281,6 +331,56 @@ describe('memoryRecall', () => {
       assert.ok('summary' in row, 'Missing field: summary');
       assert.ok('type' in row, 'Missing field: type');
       assert.ok('confidence' in row, 'Missing field: confidence');
+      assert.ok('origin_space_id' in row, 'Missing field: origin_space_id');
+      assert.ok('created_via' in row, 'Missing field: created_via');
+      assert.ok('matched_space_id' in row, 'Missing field: matched_space_id');
     }
+  });
+
+  test('6. space_id with include_org=false returns channel-origin memory but excludes unrelated org memory', async () => {
+    const result = await memoryRecall(
+      {
+        caller_employee_slug: 'mcp-recall-test',
+        query: QUERY_TERM,
+        scope: 'all',
+        space_id: SPACE_ID,
+        include_org: false,
+        limit: 10,
+      },
+      makeCtx(),
+    );
+
+    assert.ok(!result.isError, `Unexpected error: ${result.content[0]?.text}`);
+
+    const rows = JSON.parse(result.content[0].text) as Array<Record<string, unknown>>;
+    assert.ok(rows.length >= 1, 'Expected channel-origin result');
+    assert.ok(
+      rows.some((row) => String(row.title).includes('Channel')),
+      `Expected channel-origin page in results, got ${rows.map((row) => row.title).join(', ')}`,
+    );
+    assert.ok(
+      rows.some((row) => row.matched_space_id === SPACE_ID),
+      `Expected at least one row to carry matched_space_id ${SPACE_ID}`,
+    );
+    assert.ok(
+      rows.every((row) => !String(row.title).startsWith('Org ')),
+      `Channel-only recall should exclude unrelated org pages, got ${rows.map((row) => row.title).join(', ')}`,
+    );
+  });
+
+  test('7. private space_id is rejected when employee shadow user is not a member', async () => {
+    const result = await memoryRecall(
+      {
+        caller_employee_slug: 'mcp-recall-test',
+        query: QUERY_TERM,
+        space_id: PRIVATE_SPACE_ID,
+        include_org: false,
+        limit: 10,
+      },
+      makeCtx(),
+    );
+
+    assert.strictEqual(result.isError, true, 'Private inaccessible space should produce an error result');
+    assert.match(result.content[0]?.text ?? '', /cannot access space/);
   });
 });

--- a/apps/api/test/mcp-platform-context.test.ts
+++ b/apps/api/test/mcp-platform-context.test.ts
@@ -48,6 +48,7 @@ function makeCtx(): ToolContext {
 }
 
 let triggeringMessageId: string;
+let triggeringSpaceId: string;
 
 before(async () => {
   await withClient(async (c) => {
@@ -88,6 +89,7 @@ before(async () => {
 
     // Seed a space for the message.
     const spaceId = `mcp-ctx-space-${Date.now()}`;
+    triggeringSpaceId = spaceId;
     await c.query(
       `INSERT INTO spaces (id, org_id, name, created_by)
        VALUES ($1, $2, 'MCP Ctx Test Space', $3)
@@ -163,6 +165,67 @@ before(async () => {
       [orgPageId],
     );
     seededIds.push({ table: 'wiki_pages', id: orgPageId });
+
+    // Org-visible memory that originated from the trigger channel. The
+    // context packet layer should route this to channel memory while the
+    // flat legacy snippet list remains backward-compatible.
+    const channelPageId = `mcp-ctx-channel-page-${Date.now()}`;
+    await c.query(
+      `INSERT INTO wiki_pages
+         (id, org_id, type, scope, title, slug, summary, content, confidence,
+          origin_space_id, created_via, is_deleted, created_at, updated_at)
+       VALUES ($1, $2, 'procedure', 'org', $3, $4, $5, $6, 0.95, $7,
+          'test_channel_origin', false, NOW(), NOW())`,
+      [
+        channelPageId,
+        ORG_ID,
+        `Channel ${QUERY_TERM} Procedure`,
+        `mcp-ctx-channel-procedure-${Date.now()}`,
+        `Summary about ${QUERY_TERM} from the trigger channel.`,
+        `The ${QUERY_TERM} procedure was captured from the trigger channel.`,
+        spaceId,
+      ],
+    );
+    await c.query(
+      `UPDATE wiki_pages SET search_vector =
+         setweight(to_tsvector('english', COALESCE(title, '')), 'A') ||
+         setweight(to_tsvector('english', COALESCE(summary, '')), 'B') ||
+         setweight(to_tsvector('english', COALESCE(content, '')), 'C')
+       WHERE id = $1`,
+      [channelPageId],
+    );
+    seededIds.push({ table: 'wiki_pages', id: channelPageId });
+
+    const citedPageId = `mcp-ctx-cited-page-${Date.now()}`;
+    await c.query(
+      `INSERT INTO wiki_pages
+         (id, org_id, type, scope, title, slug, summary, content, confidence,
+          is_deleted, created_at, updated_at)
+       VALUES ($1, $2, 'fact', 'org', $3, $4, $5, $6, 0.92, false, NOW(), NOW())`,
+      [
+        citedPageId,
+        ORG_ID,
+        `Cited ${QUERY_TERM} Context`,
+        `mcp-ctx-cited-context-${Date.now()}`,
+        `Summary about ${QUERY_TERM} from a message citation.`,
+        `The ${QUERY_TERM} cited page is linked to the trigger channel only through citation provenance.`,
+      ],
+    );
+    await c.query(
+      `UPDATE wiki_pages SET search_vector =
+         setweight(to_tsvector('english', COALESCE(title, '')), 'A') ||
+         setweight(to_tsvector('english', COALESCE(summary, '')), 'B') ||
+         setweight(to_tsvector('english', COALESCE(content, '')), 'C')
+       WHERE id = $1`,
+      [citedPageId],
+    );
+    await c.query(
+      `INSERT INTO wiki_citations
+         (id, org_id, page_id, source_type, source_id, source_space_id, source_user_id, excerpt)
+       VALUES (gen_random_uuid()::text, $1, $2, 'message', $3, $4, $5, $6)`,
+      [ORG_ID, citedPageId, msgId, spaceId, TEST_USER_ID, `Citation excerpt for ${QUERY_TERM}`],
+    );
+    seededIds.push({ table: 'wiki_pages', id: citedPageId });
   });
 });
 
@@ -250,6 +313,59 @@ describe('platformContext', () => {
     assert.ok(employeePage !== undefined, 'Employee-tagged wiki page should appear in snippets');
   });
 
+  test('3b. context_packets separate company, channel, and employee memory', async () => {
+    _clearPlatformContextCache();
+    const result = await platformContext(
+      {
+        caller_employee_slug: 'mcp-ctx-test',
+        trigger: {
+          kind: 'message',
+          triggering_message_id: triggeringMessageId,
+          space_id: triggeringSpaceId,
+        },
+      },
+      makeCtx(),
+    );
+
+    assert.ok(!result.isError, `Unexpected error: ${result.content[0]?.text}`);
+
+    const parsed = JSON.parse(result.content[0].text) as Record<string, unknown>;
+    const packets = parsed.context_packets as Array<Record<string, unknown>>;
+    assert.ok(Array.isArray(packets), 'context_packets is an array');
+
+    const company = packets.find((packet) => packet.id === 'company_memory');
+    const channel = packets.find((packet) => packet.id === `space:${triggeringSpaceId}:memory`);
+    const employee = packets.find((packet) => packet.id === 'employee_memory');
+    assert.ok(company, 'company memory packet exists');
+    assert.ok(channel, 'channel memory packet exists');
+    assert.ok(employee, 'employee memory packet exists');
+
+    const companyItems = company.items as Array<Record<string, unknown>>;
+    const channelItems = channel.items as Array<Record<string, unknown>>;
+    const employeeItems = employee.items as Array<Record<string, unknown>>;
+
+    assert.ok(
+      companyItems.some((item) => String(item.title).includes('Org')),
+      'company packet should contain org-wide memory',
+    );
+    assert.ok(
+      channelItems.some((item) => String(item.title).includes('Channel')),
+      'channel packet should contain channel-origin memory',
+    );
+    assert.ok(
+      channelItems.some((item) => String(item.title).includes('Cited')),
+      'channel packet should contain citation-linked memory',
+    );
+    assert.ok(
+      employeeItems.some((item) => String(item.title).includes('Employee')),
+      'employee packet should contain employee memory',
+    );
+    assert.ok(
+      channel.retrieval_hint,
+      'channel packet should include a retrieval hint for follow-up recall',
+    );
+  });
+
   test('4. without trigger message, fallback returns top-confidence snippets', async () => {
     _clearPlatformContextCache();
     const result = await platformContext(
@@ -265,6 +381,34 @@ describe('platformContext', () => {
     assert.ok(parsed.org, 'org field present');
     assert.ok(parsed.employee, 'employee field present');
     assert.ok(Array.isArray(parsed.relevant_wiki_snippets), 'relevant_wiki_snippets is array');
+  });
+
+  test('4b. channel trigger without message still routes source-linked memory into channel packet', async () => {
+    _clearPlatformContextCache();
+    const result = await platformContext(
+      {
+        caller_employee_slug: 'mcp-ctx-test',
+        trigger: { kind: 'channel_wake', space_id: triggeringSpaceId },
+      },
+      makeCtx(),
+    );
+
+    assert.ok(!result.isError, `Unexpected error: ${result.content[0]?.text}`);
+
+    const parsed = JSON.parse(result.content[0].text) as Record<string, unknown>;
+    const packets = parsed.context_packets as Array<Record<string, unknown>>;
+    const channel = packets.find((packet) => packet.id === `space:${triggeringSpaceId}:memory`);
+    assert.ok(channel, 'channel memory packet exists');
+
+    const channelItems = channel.items as Array<Record<string, unknown>>;
+    assert.ok(
+      channelItems.some((item) => String(item.title).includes('Channel')),
+      'channel packet should contain origin-space memory in no-query fallback',
+    );
+    assert.ok(
+      channelItems.some((item) => String(item.title).includes('Cited')),
+      'channel packet should contain citation-linked memory in no-query fallback',
+    );
   });
 
   test('5. second call within 60s returns _cache_hit: true', async () => {

--- a/apps/api/test/mcp-server.test.ts
+++ b/apps/api/test/mcp-server.test.ts
@@ -155,6 +155,19 @@ test('3. POST /tools/list with valid bearer returns tool catalog', async () => {
   assert.ok(names.has('task_query'), 'task_query in catalog');
   assert.ok(names.has('thread_fetch'), 'thread_fetch in catalog');
   assert.ok(names.has('member_list'), 'member_list in catalog');
+
+  const memoryRecall = body.tools.find((t: any) => t.name === 'memory_recall');
+  const wikiSearch = body.tools.find((t: any) => t.name === 'wiki_search');
+  const platformContext = body.tools.find((t: any) => t.name === 'platform_context');
+  assert.ok(memoryRecall?.inputSchema?.properties?.space_id, 'memory_recall exposes space_id');
+  assert.ok(memoryRecall?.inputSchema?.properties?.include_org, 'memory_recall exposes include_org');
+  assert.ok(wikiSearch?.inputSchema?.properties?.space_id, 'wiki_search exposes space_id');
+  assert.ok(wikiSearch?.inputSchema?.properties?.include_org, 'wiki_search exposes include_org');
+  assert.match(
+    String(platformContext?.description ?? ''),
+    /context_packets/,
+    'platform_context advertises context_packets',
+  );
 });
 
 test('4. POST /tools/call platform_context returns org, employee, date', async () => {
@@ -178,6 +191,15 @@ test('4. POST /tools/call platform_context returns org, employee, date', async (
   assert.equal(parsed.employee?.slug, TEST_EMPLOYEE_SLUG);
   assert.equal(parsed.employee?.trust_level, 'standard');
   assert.ok(Array.isArray(parsed.teammates), 'teammates is array');
+  assert.ok(Array.isArray(parsed.context_packets), 'context_packets is array');
+  assert.ok(
+    parsed.context_packets.some((packet: any) => packet.id === 'company_memory'),
+    'company_memory packet present',
+  );
+  assert.ok(
+    parsed.context_packets.some((packet: any) => packet.id === 'employee_memory'),
+    'employee_memory packet present',
+  );
 });
 
 test('5. POST /tools/call memory_recall returns at least one page for "BSL"', async () => {

--- a/apps/api/test/mcp-tool-aliases.test.ts
+++ b/apps/api/test/mcp-tool-aliases.test.ts
@@ -10,3 +10,23 @@ test('wiki_search is exposed as a compatibility alias for memory_recall', () => 
   assert.ok(names.has('wiki_search'), 'wiki_search schema exists');
   assert.equal(ALL_TOOLS[TOOL_ALIASES.wiki_search], ALL_TOOLS.memory_recall);
 });
+
+test('scoped recall and context packet contract are advertised in tool schemas', () => {
+  const memorySchema = toolSchemas.find((tool) => tool.name === 'memory_recall') as any;
+  const wikiSearchSchema = toolSchemas.find((tool) => tool.name === 'wiki_search') as any;
+  const platformSchema = toolSchemas.find((tool) => tool.name === 'platform_context') as any;
+
+  for (const schema of [memorySchema, wikiSearchSchema]) {
+    assert.ok(schema, 'recall schema exists');
+    const properties = schema.inputSchema?.properties ?? {};
+    assert.ok(properties.space_id, `${schema.name} should advertise space_id`);
+    assert.ok(properties.include_org, `${schema.name} should advertise include_org`);
+    assert.equal(properties.include_org.type, 'boolean');
+  }
+
+  assert.match(
+    String(platformSchema?.description ?? ''),
+    /context_packets/,
+    'platform_context description should advertise context packets',
+  );
+});

--- a/apps/api/test/retrieve-context.test.ts
+++ b/apps/api/test/retrieve-context.test.ts
@@ -51,6 +51,22 @@ async function withClient<T>(fn: (c: pg.Client) => Promise<T>): Promise<T> {
 
 before(async () => {
   await withClient(async (c) => {
+    // Clean up any stale rows from interrupted local test runs.
+    await c.query(
+      `DELETE FROM wiki_pages
+       WHERE agent_employee_id IN (SELECT id FROM agent_employees WHERE user_id = $1)`,
+      [USER_ID],
+    );
+    await c.query(`DELETE FROM wiki_citations WHERE page_id LIKE 'rctest-space-%'`);
+    await c.query(`DELETE FROM wiki_pages WHERE id LIKE 'rctest-space-%'`);
+    await c.query(`DELETE FROM messages WHERE id LIKE 'rctest-space-message-%' OR user_id = $1`, [USER_ID]);
+    await c.query(`DELETE FROM space_members WHERE space_id LIKE 'rctest-space-%'`);
+    await c.query(`DELETE FROM spaces WHERE id LIKE 'rctest-space-%'`);
+    await c.query(`DELETE FROM agent_memory WHERE user_id = $1`, [USER_ID]);
+    await c.query(`DELETE FROM notes WHERE user_id = $1`, [USER_ID]);
+    await c.query(`DELETE FROM agent_employees WHERE user_id = $1`, [USER_ID]);
+    await c.query(`DELETE FROM org_members WHERE user_id = $1`, [USER_ID]);
+
     // Ensure test user exists.
     await c.query(
       `INSERT INTO users (id, email, name, is_agent)
@@ -187,6 +203,19 @@ after(async () => {
     for (const { table, id } of [...seededIds].reverse()) {
       await c.query(`DELETE FROM ${table} WHERE id = $1`, [id]);
     }
+    await c.query(
+      `DELETE FROM wiki_pages
+       WHERE agent_employee_id IN (SELECT id FROM agent_employees WHERE user_id = $1)`,
+      [USER_ID],
+    );
+    await c.query(`DELETE FROM wiki_citations WHERE page_id LIKE 'rctest-space-%'`);
+    await c.query(`DELETE FROM wiki_pages WHERE id LIKE 'rctest-space-%'`);
+    await c.query(`DELETE FROM messages WHERE id LIKE 'rctest-space-message-%' OR user_id = $1`, [USER_ID]);
+    await c.query(`DELETE FROM space_members WHERE space_id LIKE 'rctest-space-%'`);
+    await c.query(`DELETE FROM spaces WHERE id LIKE 'rctest-space-%'`);
+    await c.query(`DELETE FROM agent_memory WHERE user_id = $1`, [USER_ID]);
+    await c.query(`DELETE FROM notes WHERE user_id = $1`, [USER_ID]);
+    await c.query(`DELETE FROM agent_employees WHERE user_id = $1`, [USER_ID]);
     await c.query(`DELETE FROM org_members WHERE user_id = $1`, [USER_ID]);
     await c.query(`DELETE FROM users WHERE id = $1`, [USER_ID]);
   });
@@ -295,6 +324,118 @@ describe('retrieveContext', () => {
   });
 
   // ─── Task 1.2: Hybrid FTS + vector ranking ─────────────────────────────────
+
+  test('6b. space_id narrows wiki retrieval to company plus current channel context', async () => {
+    const TERM = `xyzspacecontext${Date.now()}`;
+    const SPACE_A_ID = `rctest-space-a-${Date.now()}`;
+    const SPACE_B_ID = `rctest-space-b-${Date.now()}`;
+    const orgPageId = `rctest-space-org-${Date.now()}`;
+    const spacePageId = `rctest-space-local-${Date.now()}`;
+    const otherSpacePageId = `rctest-space-other-${Date.now()}`;
+    const citationPageId = `rctest-space-citation-${Date.now()}`;
+    const citationMessageId = `rctest-space-message-${Date.now()}`;
+
+    await withClient(async (c) => {
+      for (const [spaceId, name] of [[SPACE_A_ID, 'Retrieve Space A'], [SPACE_B_ID, 'Retrieve Space B']] as const) {
+        await c.query(
+          `INSERT INTO spaces (id, org_id, name, type, is_archived)
+           VALUES ($1, $2, $3, 'public', false)
+           ON CONFLICT (id) DO NOTHING`,
+          [spaceId, ORG_ID, name],
+        );
+        await c.query(
+          `INSERT INTO space_members (id, space_id, user_id, is_muted, notification_level, joined_at)
+           VALUES (gen_random_uuid()::text, $1, $2, false, 'all', NOW())
+           ON CONFLICT (space_id, user_id) DO NOTHING`,
+          [spaceId, USER_ID],
+        );
+      }
+
+      const insertPage = async (
+        id: string,
+        scope: 'org' | 'space',
+        title: string,
+        slug: string,
+        spaceId: string | null,
+        originSpaceId: string | null,
+      ) => {
+        await c.query(
+          `INSERT INTO wiki_pages
+             (id, org_id, type, scope, space_id, origin_space_id, title, slug, content,
+              confidence, is_deleted, created_at, updated_at)
+           VALUES ($1, $2, 'fact', $3, $4, $5, $6, $7, $8, 1.0, false, NOW(), NOW())`,
+          [id, ORG_ID, scope, spaceId, originSpaceId, title, slug, `The ${TERM} marker belongs to ${title}.`],
+        );
+        await c.query(
+          `UPDATE wiki_pages SET search_vector =
+             setweight(to_tsvector('english', COALESCE(title, '')), 'A') ||
+             setweight(to_tsvector('english', COALESCE(summary, '')), 'B') ||
+             setweight(to_tsvector('english', COALESCE(content, '')), 'C')
+           WHERE id = $1`,
+          [id],
+        );
+      };
+
+      await insertPage(orgPageId, 'org', `Company ${TERM} Context`, `company-${TERM}`, null, null);
+      await insertPage(spacePageId, 'space', `Channel ${TERM} Context`, `channel-${TERM}`, SPACE_A_ID, SPACE_A_ID);
+      await insertPage(otherSpacePageId, 'space', `Other Channel ${TERM} Context`, `other-channel-${TERM}`, SPACE_B_ID, SPACE_B_ID);
+      await insertPage(citationPageId, 'org', `Cited ${TERM} Context`, `cited-${TERM}`, null, null);
+
+      await c.query(
+        `INSERT INTO messages (id, org_id, space_id, user_id, content, created_at, updated_at)
+         VALUES ($1, $2, $3, $4, $5, NOW(), NOW())`,
+        [citationMessageId, ORG_ID, SPACE_A_ID, USER_ID, `Message source for ${TERM} cited memory.`],
+      );
+      await c.query(
+        `INSERT INTO wiki_citations
+           (id, org_id, page_id, source_type, source_id, source_space_id, source_user_id, excerpt)
+         VALUES (gen_random_uuid()::text, $1, $2, 'message', $3, $4, $5, $6)`,
+        [ORG_ID, citationPageId, citationMessageId, SPACE_A_ID, USER_ID, `Message source for ${TERM}`],
+      );
+    });
+
+    try {
+      const withCompany = await retrieveContext({
+        query: TERM,
+        org_id: ORG_ID,
+        user_id: USER_ID,
+        types: ['wiki'],
+        space_id: SPACE_A_ID,
+        include_org: true,
+        hybrid: false,
+        limit: 10,
+      });
+      const withCompanyIds = withCompany.map((r) => r.source_id);
+      assert.ok(withCompanyIds.includes(orgPageId), 'space retrieval with include_org should include company wiki');
+      assert.ok(withCompanyIds.includes(spacePageId), 'space retrieval should include current channel wiki');
+      assert.ok(withCompanyIds.includes(citationPageId), 'space retrieval should include wiki cited from current channel');
+      assert.ok(!withCompanyIds.includes(otherSpacePageId), 'space retrieval should exclude other channel wiki');
+
+      const channelOnly = await retrieveContext({
+        query: TERM,
+        org_id: ORG_ID,
+        user_id: USER_ID,
+        types: ['wiki'],
+        space_id: SPACE_A_ID,
+        include_org: false,
+        hybrid: false,
+        limit: 10,
+      });
+      const channelOnlyIds = channelOnly.map((r) => r.source_id);
+      assert.ok(!channelOnlyIds.includes(orgPageId), 'include_org:false should exclude general company wiki');
+      assert.ok(channelOnlyIds.includes(spacePageId), 'include_org:false should keep current channel wiki');
+      assert.ok(channelOnlyIds.includes(citationPageId), 'include_org:false should keep citation-linked channel wiki');
+      assert.ok(!channelOnlyIds.includes(otherSpacePageId), 'include_org:false should still exclude other channel wiki');
+    } finally {
+      await withClient(async (c) => {
+        await c.query(`DELETE FROM wiki_citations WHERE page_id = $1`, [citationPageId]);
+        await c.query(`DELETE FROM messages WHERE id = $1`, [citationMessageId]);
+        await c.query(`DELETE FROM wiki_pages WHERE id = ANY($1)`, [[orgPageId, spacePageId, otherSpacePageId, citationPageId]]);
+        await c.query(`DELETE FROM space_members WHERE space_id = ANY($1)`, [[SPACE_A_ID, SPACE_B_ID]]);
+        await c.query(`DELETE FROM spaces WHERE id = ANY($1)`, [[SPACE_A_ID, SPACE_B_ID]]);
+      });
+    }
+  });
 
   test('7. hybrid: false bypasses vector search and returns FTS-only results', async () => {
     // With hybrid:false the code must not call fetch (no embedding generated).

--- a/apps/api/test/wiki-graph-scope.test.ts
+++ b/apps/api/test/wiki-graph-scope.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Channel-aware wiki graph tests.
+ *
+ * Run: pnpm --filter @deft/api test -- wiki-graph-scope
+ */
+import { test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import pg from 'pg';
+
+const DATABASE_URL =
+  process.env.DATABASE_URL || 'postgres://postgres:postgres@localhost:5432/deft';
+
+const ORG_ID = '1d7d869a-5e68-48d5-832e-11d8f3bb1dd6';
+const USER_ID = `wiki-graph-user-${Date.now()}`;
+const SPACE_A_ID = `wiki-graph-space-a-${Date.now()}`;
+const SPACE_B_ID = `wiki-graph-space-b-${Date.now()}`;
+
+const createdPageIds: string[] = [];
+
+async function withClient<T>(fn: (c: pg.Client) => Promise<T>): Promise<T> {
+  const c = new pg.Client({ connectionString: DATABASE_URL });
+  await c.connect();
+  try {
+    return await fn(c);
+  } finally {
+    await c.end();
+  }
+}
+
+before(async () => {
+  await withClient(async (c) => {
+    await c.query(
+      `INSERT INTO users (id, email, name, is_agent)
+       VALUES ($1, $2, 'Wiki Graph Test User', false)
+       ON CONFLICT (id) DO NOTHING`,
+      [USER_ID, `${USER_ID}@test.local`],
+    );
+    await c.query(
+      `INSERT INTO org_members (id, org_id, user_id, role, is_active)
+       VALUES (gen_random_uuid()::text, $1, $2, 'member', true)
+       ON CONFLICT (org_id, user_id) DO NOTHING`,
+      [ORG_ID, USER_ID],
+    );
+    for (const [spaceId, name] of [[SPACE_A_ID, 'Wiki Graph A'], [SPACE_B_ID, 'Wiki Graph B']] as const) {
+      await c.query(
+        `INSERT INTO spaces (id, org_id, name, type, is_archived)
+         VALUES ($1, $2, $3, 'public', false)
+         ON CONFLICT (id) DO NOTHING`,
+        [spaceId, ORG_ID, name],
+      );
+      await c.query(
+        `INSERT INTO space_members (id, space_id, user_id, is_muted, notification_level, joined_at)
+         VALUES (gen_random_uuid()::text, $1, $2, false, 'all', NOW())
+         ON CONFLICT (space_id, user_id) DO NOTHING`,
+        [spaceId, USER_ID],
+      );
+    }
+  });
+});
+
+after(async () => {
+  await withClient(async (c) => {
+    if (createdPageIds.length > 0) {
+      await c.query(`DELETE FROM wiki_links WHERE source_page_id = ANY($1) OR target_page_id = ANY($1)`, [createdPageIds]);
+      await c.query(`DELETE FROM wiki_citations WHERE page_id = ANY($1)`, [createdPageIds]);
+      await c.query(`DELETE FROM wiki_pages WHERE id = ANY($1)`, [createdPageIds]);
+    }
+    await c.query(`DELETE FROM space_members WHERE space_id = ANY($1)`, [[SPACE_A_ID, SPACE_B_ID]]);
+    await c.query(`DELETE FROM spaces WHERE id = ANY($1)`, [[SPACE_A_ID, SPACE_B_ID]]);
+    await c.query(`DELETE FROM org_members WHERE user_id = $1`, [USER_ID]);
+    await c.query(`DELETE FROM users WHERE id = $1`, [USER_ID]);
+  });
+});
+
+async function insertPage(input: {
+  scope: 'org' | 'space';
+  title: string;
+  slug: string;
+  spaceId?: string | null;
+  originSpaceId?: string | null;
+}) {
+  const id = `wiki-graph-page-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  await withClient(async (c) => {
+    await c.query(
+      `INSERT INTO wiki_pages
+         (id, org_id, scope, space_id, origin_space_id, origin_user_id, created_via,
+          type, title, slug, content, confidence, is_deleted, created_at, updated_at)
+       VALUES ($1, $2, $3, $4, $5, $6, 'test', 'fact', $7, $8, $9, 1.0, false, NOW(), NOW())`,
+      [
+        id,
+        ORG_ID,
+        input.scope,
+        input.spaceId ?? null,
+        input.originSpaceId ?? null,
+        USER_ID,
+        input.title,
+        input.slug,
+        `${input.title} body`,
+      ],
+    );
+  });
+  createdPageIds.push(id);
+  return id;
+}
+
+async function callGraph(path: string) {
+  const { Hono } = await import('hono');
+  const { wikiRoutes } = await import('../src/routes/wiki.js');
+  const app = new Hono();
+  app.use('*', async (c, next) => {
+    c.set('user', { id: USER_ID, org_id: ORG_ID, email: `${USER_ID}@test.local`, name: 'Wiki Graph Test User' });
+    await next();
+  });
+  app.route('/api/wiki', wikiRoutes);
+  return app.request(path);
+}
+
+test('space graph includes channel-scoped and channel-origin pages, but not unrelated org/pages', async () => {
+  const suffix = Date.now();
+  const orgGeneralId = await insertPage({
+    scope: 'org',
+    title: 'General Company Page',
+    slug: `wiki-graph-general-${suffix}`,
+  });
+  const orgFromSpaceId = await insertPage({
+    scope: 'org',
+    title: 'Channel Origin Company Page',
+    slug: `wiki-graph-origin-${suffix}`,
+    originSpaceId: SPACE_A_ID,
+  });
+  const spaceAId = await insertPage({
+    scope: 'space',
+    title: 'Space A Local Page',
+    slug: `wiki-graph-space-a-${suffix}`,
+    spaceId: SPACE_A_ID,
+    originSpaceId: SPACE_A_ID,
+  });
+  const spaceBId = await insertPage({
+    scope: 'space',
+    title: 'Space B Local Page',
+    slug: `wiki-graph-space-b-${suffix}`,
+    spaceId: SPACE_B_ID,
+    originSpaceId: SPACE_B_ID,
+  });
+
+  const orgRes = await callGraph('/api/wiki/graph?mode=org&limit=500');
+  assert.equal(orgRes.status, 200);
+  const orgGraph = await orgRes.json() as any;
+  const orgIds = orgGraph.nodes.map((n: any) => n.id);
+  assert.ok(orgIds.includes(orgGeneralId), 'org graph should include general org page');
+  assert.ok(orgIds.includes(orgFromSpaceId), 'org graph should include org page that originated in a channel');
+  assert.ok(!orgIds.includes(spaceAId), 'org graph should not include space-scoped pages');
+
+  const spaceRes = await callGraph(`/api/wiki/graph?mode=space&space_id=${SPACE_A_ID}&limit=500`);
+  assert.equal(spaceRes.status, 200);
+  const spaceGraph = await spaceRes.json() as any;
+  const spaceIds = spaceGraph.nodes.map((n: any) => n.id);
+  assert.ok(spaceIds.includes(orgFromSpaceId), 'channel graph should include org page with origin_space_id');
+  assert.ok(spaceIds.includes(spaceAId), 'channel graph should include space-scoped page');
+  assert.ok(!spaceIds.includes(orgGeneralId), 'channel graph should not include unrelated org page');
+  assert.ok(!spaceIds.includes(spaceBId), 'channel graph should not include other channel page');
+
+  const strictRes = await callGraph(`/api/wiki/graph?mode=space&space_id=${SPACE_A_ID}&include_org=false&limit=500`);
+  assert.equal(strictRes.status, 200);
+  const strictGraph = await strictRes.json() as any;
+  const strictIds = strictGraph.nodes.map((n: any) => n.id);
+  assert.ok(strictIds.includes(spaceAId), 'strict channel graph should include space-scoped page');
+  assert.ok(!strictIds.includes(orgFromSpaceId), 'strict channel graph should exclude org-origin pages');
+});

--- a/apps/web/src/app/(app)/knowledge/page.tsx
+++ b/apps/web/src/app/(app)/knowledge/page.tsx
@@ -63,9 +63,19 @@ type WikiPage = {
   tags?: string[] | null;
   version: number;
   space_id: string | null;
+  origin_space_id?: string | null;
+  origin_message_id?: string | null;
+  origin_user_id?: string | null;
+  created_via?: string | null;
   created_at: string;
   updated_at: string;
   link_count: number;
+};
+
+type SpaceOption = {
+  id: string;
+  name: string;
+  type: string;
 };
 
 /** Returns true if a decision wiki page has been reversed. */
@@ -76,6 +86,64 @@ function isDecisionReversed(entry: Pick<WikiPage, 'confidence' | 'tags'>): boole
 function getMetadataString(metadata: Record<string, unknown> | null | undefined, key: string): string | null {
   const value = metadata?.[key];
   return typeof value === 'string' && value.trim() ? value : null;
+}
+
+type MemoryRoutablePage = Pick<WikiPage, 'scope' | 'space_id' | 'origin_space_id' | 'origin_message_id' | 'created_via'>;
+
+function getMemoryRoute(page: MemoryRoutablePage): { label: string; color: string } {
+  if (page.scope === 'user') {
+    return { label: 'Personal memory', color: '#EC4899' };
+  }
+  if (page.scope === 'space' || page.space_id) {
+    return { label: 'Channel memory', color: '#7C9885' };
+  }
+  if (page.origin_space_id) {
+    return { label: 'Company memory from channel', color: '#D4A853' };
+  }
+  if (page.origin_message_id) {
+    return { label: 'Company memory from chat', color: '#D4A853' };
+  }
+  return { label: 'Company memory', color: '#5B8FA8' };
+}
+
+function getCreatedViaLabel(createdVia: string | null | undefined): string | null {
+  switch (createdVia) {
+    case 'memory_extract':
+      return 'Captured from chat';
+    case 'wiki_create':
+      return 'Saved by agent';
+    case 'space_knowledge_panel':
+      return 'Saved from channel notes';
+    case 'human_mcp':
+      return 'Saved through MCP';
+    case 'manual':
+      return 'Saved manually';
+    default:
+      return null;
+  }
+}
+
+function getMemoryProvenanceLabels(page: MemoryRoutablePage): string[] {
+  return [
+    getCreatedViaLabel(page.created_via),
+    page.origin_message_id ? 'source message linked' : null,
+    page.origin_space_id && page.scope !== 'space' ? 'channel-originated' : null,
+  ].filter((label): label is string => Boolean(label));
+}
+
+function getGraphScopeHint(mode: 'org' | 'space', includeOrg: boolean): string {
+  if (mode === 'org') return 'Company memory graph';
+  return includeOrg ? 'Channel context with company memory' : 'Channel-only context graph';
+}
+
+function MemoryRouteBadge({ page }: { page: MemoryRoutablePage }) {
+  const route = getMemoryRoute(page);
+  return (
+    <span className="text-[9px] font-medium px-1.5 py-0.5 rounded-full flex-shrink-0"
+      style={{ background: `${route.color}18`, color: route.color, border: `1px solid ${route.color}35` }}>
+      {route.label}
+    </span>
+  );
 }
 
 type WikiPageDetail = WikiPage & {
@@ -275,8 +343,13 @@ export default function KnowledgePage() {
   const [historyLoading, setHistoryLoading] = useState(false);
   const [selectedVersion, setSelectedVersion] = useState<any>(null);
   const [showGraph, setShowGraph] = useState(false);
-  const [graphData, setGraphData] = useState<{ nodes: any[]; edges: any[] } | null>(null);
+  const [graphData, setGraphData] = useState<{ nodes: any[]; edges: any[]; mode?: string; scope_label?: string; space_id?: string | null } | null>(null);
   const [graphLoading, setGraphLoading] = useState(false);
+  const [graphMode, setGraphMode] = useState<'org' | 'space'>('org');
+  const [graphSpaceId, setGraphSpaceId] = useState<string>('');
+  const [graphIncludeOrg, setGraphIncludeOrg] = useState(true);
+  const [spaces, setSpaces] = useState<SpaceOption[]>([]);
+  const [spacesLoading, setSpacesLoading] = useState(false);
   const [viewMode, setViewMode] = useState<'pages' | 'activity' | 'stats'>('pages');
   const [activityLog, setActivityLog] = useState<any[]>([]);
   const [activityLoading, setActivityLoading] = useState(false);
@@ -368,6 +441,26 @@ export default function KnowledgePage() {
       pagesAbortRef.current?.abort();
     };
   }, [fetchPages]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setSpacesLoading(true);
+    api.get('/api/spaces').then(async res => {
+      if (!res.ok) return;
+      const data = await res.json();
+      if (cancelled) return;
+      const nextSpaces = (Array.isArray(data) ? data : [])
+        .filter((s: any) => s && s.type !== 'dm' && s.type !== 'group_dm')
+        .map((s: any) => ({ id: s.id, name: s.name, type: s.type }));
+      setSpaces(nextSpaces);
+      setGraphSpaceId(prev => prev || nextSpaces[0]?.id || '');
+    }).catch(() => {
+      if (!cancelled) setSpaces([]);
+    }).finally(() => {
+      if (!cancelled) setSpacesLoading(false);
+    });
+    return () => { cancelled = true; };
+  }, []);
 
   // Fetch page detail when selected
   useEffect(() => {
@@ -468,10 +561,23 @@ export default function KnowledgePage() {
     }
   };
 
-  const fetchGraph = async () => {
+  const fetchGraph = useCallback(async (
+    mode: 'org' | 'space' = graphMode,
+    spaceId: string = graphSpaceId,
+    includeOrg: boolean = graphIncludeOrg,
+  ) => {
+    if (mode === 'space' && !spaceId) {
+      setGraphData({ nodes: [], edges: [], mode, scope_label: 'Channel', space_id: null });
+      return;
+    }
     setGraphLoading(true);
     try {
-      const res = await api.get('/api/wiki/graph');
+      const params = new URLSearchParams({ mode });
+      if (mode === 'space') {
+        params.set('space_id', spaceId);
+        params.set('include_org', String(includeOrg));
+      }
+      const res = await api.get(`/api/wiki/graph?${params.toString()}`);
       if (res.ok) {
         setGraphData(await res.json());
       }
@@ -479,7 +585,12 @@ export default function KnowledgePage() {
     } finally {
       setGraphLoading(false);
     }
-  };
+  }, [graphIncludeOrg, graphMode, graphSpaceId]);
+
+  useEffect(() => {
+    if (!showGraph) return;
+    fetchGraph(graphMode, graphSpaceId, graphIncludeOrg);
+  }, [fetchGraph, showGraph, graphMode, graphSpaceId, graphIncludeOrg]);
 
   const reverseDecision = async (entry: WikiPage, targetReversed: boolean) => {
     const confirmMsg = targetReversed
@@ -678,10 +789,7 @@ export default function KnowledgePage() {
                       style={{ background: `${(TYPE_CONFIG[detail.type] || TYPE_CONFIG.fact!).color}20`, color: (TYPE_CONFIG[detail.type] || TYPE_CONFIG.fact!).color }}>
                       {WIKI_TYPE_LABELS[detail.type]?.singular ?? (TYPE_CONFIG[detail.type] || TYPE_CONFIG.fact!).label.replace(/s$/, '')}
                     </span>
-                    <span className="text-[9px] font-medium px-1.5 py-0.5 rounded-full capitalize"
-                      style={{ background: 'var(--surface-container-low)', color: 'var(--text-tertiary)', border: '1px solid var(--border-default)' }}>
-                      {detail.scope}
-                    </span>
+                    <MemoryRouteBadge page={detail} />
                     <span className="text-[10px]" style={{ color: 'var(--text-tertiary)' }}>v{detail.version}</span>
                     <ConfidenceBar value={detail.confidence} />
                     <span className="text-[11px]" style={{ color: 'var(--text-tertiary)' }}>
@@ -716,6 +824,11 @@ export default function KnowledgePage() {
                   <p className="text-[11px] mt-2" style={{ color: 'var(--text-tertiary)' }}>
                     Updated {formatRelative(detail.updated_at)}
                   </p>
+                  {getMemoryProvenanceLabels(detail).length > 0 && (
+                    <p className="text-[11px] mt-1" style={{ color: 'var(--text-tertiary)' }}>
+                      {getMemoryProvenanceLabels(detail).join(' / ')}
+                    </p>
+                  )}
                 </>
               )}
             </div>
@@ -915,7 +1028,7 @@ export default function KnowledgePage() {
             </button>
             {/* Graph toggle */}
             <button
-              onClick={() => { if (!showGraph) fetchGraph(); setShowGraph(!showGraph); setViewMode('pages'); }}
+              onClick={() => { setShowGraph(prev => !prev); setViewMode('pages'); }}
               className="hidden md:flex items-center gap-1 px-2 py-1.5 rounded-lg text-[11px] font-medium transition-colors"
               style={{
                 background: showGraph ? 'var(--surface-container-high)' : 'transparent',
@@ -960,7 +1073,7 @@ export default function KnowledgePage() {
                 },
                 {
                   label: 'Graph',
-                  onClick: () => { if (!showGraph) fetchGraph(); setShowGraph(true); setViewMode('pages'); },
+                  onClick: () => { setShowGraph(true); setViewMode('pages'); },
                 },
                 {
                   label: 'Export',
@@ -1036,14 +1149,80 @@ export default function KnowledgePage() {
       <div className="flex flex-col flex-1 overflow-hidden px-4 md:px-6 pb-4 md:pb-6">
       {/* Graph View — interactive force-directed graph */}
       {showGraph && (
-        <div className="flex-1 rounded-lg overflow-hidden"
+        <div className="flex-1 rounded-lg overflow-hidden flex flex-col"
           style={{ background: 'var(--surface-container-low)', border: '1px solid var(--border-default)' }}>
+          <div className="flex flex-wrap items-center gap-2 px-3 py-2 flex-shrink-0"
+            style={{ background: 'var(--surface-container)', borderBottom: '1px solid var(--border-default)' }}>
+            <div className="flex items-center gap-1 rounded-lg p-0.5" style={{ background: 'var(--surface-container-low)', border: '1px solid var(--border-default)' }}>
+              <button
+                onClick={() => setGraphMode('org')}
+                className="px-2.5 py-1 rounded-md text-[11px] font-medium transition-colors"
+                style={{
+                  background: graphMode === 'org' ? 'var(--accent)' : 'transparent',
+                  color: graphMode === 'org' ? 'white' : 'var(--text-secondary)',
+                }}
+              >
+                Company
+              </button>
+              <button
+                onClick={() => setGraphMode('space')}
+                className="px-2.5 py-1 rounded-md text-[11px] font-medium transition-colors"
+                style={{
+                  background: graphMode === 'space' ? 'var(--accent)' : 'transparent',
+                  color: graphMode === 'space' ? 'white' : 'var(--text-secondary)',
+                }}
+              >
+                Channel
+              </button>
+            </div>
+            {graphMode === 'space' && (
+              <>
+                <select
+                  value={graphSpaceId}
+                  onChange={e => setGraphSpaceId(e.target.value)}
+                  disabled={spacesLoading || spaces.length === 0}
+                  className="px-2 py-1 rounded-lg text-[11px] outline-none"
+                  style={{ background: 'var(--surface-container-low)', border: '1px solid var(--border-default)', color: 'var(--text-primary)' }}
+                >
+                  {spaces.length === 0 ? (
+                    <option value="">{spacesLoading ? 'Loading channels...' : 'No channels'}</option>
+                  ) : spaces.map(space => (
+                    <option key={space.id} value={space.id}>{space.name}</option>
+                  ))}
+                </select>
+                <button
+                  onClick={() => setGraphIncludeOrg(v => !v)}
+                  className="px-2 py-1 rounded-lg text-[11px] font-medium transition-colors"
+                  style={{
+                    background: graphIncludeOrg ? 'var(--surface-container-high)' : 'transparent',
+                    border: '1px solid var(--border-default)',
+                    color: graphIncludeOrg ? 'var(--text-primary)' : 'var(--text-tertiary)',
+                  }}
+                >
+                  Include company memory
+                </button>
+              </>
+            )}
+            <span className="text-[11px] px-2 py-1 rounded-lg"
+              style={{ background: 'var(--surface-container-low)', border: '1px solid var(--border-default)', color: 'var(--text-tertiary)' }}>
+              {getGraphScopeHint(graphMode, graphIncludeOrg)}
+            </span>
+            <button
+              onClick={() => fetchGraph(graphMode, graphSpaceId, graphIncludeOrg)}
+              className="ml-auto flex items-center gap-1 px-2 py-1 rounded-lg text-[11px] font-medium transition-colors"
+              style={{ background: 'var(--surface-container-low)', border: '1px solid var(--border-default)', color: 'var(--text-secondary)' }}
+            >
+              <RefreshCw size={11} /> Refresh
+            </button>
+          </div>
           {graphLoading ? (
-            <div className="flex items-center justify-center py-12">
+            <div className="flex-1 flex items-center justify-center py-12">
               <Loader2 size={20} className="animate-spin" style={{ color: 'var(--text-tertiary)' }} />
             </div>
           ) : !graphData || graphData.nodes.length === 0 ? (
-            <p className="text-center py-8 text-[13px]" style={{ color: 'var(--text-tertiary)' }}>No graph data</p>
+            <p className="flex-1 flex items-center justify-center text-[13px]" style={{ color: 'var(--text-tertiary)' }}>
+              {graphMode === 'space' ? 'No channel graph data yet' : 'No graph data'}
+            </p>
           ) : (
             <div className="relative w-full h-full min-h-[450px]">
               {/* Legend */}
@@ -1059,7 +1238,7 @@ export default function KnowledgePage() {
               {/* Stats */}
               <div className="absolute top-3 right-3 z-10 text-[11px] px-2 py-1 rounded-lg"
                 style={{ background: 'var(--surface-container)', color: 'var(--text-tertiary)' }}>
-                {graphData.nodes.length} pages &middot; {graphData.edges.length} connections
+                {graphData.scope_label || (graphMode === 'space' ? 'Channel' : 'Company')} &middot; {graphData.nodes.length} pages &middot; {graphData.edges.length} connections
               </div>
               <Suspense fallback={<div className="flex items-center justify-center py-12"><Loader2 size={20} className="animate-spin" style={{ color: 'var(--text-tertiary)' }} /></div>}>
                 <KnowledgeGraph
@@ -1291,6 +1470,7 @@ export default function KnowledgePage() {
                           style={{ background: `${config.color}20`, color: config.color }}>
                           {WIKI_TYPE_LABELS[entry.type]?.singular ?? config.label.replace(/s$/, '')}
                         </span>
+                        <MemoryRouteBadge page={entry} />
                         {isDecision && (
                           <span className="text-[9px] font-medium px-1.5 py-0.5 rounded-full flex-shrink-0"
                             style={{
@@ -1301,23 +1481,22 @@ export default function KnowledgePage() {
                             {reversed ? 'Reversed' : 'Active'}
                           </span>
                         )}
-                        {entry.scope !== 'org' && (
-                          <span className="text-[9px] font-medium px-1.5 py-0.5 rounded-full capitalize flex-shrink-0"
-                            style={{ background: 'var(--surface-container)', color: 'var(--text-tertiary)', border: '1px solid var(--border-default)' }}>
-                            {entry.scope}
-                          </span>
-                        )}
                       </div>
                       {entry.summary && (
                         <p className="text-[12px] line-clamp-2 mb-1" style={{ color: 'var(--text-secondary)' }}>
                           {entry.summary}
                         </p>
                       )}
-                      <div className="flex items-center gap-3 mt-1.5">
+                      <div className="flex items-center gap-3 mt-1.5 flex-wrap">
                         <ConfidenceBar value={entry.confidence} />
                         {entry.link_count > 0 && (
                           <span className="text-[11px] flex items-center gap-0.5" style={{ color: 'var(--text-tertiary)' }}>
                             <Link2 size={10} /> {entry.link_count} links
+                          </span>
+                        )}
+                        {getMemoryProvenanceLabels(entry).length > 0 && (
+                          <span className="text-[11px]" style={{ color: 'var(--text-tertiary)' }}>
+                            {getMemoryProvenanceLabels(entry).join(' / ')}
                           </span>
                         )}
                         <span className="text-[11px]" style={{ color: 'var(--text-tertiary)' }}>

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -115,9 +115,10 @@ The init service runs `pnpm db:push-full && pnpm db:seed` inside the Deft image.
 No host Node.js or pnpm install is required for the Docker self-host path.
 
 `db:push-full` enables the `vector` extension, syncs the schema, and applies the
-full-text-search extras Drizzle cannot express. `db:seed` seeds Defty, internal
-agent/tool bundles, task templates, and first-party employee templates. It is
-idempotent and does not insert demo users.
+supplemental SQL files for search indexes and safe metadata backfills that
+Drizzle cannot fully express. `db:seed` seeds Defty, internal agent/tool bundles,
+task templates, and first-party employee templates. It is idempotent and does not
+insert demo users.
 
 ### 4. Verify
 

--- a/packages/db/drizzle/0074_wiki_provenance_graph_scope.sql
+++ b/packages/db/drizzle/0074_wiki_provenance_graph_scope.sql
@@ -1,0 +1,92 @@
+-- Preserve where knowledge came from separately from where it is scoped.
+-- `space_id` remains the access/scope space for space-scoped pages.
+-- `origin_*` records the chat/user/message provenance for org- and space-scoped pages.
+
+ALTER TABLE "wiki_pages"
+  ADD COLUMN IF NOT EXISTS "origin_space_id" text REFERENCES "spaces"("id") ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS "origin_message_id" text REFERENCES "messages"("id") ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS "origin_user_id" text REFERENCES "users"("id") ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS "created_via" text;
+
+ALTER TABLE "wiki_citations"
+  ADD COLUMN IF NOT EXISTS "org_id" text REFERENCES "orgs"("id") ON DELETE CASCADE,
+  ADD COLUMN IF NOT EXISTS "source_space_id" text REFERENCES "spaces"("id") ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS "source_user_id" text REFERENCES "users"("id") ON DELETE SET NULL;
+
+WITH candidates AS (
+  SELECT
+    wp.id,
+    COALESCE(
+      NULLIF(wp.metadata->>'origin_space_id', ''),
+      NULLIF(wp.metadata->>'source_space_id', ''),
+      wc.source_space_id,
+      msg.space_id,
+      CASE WHEN wp.scope = 'space' THEN wp.space_id ELSE NULL END
+    ) AS origin_space_id,
+    COALESCE(
+      NULLIF(wp.metadata->>'origin_message_id', ''),
+      NULLIF(wp.metadata->>'source_message_id', ''),
+      CASE WHEN wc.source_type = 'message' THEN wc.source_id ELSE NULL END
+    ) AS origin_message_id,
+    COALESCE(
+      NULLIF(wp.metadata->>'origin_user_id', ''),
+      NULLIF(wp.metadata->>'source_user_id', ''),
+      wc.source_user_id,
+      msg.user_id,
+      wp.user_id
+    ) AS origin_user_id,
+    COALESCE(
+      NULLIF(wp.metadata->>'created_via', ''),
+      NULLIF(wp.metadata->>'source', ''),
+      CASE WHEN wp.agent_employee_id IS NOT NULL THEN 'agent' ELSE 'manual' END
+    ) AS created_via
+  FROM wiki_pages wp
+  LEFT JOIN LATERAL (
+    SELECT wc.source_type, wc.source_id, wc.source_space_id, wc.source_user_id
+    FROM wiki_citations wc
+    WHERE wc.page_id = wp.id
+    ORDER BY wc.created_at DESC
+    LIMIT 1
+  ) wc ON true
+  LEFT JOIN messages msg ON msg.id = wc.source_id AND wc.source_type = 'message'
+),
+valid AS (
+  SELECT
+    c.id,
+    s.id AS origin_space_id,
+    m.id AS origin_message_id,
+    u.id AS origin_user_id,
+    c.created_via
+  FROM candidates c
+  LEFT JOIN spaces s ON s.id = c.origin_space_id
+  LEFT JOIN messages m ON m.id = c.origin_message_id
+  LEFT JOIN users u ON u.id = c.origin_user_id
+)
+UPDATE wiki_pages wp
+SET
+  origin_space_id = COALESCE(wp.origin_space_id, valid.origin_space_id),
+  origin_message_id = COALESCE(wp.origin_message_id, valid.origin_message_id),
+  origin_user_id = COALESCE(wp.origin_user_id, valid.origin_user_id),
+  created_via = COALESCE(wp.created_via, valid.created_via)
+FROM valid
+WHERE valid.id = wp.id;
+
+UPDATE wiki_citations wc
+SET org_id = wp.org_id
+FROM wiki_pages wp
+WHERE wc.page_id = wp.id
+  AND wc.org_id IS NULL;
+
+UPDATE wiki_citations wc
+SET
+  source_space_id = COALESCE(wc.source_space_id, msg.space_id),
+  source_user_id = COALESCE(wc.source_user_id, msg.user_id)
+FROM messages msg
+WHERE wc.source_type = 'message'
+  AND wc.source_id = msg.id;
+
+CREATE INDEX IF NOT EXISTS "wiki_pages_org_origin_space" ON "wiki_pages" ("org_id", "origin_space_id");
+CREATE INDEX IF NOT EXISTS "wiki_pages_org_scope_space" ON "wiki_pages" ("org_id", "scope", "space_id");
+CREATE INDEX IF NOT EXISTS "wiki_pages_org_created_via" ON "wiki_pages" ("org_id", "created_via");
+CREATE INDEX IF NOT EXISTS "wiki_citations_org_source_space" ON "wiki_citations" ("org_id", "source_space_id");
+CREATE INDEX IF NOT EXISTS "wiki_citations_source" ON "wiki_citations" ("source_type", "source_id");

--- a/packages/db/scripts/apply-extras.ts
+++ b/packages/db/scripts/apply-extras.ts
@@ -15,6 +15,7 @@ const databaseUrl = resolveDatabaseUrl();
 const files = [
   '0020_wiki_search_vector.sql',
   '0033_tasks_embedding.sql',
+  '0074_wiki_provenance_graph_scope.sql',
 ];
 
 async function main() {

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1298,6 +1298,10 @@ export const wikiPages = pgTable('wiki_pages', {
   ...orgId(),
   scope: wikiPageScopeEnum('scope').default('org').notNull(),
   space_id: text('space_id').references(() => spaces.id),
+  origin_space_id: text('origin_space_id').references(() => spaces.id, { onDelete: 'set null' }),
+  origin_message_id: text('origin_message_id').references(() => messages.id, { onDelete: 'set null' }),
+  origin_user_id: text('origin_user_id').references(() => users.id, { onDelete: 'set null' }),
+  created_via: text('created_via'),
   user_id: text('user_id').references(() => users.id),
   agent_employee_id: text('agent_employee_id'),
   type: wikiPageTypeEnum('type').notNull(),
@@ -1318,6 +1322,9 @@ export const wikiPages = pgTable('wiki_pages', {
   uniqueIndex('wiki_pages_org_slug').on(t.org_id, t.slug),
   index('wiki_pages_org_type').on(t.org_id, t.type),
   index('wiki_pages_org_scope').on(t.org_id, t.scope),
+  index('wiki_pages_org_origin_space').on(t.org_id, t.origin_space_id),
+  index('wiki_pages_org_scope_space').on(t.org_id, t.scope, t.space_id),
+  index('wiki_pages_org_created_via').on(t.org_id, t.created_via),
   index('wiki_pages_tags_gin').on(t.tags),
   index('wiki_pages_ref_users_gin').on(t.referenced_user_ids),
 ]);
@@ -1337,13 +1344,18 @@ export const wikiLinks = pgTable('wiki_links', {
 
 export const wikiCitations = pgTable('wiki_citations', {
   ...id(),
+  org_id: text('org_id').references(() => orgs.id, { onDelete: 'cascade' }),
   page_id: text('page_id').notNull().references(() => wikiPages.id, { onDelete: 'cascade' }),
   source_type: text('source_type').notNull(),
   source_id: text('source_id').notNull(),
+  source_space_id: text('source_space_id').references(() => spaces.id, { onDelete: 'set null' }),
+  source_user_id: text('source_user_id').references(() => users.id, { onDelete: 'set null' }),
   excerpt: text('excerpt'),
   created_at: timestamp('created_at').defaultNow().notNull(),
 }, (t) => [
   index('wiki_citations_page').on(t.page_id),
+  index('wiki_citations_org_source_space').on(t.org_id, t.source_space_id),
+  index('wiki_citations_source').on(t.source_type, t.source_id),
 ]);
 
 export const wikiOpsLog = pgTable('wiki_ops_log', {


### PR DESCRIPTION
## Summary
- add channel-aware knowledge provenance so wiki pages and citations remember source space/message/user without changing access scope
- add channel-scoped `memory_recall`, `wiki_search`, and `platform_context` behavior for MCP agents, including channel/company/employee context packets
- add Knowledge graph company/channel modes and memory route badges so humans can inspect org-wide vs channel-local knowledge
- harden memory extraction provenance fallback and keep `db:push-full` applying the safe 0074 metadata backfill on fresh/self-host installs

## Validation
- `pnpm --filter @deft/db exec tsx scripts/apply-extras.ts`
- `git diff --check`
- `pnpm --filter @deft/api exec tsc --noEmit`
- `pnpm --filter @deft/web exec tsc --noEmit`
- focused API certification: `pnpm exec tsx --test --test-concurrency=1 --test-force-exit test/mcp-memory-recall.test.ts test/mcp-platform-context.test.ts test/mcp-tool-aliases.test.ts test/mcp-server.test.ts test/retrieve-context.test.ts test/agent-approval-resolver.test.ts test/wiki-graph-scope.test.ts test/memory-extract-embed-enqueue.test.ts test/memory-extract-no-agent-memory.test.ts` (62/62 passing)
- live local REST workflow: Diego created a chat message, converted it into source-linked space knowledge, and `/api/wiki/graph?mode=space` returned the new node with provenance
- Playwright browser smoke: `/knowledge` graph mode, channel mode, and graph labels rendered without console errors

## Notes
The broader `apps/api` test suite still has unrelated local fixture/env failures in this checkout (missing seeded users/hardcoded org IDs/FK cleanup assumptions). The relevant memory extraction and context-router clusters are covered by the focused certification above.