### PR TITLE
[codex] Polish MCP access receipts and history

### DIFF
--- a/apps/api/src/lib/oauth-audit-receipts.ts
+++ b/apps/api/src/lib/oauth-audit-receipts.ts
@@ -1,0 +1,256 @@
+import { and, eq, inArray } from 'drizzle-orm';
+import { projects, spaces, tasks } from '@deft/db/schema';
+import { db } from './db.js';
+
+export type AuditReceipt = {
+  title: string;
+  detail: string;
+  href?: string;
+  target_kind?: 'task' | 'message' | 'wiki' | 'token' | 'app' | 'tool';
+  target_id?: string;
+  preview?: string;
+};
+
+export type AuditActionRow = {
+  id: string;
+  event: string;
+  metadata: Record<string, unknown> | null;
+  created_at: Date;
+};
+
+export type EnrichedAuditAction<T extends AuditActionRow = AuditActionRow> = T & {
+  receipt: AuditReceipt;
+};
+
+type ToolResultRecord = Record<string, unknown>;
+
+const TASK_WRITE_TOOLS = new Set(['task_create', 'task_update', 'task_transition', 'comment_on_task']);
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : null;
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+function asNumber(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function cleanPreview(value: unknown, max = 110): string | null {
+  const raw = asString(value);
+  if (!raw) return null;
+  const compact = raw.replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim();
+  if (!compact) return null;
+  return compact.length > max ? `${compact.slice(0, max - 1)}...` : compact;
+}
+
+function parseToolResult(action: AuditActionRow): ToolResultRecord | null {
+  const metadata = action.metadata ?? {};
+  const result = asRecord(metadata.result);
+  if (!result) return null;
+  const content = Array.isArray(result.content) ? result.content : [];
+  const first = asRecord(content[0]);
+  const text = typeof first?.text === 'string' ? first.text : null;
+  if (!text) return null;
+  try {
+    const parsed = JSON.parse(text);
+    return asRecord(parsed);
+  } catch {
+    return null;
+  }
+}
+
+function toolName(action: AuditActionRow): string | null {
+  return asString(action.metadata?.tool_name);
+}
+
+function taskKey(prefix: string | null | undefined, number: number | null | undefined): string | null {
+  if (!prefix || !number) return null;
+  return `${prefix}-${number}`;
+}
+
+function fallbackTitle(action: AuditActionRow): string {
+  const tool = toolName(action);
+  if (action.event === 'token_issued') return 'Token created';
+  if (action.event === 'token_revoked') return 'Token revoked';
+  if (action.event === 'grant_revoked') return 'App connection revoked';
+  if (action.event === 'mcp_tool_call') return tool ? `Called ${tool}` : 'Tool call';
+  if (action.event === 'mcp_idempotency_result') {
+    if (tool === 'task_create') return 'Created task';
+    if (tool === 'task_transition') return 'Changed task status';
+    if (tool === 'task_update') return 'Updated task';
+    if (tool === 'comment_on_task') return 'Commented on task';
+    if (tool === 'message_post') return 'Posted message';
+    if (tool === 'memory_write') return 'Saved memory';
+    return tool ? `${tool} completed` : 'Write completed';
+  }
+  return action.event.replaceAll('_', ' ');
+}
+
+function defaultReceipt(action: AuditActionRow): AuditReceipt {
+  const metadata = action.metadata ?? {};
+  if (action.event === 'token_issued') {
+    const scopes = Array.isArray(metadata.scopes) ? metadata.scopes.length : null;
+    const name = asString(metadata.token_name);
+    return {
+      title: 'Token created',
+      detail: [name, scopes ? `${scopes} scopes granted` : null].filter(Boolean).join(' / ') || 'ready to use',
+      target_kind: 'token',
+      target_id: asString(metadata.token_id) ?? undefined,
+    };
+  }
+  if (action.event === 'token_revoked') {
+    return {
+      title: 'Token revoked',
+      detail: 'access removed',
+      target_kind: 'token',
+      target_id: asString(metadata.token_id) ?? undefined,
+    };
+  }
+  if (action.event === 'grant_revoked') {
+    return {
+      title: 'App connection revoked',
+      detail: 'access removed',
+      target_kind: 'app',
+      target_id: asString(metadata.grant_id) ?? undefined,
+    };
+  }
+  if (action.event === 'mcp_tool_call') {
+    const tool = toolName(action);
+    const ok = typeof metadata.success === 'boolean' ? (metadata.success ? 'ok' : 'failed') : null;
+    return {
+      title: tool ? `Called ${tool}` : 'Tool call',
+      detail: ok ?? 'recorded',
+      target_kind: 'tool',
+    };
+  }
+  return {
+    title: fallbackTitle(action),
+    detail: 'recorded',
+    target_kind: 'tool',
+  };
+}
+
+export async function enrichOAuthAuditActions<T extends AuditActionRow>(
+  orgId: string,
+  actions: T[],
+): Promise<Array<EnrichedAuditAction<T>>> {
+  if (actions.length === 0) return [];
+
+  const parsedResults = new Map<string, ToolResultRecord | null>();
+  const taskIds = new Set<string>();
+  const spaceIds = new Set<string>();
+
+  for (const action of actions) {
+    const result = parseToolResult(action);
+    parsedResults.set(action.id, result);
+    const tool = toolName(action);
+    if (!result || action.event !== 'mcp_idempotency_result') continue;
+
+    if (tool && TASK_WRITE_TOOLS.has(tool)) {
+      const id = tool === 'comment_on_task'
+        ? asString(result.task_id)
+        : asString(result.id) ?? asString(result.task_id);
+      if (id) taskIds.add(id);
+    }
+    if (tool === 'message_post') {
+      const spaceId = asString(result.space_id);
+      if (spaceId) spaceIds.add(spaceId);
+    }
+  }
+
+  const taskMap = new Map<string, {
+    id: string;
+    number: number | null;
+    title: string;
+    status: string;
+    project_prefix: string | null;
+  }>();
+
+  if (taskIds.size > 0) {
+    const taskRows = await db
+      .select({
+        id: tasks.id,
+        number: tasks.number,
+        title: tasks.title,
+        status: tasks.status,
+        project_prefix: projects.prefix,
+      })
+      .from(tasks)
+      .innerJoin(projects, eq(tasks.project_id, projects.id))
+      .where(and(eq(tasks.org_id, orgId), inArray(tasks.id, [...taskIds])));
+    for (const task of taskRows) taskMap.set(task.id, task);
+  }
+
+  const spaceMap = new Map<string, string>();
+  if (spaceIds.size > 0) {
+    const spaceRows = await db
+      .select({ id: spaces.id, name: spaces.name })
+      .from(spaces)
+      .where(and(eq(spaces.org_id, orgId), inArray(spaces.id, [...spaceIds])));
+    for (const space of spaceRows) spaceMap.set(space.id, space.name);
+  }
+
+  return actions.map((action) => {
+    const result = parsedResults.get(action.id);
+    const metadata = action.metadata ?? {};
+    const tool = toolName(action);
+    let receipt = defaultReceipt(action);
+
+    if (action.event === 'mcp_idempotency_result' && result && tool) {
+      if (TASK_WRITE_TOOLS.has(tool)) {
+        const taskId = tool === 'comment_on_task'
+          ? asString(result.task_id)
+          : asString(result.id) ?? asString(result.task_id);
+        const task = taskId ? taskMap.get(taskId) : undefined;
+        const key = asString(result.task_key)
+          ?? taskKey(task?.project_prefix, task?.number)
+          ?? taskKey(null, asNumber(result.number))
+          ?? 'task';
+        const title = task?.title ?? asString(result.title) ?? 'Untitled task';
+        const transition = asRecord(result.transition);
+        const from = asString(transition?.from);
+        const to = asString(transition?.to) ?? task?.status ?? asString(result.status);
+
+        receipt = {
+          title: fallbackTitle(action),
+          detail: tool === 'task_transition'
+            ? `${key}: ${from ?? 'previous'} -> ${to ?? 'updated'}`
+            : `${key}: ${title}`,
+          href: taskId ? `/tasks?task=${encodeURIComponent(taskId)}` : undefined,
+          target_kind: 'task',
+          target_id: taskId ?? undefined,
+          preview: title,
+        };
+      } else if (tool === 'message_post') {
+        const messageId = asString(result.id);
+        const spaceId = asString(result.space_id);
+        const spaceName = spaceId ? spaceMap.get(spaceId) : null;
+        const preview = cleanPreview(result.content);
+        receipt = {
+          title: 'Posted message',
+          detail: `${spaceName ? `#${spaceName}` : 'space'}${preview ? `: ${preview}` : ''}`,
+          href: messageId && spaceId ? `/chat?space=${encodeURIComponent(spaceId)}&message=${encodeURIComponent(messageId)}` : undefined,
+          target_kind: 'message',
+          target_id: messageId ?? undefined,
+          preview: preview ?? undefined,
+        };
+      } else if (tool === 'memory_write') {
+        const title = asString(result.title) ?? asString(metadata.title) ?? 'memory';
+        const slug = asString(result.slug);
+        receipt = {
+          title: 'Saved memory',
+          detail: title,
+          href: slug ? `/knowledge?slug=${encodeURIComponent(slug)}` : undefined,
+          target_kind: 'wiki',
+          target_id: asString(result.id) ?? slug ?? undefined,
+          preview: cleanPreview(result.summary ?? result.content) ?? undefined,
+        };
+      }
+    }
+
+    return { ...action, receipt };
+  });
+}

--- a/apps/api/src/lib/oauth-mcp.ts
+++ b/apps/api/src/lib/oauth-mcp.ts
@@ -240,7 +240,7 @@ export async function issueTokensForGrant(
     rotated_from: rotatedFromRefreshTokenId,
     expires_at: refreshExpiresAt,
   });
