### PR TITLE
[codex] Build self-host tool images before init

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,14 +46,16 @@ Open `.env` and set the three required values. AI keys are optional and can be a
 | `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `OPENROUTER_API_KEY`, or `OLLAMA_URL` | Optional | Configure one provider for AI features; can also be set per-org in Settings -> AI |
 
 ```bash
-# 2. Build and start the stack (Postgres + Redis + Deft)
-docker compose up -d --build
+# 2. Build app + tool images, then start the stack
+docker compose build deft init doctor smoke
+docker compose up -d
 
 # 3. Initialize the database from inside Docker (run once on first boot)
 docker compose run --rm init
 
 # Optional: verify the self-host stack
 docker compose run --rm doctor
+docker compose run --rm smoke
 ```
 
 > **Note:** Use `pnpm db:push-full`, not `pnpm db:migrate`. `push-full` is the supported path for fresh installs — it diffs the live schema against `packages/db/src/schema.ts`, then applies supplemental SQL files for generated search columns, GIN/vector indexes, and safe metadata backfills that Drizzle's pushed schema can't fully express. Plain `pnpm db:push` skips those extras and leaves search/backfill behavior incomplete. Versioned `db:migrate` upgrade paths are not yet supported and will arrive post-alpha.

--- a/docs/self-hosting-vps-domain-https.md
+++ b/docs/self-hosting-vps-domain-https.md
@@ -108,7 +108,8 @@ pnpm selfhost:bootstrap --prod
 If you do not have host-side Node.js/pnpm, run the Docker-only sequence:
 
 ```bash
-docker compose -f docker-compose.yml -f compose.prod.yml up -d --build
+docker compose -f docker-compose.yml -f compose.prod.yml build deft init doctor smoke
+docker compose -f docker-compose.yml -f compose.prod.yml up -d
 docker compose -f docker-compose.yml -f compose.prod.yml run --rm init
 docker compose -f docker-compose.yml -f compose.prod.yml run --rm doctor
 docker compose -f docker-compose.yml -f compose.prod.yml run --rm smoke
@@ -217,7 +218,8 @@ Before upgrades, take a Postgres backup. Then:
 
 ```bash
 git pull
-docker compose -f docker-compose.yml -f compose.prod.yml up -d --build
+docker compose -f docker-compose.yml -f compose.prod.yml build deft init doctor smoke
+docker compose -f docker-compose.yml -f compose.prod.yml up -d
 docker compose -f docker-compose.yml -f compose.prod.yml run --rm init
 docker compose -f docker-compose.yml -f compose.prod.yml run --rm doctor
 docker compose -f docker-compose.yml -f compose.prod.yml run --rm smoke

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -97,11 +97,14 @@ call the wrong API URL. Fix the `NEXT_PUBLIC_*` values and rebuild.
 ### 2. Start the stack
 
 ```bash
-docker compose up -d --build
+docker compose build deft init doctor smoke
+docker compose up -d
 ```
 
-This builds Deft and starts Postgres with pgvector plus Redis. The first build
-can take a few minutes.
+This builds the app and one-shot tool images, then starts Postgres with pgvector
+plus Redis. The first build can take a few minutes. Building `init`, `doctor`,
+and `smoke` alongside `deft` matters on updates because those services run
+schema and verification code from the image.
 
 ### 3. Initialise the database
 
@@ -209,7 +212,8 @@ For production, use the overlay that does not publish Postgres or Redis to host
 ports:
 
 ```bash
-docker compose -f docker-compose.yml -f compose.prod.yml up -d --build
+docker compose -f docker-compose.yml -f compose.prod.yml build deft init doctor smoke
+docker compose -f docker-compose.yml -f compose.prod.yml up -d
 docker compose -f docker-compose.yml -f compose.prod.yml run --rm init
 docker compose -f docker-compose.yml -f compose.prod.yml run --rm doctor
 docker compose -f docker-compose.yml -f compose.prod.yml run --rm smoke
@@ -375,7 +379,8 @@ Deft is alpha and does not yet publish stable tagged releases. To roll forward:
 
 ```bash
 git pull
-docker compose up -d --build
+docker compose build deft init doctor smoke
+docker compose up -d
 docker compose run --rm init
 docker compose run --rm doctor
 ```

--- a/scripts/selfhost-bootstrap.ts
+++ b/scripts/selfhost-bootstrap.ts
@@ -110,7 +110,10 @@ async function main() {
   }
 
   const compose = ['compose', ...composeFiles];
-  await run('docker', [...compose, 'up', '-d', ...(skipBuild ? [] : ['--build'])]);
+  if (!skipBuild) {
+    await run('docker', [...compose, 'build', 'deft', 'init', 'doctor', 'smoke']);
+  }
+  await run('docker', [...compose, 'up', '-d']);
   if (seedPilotDemo) {
     await run('docker', [...compose, 'run', '--rm', 'init', 'sh', '-c', 'pnpm db:push-full && pnpm db:seed:pilot']);
   } else {


### PR DESCRIPTION
﻿## What changed

- Build the `deft`, `init`, `doctor`, and `smoke` Docker images explicitly before starting a self-host stack.
- Update the README and self-hosting docs so Docker-only installs and upgrades use the same safer sequence.

## Why

During the public demo sync, the app image was rebuilt but the one-shot `init` image stayed stale. That meant database schema extras such as the wiki provenance/scope migration were not applied, causing knowledge/wiki endpoints and MCP context packets to miss expected data until the migration was applied manually.

Building the tool images alongside the app keeps init/doctor/smoke aligned with the checked-out code before database initialization or verification runs.

## Validation

- `pnpm exec tsx scripts/selfhost-bootstrap.ts --check-only`
- `pnpm exec tsx scripts/selfhost-bootstrap.ts --prod --check-only`
- `git diff --check`
- Public demo repair and certification: `reports/public-demo-context-packet-sync-2026-06-29.html`
- Public demo MCP dogfood: context packets present, channel memory recall works, idempotent task write flow works, receipts visible in activity
- Public demo browser smoke: dashboard, chat, tasks, knowledge, inbox, and MCP access loaded without console errors
