### PR TITLE
[codex] Polish knowledge graph deep links

### DIFF
--- a/apps/web/src/app/(app)/knowledge/page.tsx
+++ b/apps/web/src/app/(app)/knowledge/page.tsx
@@ -447,13 +447,42 @@ export default function KnowledgePage() {
     }
   }, [page, filter, scopeFilter, debouncedSearchQuery]);
 
-  // Sync filter from URL ?type= param, open detail from ?slug= param
+  // Sync deep-link state from URL params.
   useEffect(() => {
     const typeParam = searchParams.get('type');
     const validTypes = ['concept', 'entity', 'decision', 'resource', 'procedure', 'preference', 'fact'];
     if (typeParam && validTypes.includes(typeParam)) {
       setFilter(typeParam);
     }
+
+    const viewParam = searchParams.get('view');
+    if (viewParam === 'graph') {
+      setShowGraph(true);
+      setViewMode('pages');
+    } else if (viewParam === 'activity' || viewParam === 'stats' || viewParam === 'doctor' || viewParam === 'pages') {
+      setShowGraph(false);
+      setViewMode(viewParam);
+    }
+
+    const graphModeParam = searchParams.get('graphMode') ?? searchParams.get('graph');
+    const spaceParam = searchParams.get('space_id') ?? searchParams.get('space') ?? searchParams.get('graph_space_id');
+    const includeOrgParam = searchParams.get('include_org') ?? searchParams.get('includeOrg');
+    if (viewParam === 'graph' || graphModeParam || spaceParam) {
+      setShowGraph(true);
+      setViewMode('pages');
+    }
+    if (graphModeParam === 'org' || graphModeParam === 'space') {
+      setGraphMode(graphModeParam);
+    } else if (spaceParam) {
+      setGraphMode('space');
+    }
+    if (spaceParam) {
+      setGraphSpaceId(spaceParam);
+    }
+    if (includeOrgParam !== null) {
+      setGraphIncludeOrg(!['0', 'false', 'no'].includes(includeOrgParam.toLowerCase()));
+    }
+
     const slugParam = searchParams.get('slug');
     if (slugParam) {
       setSelectedSlug(slugParam);


### PR DESCRIPTION
## What changed

Adds URL-state support to the Knowledge page so demo and support links can open directly into graph mode, including channel-scoped graphs.

Supported links now include examples like:

- `/knowledge?view=graph`
- `/knowledge?view=graph&graph=space&space_id=<space-id>`
- `/knowledge?view=graph&graphMode=space&space_id=<space-id>&include_org=false`

## Why

During the public demo rehearsal, the company and channel graph worked once toggled manually, but direct URLs always landed on the page list. For recording and customer support, graph deep links should land exactly on the surface being discussed.

## Validation

- `pnpm --filter @deft/web typecheck`
- `pnpm --filter @deft/web build`
- Chrome dogfood on `demo.deft.ing`: dashboard, marketing chat, task board, Knowledge graph, channel graph, MCP Access
- Demo cleanup verified: removed old deleted-message debris and temporary MCP smoke artifacts from the public demo database