-  await auditOAuth({ orgId, userId, clientId, event: 'token_issued', metadata: { scopes, resource } });
+  await auditOAuth({ orgId, userId, clientId, event: 'token_issued', metadata: { grant_id: grantId, scopes, resource } });
   return {
     access_token: accessToken,
     token_type: 'Bearer',

--- a/apps/api/src/routes/mcp-access.ts
+++ b/apps/api/src/routes/mcp-access.ts
@@ -1,9 +1,10 @@
 import { Hono } from 'hono';
 import { z } from 'zod';
-import { and, desc, eq, isNull } from 'drizzle-orm';
+import { and, desc, eq, isNotNull, isNull, sql } from 'drizzle-orm';
 import { db } from '../lib/db.js';
-import { mcpTokens, oauthAuditEvents } from '@deft/db/schema';
+import { mcpTokens, oauthAccessTokens, oauthAuditEvents, oauthGrants } from '@deft/db/schema';
 import { issuePersonalMcpToken } from '../lib/mcp-token.js';
+import { enrichOAuthAuditActions } from '../lib/oauth-audit-receipts.js';
 
 export const mcpAccessRoutes = new Hono();
 
@@ -28,6 +29,45 @@ function endpointUrl(): string {
   return `${base.replace(/\/$/, '')}/api/mcp/v1`;
 }
 
+async function recentActionsForPersonalToken(orgId: string, userId: string, tokenId: string, limit = 8) {
+  const actions = await db
+    .select({
+      id: oauthAuditEvents.id,
+      event: oauthAuditEvents.event,
+      metadata: oauthAuditEvents.metadata,
+      created_at: oauthAuditEvents.created_at,
+    })
+    .from(oauthAuditEvents)
+    .where(and(
+      eq(oauthAuditEvents.org_id, orgId),
+      eq(oauthAuditEvents.user_id, userId),
+      eq(oauthAuditEvents.client_id, `personal-token:${tokenId}`),
+    ))
+    .orderBy(desc(oauthAuditEvents.created_at))
+    .limit(limit);
+  return enrichOAuthAuditActions(orgId, actions);
+}
+
+async function recentActionsForGrant(orgId: string, userId: string, clientId: string, grantId: string, limit = 8) {
+  const actions = await db
+    .select({
+      id: oauthAuditEvents.id,
+      event: oauthAuditEvents.event,
+      metadata: oauthAuditEvents.metadata,
+      created_at: oauthAuditEvents.created_at,
+    })
+    .from(oauthAuditEvents)
+    .where(and(
+      eq(oauthAuditEvents.org_id, orgId),
+      eq(oauthAuditEvents.user_id, userId),
+      eq(oauthAuditEvents.client_id, clientId),
+      sql`${oauthAuditEvents.metadata}->>'grant_id' = ${grantId}`,
+    ))
+    .orderBy(desc(oauthAuditEvents.created_at))
+    .limit(limit);
+  return enrichOAuthAuditActions(orgId, actions);
+}
+
 mcpAccessRoutes.get('/tokens', async (c) => {
   const user = c.get('user');
   const rows = await db
@@ -49,25 +89,76 @@ mcpAccessRoutes.get('/tokens', async (c) => {
     .orderBy(desc(mcpTokens.created_at));
 
   const tokens = await Promise.all(rows.map(async (token) => {
-    const recentActions = await db
-      .select({
-        id: oauthAuditEvents.id,
-        event: oauthAuditEvents.event,
-        metadata: oauthAuditEvents.metadata,
-        created_at: oauthAuditEvents.created_at,
-      })
-      .from(oauthAuditEvents)
-      .where(and(
-        eq(oauthAuditEvents.org_id, user.org_id),
-        eq(oauthAuditEvents.user_id, user.id),
-        eq(oauthAuditEvents.client_id, `personal-token:${token.id}`),
-      ))
-      .orderBy(desc(oauthAuditEvents.created_at))
-      .limit(8);
+    const recentActions = await recentActionsForPersonalToken(user.org_id, user.id, token.id);
     return { ...token, recent_actions: recentActions };
   }));
 
   return c.json({ tokens, mcp_endpoint_url: endpointUrl(), allowed_scopes: ALLOWED_SCOPES });
+});
+
+mcpAccessRoutes.get('/history', async (c) => {
+  const user = c.get('user');
+  const [tokenRows, grantRows] = await Promise.all([
+    db
+      .select({
+        id: mcpTokens.id,
+        name: mcpTokens.name,
+        token_prefix: mcpTokens.token_prefix,
+        scopes: mcpTokens.scopes,
+        last_used_at: mcpTokens.last_used_at,
+        created_at: mcpTokens.created_at,
+        revoked_at: mcpTokens.revoked_at,
+      })
+      .from(mcpTokens)
+      .where(and(
+        eq(mcpTokens.org_id, user.org_id),
+        eq(mcpTokens.user_id, user.id),
+        eq(mcpTokens.principal_kind, 'human'),
+        isNotNull(mcpTokens.revoked_at),
+      ))
+      .orderBy(desc(mcpTokens.revoked_at))
+      .limit(20),
+    db
+      .select({
+        id: oauthGrants.id,
+        client_id: oauthGrants.client_id,
+        app_name: oauthGrants.app_name,
+        connector_profile: oauthGrants.connector_profile,
+        scopes: oauthGrants.scopes,
+        created_at: oauthGrants.created_at,
+        updated_at: oauthGrants.updated_at,
+        revoked_at: oauthGrants.revoked_at,
+      })
+      .from(oauthGrants)
+      .where(and(
+        eq(oauthGrants.org_id, user.org_id),
+        eq(oauthGrants.user_id, user.id),
+        isNotNull(oauthGrants.revoked_at),
+      ))
+      .orderBy(desc(oauthGrants.revoked_at))
+      .limit(20),
+  ]);
+
+  const revokedTokens = await Promise.all(tokenRows.map(async (token) => ({
+    ...token,
+    recent_actions: await recentActionsForPersonalToken(user.org_id, user.id, token.id, 10),
+  })));
+
+  const revokedGrants = await Promise.all(grantRows.map(async (grant) => {
+    const [lastUsed] = await db
+      .select({ last_used_at: oauthAccessTokens.last_used_at })
+      .from(oauthAccessTokens)
+      .where(and(eq(oauthAccessTokens.grant_id, grant.id), isNotNull(oauthAccessTokens.last_used_at)))
+      .orderBy(desc(oauthAccessTokens.last_used_at))
+      .limit(1);
+    return {
+      ...grant,
+      last_used_at: lastUsed?.last_used_at ?? null,
+      recent_actions: await recentActionsForGrant(user.org_id, user.id, grant.client_id, grant.id, 10),
+    };
+  }));
+
+  return c.json({ revoked_tokens: revokedTokens, revoked_grants: revokedGrants });
 });
 
 mcpAccessRoutes.post('/tokens', async (c) => {

--- a/apps/api/src/routes/oauth-mcp.ts
+++ b/apps/api/src/routes/oauth-mcp.ts
@@ -19,6 +19,7 @@ import {
   validateAuthorizeRequest,
 } from '../lib/oauth-mcp.js';
 import { isHttpsPublicUrl } from '../lib/public-url.js';
+import { enrichOAuthAuditActions } from '../lib/oauth-audit-receipts.js';
 
 export const oauthWellKnownRoutes = new Hono();
 export const oauthPublicRoutes = new Hono();
@@ -299,14 +300,15 @@ oauthProtectedRoutes.get('/grants', async (c) => {
         eq(oauthAuditEvents.org_id, user.org_id),
         eq(oauthAuditEvents.user_id, user.id),
         eq(oauthAuditEvents.client_id, grant.client_id),
-        sql`(${oauthAuditEvents.metadata}->>'grant_id' = ${grant.id} OR ${oauthAuditEvents.metadata}->>'grant_id' IS NULL)`,
+        sql`${oauthAuditEvents.metadata}->>'grant_id' = ${grant.id}`,
       ))
       .orderBy(desc(oauthAuditEvents.created_at))
       .limit(8);
+    const enrichedActions = await enrichOAuthAuditActions(user.org_id, recentActions);
     return {
       ...grant,
       last_used_at: lastUsed?.last_used_at ?? null,
-      recent_actions: recentActions,
+      recent_actions: enrichedActions,
     };
   }));
   return c.json({ grants: rows });

--- a/apps/api/test/mcp-access-history.test.ts
+++ b/apps/api/test/mcp-access-history.test.ts
@@ -1,0 +1,282 @@
+import { randomUUID } from 'node:crypto';
+import { resolve } from 'node:path';
+import { test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import pg from 'pg';
+import { Hono } from 'hono';
+import dotenv from 'dotenv';
+import { mcpAccessRoutes } from '../src/routes/mcp-access.js';
+
+dotenv.config({ path: resolve(process.cwd(), '.env'), quiet: true });
+dotenv.config({ path: resolve(process.cwd(), '..', '..', '.env'), quiet: true });
+
+const DATABASE_URL =
+  process.env.DATABASE_URL || 'postgres://postgres:postgres@localhost:5432/deft';
+
+const TEST_ID = randomUUID();
+const ORG_ID = `mcp-access-history-org-${TEST_ID}`;
+const USER_ID = `mcp-access-history-user-${TEST_ID}`;
+const ORG_SLUG = `mcp-access-history-${TEST_ID.slice(0, 8)}`;
+const PROJECT_ID = `mcp-access-history-project-${TEST_ID}`;
+const TASK_ID = `mcp-access-history-task-${TEST_ID}`;
+const SPACE_ID = `mcp-access-history-space-${TEST_ID}`;
+const MESSAGE_ID = `mcp-access-history-message-${TEST_ID}`;
+const ACTIVE_TOKEN_ID = `mcp-access-history-active-token-${TEST_ID}`;
+const REVOKED_TOKEN_ID = `mcp-access-history-revoked-token-${TEST_ID}`;
+const GRANT_ID = `mcp-access-history-grant-${TEST_ID}`;
+const CLIENT_ID = `mcp-access-history-client-${TEST_ID}`;
+
+let testApp: Hono;
+
+async function withClient<T>(fn: (client: pg.Client) => Promise<T>): Promise<T> {
+  const client = new pg.Client({ connectionString: DATABASE_URL });
+  await client.connect();
+  try {
+    return await fn(client);
+  } finally {
+    await client.end();
+  }
+}
+
+function toolResult(content: Record<string, unknown>) {
+  return {
+    content: [{ type: 'text', text: JSON.stringify(content) }],
+  };
+}
+
+async function cleanup() {
+  await withClient(async (client) => {
+    await client.query(`DELETE FROM oauth_audit_events WHERE org_id = $1`, [ORG_ID]);
+    await client.query(`DELETE FROM oauth_access_tokens WHERE org_id = $1`, [ORG_ID]);
+    await client.query(`DELETE FROM oauth_grants WHERE org_id = $1`, [ORG_ID]);
+    await client.query(`DELETE FROM mcp_tokens WHERE org_id = $1`, [ORG_ID]);
+    await client.query(`DELETE FROM messages WHERE org_id = $1`, [ORG_ID]);
+    await client.query(`DELETE FROM space_members WHERE space_id = $1`, [SPACE_ID]);
+    await client.query(`DELETE FROM spaces WHERE org_id = $1`, [ORG_ID]);
+    await client.query(`DELETE FROM task_activity WHERE org_id = $1`, [ORG_ID]);
+    await client.query(`DELETE FROM tasks WHERE org_id = $1`, [ORG_ID]);
+    await client.query(`DELETE FROM projects WHERE org_id = $1`, [ORG_ID]);
+    await client.query(`DELETE FROM org_members WHERE org_id = $1`, [ORG_ID]);
+    await client.query(`DELETE FROM users WHERE id = $1`, [USER_ID]);
+    await client.query(`DELETE FROM orgs WHERE id = $1`, [ORG_ID]);
+  });
+}
+
+async function seedWorkspace() {
+  await withClient(async (client) => {
+    await client.query(
+      `INSERT INTO orgs (id, name, slug)
+       VALUES ($1, 'MCP Access History Test Org', $2)`,
+      [ORG_ID, ORG_SLUG],
+    );
+    await client.query(
+      `INSERT INTO users (id, email, name, email_verified)
+       VALUES ($1, $2, 'MCP Access History User', true)`,
+      [USER_ID, `mcp-access-history-${TEST_ID}@test.local`],
+    );
+    await client.query(
+      `INSERT INTO org_members (id, org_id, user_id, role, is_active)
+       VALUES ($1, $2, $3, 'owner', true)`,
+      [`mcp-access-history-member-${TEST_ID}`, ORG_ID, USER_ID],
+    );
+    await client.query(
+      `INSERT INTO projects (id, org_id, name, prefix, lead_id, task_counter)
+       VALUES ($1, $2, 'Launch Proof Project', 'MKT', $3, 7)`,
+      [PROJECT_ID, ORG_ID, USER_ID],
+    );
+    await client.query(
+      `INSERT INTO tasks
+        (id, org_id, project_id, number, title, status, priority, assignee_id, created_by, is_deleted)
+       VALUES
+        ($1, $2, $3, 7, 'Receipt polish launch blocker', 'done', 'p1', $4, $4, false)`,
+      [TASK_ID, ORG_ID, PROJECT_ID, USER_ID],
+    );
+    await client.query(
+      `INSERT INTO spaces (id, org_id, name, type, created_by)
+       VALUES ($1, $2, 'launch', 'public', $3)`,
+      [SPACE_ID, ORG_ID, USER_ID],
+    );
+    await client.query(
+      `INSERT INTO space_members (id, space_id, user_id)
+       VALUES ($1, $2, $3)`,
+      [`mcp-access-history-space-member-${TEST_ID}`, SPACE_ID, USER_ID],
+    );
+    await client.query(
+      `INSERT INTO messages (id, org_id, space_id, user_id, content)
+       VALUES ($1, $2, $3, $4, 'Receipt polish dogfood complete from MCP history test')`,
+      [MESSAGE_ID, ORG_ID, SPACE_ID, USER_ID],
+    );
+    await client.query(
+      `INSERT INTO mcp_tokens
+        (id, org_id, user_id, principal_kind, name, token_hash, token_prefix, scopes, last_used_at, created_by)
+       VALUES
+        ($1, $2, $3, 'human', 'Active MCP app', 'active-hash-$1', 'dft_active', ARRAY['read:workspace','write:tasks','write:messages'], now(), $3),
+        ($4, $2, $3, 'human', 'Revoked MCP app', 'revoked-hash-$4', 'dft_revoked', ARRAY['read:workspace','write:tasks','write:messages'], now(), $3)`,
+      [ACTIVE_TOKEN_ID, ORG_ID, USER_ID, REVOKED_TOKEN_ID],
+    );
+    await client.query(
+      `UPDATE mcp_tokens SET revoked_at = now() WHERE id = $1`,
+      [REVOKED_TOKEN_ID],
+    );
+    await client.query(
+      `INSERT INTO oauth_grants
+        (id, org_id, user_id, client_id, app_name, connector_profile, scopes, revoked_at)
+       VALUES
+        ($1, $2, $3, $4, 'Codex Test Client', 'agentic-work', ARRAY['read:workspace','write:tasks'], now())`,
+      [GRANT_ID, ORG_ID, USER_ID, CLIENT_ID],
+    );
+    await client.query(
+      `INSERT INTO oauth_access_tokens
+        (id, token_hash, grant_id, org_id, user_id, client_id, resource, scopes, expires_at, last_used_at, revoked_at)
+       VALUES
+        ($1, $2, $3, $4, $5, $6, 'http://localhost:3301/api/mcp/v1', ARRAY['read:workspace','write:tasks'], now() + interval '1 hour', now(), now())`,
+      [`mcp-access-history-access-token-${TEST_ID}`, `access-token-hash-${TEST_ID}`, GRANT_ID, ORG_ID, USER_ID, CLIENT_ID],
+    );
+
+    const activeTaskMetadata = {
+      tool_name: 'task_create',
+      result: toolResult({ id: TASK_ID, title: 'Receipt polish launch blocker' }),
+    };
+    const activeMessageMetadata = {
+      tool_name: 'message_post',
+      result: toolResult({
+        id: MESSAGE_ID,
+        space_id: SPACE_ID,
+        content: 'Receipt polish dogfood complete from MCP history test',
+      }),
+    };
+    const revokedTaskMetadata = {
+      tool_name: 'task_transition',
+      result: toolResult({
+        id: TASK_ID,
+        transition: { from: 'in_review', to: 'done' },
+      }),
+    };
+    const revokedGrantMetadata = {
+      grant_id: GRANT_ID,
+      tool_name: 'task_update',
+      result: toolResult({
+        id: TASK_ID,
+        title: 'Receipt polish launch blocker',
+      }),
+    };
+
+    await client.query(
+      `INSERT INTO oauth_audit_events (id, org_id, user_id, client_id, event, metadata, created_at)
+       VALUES
+        ($1, $2, $3, $4, 'mcp_idempotency_result', $5::jsonb, now() - interval '4 minutes'),
+        ($6, $2, $3, $4, 'mcp_idempotency_result', $7::jsonb, now() - interval '3 minutes'),
+        ($8, $2, $3, $9, 'mcp_idempotency_result', $10::jsonb, now() - interval '2 minutes'),
+        ($11, $2, $3, $9, 'token_revoked', $12::jsonb, now() - interval '1 minute'),
+        ($13, $2, $3, $14, 'mcp_idempotency_result', $15::jsonb, now() - interval '2 minutes'),
+        ($16, $2, $3, $14, 'grant_revoked', $17::jsonb, now() - interval '1 minute')`,
+      [
+        `mcp-access-history-active-task-event-${TEST_ID}`,
+        ORG_ID,
+        USER_ID,
+        `personal-token:${ACTIVE_TOKEN_ID}`,
+        JSON.stringify(activeTaskMetadata),
+        `mcp-access-history-active-message-event-${TEST_ID}`,
+        JSON.stringify(activeMessageMetadata),
+        `mcp-access-history-revoked-task-event-${TEST_ID}`,
+        `personal-token:${REVOKED_TOKEN_ID}`,
+        JSON.stringify(revokedTaskMetadata),
+        `mcp-access-history-revoked-token-event-${TEST_ID}`,
+        JSON.stringify({ token_id: REVOKED_TOKEN_ID, surface: 'mcp-access' }),
+        `mcp-access-history-revoked-grant-task-event-${TEST_ID}`,
+        CLIENT_ID,
+        JSON.stringify(revokedGrantMetadata),
+        `mcp-access-history-revoked-grant-event-${TEST_ID}`,
+        JSON.stringify({ grant_id: GRANT_ID, surface: 'oauth-mcp' }),
+      ],
+    );
+  });
+}
+
+before(async () => {
+  await cleanup();
+  await seedWorkspace();
+  testApp = new Hono();
+  testApp.use('*', async (c, next) => {
+    c.set('user', {
+      id: USER_ID,
+      org_id: ORG_ID,
+      email: `mcp-access-history-${TEST_ID}@test.local`,
+      name: 'MCP Access History User',
+    } as never);
+    await next();
+  });
+  testApp.route('/api/mcp-access', mcpAccessRoutes);
+});
+
+after(async () => {
+  await cleanup();
+});
+
+test('active personal MCP tokens include enriched task and message receipts', async () => {
+  const res = await testApp.request('/api/mcp-access/tokens');
+  assert.equal(res.status, 200);
+  const body = await res.json() as {
+    tokens: Array<{
+      id: string;
+      recent_actions: Array<{
+        event: string;
+        receipt: { title: string; detail: string; href?: string; target_kind?: string };
+      }>;
+    }>;
+  };
+
+  assert.equal(body.tokens.length, 1);
+  assert.equal(body.tokens[0]?.id, ACTIVE_TOKEN_ID);
+
+  const receipts = body.tokens[0]?.recent_actions.map((action) => action.receipt) ?? [];
+  const taskReceipt = receipts.find((receipt) => receipt.title === 'Created task');
+  assert.ok(taskReceipt);
+  assert.equal(taskReceipt.target_kind, 'task');
+  assert.match(taskReceipt.detail, /MKT-7: Receipt polish launch blocker/);
+  assert.equal(taskReceipt.href, `/tasks?task=${encodeURIComponent(TASK_ID)}`);
+
+  const messageReceipt = receipts.find((receipt) => receipt.title === 'Posted message');
+  assert.ok(messageReceipt);
+  assert.equal(messageReceipt.target_kind, 'message');
+  assert.match(messageReceipt.detail, /#launch: Receipt polish dogfood complete/);
+  assert.equal(
+    messageReceipt.href,
+    `/chat?space=${encodeURIComponent(SPACE_ID)}&message=${encodeURIComponent(MESSAGE_ID)}`,
+  );
+});
+
+test('history endpoint returns revoked token and OAuth grant receipts with enriched targets', async () => {
+  const res = await testApp.request('/api/mcp-access/history');
+  assert.equal(res.status, 200);
+  const body = await res.json() as {
+    revoked_tokens: Array<{
+      id: string;
+      recent_actions: Array<{ event: string; receipt: { title: string; detail: string; href?: string } }>;
+    }>;
+    revoked_grants: Array<{
+      id: string;
+      last_used_at: string | null;
+      recent_actions: Array<{ event: string; receipt: { title: string; detail: string; href?: string } }>;
+    }>;
+  };
+
+  assert.equal(body.revoked_tokens.length, 1);
+  assert.equal(body.revoked_tokens[0]?.id, REVOKED_TOKEN_ID);
+  const revokedTokenReceipts = body.revoked_tokens[0]?.recent_actions.map((action) => action.receipt) ?? [];
+  assert.ok(revokedTokenReceipts.find((receipt) => receipt.title === 'Token revoked'));
+  const transitionReceipt = revokedTokenReceipts.find((receipt) => receipt.title === 'Changed task status');
+  assert.ok(transitionReceipt);
+  assert.match(transitionReceipt.detail, /MKT-7: in_review -> done/);
+  assert.equal(transitionReceipt.href, `/tasks?task=${encodeURIComponent(TASK_ID)}`);
+
+  assert.equal(body.revoked_grants.length, 1);
+  assert.equal(body.revoked_grants[0]?.id, GRANT_ID);
+  assert.ok(body.revoked_grants[0]?.last_used_at);
+  const revokedGrantReceipts = body.revoked_grants[0]?.recent_actions.map((action) => action.receipt) ?? [];
+  assert.ok(revokedGrantReceipts.find((receipt) => receipt.title === 'App connection revoked'));
+  const grantTaskReceipt = revokedGrantReceipts.find((receipt) => receipt.title === 'Updated task');
+  assert.ok(grantTaskReceipt);
+  assert.match(grantTaskReceipt.detail, /MKT-7: Receipt polish launch blocker/);
+  assert.equal(grantTaskReceipt.href, `/tasks?task=${encodeURIComponent(TASK_ID)}`);
+});

--- a/apps/api/test/mcp-server.test.ts
+++ b/apps/api/test/mcp-server.test.ts
@@ -86,6 +86,11 @@ async function seedTestEmployee(userId: string) {
 async function teardownTestEmployee() {
   await withClient(async (c) => {
     // Delete any wiki pages created by the test employee
+    await c.query(
+      `DELETE FROM wiki_ops_log
+       WHERE page_id IN (SELECT id FROM wiki_pages WHERE agent_employee_id = $1)`,
+      [TEST_EMPLOYEE_ID]
+    );
     await c.query(`DELETE FROM wiki_pages WHERE agent_employee_id = $1`, [TEST_EMPLOYEE_ID]);
     await c.query(`DELETE FROM agent_mcp_call_audit WHERE employee_id = $1`, [TEST_EMPLOYEE_ID]);
     await c.query(`DELETE FROM agent_employees WHERE id = $1`, [TEST_EMPLOYEE_ID]);

--- a/apps/api/test/mcp-write-tools.test.ts
+++ b/apps/api/test/mcp-write-tools.test.ts
@@ -209,6 +209,15 @@ async function teardownFixtures() {
       }
     }
     await c.query(
+      `DELETE FROM wiki_ops_log
+       WHERE page_id IN (
+         SELECT id FROM wiki_pages
+         WHERE agent_employee_id IN ($1,$2,$3,$4)
+            OR user_id = $5
+       )`,
+      [EMP_CONSERVATIVE_ID, EMP_STANDARD_ID, EMP_AUTONOMOUS_ID, OTHER_EMP_ID, OTHER_HUMAN_USER_ID]
+    );
+    await c.query(
       `DELETE FROM wiki_pages WHERE agent_employee_id IN ($1,$2,$3,$4)`,
       [EMP_CONSERVATIVE_ID, EMP_STANDARD_ID, EMP_AUTONOMOUS_ID, OTHER_EMP_ID]
     );
@@ -225,6 +234,30 @@ async function teardownFixtures() {
       [[EMP_CONSERVATIVE_ID, EMP_STANDARD_ID, EMP_AUTONOMOUS_ID, OTHER_EMP_ID]]
     );
     await c.query(`DELETE FROM org_members WHERE user_id = $1`, [OTHER_HUMAN_USER_ID]);
+    const testUserIds = [TEST_USER_ID, OTHER_HUMAN_USER_ID];
+    await c.query(`DELETE FROM people_patterns WHERE user_id = ANY($1::text[])`, [testUserIds]);
+    await c.query(`DELETE FROM people_influence WHERE user_id = ANY($1::text[])`, [testUserIds]);
+    await c.query(`DELETE FROM people_expertise WHERE user_id = ANY($1::text[])`, [testUserIds]);
+    await c.query(
+      `DELETE FROM people_interactions
+       WHERE user_a_id = ANY($1::text[]) OR user_b_id = ANY($1::text[])`,
+      [testUserIds]
+    );
+    await c.query(
+      `DELETE FROM people_relationships
+       WHERE user_a_id = ANY($1::text[]) OR user_b_id = ANY($1::text[])`,
+      [testUserIds]
+    );
+    await c.query(
+      `DELETE FROM oneone_preps
+       WHERE manager_id = ANY($1::text[]) OR report_id = ANY($1::text[])`,
+      [testUserIds]
+    );
+    await c.query(
+      `DELETE FROM burnout_alerts
+       WHERE user_id = ANY($1::text[]) OR alerted_to = ANY($1::text[])`,
+      [testUserIds]
+    );
     await c.query(`DELETE FROM users WHERE id IN ($1, $2)`, [TEST_USER_ID, OTHER_HUMAN_USER_ID]);
     if (createdTestOrg) {
       await c.query(

--- a/apps/web/src/app/(app)/settings/mcp-access/page.tsx
+++ b/apps/web/src/app/(app)/settings/mcp-access/page.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
-import { Activity, Bot, Check, Copy, FileText, Globe2, KeyRound, Loader2, Plug, Trash2 } from 'lucide-react';
+import { Activity, Bot, Check, ChevronDown, ChevronRight, Copy, FileText, Globe2, History, KeyRound, Loader2, Plug, Terminal, Trash2 } from 'lucide-react';
 import { api } from '@/lib/api';
 import { PageHeader } from '@/components/page-header';
 import { TabStrip } from '@/components/tab-strip';
@@ -74,7 +74,16 @@ type RemoteReadiness = {
   authorization_server_metadata: string;
   https_ready: boolean;
   scopes: string[];
-  profile: string;
+  profiles?: string[];
+};
+
+type AuditReceipt = {
+  title: string;
+  detail: string;
+  href?: string;
+  target_kind?: string;
+  target_id?: string;
+  preview?: string;
 };
 
 type OAuthAuditAction = {
@@ -82,6 +91,7 @@ type OAuthAuditAction = {
   event: string;
   metadata: Record<string, unknown> | null;
   created_at: string;
+  receipt?: AuditReceipt;
 };
 
 type OAuthGrant = {
@@ -96,11 +106,26 @@ type OAuthGrant = {
   recent_actions: OAuthAuditAction[];
 };
 
+type RevokedMcpToken = McpToken & {
+  revoked_at: string;
+  recent_actions: OAuthAuditAction[];
+};
+
+type RevokedOAuthGrant = OAuthGrant & {
+  revoked_at: string;
+};
+
+type McpAccessHistory = {
+  revoked_tokens: RevokedMcpToken[];
+  revoked_grants: RevokedOAuthGrant[];
+};
+
 function formatDate(value: string | null | undefined) {
   return value ? new Date(value).toLocaleString() : 'never';
 }
 
 function actionTitle(action: OAuthAuditAction) {
+  if (action.receipt?.title) return action.receipt.title;
   const metadata = action.metadata ?? {};
   const toolName = typeof metadata.tool_name === 'string' ? metadata.tool_name : null;
   if (action.event === 'token_issued') return 'Token created';
@@ -135,6 +160,7 @@ function actionResult(action: OAuthAuditAction): Record<string, unknown> | null 
 }
 
 function actionDetail(action: OAuthAuditAction) {
+  if (action.receipt?.detail) return action.receipt.detail;
   const metadata = action.metadata ?? {};
   const toolName = typeof metadata.tool_name === 'string' ? metadata.tool_name : null;
   const result = actionResult(action);
@@ -164,6 +190,7 @@ function actionDetail(action: OAuthAuditAction) {
 }
 
 function actionHref(action: OAuthAuditAction) {
+  if (action.receipt?.href) return action.receipt.href;
   const toolName = typeof action.metadata?.tool_name === 'string' ? action.metadata.tool_name : null;
   const result = actionResult(action);
   if (!result) return null;
@@ -215,6 +242,8 @@ export default function McpAccessPage() {
   const [tokens, setTokens] = useState<McpToken[]>([]);
   const [remote, setRemote] = useState<RemoteReadiness | null>(null);
   const [grants, setGrants] = useState<OAuthGrant[]>([]);
+  const [history, setHistory] = useState<McpAccessHistory | null>(null);
+  const [historyOpen, setHistoryOpen] = useState(false);
   const [endpoint, setEndpoint] = useState('');
   const [loading, setLoading] = useState(true);
   const [busy, setBusy] = useState(false);
@@ -238,14 +267,22 @@ export default function McpAccessPage() {
       const body = await res.json();
       setTokens(body.tokens ?? []);
       setEndpoint(body.mcp_endpoint_url ?? '');
-      const [readinessRes, grantsRes] = await Promise.all([
+      const [readinessRes, grantsRes, historyRes] = await Promise.all([
         api.get('/api/oauth/readiness'),
         api.get('/api/oauth/grants'),
+        api.get('/api/mcp-access/history'),
       ]);
       if (readinessRes.ok) setRemote(await readinessRes.json());
       if (grantsRes.ok) {
         const grantsBody = await grantsRes.json();
         setGrants(grantsBody.grants ?? []);
+      }
+      if (historyRes.ok) {
+        const historyBody = await historyRes.json();
+        setHistory({
+          revoked_tokens: historyBody.revoked_tokens ?? [],
+          revoked_grants: historyBody.revoked_grants ?? [],
+        });
       }
     } catch (err) {
       setError((err as Error).message);
@@ -313,15 +350,44 @@ export default function McpAccessPage() {
     }
   }
 
+  const endpointForConfig = endpoint || '<deft-api-url>/api/mcp/v1';
   const tokenForConfig = newToken ?? '<paste-token-here>';
-  const clientConfig = JSON.stringify({
-    mcpServers: {
-      deft: {
-        url: endpoint || '<deft-api-url>/api/mcp/v1',
-        headers: { Authorization: `Bearer ${tokenForConfig}` },
-      },
+  const configSnippets = useMemo(() => [
+    {
+      id: 'codex',
+      title: 'Codex config',
+      detail: 'Paste into Codex MCP server config when using streamable HTTP with a personal bearer token.',
+      value: [
+        '[mcp_servers.deft]',
+        `url = "${endpointForConfig}"`,
+        `http_headers = { Authorization = "Bearer ${tokenForConfig}" }`,
+      ].join('\n'),
     },
-  }, null, 2);
+    {
+      id: 'claude-desktop',
+      title: 'Claude Desktop / Claude Code JSON',
+      detail: 'Paste into a client that accepts mcpServers JSON with HTTP headers.',
+      value: JSON.stringify({
+        mcpServers: {
+          deft: {
+            type: 'http',
+            url: endpointForConfig,
+            headers: { Authorization: `Bearer ${tokenForConfig}` },
+          },
+        },
+      }, null, 2),
+    },
+    {
+      id: 'raw',
+      title: 'Raw endpoint and header',
+      detail: 'Use this when a client asks for the MCP URL and bearer header separately.',
+      value: [
+        `MCP URL: ${endpointForConfig}`,
+        `Authorization: Bearer ${tokenForConfig}`,
+      ].join('\n'),
+    },
+  ], [endpointForConfig, tokenForConfig]);
+  const historyCount = (history?.revoked_tokens.length ?? 0) + (history?.revoked_grants.length ?? 0);
 
   return (
     <div className="flex flex-col h-full overflow-y-auto">
@@ -459,16 +525,33 @@ export default function McpAccessPage() {
         )}
 
         <section className="rounded-lg p-4" style={{ background: 'var(--surface-container-low)', border: '1px solid var(--border-default)' }}>
-          <div className="flex items-center justify-between gap-3">
-            <div>
-              <h2 className="text-[14px] font-semibold" style={{ color: 'var(--text-primary)' }}>Client config</h2>
-              <p className="text-[12px]" style={{ color: 'var(--text-secondary)' }}>Use this shape in Claude Desktop, Claude Code, ChatGPT MCP apps, or any streamable HTTP MCP client.</p>
+          <div className="flex items-start gap-3">
+            <div className="w-8 h-8 rounded-md flex items-center justify-center shrink-0" style={{ background: 'var(--accent-muted)', color: 'var(--accent)' }}>
+              <Terminal size={16} />
             </div>
-            <button type="button" onClick={() => copy('config', clientConfig)} className="inline-flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-[12px]" style={{ border: '1px solid var(--border-default)', color: 'var(--text-primary)' }}>
-              <Copy size={13} /> Copy
-            </button>
+            <div className="flex-1 min-w-0">
+              <h2 className="text-[14px] font-semibold" style={{ color: 'var(--text-primary)' }}>One-click client config</h2>
+              <p className="text-[12px] mt-1" style={{ color: 'var(--text-secondary)' }}>
+                Generate a token above, then copy the snippet that matches your AI client. Each config points at Deft's streamable HTTP MCP endpoint.
+              </p>
+              <div className="grid md:grid-cols-3 gap-3 mt-4">
+                {configSnippets.map((snippet) => (
+                  <div key={snippet.id} className="rounded-md p-3 min-w-0" style={{ background: 'var(--surface-container)', border: '1px solid var(--border-default)' }}>
+                    <div className="flex items-start justify-between gap-2">
+                      <div className="min-w-0">
+                        <div className="text-[13px] font-medium" style={{ color: 'var(--text-primary)' }}>{snippet.title}</div>
+                        <p className="text-[11px] mt-1 leading-relaxed" style={{ color: 'var(--text-secondary)' }}>{snippet.detail}</p>
+                      </div>
+                      <button type="button" onClick={() => copy(snippet.title.toLowerCase(), snippet.value)} className="p-1.5 rounded-md shrink-0" style={{ color: 'var(--text-secondary)', border: '1px solid var(--border-default)' }} aria-label={`Copy ${snippet.title}`}>
+                        <Copy size={13} />
+                      </button>
+                    </div>
+                    <pre className="mt-3 overflow-x-auto rounded-md p-3 text-[11px] max-h-52" style={{ background: 'var(--surface-container-high, var(--surface-container-low))', color: 'var(--text-primary)' }}>{snippet.value}</pre>
+                  </div>
+                ))}
+              </div>
+            </div>
           </div>
-          <pre className="mt-3 overflow-x-auto rounded-md p-3 text-[11px]" style={{ background: 'var(--surface-container)', color: 'var(--text-primary)' }}>{clientConfig}</pre>
         </section>
 
         <section className="rounded-lg p-4" style={{ background: 'var(--surface-container-low)', border: '1px solid var(--border-default)' }}>
@@ -604,6 +687,104 @@ export default function McpAccessPage() {
                   </button>
                 </div>
               ))}
+            </div>
+          )}
+        </section>
+
+        <section className="rounded-lg p-4" style={{ background: 'var(--surface-container-low)', border: '1px solid var(--border-default)' }}>
+          <button
+            type="button"
+            onClick={() => setHistoryOpen((value) => !value)}
+            className="w-full flex items-center justify-between gap-3 text-left"
+          >
+            <div className="flex items-center gap-3 min-w-0">
+              <div className="w-8 h-8 rounded-md flex items-center justify-center shrink-0" style={{ background: 'var(--accent-muted)', color: 'var(--accent)' }}>
+                <History size={16} />
+              </div>
+              <div className="min-w-0">
+                <h2 className="text-[14px] font-semibold" style={{ color: 'var(--text-primary)' }}>Connection history</h2>
+                <p className="text-[12px] mt-0.5" style={{ color: 'var(--text-secondary)' }}>
+                  Revoked personal tokens and AI app grants, with their last recorded actions.
+                </p>
+              </div>
+            </div>
+            <div className="flex items-center gap-2 shrink-0">
+              <span className="text-[11px] rounded-md px-2 py-1" style={{ color: 'var(--text-secondary)', border: '1px solid var(--border-default)' }}>
+                {historyCount} archived
+              </span>
+              {historyOpen ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
+            </div>
+          </button>
+
+          {historyOpen && (
+            <div className="mt-4 space-y-4">
+              {!history || historyCount === 0 ? (
+                <p className="text-[13px]" style={{ color: 'var(--text-secondary)' }}>No revoked connections yet.</p>
+              ) : (
+                <>
+                  {history.revoked_tokens.length > 0 && (
+                    <div>
+                      <div className="text-[11px] font-semibold uppercase tracking-[0.08em] mb-2" style={{ color: 'var(--text-tertiary)' }}>
+                        Personal tokens
+                      </div>
+                      <div className="space-y-2">
+                        {history.revoked_tokens.map((token) => (
+                          <div key={token.id} className="rounded-md p-3" style={{ background: 'var(--surface-container)', border: '1px solid var(--border-default)' }}>
+                            <div className="flex flex-wrap items-start justify-between gap-2">
+                              <div className="min-w-0">
+                                <div className="text-[13px] font-medium" style={{ color: 'var(--text-primary)' }}>{token.name}</div>
+                                <div className="text-[11px] mt-0.5" style={{ color: 'var(--text-tertiary)' }}>
+                                  {token.token_prefix}... / revoked {formatDate(token.revoked_at)} / last used {formatDate(token.last_used_at)}
+                                </div>
+                              </div>
+                              <span className="text-[10px] rounded px-1.5 py-0.5" style={{ color: 'var(--danger)', border: '1px solid color-mix(in srgb, var(--danger) 35%, transparent)' }}>
+                                revoked
+                              </span>
+                            </div>
+                            <div className="flex flex-wrap gap-1 mt-2">
+                              {token.scopes.map((scope) => (
+                                <span key={scope} className="text-[10px] rounded px-1.5 py-0.5" style={{ color: 'var(--text-secondary)', border: '1px solid var(--border-default)' }}>{scope}</span>
+                              ))}
+                            </div>
+                            <RecentActionList actions={token.recent_actions} />
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+
+                  {history.revoked_grants.length > 0 && (
+                    <div>
+                      <div className="text-[11px] font-semibold uppercase tracking-[0.08em] mb-2" style={{ color: 'var(--text-tertiary)' }}>
+                        AI app connections
+                      </div>
+                      <div className="space-y-2">
+                        {history.revoked_grants.map((grant) => (
+                          <div key={grant.id} className="rounded-md p-3" style={{ background: 'var(--surface-container)', border: '1px solid var(--border-default)' }}>
+                            <div className="flex flex-wrap items-start justify-between gap-2">
+                              <div className="min-w-0">
+                                <div className="text-[13px] font-medium" style={{ color: 'var(--text-primary)' }}>{grant.app_name}</div>
+                                <div className="text-[11px] mt-0.5" style={{ color: 'var(--text-tertiary)' }}>
+                                  {grant.connector_profile} / revoked {formatDate(grant.revoked_at)} / last used {formatDate(grant.last_used_at)}
+                                </div>
+                              </div>
+                              <span className="text-[10px] rounded px-1.5 py-0.5" style={{ color: 'var(--danger)', border: '1px solid color-mix(in srgb, var(--danger) 35%, transparent)' }}>
+                                revoked
+                              </span>
+                            </div>
+                            <div className="flex flex-wrap gap-1 mt-2">
+                              {grant.scopes.map((scope) => (
+                                <span key={scope} className="text-[10px] rounded px-1.5 py-0.5" style={{ color: 'var(--text-secondary)', border: '1px solid var(--border-default)' }}>{scope}</span>
+                              ))}
+                            </div>
+                            <RecentActionList actions={grant.recent_actions} />
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                </>
+              )}
             </div>
           )}
         </section>


### PR DESCRIPTION
## Summary
- enrich MCP Access recent actions with human-readable receipts for task, message, wiki, token, app, and tool activity
- add connection history for revoked personal MCP tokens and revoked OAuth AI-app grants
- add copyable Codex and Claude HTTP MCP config snippets on Settings -> MCP Access
- scope OAuth audit history by grant id and record grant ids on future OAuth token issuance
- add regression coverage for enriched active-token and revoked-connection receipts

## Validation
- pnpm --filter @deft/api typecheck
- pnpm --filter @deft/web typecheck
- DATABASE_URL=postgres://postgres:prodpostgresclean@localhost:55511/deft pnpm --filter @deft/api exec tsx --test --test-concurrency=1 --test-force-exit test/oauth-mcp.test.ts
- DATABASE_URL=postgres://postgres:prodpostgresclean@localhost:55511/deft pnpm --filter @deft/api exec tsx --test --test-concurrency=1 --test-force-exit test/mcp-server.test.ts
- DATABASE_URL=postgres://postgres:prodpostgresclean@localhost:55511/deft pnpm --filter @deft/api exec tsx --test --test-concurrency=1 --test-force-exit test/mcp-human-context-packets.test.ts
- DATABASE_URL=postgres://postgres:prodpostgresclean@localhost:55511/deft pnpm --filter @deft/api exec tsx --test --test-concurrency=1 --test-force-exit test/mcp-write-tools.test.ts
- DATABASE_URL=postgres://postgres:prodpostgresclean@localhost:55511/deft pnpm --filter @deft/api exec tsx --test --test-concurrency=1 --test-force-exit test/mcp-access-history.test.ts
- local MCP SDK dogfood: created a personal token, discovered 27 tools, created/transitioned a task, posted a message, revoked the token, and verified active/history receipts
- Playwright UI smoke: copied Codex config, opened connection history, verified enriched desktop/mobile receipts