### PR TITLE
[codex] Polish knowledge console

### DIFF
--- a/apps/api/src/lib/mcp-tools/memory.ts
+++ b/apps/api/src/lib/mcp-tools/memory.ts
@@ -14,6 +14,7 @@ import type { ToolContext, ToolResult } from './types.js';
 import { errorResult, textResult } from './types.js';
 import { invalidatePlatformContextCacheFor } from './context.js';
 import { retrieveContext } from '../retrieve-context.js';
+import { wikiPageRelevantToSpaceCondition } from '../wiki-visibility.js';
 
 const VALID_TYPES = new Set([
   'concept',
@@ -47,25 +48,6 @@ function contextResultMatchesMemoryScope(
   if (scope === 'own') return isOwnScope;
   if (scope === 'org') return isOrgScope;
   return isOrgScope || isOwnScope;
-}
-
-function wikiPageRelevantToSpaceCondition(spaceId: string, orgId: string) {
-  return or(
-    and(eq(wikiPages.scope, 'space'), eq(wikiPages.space_id, spaceId)),
-    eq(wikiPages.origin_space_id, spaceId),
-    sql`EXISTS (
-      SELECT 1
-      FROM wiki_citations wc
-      LEFT JOIN messages m
-        ON m.id = wc.source_id
-       AND wc.source_type = 'message'
-      WHERE wc.page_id = ${wikiPages.id}
-        AND (
-          wc.source_space_id = ${spaceId}
-          OR (m.space_id = ${spaceId} AND m.org_id = ${orgId})
-        )
-    )`,
-  );
 }
 
 function wikiRetrievalScopeCondition(orgId: string, spaceId: string | undefined, includeOrg: boolean) {

--- a/apps/api/src/lib/retrieve-context.ts
+++ b/apps/api/src/lib/retrieve-context.ts
@@ -14,7 +14,7 @@ import { db } from './db.js';
 import { wikiPages, agentMemory, notes, tasks, spaceMembers, projects } from '@deft/db/schema';
 import { embedQuiet, EMBED_DIMS } from './embed.js';
 import { unrestrictedTaskCondition, visibleTaskCondition } from './task-visibility.js';
-import { visibleWikiPageCondition } from './wiki-visibility.js';
+import { visibleWikiPageCondition, wikiPageRelevantToSpaceCondition } from './wiki-visibility.js';
 
 // ─── Public types ─────────────────────────────────────────────────────────────
 
@@ -114,25 +114,6 @@ function employeeWikiCondition(agentEmployeeId: string) {
   return and(
     eq(wikiPages.agent_employee_id, agentEmployeeId),
     sql`${wikiPages.scope} != 'org'`,
-  );
-}
-
-function wikiPageRelevantToSpaceCondition(spaceId: string, orgId: string) {
-  return or(
-    and(eq(wikiPages.scope, 'space'), eq(wikiPages.space_id, spaceId)),
-    eq(wikiPages.origin_space_id, spaceId),
-    sql`EXISTS (
-      SELECT 1
-      FROM wiki_citations wc
-      LEFT JOIN messages m
-        ON m.id = wc.source_id
-       AND wc.source_type = 'message'
-      WHERE wc.page_id = ${wikiPages.id}
-        AND (
-          wc.source_space_id = ${spaceId}
-          OR (m.space_id = ${spaceId} AND m.org_id = ${orgId})
-        )
-    )`,
   );
 }
 

--- a/apps/api/src/lib/wiki-visibility.ts
+++ b/apps/api/src/lib/wiki-visibility.ts
@@ -1,4 +1,4 @@
-import { eq, or, sql } from 'drizzle-orm';
+import { and, eq, or, sql } from 'drizzle-orm';
 import { spaceMembers, wikiPages } from '@deft/db/schema';
 
 export function visibleWikiPageCondition(userId: string) {
@@ -9,6 +9,32 @@ export function visibleWikiPageCondition(userId: string) {
       select 1 from ${spaceMembers}
       where ${spaceMembers.space_id} = ${wikiPages.space_id}
         and ${spaceMembers.user_id} = ${userId}
+    )`,
+  );
+}
+
+export function wikiPageRelevantToSpaceCondition(
+  spaceId: string,
+  orgId: string,
+  includeOriginAndCitations = true,
+) {
+  const directSpacePage = and(eq(wikiPages.scope, 'space'), eq(wikiPages.space_id, spaceId));
+  if (!includeOriginAndCitations) return directSpacePage;
+
+  return or(
+    directSpacePage,
+    eq(wikiPages.origin_space_id, spaceId),
+    sql`EXISTS (
+      SELECT 1
+      FROM wiki_citations wc
+      LEFT JOIN messages m
+        ON m.id = wc.source_id
+       AND wc.source_type = 'message'
+      WHERE wc.page_id = ${wikiPages.id}
+        AND (
+          wc.source_space_id = ${spaceId}
+          OR (m.space_id = ${spaceId} AND m.org_id = ${orgId})
+        )
     )`,
   );
 }

--- a/apps/api/src/routes/knowledge.ts
+++ b/apps/api/src/routes/knowledge.ts
@@ -5,7 +5,7 @@ import { wikiPages, wikiCitations, messages, users, spaces } from '@deft/db/sche
 import { getIO } from '../socket.js';
 import { enqueue, QUEUE_NAMES } from '../lib/queues.js';
 import { requireSpaceMembership } from '../lib/space-membership.js';
-import { visibleWikiPageCondition } from '../lib/wiki-visibility.js';
+import { visibleWikiPageCondition, wikiPageRelevantToSpaceCondition } from '../lib/wiki-visibility.js';
 
 export const knowledgeRoutes = new Hono();
 export const knowledgeAggRoutes = new Hono();
@@ -77,25 +77,6 @@ function sourceSpaceIdSql() {
     ORDER BY wc.created_at DESC
     LIMIT 1
   )`;
-}
-
-function pageRelevantToSpaceCondition(spaceId: string, orgId: string) {
-  return or(
-    eq(wikiPages.space_id, spaceId),
-    eq(wikiPages.origin_space_id, spaceId),
-    sql`EXISTS (
-      SELECT 1
-      FROM wiki_citations wc
-      LEFT JOIN messages m
-        ON m.id = wc.source_id
-       AND wc.source_type = 'message'
-      WHERE wc.page_id = ${wikiPages.id}
-        AND (
-          wc.source_space_id = ${spaceId}
-          OR (m.space_id = ${spaceId} AND m.org_id = ${orgId})
-        )
-    )`,
-  );
 }
 
 function cleanMetadata(value: unknown): Record<string, unknown> | null {
@@ -220,7 +201,7 @@ knowledgeRoutes.get('/:spaceId/knowledge', async (c) => {
       eq(wikiPages.org_id, user.org_id),
       eq(wikiPages.is_deleted, false),
       visibleWikiPageCondition(user.id),
-      pageRelevantToSpaceCondition(spaceId, user.org_id)!,
+      wikiPageRelevantToSpaceCondition(spaceId, user.org_id)!,
     ];
 
     if (typeFilter) {

--- a/apps/api/src/routes/wiki.ts
+++ b/apps/api/src/routes/wiki.ts
@@ -2,10 +2,13 @@ import { Hono } from 'hono';
 import { z } from 'zod';
 import { eq, and, desc, sql, or, ilike, inArray } from 'drizzle-orm';
 import { db } from '../lib/db.js';
-import { wikiPages, wikiLinks, wikiCitations, wikiOpsLog, wikiPageVersions, spaces, notifications, orgMembers, messages } from '@deft/db/schema';
+import { wikiPages, wikiLinks, wikiCitations, wikiOpsLog, wikiPageVersions, spaces, notifications, orgMembers, messages, spaceMembers } from '@deft/db/schema';
 import { ne } from 'drizzle-orm';
 import { requireSpaceMembership } from '../lib/space-membership.js';
-import { visibleWikiPageCondition } from '../lib/wiki-visibility.js';
+import { visibleWikiPageCondition, wikiPageRelevantToSpaceCondition } from '../lib/wiki-visibility.js';
+import { retrieveContext } from '../lib/retrieve-context.js';
+import { llm } from '../lib/llm.js';
+import { getOrgAIConfig, hasUsableReasonProvider } from '../lib/org-ai-config.js';
 
 /** Notify all org members about a wiki change (except the actor) */
 async function notifyWikiChange(orgId: string, actorId: string, title: string, body: string, slug: string) {
@@ -44,26 +47,47 @@ function slugify(title: string): string {
     .slice(0, 80);
 }
 
-function wikiPageRelevantToSpaceCondition(spaceId: string, orgId: string, includeOrg: boolean) {
-  const relevant = or(
-    and(eq(wikiPages.scope, 'space'), eq(wikiPages.space_id, spaceId)),
-    ...(includeOrg ? [
-      eq(wikiPages.origin_space_id, spaceId),
+function visibleWikiOpsLogCondition(userId: string) {
+  return or(
+    sql`${wikiOpsLog.page_id} IS NULL`,
+    and(
+      eq(wikiPages.is_deleted, false),
+      visibleWikiPageCondition(userId),
+    ),
+  );
+}
+
+function visibleWikiCitationCondition(userId: string, orgId: string) {
+  return and(
+    or(eq(wikiCitations.org_id, orgId), sql`${wikiCitations.org_id} IS NULL`),
+    or(
+      sql`${wikiCitations.source_type} != 'message'`,
       sql`EXISTS (
         SELECT 1
-        FROM wiki_citations wc
-        LEFT JOIN messages m
-          ON m.id = wc.source_id
-         AND wc.source_type = 'message'
-        WHERE wc.page_id = ${wikiPages.id}
-          AND (
-            wc.source_space_id = ${spaceId}
-            OR (m.space_id = ${spaceId} AND m.org_id = ${orgId})
-          )
+        FROM ${spaceMembers}
+        WHERE ${spaceMembers.space_id} = COALESCE(${wikiCitations.source_space_id}, ${messages.space_id})
+          AND ${spaceMembers.user_id} = ${userId}
       )`,
-    ] : []),
+    ),
   );
-  return relevant;
+}
+
+function compactSourceText(value: string | null | undefined, max = 900) {
+  return (value ?? '')
+    .replace(/<[^>]*>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, max);
+}
+
+function askKnowledgeFallback(query: string, sourceCount: number, providerReady: boolean) {
+  if (sourceCount === 0) {
+    return `I could not find matching knowledge for "${query}" yet. Try a broader term, or save the relevant decision/resource into Knowledge first.`;
+  }
+  if (!providerReady) {
+    return 'A reasoning provider is not configured, so I can only return the most relevant knowledge sources right now.';
+  }
+  return 'I found relevant knowledge sources, but the reasoning call failed. Review the sources below and try again.';
 }
 
 // GET /api/wiki — list/search wiki pages
@@ -291,7 +315,10 @@ wikiRoutes.get('/log', async (c) => {
     const limit = Math.min(parseInt(c.req.query('limit') || '50'), 100);
     const offset = (page - 1) * limit;
 
-    const conditions: any[] = [eq(wikiOpsLog.org_id, user.org_id)];
+    const conditions: any[] = [
+      eq(wikiOpsLog.org_id, user.org_id),
+      visibleWikiOpsLogCondition(user.id),
+    ];
     if (opFilter) conditions.push(eq(wikiOpsLog.operation, opFilter));
 
     const entries = await db.select({
@@ -313,6 +340,7 @@ wikiRoutes.get('/log', async (c) => {
 
     const [countResult] = await db.select({ count: sql<number>`count(*)` })
       .from(wikiOpsLog)
+      .leftJoin(wikiPages, eq(wikiOpsLog.page_id, wikiPages.id))
       .where(and(...conditions));
 
     return c.json({ entries, total: Number(countResult?.count || 0), page, limit });
@@ -354,7 +382,13 @@ wikiRoutes.get('/stats', async (c) => {
 
     const [linkCount] = await db.select({ count: sql<number>`count(*)` })
       .from(wikiLinks)
-      .where(eq(wikiLinks.org_id, orgId));
+      .innerJoin(wikiPages, eq(wikiLinks.source_page_id, wikiPages.id))
+      .where(and(
+        eq(wikiLinks.org_id, orgId),
+        eq(wikiPages.org_id, orgId),
+        eq(wikiPages.is_deleted, false),
+        visibleWikiPageCondition(user.id),
+      ));
 
     // Pages needing review (low confidence)
     const needsReview = await db.select({
@@ -375,9 +409,11 @@ wikiRoutes.get('/stats', async (c) => {
       count: sql<number>`count(*)`,
     })
       .from(wikiOpsLog)
+      .leftJoin(wikiPages, eq(wikiOpsLog.page_id, wikiPages.id))
       .where(and(
         eq(wikiOpsLog.org_id, orgId),
         sql`${wikiOpsLog.created_at} > NOW() - INTERVAL '7 days'`,
+        visibleWikiOpsLogCondition(user.id),
       ))
       .groupBy(wikiOpsLog.operation);
 
@@ -405,9 +441,11 @@ wikiRoutes.get('/contradictions', async (c) => {
       created_at: wikiOpsLog.created_at,
     })
       .from(wikiOpsLog)
+      .leftJoin(wikiPages, eq(wikiOpsLog.page_id, wikiPages.id))
       .where(and(
         eq(wikiOpsLog.org_id, user.org_id),
         eq(wikiOpsLog.operation, 'contradiction'),
+        visibleWikiOpsLogCondition(user.id),
       ))
       .orderBy(desc(wikiOpsLog.created_at))
       .limit(50);
@@ -459,6 +497,260 @@ wikiRoutes.get('/export', async (c) => {
 });
 
 // GET /api/wiki/:slug — get single page with links and citations
+const askKnowledgeSchema = z.object({
+  query: z.string().min(2).max(1000),
+  space_id: z.string().nullable().optional(),
+  include_org: z.boolean().default(true),
+  limit: z.number().int().min(1).max(12).default(6),
+});
+
+// GET /api/wiki/doctor - read-only knowledge health checks
+wikiRoutes.get('/doctor', async (c) => {
+  try {
+    const user = c.get('user');
+    const visiblePageBase = and(
+      eq(wikiPages.org_id, user.org_id),
+      eq(wikiPages.is_deleted, false),
+      visibleWikiPageCondition(user.id),
+    );
+
+    const lowConfidence = await db.select({
+      id: wikiPages.id,
+      slug: wikiPages.slug,
+      title: wikiPages.title,
+      type: wikiPages.type,
+      scope: wikiPages.scope,
+      confidence: wikiPages.confidence,
+      updated_at: wikiPages.updated_at,
+    })
+      .from(wikiPages)
+      .where(and(visiblePageBase, sql`${wikiPages.confidence} < 0.5`))
+      .orderBy(wikiPages.confidence)
+      .limit(20);
+
+    const [lowConfidenceCount] = await db.select({ count: sql<number>`count(*)` })
+      .from(wikiPages)
+      .where(and(visiblePageBase, sql`${wikiPages.confidence} < 0.5`));
+
+    const stale = await db.select({
+      id: wikiPages.id,
+      slug: wikiPages.slug,
+      title: wikiPages.title,
+      type: wikiPages.type,
+      scope: wikiPages.scope,
+      confidence: wikiPages.confidence,
+      updated_at: wikiPages.updated_at,
+    })
+      .from(wikiPages)
+      .where(and(
+        visiblePageBase,
+        sql`${wikiPages.updated_at} < NOW() - INTERVAL '90 days'`,
+      ))
+      .orderBy(wikiPages.updated_at)
+      .limit(20);
+
+    const [staleCount] = await db.select({ count: sql<number>`count(*)` })
+      .from(wikiPages)
+      .where(and(
+        visiblePageBase,
+        sql`${wikiPages.updated_at} < NOW() - INTERVAL '90 days'`,
+      ));
+
+    const orphaned = await db.select({
+      id: wikiPages.id,
+      slug: wikiPages.slug,
+      title: wikiPages.title,
+      type: wikiPages.type,
+      scope: wikiPages.scope,
+      confidence: wikiPages.confidence,
+      updated_at: wikiPages.updated_at,
+    })
+      .from(wikiPages)
+      .where(and(
+        visiblePageBase,
+        sql`NOT EXISTS (
+          SELECT 1 FROM wiki_links wl
+          WHERE wl.source_page_id = ${wikiPages.id}
+             OR wl.target_page_id = ${wikiPages.id}
+        )`,
+        sql`NOT EXISTS (
+          SELECT 1 FROM wiki_citations wc
+          WHERE wc.page_id = ${wikiPages.id}
+        )`,
+      ))
+      .orderBy(desc(wikiPages.updated_at))
+      .limit(20);
+
+    const [orphanedCount] = await db.select({ count: sql<number>`count(*)` })
+      .from(wikiPages)
+      .where(and(
+        visiblePageBase,
+        sql`NOT EXISTS (
+          SELECT 1 FROM wiki_links wl
+          WHERE wl.source_page_id = ${wikiPages.id}
+             OR wl.target_page_id = ${wikiPages.id}
+        )`,
+        sql`NOT EXISTS (
+          SELECT 1 FROM wiki_citations wc
+          WHERE wc.page_id = ${wikiPages.id}
+        )`,
+      ));
+
+    const contradictions = await db.select({
+      id: wikiOpsLog.id,
+      details: wikiOpsLog.details,
+      created_at: wikiOpsLog.created_at,
+      page_id: wikiOpsLog.page_id,
+      page_slug: wikiPages.slug,
+      page_title: wikiPages.title,
+    })
+      .from(wikiOpsLog)
+      .leftJoin(wikiPages, eq(wikiOpsLog.page_id, wikiPages.id))
+      .where(and(
+        eq(wikiOpsLog.org_id, user.org_id),
+        eq(wikiOpsLog.operation, 'contradiction'),
+        visibleWikiOpsLogCondition(user.id),
+      ))
+      .orderBy(desc(wikiOpsLog.created_at))
+      .limit(20);
+
+    const [contradictionsCount] = await db.select({ count: sql<number>`count(*)` })
+      .from(wikiOpsLog)
+      .leftJoin(wikiPages, eq(wikiOpsLog.page_id, wikiPages.id))
+      .where(and(
+        eq(wikiOpsLog.org_id, user.org_id),
+        eq(wikiOpsLog.operation, 'contradiction'),
+        visibleWikiOpsLogCondition(user.id),
+      ));
+
+    return c.json({
+      generated_at: new Date().toISOString(),
+      summary: {
+        low_confidence: Number(lowConfidenceCount?.count ?? lowConfidence.length),
+        stale: Number(staleCount?.count ?? stale.length),
+        orphaned: Number(orphanedCount?.count ?? orphaned.length),
+        contradictions: Number(contradictionsCount?.count ?? contradictions.length),
+      },
+      issues: {
+        low_confidence: lowConfidence,
+        stale,
+        orphaned,
+        contradictions,
+      },
+    });
+  } catch (err) {
+    console.error('Failed to run wiki doctor:', err);
+    return c.json({ error: 'Failed to run knowledge doctor', code: 'INTERNAL_ERROR' }, 500);
+  }
+});
+
+// POST /api/wiki/ask - answer over visible knowledge using the shared retrieval gateway
+wikiRoutes.post('/ask', async (c) => {
+  try {
+    const user = c.get('user');
+    const body = await c.req.json().catch(() => null);
+    const parsed = askKnowledgeSchema.safeParse(body);
+    if (!parsed.success) {
+      return c.json({ error: 'Invalid request', code: 'VALIDATION_ERROR', issues: parsed.error.issues }, 400);
+    }
+
+    const { query, space_id, include_org, limit } = parsed.data;
+    if (space_id) {
+      const isMember = await requireSpaceMembership(space_id, user.id);
+      if (!isMember) {
+        return c.json({ error: 'Not a member of this space', code: 'FORBIDDEN' }, 403);
+      }
+    }
+
+    const hits = await retrieveContext({
+      query,
+      org_id: user.org_id,
+      user_id: user.id,
+      space_id: space_id ?? undefined,
+      include_org,
+      types: ['wiki', 'decisions', 'notes'],
+      limit,
+    });
+
+    const sources = hits.map((hit, index) => ({
+      index: index + 1,
+      source_type: hit.source_type,
+      source_id: hit.source_id,
+      title: hit.title,
+      excerpt: compactSourceText(hit.content, 500),
+      score: hit.score,
+      scope: hit.scope ?? null,
+      confidence: hit.confidence ?? null,
+      slug: typeof hit.metadata?.slug === 'string' ? hit.metadata.slug : null,
+      type: typeof hit.metadata?.type === 'string' ? hit.metadata.type : hit.source_type,
+      summary: typeof hit.metadata?.summary === 'string' ? hit.metadata.summary : null,
+      space_id: typeof hit.metadata?.matched_space_id === 'string'
+        ? hit.metadata.matched_space_id
+        : typeof hit.metadata?.space_id === 'string'
+          ? hit.metadata.space_id
+          : null,
+      origin_space_id: typeof hit.metadata?.origin_space_id === 'string' ? hit.metadata.origin_space_id : null,
+      origin_message_id: typeof hit.metadata?.origin_message_id === 'string' ? hit.metadata.origin_message_id : null,
+      created_via: typeof hit.metadata?.created_via === 'string' ? hit.metadata.created_via : null,
+    }));
+
+    const providerReady = await hasUsableReasonProvider(user.org_id);
+    if (!providerReady || sources.length === 0) {
+      return c.json({
+        answer: askKnowledgeFallback(query, sources.length, providerReady),
+        mode: 'retrieval_only',
+        model: null,
+        sources,
+      });
+    }
+
+    const contextBlock = sources.map((source) => [
+      `[${source.index}] ${source.title}`,
+      `Type: ${source.type}; Scope: ${source.scope ?? 'unknown'}; Confidence: ${source.confidence ?? 'unknown'}; Score: ${source.score.toFixed(3)}`,
+      source.summary ? `Summary: ${source.summary}` : null,
+      `Excerpt: ${source.excerpt}`,
+    ].filter(Boolean).join('\n')).join('\n\n');
+
+    try {
+      const orgConfig = await getOrgAIConfig(user.org_id);
+      const result = await llm({
+        task: 'reason',
+        orgId: user.org_id,
+        orgConfig,
+        system: [
+          'You answer questions about a workspace knowledge base.',
+          'Use only the supplied sources.',
+          'If the sources do not answer the question, say what is missing.',
+          'Cite sources inline using [1], [2], etc. Keep the answer concise.',
+        ].join(' '),
+        messages: [{
+          role: 'user',
+          content: `Question: ${query}\n\nSources:\n${contextBlock}`,
+        }],
+        maxTokens: 900,
+      });
+
+      return c.json({
+        answer: result.text.trim(),
+        mode: 'answered',
+        model: result.model,
+        sources,
+      });
+    } catch (err) {
+      console.warn('[wiki/ask] reasoning call failed:', err);
+      return c.json({
+        answer: askKnowledgeFallback(query, sources.length, true),
+        mode: 'retrieval_only',
+        model: null,
+        sources,
+      });
+    }
+  } catch (err) {
+    console.error('Failed to ask wiki:', err);
+    return c.json({ error: 'Failed to ask knowledge', code: 'INTERNAL_ERROR' }, 500);
+  }
+});
+
 wikiRoutes.get('/:slug', async (c) => {
   try {
     const user = c.get('user');
@@ -489,7 +781,13 @@ wikiRoutes.get('/:slug', async (c) => {
     })
       .from(wikiLinks)
       .innerJoin(wikiPages, eq(wikiLinks.target_page_id, wikiPages.id))
-      .where(eq(wikiLinks.source_page_id, page.id));
+      .where(and(
+        eq(wikiLinks.source_page_id, page.id),
+        eq(wikiLinks.org_id, user.org_id),
+        eq(wikiPages.org_id, user.org_id),
+        eq(wikiPages.is_deleted, false),
+        visibleWikiPageCondition(user.id),
+      ));
 
     // Get backlinks (inbound)
     const backlinks = await db.select({
@@ -501,7 +799,13 @@ wikiRoutes.get('/:slug', async (c) => {
     })
       .from(wikiLinks)
       .innerJoin(wikiPages, eq(wikiLinks.source_page_id, wikiPages.id))
-      .where(eq(wikiLinks.target_page_id, page.id));
+      .where(and(
+        eq(wikiLinks.target_page_id, page.id),
+        eq(wikiLinks.org_id, user.org_id),
+        eq(wikiPages.org_id, user.org_id),
+        eq(wikiPages.is_deleted, false),
+        visibleWikiPageCondition(user.id),
+      ));
 
     // Get citations
     const citations = await db.select({
@@ -519,7 +823,10 @@ wikiRoutes.get('/:slug', async (c) => {
         eq(wikiCitations.source_id, messages.id),
         eq(wikiCitations.source_type, 'message'),
       ))
-      .where(eq(wikiCitations.page_id, page.id))
+      .where(and(
+        eq(wikiCitations.page_id, page.id),
+        visibleWikiCitationCondition(user.id, user.org_id),
+      ))
       .orderBy(desc(wikiCitations.created_at));
 
     return c.json({
@@ -614,6 +921,8 @@ wikiRoutes.post('/', async (c) => {
         .from(wikiPages)
         .where(and(
           eq(wikiPages.org_id, user.org_id),
+          eq(wikiPages.is_deleted, false),
+          visibleWikiPageCondition(user.id),
           inArray(wikiPages.slug, related_slugs),
         ));
 
@@ -717,6 +1026,8 @@ wikiRoutes.patch('/:slug', async (c) => {
         .from(wikiPages)
         .where(and(
           eq(wikiPages.org_id, user.org_id),
+          eq(wikiPages.is_deleted, false),
+          visibleWikiPageCondition(user.id),
           inArray(wikiPages.slug, parsed.data.related_slugs),
         ));
 

--- a/apps/api/test/in-chat-knowledge-panel.test.ts
+++ b/apps/api/test/in-chat-knowledge-panel.test.ts
@@ -119,6 +119,7 @@ after(async () => {
 
 async function insertWikiPage(overrides: Record<string, unknown> = {}): Promise<string> {
   const id = `ick-page-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  const spaceId = overrides.space_id ?? null;
   await withClient(async (c) => {
     await c.query(
       `INSERT INTO wiki_pages
@@ -128,8 +129,8 @@ async function insertWikiPage(overrides: Record<string, unknown> = {}): Promise<
       [
         id,
         overrides.org_id ?? ORG_ID,
-        overrides.scope ?? 'org',
-        overrides.space_id ?? null,
+        overrides.scope ?? (spaceId ? 'space' : 'org'),
+        spaceId,
         overrides.origin_space_id ?? null,
         overrides.origin_message_id ?? null,
         overrides.origin_user_id ?? null,

--- a/apps/api/test/wiki-graph-scope.test.ts
+++ b/apps/api/test/wiki-graph-scope.test.ts
@@ -6,16 +6,18 @@
 import { test, before, after } from 'node:test';
 import assert from 'node:assert/strict';
 import pg from 'pg';
+import { env } from '../src/lib/env.js';
 
-const DATABASE_URL =
-  process.env.DATABASE_URL || 'postgres://postgres:postgres@localhost:5432/deft';
+const DATABASE_URL = env.DATABASE_URL;
 
 const ORG_ID = '1d7d869a-5e68-48d5-832e-11d8f3bb1dd6';
 const USER_ID = `wiki-graph-user-${Date.now()}`;
 const SPACE_A_ID = `wiki-graph-space-a-${Date.now()}`;
 const SPACE_B_ID = `wiki-graph-space-b-${Date.now()}`;
+const HIDDEN_SPACE_ID = `wiki-graph-hidden-space-${Date.now()}`;
 
 const createdPageIds: string[] = [];
+const createdMessageIds: string[] = [];
 
 async function withClient<T>(fn: (c: pg.Client) => Promise<T>): Promise<T> {
   const c = new pg.Client({ connectionString: DATABASE_URL });
@@ -55,18 +57,28 @@ before(async () => {
         [spaceId, USER_ID],
       );
     }
+    await c.query(
+      `INSERT INTO spaces (id, org_id, name, type, is_archived)
+       VALUES ($1, $2, 'Wiki Graph Hidden', 'private', false)
+       ON CONFLICT (id) DO NOTHING`,
+      [HIDDEN_SPACE_ID, ORG_ID],
+    );
   });
 });
 
 after(async () => {
   await withClient(async (c) => {
+    await c.query(`DELETE FROM wiki_ops_log WHERE page_id = ANY($1)`, [createdPageIds]);
     if (createdPageIds.length > 0) {
       await c.query(`DELETE FROM wiki_links WHERE source_page_id = ANY($1) OR target_page_id = ANY($1)`, [createdPageIds]);
       await c.query(`DELETE FROM wiki_citations WHERE page_id = ANY($1)`, [createdPageIds]);
       await c.query(`DELETE FROM wiki_pages WHERE id = ANY($1)`, [createdPageIds]);
     }
-    await c.query(`DELETE FROM space_members WHERE space_id = ANY($1)`, [[SPACE_A_ID, SPACE_B_ID]]);
-    await c.query(`DELETE FROM spaces WHERE id = ANY($1)`, [[SPACE_A_ID, SPACE_B_ID]]);
+    if (createdMessageIds.length > 0) {
+      await c.query(`DELETE FROM messages WHERE id = ANY($1)`, [createdMessageIds]);
+    }
+    await c.query(`DELETE FROM space_members WHERE space_id = ANY($1)`, [[SPACE_A_ID, SPACE_B_ID, HIDDEN_SPACE_ID]]);
+    await c.query(`DELETE FROM spaces WHERE id = ANY($1)`, [[SPACE_A_ID, SPACE_B_ID, HIDDEN_SPACE_ID]]);
     await c.query(`DELETE FROM org_members WHERE user_id = $1`, [USER_ID]);
     await c.query(`DELETE FROM users WHERE id = $1`, [USER_ID]);
   });
@@ -101,6 +113,52 @@ async function insertPage(input: {
   });
   createdPageIds.push(id);
   return id;
+}
+
+async function insertMessage(spaceId: string, content: string) {
+  const id = `wiki-graph-message-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  await withClient(async (c) => {
+    await c.query(
+      `INSERT INTO messages
+         (id, org_id, space_id, user_id, content, is_pinned, is_deleted, created_at, updated_at)
+       VALUES ($1, $2, $3, $4, $5, false, false, NOW(), NOW())`,
+      [id, ORG_ID, spaceId, USER_ID, content],
+    );
+  });
+  createdMessageIds.push(id);
+  return id;
+}
+
+async function insertWikiLink(sourcePageId: string, targetPageId: string, context: string) {
+  await withClient(async (c) => {
+    await c.query(
+      `INSERT INTO wiki_links (id, org_id, source_page_id, target_page_id, context, created_at)
+       VALUES (gen_random_uuid()::text, $1, $2, $3, $4, NOW())
+       ON CONFLICT (source_page_id, target_page_id) DO NOTHING`,
+      [ORG_ID, sourcePageId, targetPageId, context],
+    );
+  });
+}
+
+async function insertWikiCitation(pageId: string, messageId: string, spaceId: string, excerpt: string) {
+  await withClient(async (c) => {
+    await c.query(
+      `INSERT INTO wiki_citations
+         (id, org_id, page_id, source_type, source_id, source_space_id, source_user_id, excerpt, created_at)
+       VALUES (gen_random_uuid()::text, $1, $2, 'message', $3, $4, $5, $6, NOW())`,
+      [ORG_ID, pageId, messageId, spaceId, USER_ID, excerpt],
+    );
+  });
+}
+
+async function insertWikiOp(pageId: string, operation: string, marker: string) {
+  await withClient(async (c) => {
+    await c.query(
+      `INSERT INTO wiki_ops_log (id, org_id, operation, page_id, details, performed_by, created_at)
+       VALUES (gen_random_uuid()::text, $1, $2, $3, $4::jsonb, $5, NOW())`,
+      [ORG_ID, operation, pageId, JSON.stringify({ marker }), USER_ID],
+    );
+  });
 }
 
 async function callGraph(path: string) {
@@ -166,4 +224,67 @@ test('space graph includes channel-scoped and channel-origin pages, but not unre
   const strictIds = strictGraph.nodes.map((n: any) => n.id);
   assert.ok(strictIds.includes(spaceAId), 'strict channel graph should include space-scoped page');
   assert.ok(!strictIds.includes(orgFromSpaceId), 'strict channel graph should exclude org-origin pages');
+});
+
+test('wiki log and page detail only expose visible linked pages, citations, and ops', async () => {
+  const suffix = Date.now();
+  const sourceSlug = `wiki-graph-visible-source-${suffix}`;
+  const hiddenSlug = `wiki-graph-hidden-target-${suffix}`;
+  const visibleSourceId = await insertPage({
+    scope: 'space',
+    title: 'Visible Source Page',
+    slug: sourceSlug,
+    spaceId: SPACE_A_ID,
+    originSpaceId: SPACE_A_ID,
+  });
+  const visibleTargetId = await insertPage({
+    scope: 'space',
+    title: 'Visible Target Page',
+    slug: `wiki-graph-visible-target-${suffix}`,
+    spaceId: SPACE_A_ID,
+    originSpaceId: SPACE_A_ID,
+  });
+  const hiddenTargetId = await insertPage({
+    scope: 'space',
+    title: 'Hidden Target Page',
+    slug: hiddenSlug,
+    spaceId: HIDDEN_SPACE_ID,
+    originSpaceId: HIDDEN_SPACE_ID,
+  });
+
+  await insertWikiLink(visibleSourceId, visibleTargetId, 'visible link');
+  await insertWikiLink(visibleSourceId, hiddenTargetId, 'hidden link');
+
+  const visibleMessageId = await insertMessage(SPACE_A_ID, 'Visible citation source');
+  const hiddenMessageId = await insertMessage(HIDDEN_SPACE_ID, 'Hidden citation source');
+  await insertWikiCitation(visibleSourceId, visibleMessageId, SPACE_A_ID, 'visible citation');
+  await insertWikiCitation(visibleSourceId, hiddenMessageId, HIDDEN_SPACE_ID, 'hidden citation');
+
+  const operation = `visibility-test-${suffix}`;
+  await insertWikiOp(visibleSourceId, operation, 'visible-op');
+  await insertWikiOp(hiddenTargetId, operation, 'hidden-op');
+  await insertWikiOp(hiddenTargetId, 'contradiction', `hidden-contradiction-${suffix}`);
+
+  const detailRes = await callGraph(`/api/wiki/${sourceSlug}`);
+  assert.equal(detailRes.status, 200);
+  const detail = await detailRes.json() as any;
+  assert.ok(detail.linked_pages.some((p: any) => p.slug !== hiddenSlug), 'visible linked page should remain visible');
+  assert.ok(!detail.linked_pages.some((p: any) => p.slug === hiddenSlug), 'hidden linked page should not be exposed');
+  assert.ok(detail.citations.some((c: any) => c.excerpt === 'visible citation'), 'visible message citation should remain visible');
+  assert.ok(!detail.citations.some((c: any) => c.excerpt === 'hidden citation'), 'hidden message citation should not be exposed');
+
+  const logRes = await callGraph(`/api/wiki/log?operation=${operation}&limit=100`);
+  assert.equal(logRes.status, 200);
+  const log = await logRes.json() as any;
+  const markers = log.entries.map((entry: any) => entry.details?.marker);
+  assert.ok(markers.includes('visible-op'), 'visible ops log entry should be returned');
+  assert.ok(!markers.includes('hidden-op'), 'ops log entry for hidden page should not be returned');
+
+  const contradictionsRes = await callGraph('/api/wiki/contradictions');
+  assert.equal(contradictionsRes.status, 200);
+  const contradictions = await contradictionsRes.json() as any;
+  assert.ok(
+    !contradictions.contradictions.some((entry: any) => entry.details?.marker === `hidden-contradiction-${suffix}`),
+    'contradictions tied to hidden pages should not be returned',
+  );
 });

--- a/apps/web/src/app/(app)/knowledge/page.tsx
+++ b/apps/web/src/app/(app)/knowledge/page.tsx
@@ -14,6 +14,7 @@ import {
   Brain, Users, Scale, LinkIcon, Cog, Heart, Lightbulb,
   Plus, Pencil, Trash2, X, Check, History, GitBranch,
   Activity, Download, BarChart3, AlertTriangle, RotateCcw, RefreshCw,
+  Sparkles,
 } from 'lucide-react';
 import { PageHeader } from '@/components/page-header';
 import { OverflowMenu } from '@/components/overflow-menu';
@@ -151,6 +152,31 @@ type WikiPageDetail = WikiPage & {
   linked_pages: { slug: string; title: string; type: string; summary: string | null; confidence?: number; context?: string }[];
   backlinks: { slug: string; title: string; type: string; summary?: string | null; context?: string }[];
   citations: { id: string; source_type: string; source_id: string; excerpt: string | null; created_at: string; source_space_id?: string | null }[];
+};
+
+type AskKnowledgeSource = {
+  index: number;
+  source_type: string;
+  source_id: string;
+  title: string;
+  excerpt: string;
+  score: number;
+  scope: string | null;
+  confidence: number | null;
+  slug: string | null;
+  type: string;
+  summary: string | null;
+  space_id: string | null;
+  origin_space_id: string | null;
+  origin_message_id: string | null;
+  created_via: string | null;
+};
+
+type AskKnowledgeResponse = {
+  answer: string;
+  mode: 'answered' | 'retrieval_only';
+  model: string | null;
+  sources: AskKnowledgeSource[];
 };
 
 function ConfidenceBar({ value }: { value: number }) {
@@ -350,13 +376,20 @@ export default function KnowledgePage() {
   const [graphIncludeOrg, setGraphIncludeOrg] = useState(true);
   const [spaces, setSpaces] = useState<SpaceOption[]>([]);
   const [spacesLoading, setSpacesLoading] = useState(false);
-  const [viewMode, setViewMode] = useState<'pages' | 'activity' | 'stats'>('pages');
+  const [viewMode, setViewMode] = useState<'pages' | 'activity' | 'stats' | 'doctor'>('pages');
   const [activityLog, setActivityLog] = useState<any[]>([]);
   const [activityLoading, setActivityLoading] = useState(false);
   const [stats, setStats] = useState<any>(null);
   const [statsLoading, setStatsLoading] = useState(false);
+  const [doctor, setDoctor] = useState<any>(null);
+  const [doctorLoading, setDoctorLoading] = useState(false);
   const [reversingId, setReversingId] = useState<string | null>(null);
   const [reverseError, setReverseError] = useState<string | null>(null);
+  const [askQuery, setAskQuery] = useState('');
+  const [askScope, setAskScope] = useState<'company' | 'channel'>('company');
+  const [askLoading, setAskLoading] = useState(false);
+  const [askError, setAskError] = useState<string | null>(null);
+  const [askResult, setAskResult] = useState<AskKnowledgeResponse | null>(null);
   const pagesAbortRef = useRef<AbortController | null>(null);
   const pagesRequestIdRef = useRef(0);
   const limit = 50;
@@ -640,6 +673,47 @@ export default function KnowledgePage() {
     }
   };
 
+  const fetchDoctor = async () => {
+    setDoctorLoading(true);
+    try {
+      const res = await api.get('/api/wiki/doctor');
+      if (res.ok) {
+        setDoctor(await res.json());
+      }
+    } catch {
+    } finally {
+      setDoctorLoading(false);
+    }
+  };
+
+  const askKnowledge = async () => {
+    const query = askQuery.trim();
+    if (!query) return;
+    setAskLoading(true);
+    setAskError(null);
+    try {
+      const body: Record<string, unknown> = {
+        query,
+        limit: 6,
+        include_org: askScope === 'channel' ? graphIncludeOrg : true,
+      };
+      if (askScope === 'channel' && graphSpaceId) {
+        body.space_id = graphSpaceId;
+      }
+      const res = await api.post('/api/wiki/ask', body);
+      const data = await res.json().catch(() => null);
+      if (!res.ok) {
+        setAskError(data?.error || 'Could not ask knowledge.');
+        return;
+      }
+      setAskResult(data);
+    } catch (err) {
+      setAskError(err instanceof Error ? err.message : 'Could not ask knowledge.');
+    } finally {
+      setAskLoading(false);
+    }
+  };
+
   const typeFilters = [
     { value: 'all', label: 'All' },
     { value: 'concept', label: 'Concepts' },
@@ -657,6 +731,19 @@ export default function KnowledgePage() {
     { value: 'space', label: 'Space' },
     { value: 'user', label: 'Personal' },
   ];
+
+  const openKnowledgeView = (next: 'pages' | 'activity' | 'stats' | 'doctor' | 'graph') => {
+    if (next === 'graph') {
+      setShowGraph(true);
+      setViewMode('pages');
+      return;
+    }
+    setShowGraph(false);
+    setViewMode(next);
+    if (next === 'activity' && activityLog.length === 0) fetchActivity();
+    if (next === 'stats' && !stats) fetchStats();
+    if (next === 'doctor' && !doctor) fetchDoctor();
+  };
 
   const detailResourceUrl = getMetadataString(detail?.metadata, 'url');
 
@@ -1072,6 +1159,14 @@ export default function KnowledgePage() {
                   },
                 },
                 {
+                  label: 'Doctor',
+                  onClick: () => {
+                    setViewMode('doctor');
+                    setShowGraph(false);
+                    if (!doctor) fetchDoctor();
+                  },
+                },
+                {
                   label: 'Graph',
                   onClick: () => { setShowGraph(true); setViewMode('pages'); },
                 },
@@ -1090,6 +1185,31 @@ export default function KnowledgePage() {
         }
         secondary={
           <div className="flex flex-col gap-1 px-1">
+            <div className="md:hidden flex gap-2">
+              <select
+                value={showGraph ? 'graph' : viewMode}
+                onChange={e => openKnowledgeView(e.target.value as 'pages' | 'activity' | 'stats' | 'doctor' | 'graph')}
+                className="flex-1 text-[0.8125rem] rounded-md px-2 py-1 outline-none"
+                style={{
+                  background: 'var(--surface-container-low)',
+                  border: '1px solid var(--border-default)',
+                  color: 'var(--text-primary)',
+                }}
+              >
+                <option value="pages">Pages</option>
+                <option value="activity">Activity</option>
+                <option value="stats">Stats</option>
+                <option value="doctor">Doctor</option>
+                <option value="graph">Graph</option>
+              </select>
+              <button
+                onClick={() => setShowCreate(true)}
+                className="px-3 py-1 rounded-md text-[0.8125rem] font-medium"
+                style={{ background: 'var(--accent)', color: 'white' }}
+              >
+                New
+              </button>
+            </div>
             {/* Scope axis: <select> on mobile, inline tab strip on md+ */}
             <div className="flex gap-1">
               {/* Mobile: select */}
@@ -1147,6 +1267,151 @@ export default function KnowledgePage() {
 
       {/* Entries */}
       <div className="flex flex-col flex-1 overflow-hidden px-4 md:px-6 pb-4 md:pb-6">
+      {viewMode === 'pages' && !showGraph && (
+        <div className="mb-3 rounded-lg p-3 flex-shrink-0"
+          style={{ background: 'var(--surface-container-low)', border: '1px solid var(--border-default)' }}>
+          <div className="flex flex-col md:flex-row md:items-center gap-2">
+            <div className="flex items-center gap-2 flex-1 min-w-0">
+              <span className="w-8 h-8 rounded-lg flex items-center justify-center flex-shrink-0"
+                style={{ background: 'var(--accent-muted, rgba(91, 143, 168, 0.16))', color: 'var(--accent)' }}>
+                <Sparkles size={15} />
+              </span>
+              <input
+                value={askQuery}
+                onChange={e => setAskQuery(e.target.value)}
+                onKeyDown={e => {
+                  if (e.key === 'Enter' && !e.shiftKey) {
+                    e.preventDefault();
+                    void askKnowledge();
+                  }
+                }}
+                placeholder="Ask what the workspace knows..."
+                className="flex-1 min-w-0 px-3 py-2 rounded-lg text-[13px] outline-none"
+                style={{ background: 'var(--surface-container)', border: '1px solid var(--border-default)', color: 'var(--text-primary)' }}
+              />
+            </div>
+            <div className="flex items-center gap-2 flex-wrap">
+              <select
+                value={askScope}
+                onChange={e => setAskScope(e.target.value as 'company' | 'channel')}
+                className="px-2 py-2 rounded-lg text-[12px] outline-none"
+                style={{ background: 'var(--surface-container)', border: '1px solid var(--border-default)', color: 'var(--text-primary)' }}
+              >
+                <option value="company">Company memory</option>
+                <option value="channel">Channel context</option>
+              </select>
+              {askScope === 'channel' && (
+                <>
+                  <select
+                    value={graphSpaceId}
+                    onChange={e => setGraphSpaceId(e.target.value)}
+                    disabled={spacesLoading || spaces.length === 0}
+                    className="px-2 py-2 rounded-lg text-[12px] outline-none max-w-[180px]"
+                    style={{ background: 'var(--surface-container)', border: '1px solid var(--border-default)', color: 'var(--text-primary)' }}
+                  >
+                    {spaces.length === 0 ? (
+                      <option value="">{spacesLoading ? 'Loading channels...' : 'No channels'}</option>
+                    ) : spaces.map(space => (
+                      <option key={space.id} value={space.id}>{space.name}</option>
+                    ))}
+                  </select>
+                  <button
+                    onClick={() => setGraphIncludeOrg(v => !v)}
+                    className="px-2 py-2 rounded-lg text-[11px] font-medium"
+                    style={{
+                      background: graphIncludeOrg ? 'var(--surface-container-high)' : 'transparent',
+                      border: '1px solid var(--border-default)',
+                      color: graphIncludeOrg ? 'var(--text-primary)' : 'var(--text-tertiary)',
+                    }}
+                  >
+                    Include company
+                  </button>
+                </>
+              )}
+              <button
+                onClick={() => void askKnowledge()}
+                disabled={askLoading || !askQuery.trim() || (askScope === 'channel' && !graphSpaceId)}
+                className="px-3 py-2 rounded-lg text-[12px] font-medium disabled:opacity-40 flex items-center gap-1.5"
+                style={{ background: 'var(--accent)', color: 'white' }}
+              >
+                {askLoading ? <Loader2 size={13} className="animate-spin" /> : <Sparkles size={13} />}
+                Ask
+              </button>
+            </div>
+          </div>
+          {askError && (
+            <p className="mt-2 text-[12px]" style={{ color: '#EF4444' }}>{askError}</p>
+          )}
+          {askResult && (
+            <div className="mt-3 rounded-lg p-3"
+              style={{ background: 'var(--surface-container)', border: '1px solid var(--border-default)' }}>
+              <div className="flex items-center gap-2 mb-2">
+                <span className="text-[10px] font-medium px-1.5 py-0.5 rounded-full"
+                  style={{ background: askResult.mode === 'answered' ? '#22C55E20' : '#EAB30820', color: askResult.mode === 'answered' ? '#22C55E' : '#A16207' }}>
+                  {askResult.mode === 'answered' ? 'Answered from sources' : 'Sources only'}
+                </span>
+                {askResult.model && (
+                  <span className="text-[10px]" style={{ color: 'var(--text-tertiary)' }}>{askResult.model}</span>
+                )}
+              </div>
+              <p className="text-[13px] leading-relaxed whitespace-pre-wrap" style={{ color: 'var(--text-primary)' }}>
+                {askResult.answer}
+              </p>
+              {askResult.sources.length > 0 && (
+                <div className="mt-3 grid gap-2 md:grid-cols-2">
+                  {askResult.sources.map(source => (
+                    <div key={`${source.source_type}:${source.source_id}`} className="p-2 rounded-lg"
+                      style={{ background: 'var(--surface-container-low)', border: '1px solid var(--border-default)' }}>
+                      <div className="flex items-start gap-2">
+                        <span className="text-[10px] font-semibold w-5 h-5 rounded-full flex items-center justify-center flex-shrink-0"
+                          style={{ background: 'var(--surface-container)', color: 'var(--text-secondary)' }}>
+                          {source.index}
+                        </span>
+                        <div className="min-w-0 flex-1">
+                          {source.slug ? (
+                            <button onClick={() => setSelectedSlug(source.slug)}
+                              className="text-left text-[12px] font-medium hover:underline"
+                              style={{ color: 'var(--accent)' }}>
+                              {source.title}
+                            </button>
+                          ) : (
+                            <p className="text-[12px] font-medium" style={{ color: 'var(--text-primary)' }}>{source.title}</p>
+                          )}
+                          <div className="flex flex-wrap items-center gap-1 mt-1">
+                            <span className="text-[9px] px-1.5 py-0.5 rounded-full"
+                              style={{ background: 'var(--surface-container)', color: 'var(--text-tertiary)' }}>
+                              {source.type}
+                            </span>
+                            <span className="text-[9px] px-1.5 py-0.5 rounded-full"
+                              style={{ background: 'var(--surface-container)', color: 'var(--text-tertiary)' }}>
+                              {source.scope || 'workspace'}
+                            </span>
+                            <span className="text-[9px]" style={{ color: 'var(--text-tertiary)' }}>
+                              {Math.round(source.score * 100)}% match
+                            </span>
+                          </div>
+                          {source.excerpt && (
+                            <p className="mt-1 text-[11px] line-clamp-2" style={{ color: 'var(--text-tertiary)' }}>
+                              {source.excerpt}
+                            </p>
+                          )}
+                          {source.origin_message_id && (source.space_id || source.origin_space_id) && (
+                            <a href={`/chat?space=${source.space_id || source.origin_space_id}&message=${source.origin_message_id}`}
+                              className="inline-flex items-center gap-1 mt-1 text-[10px] hover:underline"
+                              style={{ color: 'var(--accent)' }}>
+                              Open source message <ArrowUpRight size={10} />
+                            </a>
+                          )}
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      )}
       {/* Graph View — interactive force-directed graph */}
       {showGraph && (
         <div className="flex-1 rounded-lg overflow-hidden flex flex-col"
@@ -1387,6 +1652,95 @@ export default function KnowledgePage() {
                   </div>
                 </div>
               )}
+            </>
+          )}
+        </div>
+      )}
+
+      {/* Doctor View */}
+      {viewMode === 'doctor' && !showGraph && (
+        <div className="flex-1 overflow-y-auto space-y-4">
+          {doctorLoading || !doctor ? (
+            <div className="flex items-center justify-center py-12">
+              <Loader2 size={20} className="animate-spin" style={{ color: 'var(--text-tertiary)' }} />
+            </div>
+          ) : (
+            <>
+              <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+                {[
+                  { key: 'low_confidence', label: 'Low confidence', color: '#EF4444' },
+                  { key: 'stale', label: 'Stale', color: '#EAB308' },
+                  { key: 'orphaned', label: 'Orphaned', color: '#5B8FA8' },
+                  { key: 'contradictions', label: 'Contradictions', color: '#C97B6B' },
+                ].map(item => (
+                  <div key={item.key} className="p-3 rounded-lg"
+                    style={{ background: 'var(--surface-container-low)', border: '1px solid var(--border-default)' }}>
+                    <div className="text-[18px] font-bold" style={{ color: item.color }}>{doctor.summary?.[item.key] ?? 0}</div>
+                    <div className="text-[11px]" style={{ color: 'var(--text-tertiary)' }}>{item.label}</div>
+                  </div>
+                ))}
+              </div>
+
+              {[
+                { key: 'low_confidence', label: 'Low confidence pages', hint: 'Review source evidence or confidence before agents rely on these.' },
+                { key: 'stale', label: 'Stale pages', hint: 'These have not changed in 90+ days; confirm they still match reality.' },
+                { key: 'orphaned', label: 'Orphaned pages', hint: 'These have no links or citations, so they are harder for people to trust.' },
+              ].map(section => {
+                const rows = doctor.issues?.[section.key] ?? [];
+                return (
+                  <div key={section.key} className="p-3 rounded-lg"
+                    style={{ background: 'var(--surface-container-low)', border: '1px solid var(--border-default)' }}>
+                    <div className="flex items-center justify-between gap-3 mb-1">
+                      <h3 className="text-[12px] font-semibold" style={{ color: 'var(--text-secondary)' }}>{section.label}</h3>
+                      <span className="text-[10px]" style={{ color: 'var(--text-tertiary)' }}>{rows.length}</span>
+                    </div>
+                    <p className="text-[11px] mb-2" style={{ color: 'var(--text-tertiary)' }}>{section.hint}</p>
+                    {rows.length === 0 ? (
+                      <p className="text-[12px]" style={{ color: 'var(--text-tertiary)' }}>No issues found.</p>
+                    ) : (
+                      <div className="space-y-1">
+                        {rows.map((row: any) => (
+                          <button key={row.id} onClick={() => { setViewMode('pages'); setSelectedSlug(row.slug); }}
+                            className="w-full text-left p-2 rounded-md"
+                            style={{ background: 'var(--surface-container)', color: 'var(--text-primary)' }}>
+                            <span className="text-[12px] font-medium">{row.title}</span>
+                            <span className="text-[10px] ml-2" style={{ color: 'var(--text-tertiary)' }}>
+                              {row.type} / {row.scope} / {Math.round((row.confidence ?? 0) * 100)}%
+                            </span>
+                          </button>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+
+              <div className="p-3 rounded-lg"
+                style={{ background: 'var(--surface-container-low)', border: '1px solid var(--border-default)' }}>
+                <h3 className="text-[12px] font-semibold mb-1" style={{ color: 'var(--text-secondary)' }}>Contradictions</h3>
+                <p className="text-[11px] mb-2" style={{ color: 'var(--text-tertiary)' }}>
+                  These are lint findings only. Deft shows them for review; it does not rewrite memory automatically.
+                </p>
+                {(doctor.issues?.contradictions ?? []).length === 0 ? (
+                  <p className="text-[12px]" style={{ color: 'var(--text-tertiary)' }}>No visible contradictions found.</p>
+                ) : (
+                  <div className="space-y-1">
+                    {doctor.issues.contradictions.map((row: any) => (
+                      <button key={row.id} onClick={() => { if (row.page_slug) { setViewMode('pages'); setSelectedSlug(row.page_slug); } }}
+                        className="w-full text-left p-2 rounded-md"
+                        style={{ background: 'var(--surface-container)', color: 'var(--text-primary)' }}>
+                        <span className="text-[12px] font-medium">{row.page_title || 'Knowledge contradiction'}</span>
+                        <span className="text-[10px] ml-2" style={{ color: 'var(--text-tertiary)' }}>
+                          {formatRelative(row.created_at)}
+                        </span>
+                        {row.details?.description && (
+                          <p className="text-[11px] mt-1 line-clamp-2" style={{ color: 'var(--text-tertiary)' }}>{row.details.description}</p>
+                        )}
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
             </>
           )}
         </div>

--- a/package.json
+++ b/package.json
@@ -35,6 +35,8 @@
     "pilot:clean-agent-queue": "tsx scripts/agent-demo-queue-cleanup.ts",
     "pilot:cracks:battery": "node scripts/pilot-cracks-clearance-battery.mjs",
     "pilot:hygiene": "tsx scripts/pilot-workspace-hygiene.ts",
+    "pilot:knowledge-eval": "tsx scripts/knowledge-retrieval-eval.ts",
+    "pilot:knowledge-scale": "tsx scripts/knowledge-scale-probe.ts",
     "pilot:preflight": "tsx scripts/pilot-preflight.ts",
     "pilot:preflight:strict": "tsx scripts/pilot-preflight.ts --strict",
     "pilot:reset": "pnpm db:push-full && pnpm db:seed:pilot && pnpm pilot:preflight",

--- a/scripts/knowledge-retrieval-eval.ts
+++ b/scripts/knowledge-retrieval-eval.ts
@@ -1,0 +1,221 @@
+import 'dotenv/config';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { and, desc, eq, sql } from 'drizzle-orm';
+import { db } from '../apps/api/src/lib/db.js';
+import { retrieveContext } from '../apps/api/src/lib/retrieve-context.js';
+import { orgMembers, users, wikiPages } from '@deft/db/schema';
+
+type EvalCase = {
+  name: string;
+  query: string;
+  expectedPageId: string;
+  expectedSlug: string;
+  spaceId?: string | null;
+};
+
+type EvalResult = EvalCase & {
+  ok: boolean;
+  rank: number | null;
+  hits: Array<{
+    title: string;
+    source_id: string;
+    slug: string | null;
+    score: number;
+    scope: string | null;
+  }>;
+};
+
+const TEST_EMAIL = process.env.DEFT_TEST_EMAIL || 'diego@testers-tomatoes.com';
+const RUN_ID = new Date().toISOString().replace(/[:.]/g, '-');
+const REPORT_PATH = path.resolve('reports', `knowledge-retrieval-eval-${RUN_ID}.html`);
+
+function escapeHtml(value: unknown): string {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function queryFromTitle(title: string): string {
+  return title
+    .replace(/[^a-zA-Z0-9\s-]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .split(' ')
+    .slice(0, 18)
+    .join(' ')
+    .slice(0, 180);
+}
+
+async function currentUser() {
+  const [row] = await db.select({
+    id: users.id,
+    email: users.email,
+    org_id: orgMembers.org_id,
+  })
+    .from(users)
+    .innerJoin(orgMembers, eq(orgMembers.user_id, users.id))
+    .where(and(eq(users.email, TEST_EMAIL), eq(orgMembers.is_active, true)))
+    .limit(1);
+
+  if (!row) {
+    throw new Error(`Could not find active org member for ${TEST_EMAIL}. Set DEFT_TEST_EMAIL or seed the pilot workspace.`);
+  }
+  return row;
+}
+
+async function buildCases(orgId: string): Promise<EvalCase[]> {
+  const proofRows = await db.select({
+    id: wikiPages.id,
+    slug: wikiPages.slug,
+    title: wikiPages.title,
+    space_id: wikiPages.space_id,
+    origin_space_id: wikiPages.origin_space_id,
+  })
+    .from(wikiPages)
+    .where(and(
+      eq(wikiPages.org_id, orgId),
+      eq(wikiPages.is_deleted, false),
+      sql`${wikiPages.metadata}->>'knowledge_marker' IS NOT NULL`,
+    ))
+    .orderBy(desc(wikiPages.updated_at))
+    .limit(3);
+
+  const recentRows = await db.select({
+    id: wikiPages.id,
+    slug: wikiPages.slug,
+    title: wikiPages.title,
+    space_id: wikiPages.space_id,
+    origin_space_id: wikiPages.origin_space_id,
+  })
+    .from(wikiPages)
+    .where(and(
+      eq(wikiPages.org_id, orgId),
+      eq(wikiPages.is_deleted, false),
+      sql`length(${wikiPages.title}) >= 8`,
+    ))
+    .orderBy(desc(wikiPages.updated_at))
+    .limit(8);
+
+  const byId = new Map<string, EvalCase>();
+  for (const row of [...proofRows, ...recentRows]) {
+    byId.set(row.id, {
+      name: row.title,
+      query: queryFromTitle(row.title),
+      expectedPageId: row.id,
+      expectedSlug: row.slug,
+      spaceId: row.space_id ?? row.origin_space_id ?? null,
+    });
+  }
+  return Array.from(byId.values()).slice(0, 8);
+}
+
+async function runCase(user: { id: string; org_id: string }, evalCase: EvalCase): Promise<EvalResult> {
+  const results = await retrieveContext({
+    query: evalCase.query,
+    org_id: user.org_id,
+    user_id: user.id,
+    space_id: evalCase.spaceId ?? undefined,
+    include_org: true,
+    types: ['wiki', 'decisions', 'notes'],
+    limit: 8,
+  });
+
+  const rankIndex = results.findIndex((hit) => (
+    hit.source_type === 'wiki_page' && hit.source_id === evalCase.expectedPageId
+  ) || hit.metadata?.slug === evalCase.expectedSlug);
+  return {
+    ...evalCase,
+    ok: rankIndex >= 0 && rankIndex < 5,
+    rank: rankIndex >= 0 ? rankIndex + 1 : null,
+    hits: results.slice(0, 5).map((hit) => ({
+      title: hit.title,
+      source_id: hit.source_id,
+      slug: typeof hit.metadata?.slug === 'string' ? hit.metadata.slug : null,
+      score: hit.score,
+      scope: hit.scope ?? null,
+    })),
+  };
+}
+
+async function writeReport(results: EvalResult[]) {
+  const passCount = results.filter((r) => r.ok).length;
+  const html = `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Knowledge Retrieval Eval</title>
+  <style>
+    body { font-family: Inter, ui-sans-serif, system-ui, -apple-system, Segoe UI, sans-serif; margin: 32px; color: #18212f; background: #f7f4ee; }
+    .wrap { max-width: 1080px; margin: 0 auto; }
+    h1 { margin-bottom: 4px; }
+    .summary { padding: 16px; border: 1px solid #d7cfc1; border-radius: 8px; background: #fffaf1; margin: 18px 0; }
+    .case { padding: 16px; border: 1px solid #d7cfc1; border-radius: 8px; background: white; margin: 12px 0; }
+    .pass { color: #166534; font-weight: 700; }
+    .fail { color: #b91c1c; font-weight: 700; }
+    table { width: 100%; border-collapse: collapse; margin-top: 10px; font-size: 13px; }
+    th, td { border-bottom: 1px solid #eee3d3; padding: 8px; text-align: left; vertical-align: top; }
+    code { background: #f1eadf; padding: 1px 4px; border-radius: 4px; }
+  </style>
+</head>
+<body>
+  <main class="wrap">
+    <h1>Knowledge Retrieval Eval</h1>
+    <p>Run: ${escapeHtml(RUN_ID)} / User: ${escapeHtml(TEST_EMAIL)}</p>
+    <section class="summary">
+      <strong>${passCount}/${results.length} cases passed</strong>
+      <p>Pass means the expected wiki page appeared in the top 5 results from the shared retrieveContext gateway.</p>
+    </section>
+    ${results.map((result) => `
+      <section class="case">
+        <div class="${result.ok ? 'pass' : 'fail'}">${result.ok ? 'PASS' : 'FAIL'} / ${escapeHtml(result.name)}</div>
+        <p>Query: <code>${escapeHtml(result.query)}</code> / Expected: <code>${escapeHtml(result.expectedSlug)}</code> / Rank: ${escapeHtml(result.rank ?? 'not found')}</p>
+        <table>
+          <thead><tr><th>#</th><th>Hit</th><th>Slug</th><th>Scope</th><th>Score</th></tr></thead>
+          <tbody>
+            ${result.hits.map((hit, index) => `
+              <tr>
+                <td>${index + 1}</td>
+                <td>${escapeHtml(hit.title)}</td>
+                <td>${escapeHtml(hit.slug)}</td>
+                <td>${escapeHtml(hit.scope)}</td>
+                <td>${escapeHtml(hit.score.toFixed(3))}</td>
+              </tr>
+            `).join('')}
+          </tbody>
+        </table>
+      </section>
+    `).join('')}
+  </main>
+</body>
+</html>`;
+
+  await fs.mkdir(path.dirname(REPORT_PATH), { recursive: true });
+  await fs.writeFile(REPORT_PATH, html, 'utf8');
+}
+
+async function main() {
+  const user = await currentUser();
+  const cases = await buildCases(user.org_id);
+  if (cases.length === 0) {
+    throw new Error('No wiki pages found to evaluate. Seed the pilot workspace first.');
+  }
+
+  const results: EvalResult[] = [];
+  for (const evalCase of cases) {
+    results.push(await runCase(user, evalCase));
+  }
+  await writeReport(results);
+
+  const passCount = results.filter((r) => r.ok).length;
+  console.log(`[knowledge-eval] ${passCount}/${results.length} passed`);
+  console.log(`[knowledge-eval] report: ${REPORT_PATH}`);
+  process.exit(passCount === results.length ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error('[knowledge-eval] failed:', err instanceof Error ? err.message : err);
+  process.exit(1);
+});

--- a/scripts/knowledge-scale-probe.ts
+++ b/scripts/knowledge-scale-probe.ts
@@ -1,0 +1,637 @@
+import 'dotenv/config';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { performance } from 'node:perf_hooks';
+import { and, eq, sql } from 'drizzle-orm';
+import { db } from '../apps/api/src/lib/db.js';
+import { retrieveContext } from '../apps/api/src/lib/retrieve-context.js';
+import {
+  messages,
+  orgMembers,
+  spaceMembers,
+  spaces,
+  users,
+  wikiCitations,
+  wikiLinks,
+  wikiOpsLog,
+  wikiPages,
+} from '@deft/db/schema';
+
+type UserContext = {
+  id: string;
+  email: string;
+  org_id: string;
+};
+
+type BenchResult = {
+  name: string;
+  total: number;
+  concurrency: number;
+  ok: number;
+  errors: number;
+  p50_ms: number;
+  p95_ms: number;
+  max_ms: number;
+  avg_ms: number;
+  duration_ms: number;
+  notes?: string;
+  samples?: string[];
+};
+
+type ProbeSummary = {
+  runId: string;
+  pageCount: number;
+  messageCount: number;
+  linkCount: number;
+  citationCount: number;
+  opCount: number;
+  existingCounts: Record<string, number>;
+  seedMs: number;
+  cleanupMs: number | null;
+  cleanedUp: boolean;
+  apiUrl: string;
+  webUrl: string;
+  benches: BenchResult[];
+  ui: Record<string, unknown>;
+  reportPath: string;
+};
+
+const TEST_EMAIL = process.env.DEFT_TEST_EMAIL || 'diego@testers-tomatoes.com';
+const TEST_PASSWORD = process.env.DEFT_TEST_PASSWORD || 'tomato123';
+const API_URL = process.env.DEFT_API_URL || 'http://localhost:3301';
+const WEB_URL = process.env.DEFT_WEB_URL || 'http://localhost:3000';
+const PAGE_COUNT = Number(process.env.KNOWLEDGE_SCALE_PAGES || 1600);
+const MESSAGE_COUNT = Math.max(12, Math.floor(PAGE_COUNT / 60));
+const KEEP_DATA = process.env.KNOWLEDGE_SCALE_KEEP_DATA === '1';
+const RUN_ID = `kscale-${new Date().toISOString().replace(/[:.]/g, '-')}`;
+const REPORT_PATH = path.resolve('reports', `knowledge-scale-probe-${RUN_ID}.html`);
+
+function escapeHtml(value: unknown): string {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function percentile(values: number[], pct: number): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const index = Math.min(sorted.length - 1, Math.ceil((pct / 100) * sorted.length) - 1);
+  return sorted[index]!;
+}
+
+function round(value: number): number {
+  return Math.round(value * 10) / 10;
+}
+
+async function runBench(
+  name: string,
+  total: number,
+  concurrency: number,
+  fn: (index: number) => Promise<string | void>,
+): Promise<BenchResult> {
+  const latencies: number[] = [];
+  const samples: string[] = [];
+  let next = 0;
+  let ok = 0;
+  let errors = 0;
+  const started = performance.now();
+
+  async function worker() {
+    while (true) {
+      const index = next++;
+      if (index >= total) return;
+      const t0 = performance.now();
+      try {
+        const sample = await fn(index);
+        latencies.push(performance.now() - t0);
+        ok += 1;
+        if (sample && samples.length < 4) samples.push(sample);
+      } catch (err) {
+        latencies.push(performance.now() - t0);
+        errors += 1;
+        if (samples.length < 4) samples.push(err instanceof Error ? err.message : String(err));
+      }
+    }
+  }
+
+  await Promise.all(Array.from({ length: concurrency }, () => worker()));
+  const duration = performance.now() - started;
+  const avg = latencies.reduce((sum, value) => sum + value, 0) / Math.max(1, latencies.length);
+  return {
+    name,
+    total,
+    concurrency,
+    ok,
+    errors,
+    p50_ms: round(percentile(latencies, 50)),
+    p95_ms: round(percentile(latencies, 95)),
+    max_ms: round(Math.max(0, ...latencies)),
+    avg_ms: round(avg),
+    duration_ms: round(duration),
+    samples,
+  };
+}
+
+async function currentUser(): Promise<UserContext> {
+  const [row] = await db.select({
+    id: users.id,
+    email: users.email,
+    org_id: orgMembers.org_id,
+  })
+    .from(users)
+    .innerJoin(orgMembers, eq(orgMembers.user_id, users.id))
+    .where(and(eq(users.email, TEST_EMAIL), eq(orgMembers.is_active, true)))
+    .limit(1);
+
+  if (!row) {
+    throw new Error(`Could not find active org member for ${TEST_EMAIL}`);
+  }
+  return row as UserContext;
+}
+
+async function userSpaces(userId: string, orgId: string) {
+  const rows = await db.select({
+    id: spaces.id,
+    name: spaces.name,
+  })
+    .from(spaces)
+    .innerJoin(spaceMembers, eq(spaceMembers.space_id, spaces.id))
+    .where(and(
+      eq(spaces.org_id, orgId),
+      eq(spaces.is_archived, false),
+      eq(spaceMembers.user_id, userId),
+    ))
+    .limit(12);
+
+  if (rows.length === 0) {
+    throw new Error(`User ${userId} has no visible spaces; cannot run channel-aware scale probe.`);
+  }
+  return rows;
+}
+
+async function countExisting(orgId: string) {
+  const result = await db.execute(sql`
+    SELECT
+      (SELECT count(*)::int FROM wiki_pages WHERE org_id = ${orgId} AND is_deleted = false) AS pages,
+      (SELECT count(*)::int FROM wiki_links WHERE org_id = ${orgId}) AS links,
+      (SELECT count(*)::int FROM wiki_citations WHERE org_id = ${orgId}) AS citations,
+      (SELECT count(*)::int FROM wiki_ops_log WHERE org_id = ${orgId}) AS ops
+  `) as unknown as { rows?: Array<Record<string, number>> } | Array<Record<string, number>>;
+  const row = Array.isArray(result) ? result[0] : result.rows?.[0];
+  return {
+    pages: Number(row?.pages ?? 0),
+    links: Number(row?.links ?? 0),
+    citations: Number(row?.citations ?? 0),
+    ops: Number(row?.ops ?? 0),
+  };
+}
+
+async function seedSyntheticCorpus(user: UserContext, visibleSpaces: Array<{ id: string; name: string }>) {
+  const started = performance.now();
+  const pageIds: string[] = [];
+  const messageIds: string[] = [];
+  const pageRows = [];
+  const typeCycle = ['fact', 'decision', 'resource', 'procedure', 'entity', 'preference'] as const;
+  const termCycle = [
+    'cold chain calibration buyer copy route capacity',
+    'sun gold sample box wholesale forecast',
+    'greenhouse humidity irrigation exception',
+    'packing line label audit delivery promise',
+    'restaurant buyer harvest timing invoice note',
+    'field ops quality threshold dispatch blocker',
+  ];
+
+  for (let i = 0; i < MESSAGE_COUNT; i += 1) {
+    const space = visibleSpaces[i % visibleSpaces.length]!;
+    const id = randomUUID();
+    messageIds.push(id);
+    await db.insert(messages).values({
+      id,
+      org_id: user.org_id,
+      space_id: space.id,
+      user_id: user.id,
+      content: `Scale probe ${RUN_ID} source message ${i}: ${termCycle[i % termCycle.length]}.`,
+      metadata: { scale_probe_id: RUN_ID },
+    });
+  }
+
+  for (let i = 0; i < PAGE_COUNT; i += 1) {
+    const id = randomUUID();
+    const space = visibleSpaces[i % visibleSpaces.length]!;
+    const isOrg = i % 4 === 0;
+    const terms = termCycle[i % termCycle.length]!;
+    pageIds.push(id);
+    pageRows.push({
+      id,
+      org_id: user.org_id,
+      scope: isOrg ? 'org' : 'space',
+      space_id: isOrg ? null : space.id,
+      origin_space_id: i % 3 === 0 ? space.id : null,
+      origin_message_id: i % 3 === 0 ? messageIds[i % messageIds.length] : null,
+      origin_user_id: user.id,
+      created_via: 'scale_probe',
+      type: typeCycle[i % typeCycle.length],
+      title: `Scale Probe ${i} ${terms}`,
+      slug: `${RUN_ID}-${i}`,
+      summary: `Synthetic scale probe ${i} for ${terms}.`,
+      content: [
+        `Synthetic page ${i} for ${RUN_ID}.`,
+        `This record tests retrieval for ${terms}.`,
+        `Channel ${space.name} keeps this context near the work where it originated.`,
+        `The page includes repeated operational terms so full text search and visibility filters have enough rows to chew on.`,
+      ].join(' '),
+      metadata: { scale_probe_id: RUN_ID, scale_index: i, terms },
+      confidence: 0.55 + ((i % 40) / 100),
+      tags: ['scale-probe', terms.split(' ')[0] ?? 'knowledge'],
+      referenced_user_ids: [],
+    });
+  }
+
+  for (let i = 0; i < pageRows.length; i += 200) {
+    await db.insert(wikiPages).values(pageRows.slice(i, i + 200) as any[]);
+  }
+
+  const linkRows = [];
+  for (let i = 1; i < pageIds.length; i += 1) {
+    if (i % 2 === 0) {
+      linkRows.push({
+        id: randomUUID(),
+        org_id: user.org_id,
+        source_page_id: pageIds[i - 1]!,
+        target_page_id: pageIds[i]!,
+        context: `Scale probe link ${RUN_ID}`,
+      });
+    }
+  }
+  for (let i = 0; i < linkRows.length; i += 300) {
+    await db.insert(wikiLinks).values(linkRows.slice(i, i + 300));
+  }
+
+  const citationRows = [];
+  for (let i = 0; i < pageIds.length; i += 3) {
+    const space = visibleSpaces[i % visibleSpaces.length]!;
+    citationRows.push({
+      id: randomUUID(),
+      org_id: user.org_id,
+      page_id: pageIds[i]!,
+      source_type: 'message',
+      source_id: messageIds[i % messageIds.length]!,
+      source_space_id: space.id,
+      source_user_id: user.id,
+      excerpt: `Scale probe citation ${i}: ${termCycle[i % termCycle.length]}.`,
+    });
+  }
+  for (let i = 0; i < citationRows.length; i += 300) {
+    await db.insert(wikiCitations).values(citationRows.slice(i, i + 300));
+  }
+
+  const opRows = [];
+  for (let i = 0; i < pageIds.length; i += 80) {
+    opRows.push({
+      id: randomUUID(),
+      org_id: user.org_id,
+      operation: i % 160 === 0 ? 'contradiction' : 'scale_probe_touch',
+      page_id: pageIds[i]!,
+      details: { scale_probe_id: RUN_ID, scale_index: i },
+      performed_by: user.id,
+    });
+  }
+  if (opRows.length > 0) {
+    await db.insert(wikiOpsLog).values(opRows);
+  }
+
+  return {
+    seedMs: performance.now() - started,
+    pageIds,
+    messageIds,
+    linkCount: linkRows.length,
+    citationCount: citationRows.length,
+    opCount: opRows.length,
+  };
+}
+
+async function cleanupSyntheticCorpus() {
+  const started = performance.now();
+  await db.execute(sql`
+    DELETE FROM wiki_ops_log
+    WHERE details->>'scale_probe_id' = ${RUN_ID}
+       OR page_id IN (SELECT id FROM wiki_pages WHERE metadata->>'scale_probe_id' = ${RUN_ID})
+  `);
+  await db.execute(sql`
+    DELETE FROM wiki_citations
+    WHERE page_id IN (SELECT id FROM wiki_pages WHERE metadata->>'scale_probe_id' = ${RUN_ID})
+  `);
+  await db.execute(sql`
+    DELETE FROM wiki_links
+    WHERE source_page_id IN (SELECT id FROM wiki_pages WHERE metadata->>'scale_probe_id' = ${RUN_ID})
+       OR target_page_id IN (SELECT id FROM wiki_pages WHERE metadata->>'scale_probe_id' = ${RUN_ID})
+  `);
+  await db.execute(sql`DELETE FROM wiki_pages WHERE metadata->>'scale_probe_id' = ${RUN_ID}`);
+  await db.execute(sql`DELETE FROM messages WHERE metadata->>'scale_probe_id' = ${RUN_ID}`);
+  return performance.now() - started;
+}
+
+async function loginForApi() {
+  const res = await fetch(`${API_URL}/api/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email: TEST_EMAIL, password: TEST_PASSWORD }),
+  });
+  if (!res.ok) {
+    throw new Error(`API login failed (${res.status}): ${await res.text()}`);
+  }
+  return await res.json() as { accessToken: string };
+}
+
+function authHeaders(accessToken: string) {
+  const headers: Record<string, string> = { Authorization: `Bearer ${accessToken}` };
+  if (process.env.DEFT_AUDIT_BYPASS_TOKEN) {
+    headers['x-deft-audit-token'] = process.env.DEFT_AUDIT_BYPASS_TOKEN;
+  }
+  return headers;
+}
+
+async function apiJson(pathname: string, accessToken: string, init: RequestInit = {}) {
+  const res = await fetch(`${API_URL}${pathname}`, {
+    ...init,
+    headers: {
+      ...authHeaders(accessToken),
+      ...(init.body ? { 'Content-Type': 'application/json' } : {}),
+      ...(init.headers as Record<string, string> | undefined),
+    },
+  });
+  if (!res.ok) {
+    throw new Error(`${pathname} returned ${res.status}: ${(await res.text()).slice(0, 240)}`);
+  }
+  return await res.json();
+}
+
+async function runUiProbe() {
+  const ui: Record<string, unknown> = {};
+  try {
+    const { chromium } = await import('playwright');
+    const screenshotDir = path.resolve('reports', 'screenshots');
+    await fs.mkdir(screenshotDir, { recursive: true });
+    const browser = await chromium.launch({ headless: true });
+    const page = await browser.newPage({ viewport: { width: 1280, height: 900 } });
+    page.setDefaultTimeout(30_000);
+
+    await page.goto(`${WEB_URL}/login`, { waitUntil: 'domcontentloaded' });
+    await page.locator('input[type="email"], input[name="email"]').first().fill(TEST_EMAIL);
+    await page.locator('input[type="password"], input[name="password"]').first().fill(TEST_PASSWORD);
+    await page.locator('button[type="submit"], button:has-text("Sign in"), button:has-text("Log in")').first().click();
+    await page.waitForURL((url) => !url.pathname.includes('/login'), { timeout: 30_000 });
+
+    let t0 = performance.now();
+    await page.goto(`${WEB_URL}/knowledge`, { waitUntil: 'networkidle' });
+    await page.locator('input[placeholder="Ask what the workspace knows..."]').first().waitFor();
+    ui.desktopLoadMs = round(performance.now() - t0);
+
+    const askInput = page.locator('input[placeholder="Ask what the workspace knows..."]').first();
+    await askInput.fill(`scale probe cold chain calibration ${RUN_ID}`);
+    t0 = performance.now();
+    await page.locator('div').filter({ has: askInput }).locator('button:has-text("Ask")').first().click();
+    await page.getByText(/Answered from sources|Sources only/i).first().waitFor({ timeout: 60_000 });
+    ui.desktopAskMs = round(performance.now() - t0);
+    await page.screenshot({
+      path: path.join(screenshotDir, `knowledge-scale-desktop-${RUN_ID}.png`),
+      fullPage: true,
+    });
+
+    await page.setViewportSize({ width: 390, height: 844 });
+    t0 = performance.now();
+    await page.goto(`${WEB_URL}/knowledge`, { waitUntil: 'networkidle' });
+    const selects = page.locator('select');
+    for (let i = 0; i < await selects.count(); i += 1) {
+      const select = selects.nth(i);
+      const options = await select.locator('option').evaluateAll((nodes) => nodes.map((node) => ({ value: node.value, text: node.textContent || '' })));
+      const doctor = options.find((option) => option.value === 'doctor' || /doctor/i.test(option.text));
+      if (doctor) {
+        await select.selectOption(doctor.value);
+        break;
+      }
+    }
+    await page.getByText(/Low confidence|Contradictions|Knowledge Doctor/i).first().waitFor({ timeout: 60_000 });
+    ui.mobileDoctorMs = round(performance.now() - t0);
+    await page.screenshot({
+      path: path.join(screenshotDir, `knowledge-scale-mobile-${RUN_ID}.png`),
+      fullPage: true,
+    });
+    await browser.close();
+    ui.ok = true;
+  } catch (err) {
+    ui.ok = false;
+    ui.error = err instanceof Error ? err.message : String(err);
+  }
+  return ui;
+}
+
+async function writeReport(summary: ProbeSummary) {
+  const rows = summary.benches.map((bench) => `
+    <tr>
+      <td>${escapeHtml(bench.name)}</td>
+      <td>${bench.ok}/${bench.total}</td>
+      <td>${bench.concurrency}</td>
+      <td>${bench.p50_ms}</td>
+      <td>${bench.p95_ms}</td>
+      <td>${bench.max_ms}</td>
+      <td>${bench.avg_ms}</td>
+      <td>${escapeHtml((bench.samples ?? []).join(' | '))}</td>
+    </tr>
+  `).join('');
+
+  const html = `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Knowledge Scale Probe</title>
+  <style>
+    body { margin: 0; background: #f6f0e7; color: #191714; font-family: Inter, ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif; }
+    main { max-width: 1180px; margin: 0 auto; padding: 40px 24px 64px; }
+    h1 { font-size: 34px; margin: 0 0 8px; }
+    h2 { margin: 30px 0 12px; font-size: 20px; }
+    p, li { color: #675f56; line-height: 1.55; }
+    .grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 12px; }
+    .card { background: #fff; border: 1px solid #e2d8c8; border-radius: 8px; padding: 16px; }
+    .metric { font-size: 28px; font-weight: 760; }
+    table { width: 100%; border-collapse: collapse; background: #fff; border: 1px solid #e2d8c8; border-radius: 8px; overflow: hidden; }
+    th, td { padding: 9px 10px; border-bottom: 1px solid #e2d8c8; font-size: 13px; text-align: left; vertical-align: top; }
+    th { background: #fff8ee; }
+    code { background: #efe5d7; border: 1px solid #dfd1bf; border-radius: 4px; padding: 1px 5px; font-size: 12px; }
+    .ok { color: #137a42; font-weight: 700; }
+    .warn { color: #9a5b00; font-weight: 700; }
+    @media (max-width: 900px) { .grid { grid-template-columns: 1fr 1fr; } }
+    @media (max-width: 560px) { .grid { grid-template-columns: 1fr; } main { padding: 28px 16px 48px; } }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>Knowledge Scale Probe</h1>
+    <p>Run <code>${escapeHtml(summary.runId)}</code>. Synthetic corpus was ${summary.cleanedUp ? 'cleaned up after the probe' : 'left in place'}.</p>
+
+    <section class="grid">
+      <div class="card"><div class="metric">${summary.pageCount}</div><p>synthetic wiki pages</p></div>
+      <div class="card"><div class="metric">${summary.linkCount}</div><p>synthetic links</p></div>
+      <div class="card"><div class="metric">${summary.citationCount}</div><p>synthetic citations</p></div>
+      <div class="card"><div class="metric">${summary.seedMs}ms</div><p>seed time</p></div>
+    </section>
+
+    <h2>Existing Corpus Before Probe</h2>
+    <p>Pages: <code>${summary.existingCounts.pages}</code>, links: <code>${summary.existingCounts.links}</code>, citations: <code>${summary.existingCounts.citations}</code>, ops: <code>${summary.existingCounts.ops}</code>.</p>
+
+    <h2>Benchmarks</h2>
+    <table>
+      <thead><tr><th>Path</th><th>OK</th><th>Conc.</th><th>p50 ms</th><th>p95 ms</th><th>max ms</th><th>avg ms</th><th>Samples/errors</th></tr></thead>
+      <tbody>${rows}</tbody>
+    </table>
+
+    <h2>UI Probe</h2>
+    <div class="card">
+      <p>Desktop load: <code>${escapeHtml(summary.ui.desktopLoadMs)}</code> ms. Desktop Ask: <code>${escapeHtml(summary.ui.desktopAskMs)}</code> ms. Mobile Doctor: <code>${escapeHtml(summary.ui.mobileDoctorMs)}</code> ms. UI result: <span class="${summary.ui.ok ? 'ok' : 'warn'}">${summary.ui.ok ? 'passed' : 'needs attention'}</span>.</p>
+      ${summary.ui.error ? `<p>Error: <code>${escapeHtml(summary.ui.error)}</code></p>` : ''}
+    </div>
+
+    <h2>Interpretation</h2>
+    <ul>
+      <li>Direct retrieval is the cleanest measure of the Context Router path without HTTP/auth/rate-limit overhead.</li>
+      <li>Live API list/graph/Doctor checks include auth middleware, JSON serialization, and route-level visibility filters.</li>
+      <li>Ask synthesis intentionally runs as a small sample because LLM latency and provider limits dominate that path.</li>
+      <li>Doctor's orphan/contradiction checks are the paths to watch as wiki volume grows because they use anti-join style checks across links and citations.</li>
+    </ul>
+
+    <h2>Cleanup</h2>
+    <p>Cleanup duration: <code>${escapeHtml(summary.cleanupMs)}</code> ms. Set <code>KNOWLEDGE_SCALE_KEEP_DATA=1</code> to keep synthetic data for manual UI inspection.</p>
+  </main>
+</body>
+</html>`;
+
+  await fs.mkdir(path.dirname(summary.reportPath), { recursive: true });
+  await fs.writeFile(summary.reportPath, html, 'utf8');
+}
+
+async function main() {
+  const user = await currentUser();
+  const visibleSpaces = await userSpaces(user.id, user.org_id);
+  const existingCounts = await countExisting(user.org_id);
+  console.log(`[knowledge-scale] user=${user.email} org=${user.org_id} spaces=${visibleSpaces.length}`);
+  console.log(`[knowledge-scale] seeding ${PAGE_COUNT} pages...`);
+
+  let cleanupMs: number | null = null;
+  let cleanedUp = false;
+  const benches: BenchResult[] = [];
+  const seeded = await seedSyntheticCorpus(user, visibleSpaces);
+  const seedMs = round(seeded.seedMs);
+
+  try {
+    const access = await loginForApi();
+    const queryTerms = [
+      'cold chain calibration buyer copy',
+      'sun gold sample wholesale forecast',
+      'greenhouse humidity irrigation exception',
+      'packing line label audit',
+      'restaurant buyer harvest timing',
+      'field ops quality threshold',
+    ];
+
+    benches.push(await runBench('direct retrieveContext wiki+decisions+notes', 180, 18, async (index) => {
+      const query = `${queryTerms[index % queryTerms.length]} ${RUN_ID}`;
+      const hits = await retrieveContext({
+        query,
+        org_id: user.org_id,
+        user_id: user.id,
+        space_id: visibleSpaces[index % visibleSpaces.length]?.id,
+        include_org: true,
+        types: ['wiki', 'decisions', 'notes'],
+        limit: 8,
+      });
+      if (hits.length === 0) throw new Error('no hits');
+      return hits[0]?.title;
+    }));
+
+    benches.push(await runBench('live API /api/wiki search', 90, 12, async (index) => {
+      const query = encodeURIComponent(`${queryTerms[index % queryTerms.length]} ${RUN_ID}`);
+      const data = await apiJson(`/api/wiki?q=${query}&limit=50`, access.accessToken);
+      if (!Array.isArray(data.pages) || data.pages.length === 0) throw new Error('no pages');
+      return `${data.pages.length} pages`;
+    }));
+
+    benches.push(await runBench('live API /api/wiki/graph org', 24, 4, async () => {
+      const data = await apiJson('/api/wiki/graph?mode=org&limit=1000', access.accessToken);
+      if (!Array.isArray(data.nodes)) throw new Error('missing nodes');
+      return `${data.nodes.length} nodes`;
+    }));
+
+    benches.push(await runBench('live API /api/wiki/graph channel', 24, 4, async (index) => {
+      const space = visibleSpaces[index % visibleSpaces.length]!;
+      const data = await apiJson(`/api/wiki/graph?mode=space&space_id=${space.id}&limit=1000`, access.accessToken);
+      if (!Array.isArray(data.nodes)) throw new Error('missing nodes');
+      return `${data.nodes.length} nodes`;
+    }));
+
+    benches.push(await runBench('live API /api/wiki/doctor', 18, 3, async () => {
+      const data = await apiJson('/api/wiki/doctor', access.accessToken);
+      if (!data.summary) throw new Error('missing summary');
+      return `${data.summary.orphaned} orphaned`;
+    }));
+
+    benches.push(await runBench('live API /api/wiki/ask synthesis sample', 3, 1, async (index) => {
+      const data = await apiJson('/api/wiki/ask', access.accessToken, {
+        method: 'POST',
+        body: JSON.stringify({
+          query: `${queryTerms[index % queryTerms.length]} ${RUN_ID}`,
+          include_org: true,
+          space_id: visibleSpaces[index % visibleSpaces.length]?.id,
+          limit: 6,
+        }),
+      });
+      if (!data.answer || !Array.isArray(data.sources)) throw new Error('bad ask response');
+      return `${data.mode}/${data.sources.length} sources`;
+    }));
+
+    const ui = await runUiProbe();
+    if (!KEEP_DATA) {
+      cleanupMs = round(await cleanupSyntheticCorpus());
+      cleanedUp = true;
+    }
+
+    const summary: ProbeSummary = {
+      runId: RUN_ID,
+      pageCount: PAGE_COUNT,
+      messageCount: MESSAGE_COUNT,
+      linkCount: seeded.linkCount,
+      citationCount: seeded.citationCount,
+      opCount: seeded.opCount,
+      existingCounts,
+      seedMs,
+      cleanupMs,
+      cleanedUp,
+      apiUrl: API_URL,
+      webUrl: WEB_URL,
+      benches,
+      ui,
+      reportPath: REPORT_PATH,
+    };
+    await writeReport(summary);
+    console.log(`[knowledge-scale] report: ${REPORT_PATH}`);
+    for (const bench of benches) {
+      console.log(`[knowledge-scale] ${bench.name}: ok=${bench.ok}/${bench.total} p50=${bench.p50_ms}ms p95=${bench.p95_ms}ms max=${bench.max_ms}ms`);
+    }
+    console.log(`[knowledge-scale] ui=${JSON.stringify(ui)}`);
+    process.exit(0);
+  } catch (err) {
+    if (!KEEP_DATA) {
+      cleanupMs = round(await cleanupSyntheticCorpus().catch(() => -1));
+      cleanedUp = cleanupMs >= 0;
+    }
+    throw err;
+  }
+}
+
+main().catch((err) => {
+  console.error('[knowledge-scale] failed:', err instanceof Error ? err.stack || err.message : err);
+  process.exit(1);
+});


### PR DESCRIPTION
﻿## Summary

Polishes the Knowledge Console around the new context-router model:

- centralizes channel-aware wiki visibility rules for graph, retrieval, MCP memory, and channel knowledge routes
- hardens secondary wiki surfaces so private-space links, citations, ops-log rows, and contradictions do not leak through detail/log/stats views
- adds `POST /api/wiki/ask` for grounded Ask Knowledge using existing `retrieveContext` plus provider-neutral `llm()` synthesis, with retrieval-only fallback when no reasoning provider is configured
- adds read-only `GET /api/wiki/doctor` for low-confidence, stale, orphaned, and contradiction diagnostics
- adds Ask Knowledge and Doctor surfaces to the Knowledge UI, including mobile navigation for Doctor/Graph/Stats
- adds repeatable local probes: `pnpm pilot:knowledge-eval` and `pnpm pilot:knowledge-scale`

## Why

The Knowledge tab was becoming the main interface for company memory and channel context, but the product needed a more trustworthy console: consistent scope rules, source-backed answers, a read-only health surface, and scale proof before demo/deploy.

## Validation

Local checks run before opening this PR:

- `pnpm --filter @deft/api typecheck` passed
- `pnpm --filter @deft/web typecheck` passed
- `pnpm --filter @deft/api exec tsx --test --test-concurrency=1 --test-force-exit test/wiki-graph-scope.test.ts` passed
- `pnpm pilot:knowledge-eval` passed `8/8`
- `KNOWLEDGE_SCALE_PAGES=1600 DEFT_WEB_URL=http://localhost:3000 DEFT_API_URL=http://localhost:3301 pnpm pilot:knowledge-scale` passed
- synthetic scale probe cleanup verified with `0` remaining `kscale-*` wiki pages

Prior deeper scale probe also passed locally at 10,000 synthetic wiki pages. The growth-sensitive path is direct `retrieveContext` under high concurrency, but list/search/graph/Doctor stayed comfortably fast for pilot-scale data.

## Notes

Generated HTML reports and screenshots are local artifacts and intentionally not committed.
