### PR TITLE
[codex] Polish chat governance capture flow

### DIFF
--- a/apps/api/src/lib/chat-observation.ts
+++ b/apps/api/src/lib/chat-observation.ts
@@ -6,14 +6,29 @@ import { toPlainText } from './plain-text.js';
 export const CHAT_OBSERVATION_VERSION = 1;
 export const OBSERVE_CHAT_MESSAGE_JOB = 'observe-chat-message';
 
+export function hasNoTaskDirective(content: string): boolean {
+  const plain = toPlainText(content).toLowerCase().replace(/\s+/g, ' ').trim();
+  return /\b(no task|no tasks|not a task|no actual task|not tasks?|do not create (?:a |any |individual )?(?:tasks?|todos?|tickets?)|don't create (?:a |any |individual )?(?:tasks?|todos?|tickets?)|dont create (?:a |any |individual )?(?:tasks?|todos?|tickets?))\b/.test(plain) ||
+    /\b(?:hold off|wait|not yet|later|after this is settled|once this is settled)\b.{0,80}\b(?:tasks?|todos?|tickets?)\b/.test(plain) ||
+    /\b(?:tasks?|todos?|tickets?)\b.{0,80}\b(?:not yet|later|after this is settled|once this is settled|hold off)\b/.test(plain);
+}
+
+export function hasNoKnowledgeDirective(content: string): boolean {
+  const plain = toPlainText(content).toLowerCase().replace(/\s+/g, ' ').trim();
+  return /\b(don't save|dont save|do not save|no one should save|no memory|no company memory|don't remember|dont remember|do not remember|nothing to capture|nothing to save|do not capture|don't capture|dont capture)\b/.test(plain) ||
+    /\b(?:keep|leave)\s+(?:this|that|it)?\s*(?:only\s+)?in\s+chat\b/.test(plain) ||
+    /\bignore\s+(?:this|that|the)\s+(?:for\s+)?(?:knowledge|memory|wiki|context)\b/.test(plain);
+}
+
 export function explicitObservationIgnoreReason(content: string): string | null {
   const plain = toPlainText(content).toLowerCase().replace(/\s+/g, ' ').trim();
   if (!plain) return 'empty_content';
 
   if (
     /\b(no action needed|no action required|no follow up needed|nothing to do)\b/.test(plain) ||
-    /\b(no task|no tasks|not a task|don't create (?:a )?task|dont create (?:a )?task|do not create (?:a )?task)\b/.test(plain) ||
-    /\b(don't save|dont save|do not save|no memory|don't remember|dont remember|do not remember|nothing to capture|nothing to save)\b/.test(plain) ||
+    /\b(joke only|not the task)\b/.test(plain) ||
+    hasNoTaskDirective(content) ||
+    hasNoKnowledgeDirective(content) ||
     /\b(ignore this|just thinking aloud|thinking out loud|fyi only|for visibility only)\b/.test(plain)
   ) {
     return 'explicit_no_action';

--- a/apps/api/src/lib/defty-capture.ts
+++ b/apps/api/src/lib/defty-capture.ts
@@ -1,6 +1,7 @@
 import { and, eq, sql } from 'drizzle-orm';
 import { agentActions, messages, projects, projectSpaces, spaces, tasks, wikiPages, workIntents } from '@deft/db/schema';
 import { db } from './db.js';
+import { approveAction } from './agent-approval-resolver.js';
 import { ensureDeftyEmployee } from './ensure-defty-membership.js';
 import { toPlainText, truncatePlainText } from './plain-text.js';
 import { resolveAssigneeWithMatches } from './resolve-assignee.js';
@@ -25,6 +26,7 @@ type TaskUpdatePatch = {
   comment?: string;
   description?: string;
 };
+type TaskCaptureApprovalMode = 'approval' | 'passive';
 
 async function resolveProjectForCapture(
   orgId: string,
@@ -76,13 +78,37 @@ async function resolveProjectForCapture(
 function buildFallbackTitle(content: string): string {
   const plainContent = toPlainText(content);
   const explicit = plainContent.match(
-    /\b(?:create|add|make|open|track)\b.{0,40}\b(?:task|todo|ticket)\b\s*:?\s*(.+)$/i,
+    /\b(?:create|add|make|open|track)\b.{0,40}\b(?:tasks?|todos?|tickets?)\b\s*:?\s*(.+)$/i,
   );
   const candidate = (explicit?.[1]?.trim() || plainContent).replace(/[.!?]+$/g, '');
   return truncatePlainText(candidate.replace(/^please\s+/i, ''), 80) || 'Follow up from chat';
 }
 
 type DeftyKnowledgeWikiType = 'decision' | 'resource' | 'concept' | 'entity' | 'procedure' | 'preference' | 'fact';
+
+function shouldAutoApproveKnowledgeCapture(params: {
+  captureKind: 'decision_candidate' | 'resource_candidate' | 'note_candidate';
+  targetScope: 'org' | 'space';
+}): boolean {
+  // Public decisions/resources are the durable work record. Auto-approve them
+  // quietly so chat stays clean while receipts still preserve governance.
+  return params.targetScope === 'org' &&
+    (params.captureKind === 'decision_candidate' || params.captureKind === 'resource_candidate');
+}
+
+async function autoApproveDeftyCapture(params: {
+  actionId?: string;
+  deftyUserId: string;
+  label: string;
+}): Promise<void> {
+  if (!params.actionId) return;
+  const result = await approveAction(params.actionId, params.deftyUserId);
+  if (result.status === 'error') {
+    console.warn(
+      `[defty-capture] Auto-approval failed for ${params.label} (${params.actionId}): ${result.code} ${result.message}`,
+    );
+  }
+}
 
 function normalizeComparable(value: string): string {
   return toPlainText(value)
@@ -161,13 +187,24 @@ function equivalentKnowledgeCapture(params: {
 }
 
 function isKnowledgeUpdateRequest(content: string): boolean {
-  return /\b(?:update|correct|correction|amend|revise|change|replace)\b/i.test(content);
+  const plain = toPlainText(content).trim();
+  return /^(?:(?:decision|fact|resource|note|knowledge|wiki|memory)\s*:\s*)?(?:update|correct|correction|amend|revise|change|replace)\b(?:\s+(?:the\s+)?(?:decision|fact|resource|note|knowledge|wiki|memory))?\b/i.test(plain)
+    || /\b(?:update|correct|correction|amend|revise|change|replace)\b\s+(?:the\s+)?(?:decision|fact|resource|note|knowledge|wiki|memory)\b/i.test(plain);
 }
 
 function stripKnowledgeUpdatePrefix(content: string): string {
   const plain = toPlainText(content);
-  const explicit = plain.match(/\b(?:update|correct|correction|amend|revise|change|replace)\b(?:\s+(?:the\s+)?(?:decision|fact|resource|note|knowledge|wiki|memory))?\s*:?\s*(.+)$/i);
+  const explicit = plain.match(/^(?:(?:decision|fact|resource|note|knowledge|wiki|memory)\s*:\s*)?(?:update|correct|correction|amend|revise|change|replace)\b(?:\s+(?:the\s+)?(?:decision|fact|resource|note|knowledge|wiki|memory))?\s*:?\s*(.+)$/i)
+    ?? plain.match(/\b(?:update|correct|correction|amend|revise|change|replace)\b\s+(?:the\s+)?(?:decision|fact|resource|note|knowledge|wiki|memory)\s*:?\s*(.+)$/i);
   return explicit?.[1]?.trim() || plain;
+}
+
+function extractKnowledgeUpdateTarget(content: string): string {
+  const stripped = stripKnowledgeUpdatePrefix(content)
+    .replace(/^(?:the\s+)?(?:decision|fact|resource|note|knowledge|wiki|memory)\s+/i, '')
+    .trim();
+  const target = stripped.split(/\b(?:to|should|with|so that|because|and)\b/i)[0]?.trim() ?? '';
+  return target || stripped;
 }
 
 async function findWikiPageForExplicitUpdate(params: {
@@ -197,11 +234,33 @@ async function findWikiPageForExplicitUpdate(params: {
     .limit(250);
 
   const normalizedContent = normalizeComparable(params.content);
+  const updateTarget = extractKnowledgeUpdateTarget(params.content);
+  const normalizedTarget = normalizeComparable(updateTarget);
+  const targetRefs = distinctiveReferenceTokens(updateTarget);
   const matches = rows.filter((row) => {
+    const rowReferenceText = `${row.title}\n${row.summary ?? ''}\n${row.content}`;
+    const rowRefs = distinctiveReferenceTokens(rowReferenceText);
+    if (targetRefs.size > 0) {
+      for (const ref of targetRefs) {
+        if (!rowRefs.has(ref)) return false;
+      }
+    }
+
     const normalizedTitle = normalizeComparable(row.title);
     if (normalizedTitle && normalizedContent.includes(normalizedTitle)) return true;
+    if (normalizedTarget && normalizedTarget.length >= 12) {
+      if (targetRefs.size > 0 && tokenOverlap(updateTarget, row.title) >= 0.25) {
+        return true;
+      }
+      if (normalizedTitle.includes(normalizedTarget) || normalizedTarget.includes(normalizedTitle)) {
+        return true;
+      }
+      if (tokenOverlap(updateTarget, row.title) >= 0.4) {
+        return true;
+      }
+    }
     const titleOverlap = tokenOverlap(params.title, row.title);
-    const bodyOverlap = tokenOverlap(params.content, `${row.title}\n${row.summary ?? ''}\n${row.content}`);
+    const bodyOverlap = tokenOverlap(params.content, rowReferenceText);
     return titleOverlap >= 0.85 || bodyOverlap >= 0.82;
   });
 
@@ -489,6 +548,58 @@ async function findSimilarWikiPage(params: {
   return null;
 }
 
+async function findRelatedWikiPage(params: {
+  orgId: string;
+  spaceId: string;
+  title: string;
+  content: string;
+  wikiType: DeftyKnowledgeWikiType;
+  scope: 'org' | 'space';
+}): Promise<{ id: string; title: string; slug: string } | null> {
+  const rows = await db
+    .select({
+      id: wikiPages.id,
+      title: wikiPages.title,
+      slug: wikiPages.slug,
+      content: wikiPages.content,
+      summary: wikiPages.summary,
+    })
+    .from(wikiPages)
+    .where(and(
+      eq(wikiPages.org_id, params.orgId),
+      eq(wikiPages.is_deleted, false),
+      eq(wikiPages.type, params.wikiType),
+      eq(wikiPages.scope, params.scope),
+      params.scope === 'space' ? eq(wikiPages.space_id, params.spaceId) : sql`TRUE`,
+    ))
+    .limit(250);
+
+  let best: { id: string; title: string; slug: string; score: number } | null = null;
+  for (const row of rows) {
+    const existingComparable = `${row.title}\n${row.summary ?? ''}\n${row.content ?? ''}`;
+    if (hasMissingDistinctiveReference(`${params.title}\n${params.content}`, existingComparable)) {
+      continue;
+    }
+    const candidateTitle = normalizeComparable(params.title);
+    const existingTitle = normalizeComparable(row.title);
+    const titleContains = existingTitle.length >= 12 &&
+      (candidateTitle.includes(existingTitle) || existingTitle.includes(candidateTitle));
+    const titleOverlap = tokenOverlap(params.title, row.title);
+    const bodyOverlap = tokenOverlap(params.content, existingComparable);
+    const score = titleContains ? 1 : (titleOverlap * 0.55) + (bodyOverlap * 0.45);
+    const related =
+      titleContains ||
+      (titleOverlap >= 0.55 && bodyOverlap >= 0.24) ||
+      bodyOverlap >= 0.48 ||
+      (titleOverlap >= 0.72 && bodyOverlap >= 0.16);
+    if (!related) continue;
+    if (!best || score > best.score) {
+      best = { id: row.id, title: row.title, slug: row.slug, score };
+    }
+  }
+  return best ? { id: best.id, title: best.title, slug: best.slug } : null;
+}
+
 function buildKnowledgeTitle(content: string, type: DeftyKnowledgeWikiType): string {
   const plainContent = toPlainText(content);
   const prefix = type === 'decision'
@@ -517,6 +628,8 @@ async function queueDeftyKnowledgeUpdateCapture(params: {
   captureReason?: string | null;
   extraction: 'llm' | 'deterministic' | 'classifier';
   metadata?: Record<string, unknown>;
+  autoApprove?: boolean;
+  preferUpdate?: boolean;
 }): Promise<{ queued: boolean; actionId?: string; skippedReason?: string }> {
   const {
     orgId,
@@ -529,6 +642,7 @@ async function queueDeftyKnowledgeUpdateCapture(params: {
     captureReason,
     extraction,
     metadata = {},
+    autoApprove = false,
   } = params;
   const defty = await ensureDeftyEmployee(orgId);
   const updatedBody = stripKnowledgeUpdatePrefix(content);
@@ -538,7 +652,7 @@ async function queueDeftyKnowledgeUpdateCapture(params: {
   const title = `Update knowledge: ${targetPage.title}`;
   const summary = truncatePlainText(updatedBody, 240);
 
-  return db.transaction(async (tx) => {
+  const queued = await db.transaction(async (tx) => {
     const proposedParams = {
       caller_employee_slug: defty.slug,
       page_id: targetPage.id,
@@ -642,6 +756,16 @@ async function queueDeftyKnowledgeUpdateCapture(params: {
     if (!queuedAction) throw new Error('Failed to create Defty knowledge-update approval');
     return { queued: true, actionId: queuedAction.id };
   });
+
+  if (queued.queued && autoApprove) {
+    await autoApproveDeftyCapture({
+      actionId: queued.actionId,
+      deftyUserId: defty.userId,
+      label: `knowledge update ${targetPage.slug}`,
+    });
+  }
+
+  return queued;
 }
 
 export async function queueDeftyKnowledgeCapture(params: {
@@ -650,6 +774,7 @@ export async function queueDeftyKnowledgeCapture(params: {
   spaceId: string;
   messageId: string;
   content: string;
+  rawContent?: string | null;
   title?: string | null;
   summary?: string | null;
   wikiType: DeftyKnowledgeWikiType;
@@ -658,6 +783,8 @@ export async function queueDeftyKnowledgeCapture(params: {
   extraction?: 'llm' | 'deterministic' | 'classifier';
   tags?: string[];
   metadata?: Record<string, unknown>;
+  autoApprove?: boolean;
+  preferUpdate?: boolean;
 }): Promise<{ queued: boolean; actionId?: string; skippedReason?: string }> {
   const {
     orgId,
@@ -665,6 +792,7 @@ export async function queueDeftyKnowledgeCapture(params: {
     spaceId,
     messageId,
     content,
+    rawContent,
     title,
     summary,
     wikiType,
@@ -673,10 +801,13 @@ export async function queueDeftyKnowledgeCapture(params: {
     extraction = 'classifier',
     tags = [],
     metadata = {},
+    autoApprove: forceAutoApprove,
+    preferUpdate = false,
   } = params;
 
   const plainContent = toPlainText(content);
   if (!plainContent) return { queued: false, skippedReason: 'empty_content' };
+  const rawPlainContent = toPlainText(rawContent || content);
 
   const [sourceMessage] = await db
     .select({ id: messages.id, spaceType: spaces.type })
@@ -699,12 +830,13 @@ export async function queueDeftyKnowledgeCapture(params: {
   const finalTitle = truncatePlainText(title || buildKnowledgeTitle(content, wikiType), 120);
   const finalSummary = truncatePlainText(summary || plainContent, 240);
 
-  if (isKnowledgeUpdateRequest(plainContent)) {
+  const explicitKnowledgeUpdate = isKnowledgeUpdateRequest(rawPlainContent);
+  if (explicitKnowledgeUpdate) {
     const targetPage = await findWikiPageForExplicitUpdate({
       orgId,
       spaceId,
       title: finalTitle,
-      content: plainContent,
+      content: rawPlainContent,
       wikiType,
       scope: targetScope,
     });
@@ -714,7 +846,7 @@ export async function queueDeftyKnowledgeCapture(params: {
         sourceUserId,
         spaceId,
         messageId,
-        content: plainContent,
+        content: rawPlainContent,
         targetPage,
         captureKind,
         captureReason,
@@ -722,8 +854,13 @@ export async function queueDeftyKnowledgeCapture(params: {
         metadata: {
           ...metadata,
           update_request: true,
+          extracted_content: plainContent,
         },
+        autoApprove: forceAutoApprove ?? shouldAutoApproveKnowledgeCapture({ captureKind, targetScope }),
       });
+    }
+    if (metadata.batch_capture !== true) {
+      return { queued: false, skippedReason: 'knowledge_update_target_missing' };
     }
   }
 
@@ -737,6 +874,37 @@ export async function queueDeftyKnowledgeCapture(params: {
   });
   if (similarPage) {
     return { queued: false, skippedReason: 'knowledge_already_captured' };
+  }
+
+  if (preferUpdate) {
+    const relatedPage = await findRelatedWikiPage({
+      orgId,
+      spaceId,
+      title: finalTitle,
+      content: plainContent,
+      wikiType,
+      scope: targetScope,
+    });
+    if (relatedPage) {
+      return queueDeftyKnowledgeUpdateCapture({
+        orgId,
+        sourceUserId,
+        spaceId,
+        messageId,
+        content: plainContent,
+        targetPage: relatedPage,
+        captureKind,
+        captureReason: captureReason || 'A settled discussion refined existing durable knowledge.',
+        extraction,
+        metadata: {
+          ...metadata,
+          related_wiki_update: true,
+          extracted_title: finalTitle,
+          extracted_summary: finalSummary,
+        },
+        autoApprove: forceAutoApprove ?? shouldAutoApproveKnowledgeCapture({ captureKind, targetScope }),
+      });
+    }
   }
 
   const dedupeKey = `defty_capture:${captureKind}:wiki_create:${messageId}`;
@@ -786,7 +954,8 @@ export async function queueDeftyKnowledgeCapture(params: {
     ...metadata,
   };
 
-  return db.transaction(async (tx) => {
+  const autoApprove = forceAutoApprove ?? shouldAutoApproveKnowledgeCapture({ captureKind, targetScope });
+  const queued = await db.transaction(async (tx) => {
     const proposedParams = {
       caller_employee_slug: defty.slug,
       title: finalTitle,
@@ -893,6 +1062,16 @@ export async function queueDeftyKnowledgeCapture(params: {
 
     return { queued: true, actionId: queuedAction.id };
   });
+
+  if (queued.queued && autoApprove) {
+    await autoApproveDeftyCapture({
+      actionId: queued.actionId,
+      deftyUserId: defty.userId,
+      label: `knowledge create ${dedupeKey}`,
+    });
+  }
+
+  return queued;
 }
 
 async function queueDeftyTaskUpdateCapture(params: {
@@ -908,6 +1087,7 @@ async function queueDeftyTaskUpdateCapture(params: {
   captureKind: 'task_candidate' | 'blocker_candidate';
   captureReason?: string | null;
   extraction: 'llm' | 'deterministic' | 'classifier';
+  approvalMode?: TaskCaptureApprovalMode;
 }): Promise<{ queued: boolean; actionId?: string; skippedReason?: string }> {
   const {
     orgId,
@@ -922,6 +1102,7 @@ async function queueDeftyTaskUpdateCapture(params: {
     captureKind,
     captureReason,
     extraction,
+    approvalMode = 'approval',
   } = params;
   const defty = await ensureDeftyEmployee(orgId);
   const taskRef = `${targetTask.project_prefix}-${targetTask.number}`;
@@ -964,6 +1145,7 @@ async function queueDeftyTaskUpdateCapture(params: {
           extraction,
           proposed_by: 'defty',
           target_task_ref: taskRef,
+          approval_mode: approvalMode,
         },
         dedupe_key: dedupeKey,
         metadata: {
@@ -972,6 +1154,7 @@ async function queueDeftyTaskUpdateCapture(params: {
           update_fields: Object.keys(patch).sort(),
           target_task_id: targetTask.id,
           target_task_ref: taskRef,
+          approval_mode: approvalMode,
           ...updateMetadata,
         },
       })
@@ -994,6 +1177,10 @@ async function queueDeftyTaskUpdateCapture(params: {
     }
 
     if (!intentId) throw new Error('Failed to create or recover Defty task-update intent');
+
+    if (approvalMode === 'passive') {
+      return { queued: true, skippedReason: 'passive_intent' };
+    }
 
     const [existingAction] = await tx
       .select({ id: agentActions.id })
@@ -1038,6 +1225,7 @@ async function queueDeftyTaskUpdateCapture(params: {
           extraction,
           proposed_by: 'defty',
           target_task_ref: taskRef,
+          approval_mode: approvalMode,
         } as any,
         approval_tier: 'quick',
         approval_status: 'pending',
@@ -1064,6 +1252,7 @@ export async function queueDeftyCreateTaskCapture(params: {
   captureKind: 'task_candidate' | 'blocker_candidate';
   captureReason?: string | null;
   extraction?: 'llm' | 'deterministic' | 'classifier';
+  approvalMode?: TaskCaptureApprovalMode;
 }): Promise<{ queued: boolean; actionId?: string; skippedReason?: string }> {
   const {
     orgId,
@@ -1079,6 +1268,7 @@ export async function queueDeftyCreateTaskCapture(params: {
     captureKind,
     captureReason,
     extraction = 'classifier',
+    approvalMode = 'approval',
   } = params;
 
   const plainContent = toPlainText(content);
@@ -1157,6 +1347,7 @@ export async function queueDeftyCreateTaskCapture(params: {
       captureKind,
       captureReason,
       extraction,
+      approvalMode,
     });
   }
 
@@ -1217,11 +1408,13 @@ export async function queueDeftyCreateTaskCapture(params: {
           capture_kind: captureKind,
           capture_reason: captureReason || null,
           extraction,
+          approval_mode: approvalMode,
         },
         dedupe_key: dedupeKey,
         metadata: {
           extraction,
           legacy_dedupe_key: legacyDedupeKey,
+          approval_mode: approvalMode,
         },
       })
       .onConflictDoNothing({
@@ -1244,6 +1437,10 @@ export async function queueDeftyCreateTaskCapture(params: {
 
     if (!intentId) {
       throw new Error('Failed to create or recover Defty work intent');
+    }
+
+    if (approvalMode === 'passive') {
+      return { queued: true, skippedReason: 'passive_intent' };
     }
 
     await tx.execute(sql`
@@ -1300,6 +1497,7 @@ export async function queueDeftyCreateTaskCapture(params: {
           work_intent_status: 'proposed',
           extraction,
           proposed_by: 'defty',
+          approval_mode: approvalMode,
         } as any,
         approval_tier: 'quick',
         approval_status: 'pending',

--- a/apps/api/src/lib/job-scheduler.ts
+++ b/apps/api/src/lib/job-scheduler.ts
@@ -8,6 +8,7 @@ export async function initScheduler(): Promise<void> {
   await ensureCronJob(QUEUE_NAMES.SCHEDULED_JOBS, 'meeting-prep-check', 'cron:meeting-prep');
   await ensureCronJob(QUEUE_NAMES.SCHEDULED_JOBS, 'ics-sync', 'cron:ics-sync');
   await ensureCronJob(QUEUE_NAMES.SCHEDULED_JOBS, 'chat-observation-backfill', 'cron:chat-observation-backfill');
+  await ensureCronJob(QUEUE_NAMES.SCHEDULED_JOBS, 'chat-knowledge-batch', 'cron:chat-knowledge-batch');
   await ensureCronJob(QUEUE_NAMES.SCHEDULED_JOBS, 'people-graph', 'cron:people-graph');
   await ensureCronJob(QUEUE_NAMES.SCHEDULED_JOBS, 'manager-pulse', 'cron:manager-pulse');
   await ensureCronJob(QUEUE_NAMES.SCHEDULED_JOBS, 'burnout-detect', 'cron:burnout-detect');

--- a/apps/api/src/routes/agent.ts
+++ b/apps/api/src/routes/agent.ts
@@ -947,27 +947,7 @@ agentRoutes.get('/actions/pending-by-space', async (c) => {
       AND a.org_id = ${user.org_id}
       AND a.approval_status = 'pending'
       AND a.approval_tier IN ('quick', 'full')
-      AND (
-        a.source IS DISTINCT FROM 'defty_capture'
-        OR (
-          (
-            COALESCE(
-              a.params->>'source_space_id',
-              a.params->>'origin_space_id',
-              a.params->>'space_id'
-            ) IS NULL
-            OR COALESCE(
-              a.params->>'source_space_id',
-              a.params->>'origin_space_id',
-              a.params->>'space_id'
-            ) = ${spaceId}
-          )
-          AND (
-            a.params->>'source_message_id' IS NULL
-            OR a.params->>'source_message_id' = msg.id
-          )
-        )
-      )
+      AND a.source IS DISTINCT FROM 'defty_capture'
     ORDER BY a.created_at DESC
     LIMIT 100
   `);

--- a/apps/api/src/routes/knowledge.ts
+++ b/apps/api/src/routes/knowledge.ts
@@ -247,6 +247,41 @@ knowledgeRoutes.get('/:spaceId/knowledge', async (c) => {
 });
 
 // POST /api/spaces/:spaceId/knowledge — create entry (writes to wiki_pages)
+knowledgeRoutes.post('/:spaceId/knowledge/capture-discussion', async (c) => {
+  try {
+    const user = c.get('user');
+    const spaceId = c.req.param('spaceId');
+    const body = await c.req.json().catch(() => ({}));
+    const lookbackMinutes = Math.min(
+      Math.max(Number(body?.lookback_minutes ?? 120), 15),
+      8 * 60,
+    );
+
+    const isMember = await requireSpaceMembership(spaceId, user.id);
+    if (!isMember) {
+      return c.json({ error: 'Not a member of this space', code: 'FORBIDDEN' }, 403);
+    }
+
+    await enqueue(QUEUE_NAMES.AGENT_JOBS, 'chat-knowledge-batch', {
+      orgId: user.org_id,
+      spaceId,
+      lookbackMs: lookbackMinutes * 60 * 1000,
+      quietMs: 0,
+      requestedByUserId: user.id,
+      source: 'manual_capture_discussion',
+    }, { maxAttempts: 2 });
+
+    return c.json({
+      queued: true,
+      lookback_minutes: lookbackMinutes,
+      message: 'Recent discussion capture queued',
+    });
+  } catch (err) {
+    console.error('Failed to queue discussion capture:', err);
+    return c.json({ error: 'Failed to queue discussion capture', code: 'INTERNAL_ERROR' }, 500);
+  }
+});
+
 knowledgeRoutes.post('/:spaceId/knowledge', async (c) => {
   try {
     const user = c.get('user');

--- a/apps/api/src/workers/handlers/agent-reply.ts
+++ b/apps/api/src/workers/handlers/agent-reply.ts
@@ -3,10 +3,11 @@ import type { JobData } from '../types.js';
 import { db } from '../../lib/db.js';
 import { messages, users, spaces, spaceMembers, agentActions } from '@deft/db/schema';
 import { getApprovalTier } from '../../lib/agent-approval.js';
-import { eq, and, desc, sql, ne } from 'drizzle-orm';
+import { eq, and, desc, sql, ne, lt } from 'drizzle-orm';
 import { getIO } from '../../socket.js';
 import { runAgentQuery } from '../../lib/agent-runner.js';
 import { ensureDeftyMembership, DEFTY_NAME } from '../../lib/ensure-defty-membership.js';
+import { toPlainText, truncatePlainText } from '../../lib/plain-text.js';
 
 function extractExplicitCreateTaskAction(content: string, sourceMessageId: string) {
   const title = content.match(/\b(?:task|todo|ticket)\s+(?:titled|called|named)\s+"([^"]+)"/i)?.[1]
@@ -33,6 +34,220 @@ function extractExplicitCreateTaskAction(content: string, sourceMessageId: strin
     approval_tier: getApprovalTier('create_task'),
     tool_use_id: null,
     source: 'deterministic_create_task_fallback',
+  };
+}
+
+function extractDiscussionTaskActionFromReply(replyText: string, sourceMessageId: string) {
+  const plain = toPlainText(replyText);
+  const normalized = plain.replace(/\*\*/g, '').replace(/^\s*[-*]\s*/gm, '');
+  if (!/\b(?:task proposal|proposed task creation|title\s*:|i will create a detailed task|approve this task creation|queued for your approval)\b/i.test(normalized)) {
+    return null;
+  }
+  if (/\b(?:clarify|clarification|need more information|not enough context)\b/i.test(normalized) && !/\btitle\s*:/i.test(normalized)) {
+    return null;
+  }
+
+  const labelField = (label: string) => {
+    const labels = 'title|project|description|assignee|priority|due date|source|owners|additional notes';
+    const match = normalized.match(new RegExp(`\\b${label}\\s*:\\s*(.+?)(?=\\s+(?:${labels})\\s*:|$)`, 'i'));
+    return match?.[1]?.replace(/^[#:\s-]+/, '').trim();
+  };
+
+  const title = labelField('title');
+  if (!title) return null;
+
+  const projectName = labelField('project');
+  const assigneeName = labelField('assignee');
+  const priorityMatch = normalized.match(/\bpriority\s*:\s*(p[0-3])\b/i)?.[1]?.toLowerCase();
+  const dueDate = normalized.match(/\bdue date\s*:\s*(\d{4}-\d{2}-\d{2})\b/i)?.[1];
+
+  return {
+    action: 'create_task',
+    params: {
+      title: truncatePlainText(title, 80),
+      ...(projectName ? { project_name: truncatePlainText(projectName, 120) } : {}),
+      ...(assigneeName ? { assignee_name: truncatePlainText(assigneeName, 120) } : {}),
+      ...(priorityMatch ? { priority: priorityMatch } : {}),
+      ...(dueDate ? { due_date: dueDate } : {}),
+      description: plain,
+      source_message_id: sourceMessageId,
+    },
+    approval_tier: getApprovalTier('create_task'),
+    tool_use_id: null,
+    source: 'mention',
+  };
+}
+
+function fallbackDiscussionTaskTitle(content: string): string {
+  const plain = toPlainText(content);
+  const match = plain.match(/\bfor\s+(?:the\s+)?(.+?)(?:\.|,|;|$)/i);
+  return truncatePlainText(match?.[1]?.trim() || 'Follow up from discussion', 80) || 'Follow up from discussion';
+}
+
+function buildDiscussionTaskFallbackAction(params: {
+  command: string;
+  sourceMessageId: string;
+  sourceMessages: DiscussionSourceMessage[];
+}) {
+  const highlights = params.sourceMessages
+    .slice(-12)
+    .map(formatDiscussionHighlight)
+    .filter((line) => line.trim().length > 3);
+  const description = [
+    'Review-only task proposal created from a Defty discussion command.',
+    '',
+    'The model did not return a usable tool call, so Defty preserved the recent source discussion for human review instead of taking silent action.',
+    '',
+    '**Source discussion highlights:**',
+    ...highlights,
+  ].join('\n');
+
+  return {
+    action: 'create_task',
+    params: {
+      title: fallbackDiscussionTaskTitle(params.command),
+      description,
+      source_message_id: params.sourceMessageId,
+      metadata: {
+        command_message_id: params.sourceMessageId,
+        context_mode: 'discussion',
+        discussion_source_message_ids: params.sourceMessages.map((message) => message.id),
+      },
+    },
+    approval_tier: getApprovalTier('create_task'),
+    tool_use_id: null,
+    source: 'mention',
+  };
+}
+
+function isDiscussionTaskCommand(content: string): boolean {
+  return /\b(?:create|make|draft|turn|convert|summari[sz]e)\b.{0,80}\b(?:tasks?|todos?|tickets?)\b/i.test(content) &&
+    /\b(?:discussion|thread|chat|conversation|above|this)\b/i.test(content);
+}
+
+function isDiscussionBoundaryMessage(content: string): boolean {
+  const plain = toPlainText(content);
+  return /(?:^|\s)@(agent|defty|deft)\b/i.test(plain) || isDiscussionTaskCommand(plain);
+}
+
+function isSocialOnlyDiscussionMessage(content: string): boolean {
+  const plain = toPlainText(content)
+    .toLowerCase()
+    .replace(/\b(?:human|chat|dense|edge)[a-z0-9_-]*-[a-z0-9_-]{6,}\b/g, '');
+  const hasSocialTopic = /\b(?:pizza|deep dish|thin crust|pineapple|jalapeno|mushroom|cheese|lunch|breakfast|dinner|snack|coffee|tea|cake|eat|eating|birthday|party|weekend|movie|music|sports)\b/i.test(plain);
+  if (!hasSocialTopic) return false;
+
+  const hasWorkSignal = /\b(?:task|todo|ticket|project|launch|buyer|route|truck|capacity|crate|harvest|handoff|sheet|qc|sampling|sample|label|pack|packing|cold|greenhouse|irrigation|pest|blocked|blocker|stuck|dependency|deadline|due|owner|owns|assign|confirm|update|status|decision|agreed|resolution|ship|delivery|market)\b/i.test(plain);
+  return !hasWorkSignal;
+}
+
+function discussionTaskPrompt(content: string): string {
+  return `${content}
+
+This is an explicit Defty command to synthesize the surrounding discussion into work.
+Use the recent discussion context already provided in the conversation history.
+If the discussion clearly converged on work, queue a small number of precise create_task proposals.
+Prefer one well-scoped task unless the user explicitly asked for multiple tasks.
+Preserve material disagreement details, source documents/sheets mentioned, owner commitments, timing, and the final resolution.
+The task description should make clear what each named person said or owns when that matters to execution.
+Include the source message id automatically supplied by the system.
+Do not create knowledge/wiki entries from this command; task proposals only.
+If owner, project, or scope is genuinely ambiguous, ask a short clarification instead of guessing.`;
+}
+
+type DiscussionSourceMessage = {
+  id: string;
+  userName: string;
+  content: string;
+};
+
+function formatDiscussionHighlight(message: DiscussionSourceMessage): string {
+  const content = truncatePlainText(
+    toPlainText(message.content)
+      .replace(/^[A-Z0-9][A-Z0-9_-]{2,80}:\s*/, '')
+      .replace(/\s+/g, ' ')
+      .trim(),
+    260,
+  );
+  return `- ${message.userName}: ${content}`;
+}
+
+function enrichDiscussionTaskActions(
+  actions: any[],
+  sourceMessages: DiscussionSourceMessage[],
+): any[] {
+  if (sourceMessages.length === 0) return actions;
+  const highlights = sourceMessages
+    .slice(-12)
+    .map(formatDiscussionHighlight)
+    .filter((line) => line.trim().length > 3);
+  if (highlights.length === 0) return actions;
+
+  const appendix = `\n\n**Source discussion highlights:**\n${highlights.join('\n')}`;
+  return actions.map((action) => {
+    if (action?.action !== 'create_task' && action?.action !== 'task_create') return action;
+    const params = action.params ?? {};
+    const description = String(params.description ?? '').trim();
+    const metadata = {
+      ...(params.metadata ?? {}),
+      discussion_source_message_ids: sourceMessages.map((message) => message.id),
+      context_mode: 'discussion',
+    };
+    if (description.includes('Source discussion highlights')) {
+      return {
+        ...action,
+        params: {
+          ...params,
+          metadata,
+        },
+      };
+    }
+    return {
+      ...action,
+      params: {
+        ...params,
+        description: `${description || 'Task created from discussion.'}${appendix}`,
+        metadata,
+      },
+    };
+  });
+}
+
+function withMentionProvenance(params: {
+  action: any;
+  commandMessageId: string;
+  spaceId: string;
+  discussionSourceMessages: DiscussionSourceMessage[];
+}) {
+  const { action, commandMessageId, spaceId, discussionSourceMessages } = params;
+  if (!action || typeof action !== 'object') return action;
+  const actionParams = action.params && typeof action.params === 'object' ? action.params : {};
+  const isWriteAction = [
+    'create_task',
+    'task_create',
+    'task_update',
+    'update_task',
+    'task_transition',
+    'comment_on_task',
+  ].includes(String(action.action ?? ''));
+  if (!isWriteAction) return action;
+
+  const sourceIds = discussionSourceMessages.map((message) => message.id);
+  return {
+    ...action,
+    params: {
+      ...actionParams,
+      source_message_id: commandMessageId,
+      source_space_id: spaceId,
+      origin_message_id: commandMessageId,
+      origin_space_id: spaceId,
+      metadata: {
+        ...(actionParams.metadata ?? {}),
+        command_message_id: commandMessageId,
+        context_mode: sourceIds.length > 0 ? 'discussion' : 'message',
+        ...(sourceIds.length > 0 ? { discussion_source_message_ids: sourceIds } : {}),
+      },
+    },
   };
 }
 
@@ -169,14 +384,86 @@ export async function handleAgentReply(job: JobData): Promise<void> {
 
     // Strip the @agent/@deft mention from the content for a cleaner prompt
     const cleanContent = content.replace(/<@[^|]*\|Defty?>/gi, '').replace(/@(agent|defty|deft)\b/gi, '').trim();
-    const promptContent = cleanContent || 'Hey, what can you help me with?';
+    const wantsDiscussionTask = isDiscussionTaskCommand(cleanContent);
+    const discussionSourceMessages: DiscussionSourceMessage[] = [];
+
+    if (wantsDiscussionTask && !isDmLike && !parentId) {
+      const [trigger] = await db
+        .select({ created_at: messages.created_at })
+        .from(messages)
+        .where(and(
+          eq(messages.id, messageId),
+          eq(messages.org_id, orgId),
+        ))
+        .limit(1);
+
+      if (trigger) {
+        const recentChannelMessages = await db.select({
+          id: messages.id,
+          content: messages.content,
+          user_id: messages.user_id,
+          user_name: users.name,
+        })
+          .from(messages)
+          .innerJoin(users, eq(messages.user_id, users.id))
+          .where(and(
+            eq(messages.space_id, spaceId),
+            eq(messages.org_id, orgId),
+            eq(messages.is_deleted, false),
+            sql`${messages.parent_id} IS NULL`,
+            lt(messages.created_at, trigger.created_at),
+            ne(messages.user_id, agentUserId),
+          ))
+          .orderBy(desc(messages.created_at))
+          .limit(80);
+
+        const orderedRecentMessages = recentChannelMessages.reverse();
+        let previousBoundaryIndex = -1;
+        for (let index = orderedRecentMessages.length - 1; index >= 0; index -= 1) {
+          if (isDiscussionBoundaryMessage(orderedRecentMessages[index]!.content)) {
+            previousBoundaryIndex = index;
+            break;
+          }
+        }
+        const scopedRecentMessages = previousBoundaryIndex >= 0
+          ? orderedRecentMessages.slice(previousBoundaryIndex + 1).slice(-40)
+          : orderedRecentMessages.slice(-40);
+        const workScopedRecentMessages = scopedRecentMessages.filter((msg) =>
+          !isSocialOnlyDiscussionMessage(msg.content),
+        );
+
+        if (workScopedRecentMessages.length > 0) {
+          conversationHistory.push({
+            role: 'user',
+            content: '[Recent channel discussion before this Defty request]',
+          });
+          for (const msg of workScopedRecentMessages) {
+            discussionSourceMessages.push({
+              id: msg.id,
+              userName: msg.user_name,
+              content: msg.content,
+            });
+            conversationHistory.push({
+              role: 'user',
+              content: `[${msg.user_name}]: ${msg.content}`,
+            });
+          }
+        }
+      }
+    }
+
+    const promptContent = wantsDiscussionTask
+      ? discussionTaskPrompt(cleanContent || 'Create tasks from this discussion.')
+      : cleanContent || 'Hey, what can you help me with?';
 
     // Call the agent reasoning engine with a 60s hard timeout so a stuck
     // MCP tool / Anthropic call can never wedge the worker.
     const AGENT_TIMEOUT_MS = 60_000;
     const abort = new AbortController();
     const timeout = setTimeout(() => abort.abort(), AGENT_TIMEOUT_MS);
-    const result = await Promise.race([
+    let result: Awaited<ReturnType<typeof runAgentQuery>>;
+    try {
+      result = await Promise.race([
       runAgentQuery({
         content: promptContent,
         orgId,
@@ -197,17 +484,79 @@ export async function handleAgentReply(job: JobData): Promise<void> {
       new Promise<never>((_, reject) =>
         setTimeout(() => reject(new Error('agent-reply: runAgentQuery timeout after 60s')), AGENT_TIMEOUT_MS),
       ),
-    ]).finally(() => clearTimeout(timeout));
+      ]);
+    } catch (err) {
+      if (!wantsDiscussionTask || discussionSourceMessages.length === 0) throw err;
+      const fallbackAction = buildDiscussionTaskFallbackAction({
+        command: cleanContent,
+        sourceMessageId: messageId,
+        sourceMessages: discussionSourceMessages,
+      });
+      console.warn('[agent-reply] Falling back to deterministic discussion task proposal', {
+        messageId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      result = {
+        text: 'I could not complete the full reasoning pass, so I prepared a conservative task proposal from the recent discussion for human review.',
+        pendingActions: [fallbackAction],
+        executedActions: [],
+        assistantBlocks: [],
+        model: 'deterministic-discussion-fallback',
+        tokensIn: 0,
+        tokensOut: 0,
+        citations: [],
+      } as Awaited<ReturnType<typeof runAgentQuery>>;
+    } finally {
+      clearTimeout(timeout);
+    }
 
     if (!result.text) {
-      console.warn('[agent-reply] Agent returned empty text, skipping reply');
-      return;
+      if (!wantsDiscussionTask || discussionSourceMessages.length === 0) {
+        console.warn('[agent-reply] Agent returned empty text, skipping reply');
+        return;
+      }
+      const fallbackAction = buildDiscussionTaskFallbackAction({
+        command: cleanContent,
+        sourceMessageId: messageId,
+        sourceMessages: discussionSourceMessages,
+      });
+      result = {
+        text: 'I prepared a conservative task proposal from the recent discussion for human review.',
+        pendingActions: [fallbackAction],
+        executedActions: [],
+        assistantBlocks: [],
+        model: 'deterministic-discussion-fallback',
+        tokensIn: 0,
+        tokensOut: 0,
+        citations: [],
+      } as Awaited<ReturnType<typeof runAgentQuery>>;
     }
 
     const fallbackCreateTask = result.pendingActions.length === 0
-      ? extractExplicitCreateTaskAction(promptContent, messageId)
+      ? wantsDiscussionTask
+        ? extractDiscussionTaskActionFromReply(result.text, messageId) ?? (
+          discussionSourceMessages.length > 0
+            ? buildDiscussionTaskFallbackAction({
+              command: cleanContent,
+              sourceMessageId: messageId,
+              sourceMessages: discussionSourceMessages,
+            })
+            : null
+        )
+        : extractExplicitCreateTaskAction(promptContent, messageId)
       : null;
-    const pendingActions = fallbackCreateTask ? [fallbackCreateTask] : result.pendingActions;
+    const rawPendingActions = fallbackCreateTask ? [fallbackCreateTask] : result.pendingActions;
+    const enrichedPendingActions = wantsDiscussionTask
+      ? enrichDiscussionTaskActions(rawPendingActions, discussionSourceMessages)
+      : rawPendingActions;
+    const pendingActions = enrichedPendingActions.map((action: any) =>
+      withMentionProvenance({
+        action,
+        commandMessageId: messageId,
+        spaceId,
+        discussionSourceMessages,
+      }),
+    );
     if (fallbackCreateTask) {
       console.warn('[agent-reply] Added deterministic create_task fallback for explicit task-create prompt', {
         messageId,

--- a/apps/api/src/workers/handlers/blocked-alert.ts
+++ b/apps/api/src/workers/handlers/blocked-alert.ts
@@ -13,7 +13,6 @@ import {
 import { eq, and, gte } from 'drizzle-orm';
 import { emitToUser } from '../../socket.js';
 import { toPlainText, truncatePlainText } from '../../lib/plain-text.js';
-import { queueDeftyCreateTaskCapture } from '../../lib/defty-capture.js';
 
 export async function handleBlockedAlert(job: JobData): Promise<void> {
   const { messageId, spaceId, content, orgId, userId } = job.data;
@@ -82,32 +81,8 @@ export async function handleBlockedAlert(job: JobData): Promise<void> {
     // one-click approve "Yes, track this as a task" from the approval
     // inbox. Independent of the lead-notification path below so it
     // still fires for users with no in-progress tasks.
-    try {
-      const plainContent = toPlainText(content);
-      const draftSnippet = truncatePlainText(plainContent, 80);
-      const queued = await queueDeftyCreateTaskCapture({
-        orgId,
-        sourceUserId: userId,
-        spaceId,
-        messageId,
-        content,
-        title: `Blocker: ${draftSnippet}`,
-        description: plainContent,
-        projectName: userTasks[0]?.project_name ?? null,
-        captureKind: 'blocker_candidate',
-        captureReason: 'A chat message looked like a blocker and may need follow-up work.',
-        extraction: 'classifier',
-      });
-      if (queued.queued) {
-        console.log(`[blocked-alert] Queued Defty blocker capture for ${userId}`);
-      } else if (queued.skippedReason === 'duplicate') {
-        console.log(`[blocked-alert] Skipped duplicate blocker capture for message ${messageId}`);
-      } else {
-        console.warn(`[blocked-alert] skipped blocker capture: ${queued.skippedReason ?? 'unknown'}`);
-      }
-    } catch (err) {
-      console.warn('[blocked-alert] failed to queue blocker capture:', err);
-    }
+    // Chat-to-task is Defty-led. This worker may notify a project lead about
+    // a real blocker, but it must not create task proposals on its own.
 
     if (shouldSkipLeadAlert) {
       console.log('[blocked-alert] Skipped lead alert: already alerted for this user within 4h');

--- a/apps/api/src/workers/handlers/chat-knowledge-batch.ts
+++ b/apps/api/src/workers/handlers/chat-knowledge-batch.ts
@@ -1,0 +1,614 @@
+import { and, eq, gte, lt, desc } from 'drizzle-orm';
+import {
+  messageClassifications,
+  messages,
+  spaces,
+  users,
+} from '@deft/db/schema';
+import type { JobData } from '../types.js';
+import { db } from '../../lib/db.js';
+import { queueDeftyKnowledgeCapture } from '../../lib/defty-capture.js';
+import { llm } from '../../lib/llm.js';
+import { getOrgAIConfig, hasAnyAIProvider } from '../../lib/org-ai-config.js';
+import { toPlainText, truncatePlainText } from '../../lib/plain-text.js';
+
+const DEFAULT_LOOKBACK_MS = 35 * 60 * 1000;
+const DEFAULT_QUIET_MS = 8 * 60 * 1000;
+const MAX_MESSAGES_PER_RUN = 800;
+const MAX_CANDIDATES_PER_SPACE = 5;
+const EPISODE_GAP_MS = 7 * 60 * 1000;
+const MAX_EPISODE_MESSAGES = 28;
+
+type ClassifiedMessageRow = {
+  messageId: string;
+  spaceId: string;
+  spaceName: string;
+  orgId: string;
+  userId: string;
+  userName: string;
+  content: string;
+  createdAt: Date;
+  confidence: number;
+  agentMentioned: boolean;
+  memorableFacts: unknown;
+  decision: string | null;
+};
+
+type RawMessageRow = Omit<ClassifiedMessageRow, 'confidence' | 'agentMentioned' | 'decision'> & {
+  confidence: number | null;
+  agentMentioned: boolean | null;
+  decision: string | null;
+};
+
+type EpisodeKind = 'durable_knowledge' | 'task_only' | 'social_ephemeral' | 'noise';
+
+type KnowledgeEpisode = {
+  index: number;
+  bucket: string;
+  rows: ClassifiedMessageRow[];
+};
+
+type EpisodeClassification = {
+  kind: EpisodeKind;
+  confidence: number;
+  wikiType: 'decision' | 'fact' | 'procedure' | 'preference' | 'entity' | 'resource';
+  title: string;
+  summary: string;
+  content: string;
+  reason: string;
+};
+
+type KnowledgeCandidate = {
+  kind: 'decision_candidate' | 'note_candidate';
+  wikiType: 'decision' | 'fact';
+  title: string;
+  summary: string;
+  content: string;
+  source: ClassifiedMessageRow;
+  evidence: ClassifiedMessageRow[];
+  episode: KnowledgeEpisode;
+  classification: EpisodeClassification;
+};
+
+function normalize(value: string): string {
+  return toPlainText(value)
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function tokenOverlap(a: string, b: string): number {
+  const toTokens = (value: string) => new Set(
+    normalize(value)
+      .split(/\s+/)
+      .filter((token) => token.length >= 3),
+  );
+  const left = toTokens(a);
+  const right = toTokens(b);
+  if (left.size === 0 || right.size === 0) return 0;
+  let intersection = 0;
+  for (const token of left) {
+    if (right.has(token)) intersection += 1;
+  }
+  const union = left.size + right.size - intersection;
+  return intersection / union;
+}
+
+function hasSocialTopic(value: string): boolean {
+  const plain = normalize(value);
+  return /\b(?:pizza|deep dish|thin crust|pineapple|jalapeno|mushroom|cheese|lunch|breakfast|dinner|snack|coffee|tea|cake|eat|eating|birthday|party|weekend|movie|music|sports|commute|weather)\b/.test(plain);
+}
+
+function hasDomainWorkSignal(value: string): boolean {
+  const plain = normalize(value);
+  return /\b(?:task|todo|ticket|project|launch|buyer|route|truck|capacity|crate|harvest|handoff|sheet|qc|sampling|sample|label|pack|packing|cold|greenhouse|irrigation|pest|blocked|blocker|stuck|dependency|deadline|due|owner|owns|assign|confirm|status|ship|delivery|market|client|customer|farm|field|greenhouse|order|invoice|trial|campaign|qa|quality|supplier|vendor|sku|inventory)\b/.test(plain);
+}
+
+function hasTaskOnlySignal(value: string): boolean {
+  const plain = normalize(value);
+  return /\b(?:task|todo|ticket|blocked|blocker|stuck|dependency|deadline|due|owner|owns|assign|follow up|need to|should|status|in review|done|complete|completed)\b/.test(plain);
+}
+
+function hasDurableSignal(value: string): boolean {
+  const plain = normalize(value);
+  return /\b(?:decided|decision|agreed|approved|final|going forward|policy|process|client|customer|buyer|launch|project|route|delivery|pickup|pallet|crate|label|labeling|handoff|checklist|signoff|ready|resolved|resolution|owner|owns|deadline|due|constraint|risk|blocked by|depends on|commit|committed|confirmed|canonical|source of truth)\b/.test(plain);
+}
+
+function hasDurableCommitmentSignal(value: string): boolean {
+  const plain = normalize(value);
+  return /\b(?:decided|decision|agreed|approved|final|going forward|policy|process|signoff|ready|resolved|resolution|deadline|due|constraint|risk|blocked by|depends on|commit|committed|confirmed|canonical|source of truth)\b/.test(plain);
+}
+
+function hasSettledKnowledgeSignal(value: string): boolean {
+  const plain = normalize(value);
+  return /\b(?:decided|decision|agreed|approved|final|going forward|policy|process|signoff|resolved|resolution|commit|committed|confirmed|canonical|source of truth)\b/.test(plain);
+}
+
+function isSocialOnly(value: string): boolean {
+  if (!hasSocialTopic(value)) return false;
+  return !hasDomainWorkSignal(value);
+}
+
+function isDurableKnowledge(value: string): boolean {
+  const plain = normalize(value);
+  if (!plain || plain.length < 16) return false;
+  if (isSocialOnly(value)) return false;
+  if (hasSocialTopic(value) && !hasDomainWorkSignal(value)) return false;
+  if (/\b(?:maybe|might|could|should we|thinking aloud|joking|kidding|lol|haha)\b/.test(plain)) return false;
+  return hasDurableSignal(value);
+}
+
+function factsFrom(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.map((item) => typeof item === 'string' ? item.trim() : '').filter(Boolean)
+    : [];
+}
+
+function isAgentMention(content: string): boolean {
+  return /(^|\s)@(agent|deft|defty)\b/i.test(toPlainText(content));
+}
+
+function isAgentCommand(content: string): boolean {
+  const plain = toPlainText(content);
+  return isAgentMention(plain) ||
+    /\b(?:create|draft|make|open|update|assign|summarize|turn)\b.{0,90}\b(?:from this discussion|from the discussion|from recent chat|this discussion into|this chat into)\b/i.test(plain) ||
+    /\b(?:defty|agent)\b.{0,80}\b(?:create|draft|make|open|update|assign|summarize)\b/i.test(plain);
+}
+
+function extractInlineDecision(content: string): string | null {
+  const plain = toPlainText(content).replace(/\s+/g, ' ').trim();
+  const explicit = plain.match(/\bdecision\s*:\s*(.+)$/i);
+  if (explicit?.[1]?.trim()) return explicit[1].trim().replace(/[.!?]+$/g, '');
+  const agreed = plain.match(/\b(?:we decided|we agreed|going forward)\b\s*:?\s*(.+)$/i);
+  if (agreed?.[1]?.trim()) return agreed[1].trim().replace(/[.!?]+$/g, '');
+  return null;
+}
+
+function dedupeCandidates(candidates: KnowledgeCandidate[]): KnowledgeCandidate[] {
+  const kept: KnowledgeCandidate[] = [];
+  for (const candidate of candidates) {
+    const duplicate = kept.some((existing) =>
+      existing.kind === candidate.kind &&
+      tokenOverlap(existing.summary, candidate.summary) >= 0.72,
+    );
+    if (!duplicate) kept.push(candidate);
+  }
+  return kept;
+}
+
+function episodeText(episode: KnowledgeEpisode): string {
+  return episode.rows
+    .map((row) => `${row.userName}: ${toPlainText(row.content)}`)
+    .join('\n');
+}
+
+function evidenceContext(rows: ClassifiedMessageRow[]): string {
+  return rows
+    .map((row) => `- ${row.userName}: ${truncatePlainText(toPlainText(row.content), 220)}`)
+    .join('\n');
+}
+
+function topicBucket(row: ClassifiedMessageRow): string {
+  const plain = normalize(row.content);
+  if (row.agentMentioned || isAgentCommand(row.content)) return 'agent';
+  if (isSocialOnly(row.content)) return 'social';
+  if (/\b(?:buyer|client|customer|order|invoice|trial)\b/.test(plain)) return 'client';
+  if (/\b(?:route|truck|delivery|pickup|cold|capacity|pallet|crate)\b/.test(plain)) return 'ops';
+  if (/\b(?:label|labeling|qc|quality|sampling|sample|pack|packing)\b/.test(plain)) return 'quality';
+  if (/\b(?:launch|campaign|market|marketing)\b/.test(plain)) return 'launch';
+  if (hasTaskOnlySignal(row.content)) return 'task';
+  if (hasDurableSignal(row.content)) return 'knowledge';
+  return 'general';
+}
+
+function shouldStartNewEpisode(current: KnowledgeEpisode, row: ClassifiedMessageRow): boolean {
+  const previous = current.rows[current.rows.length - 1];
+  if (!previous) return false;
+  if (current.rows.length >= MAX_EPISODE_MESSAGES) return true;
+
+  const gapMs = row.createdAt.getTime() - previous.createdAt.getTime();
+  if (gapMs >= EPISODE_GAP_MS) return true;
+
+  const nextBucket = topicBucket(row);
+  const currentBucket = current.bucket;
+  if (nextBucket === 'agent' || currentBucket === 'agent') return true;
+  if (nextBucket === 'social' && currentBucket !== 'social') return true;
+  if (currentBucket === 'social' && nextBucket !== 'social') return true;
+
+  if (
+    current.rows.length >= 4 &&
+    nextBucket !== currentBucket &&
+    nextBucket !== 'general' &&
+    currentBucket !== 'general' &&
+    tokenOverlap(current.rows.map((item) => item.content).join('\n'), row.content) < 0.08
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+function segmentRowsIntoEpisodes(rows: ClassifiedMessageRow[]): KnowledgeEpisode[] {
+  const episodes: KnowledgeEpisode[] = [];
+  let current: KnowledgeEpisode | null = null;
+  for (const row of rows) {
+    if (!current) {
+      current = { index: 0, bucket: topicBucket(row), rows: [row] };
+      episodes.push(current);
+      continue;
+    }
+    if (shouldStartNewEpisode(current, row)) {
+      current = { index: episodes.length, bucket: topicBucket(row), rows: [row] };
+      episodes.push(current);
+      continue;
+    }
+    current.rows.push(row);
+    if (current.bucket === 'general') current.bucket = topicBucket(row);
+  }
+  return episodes;
+}
+
+function chooseSourceRow(episode: KnowledgeEpisode): ClassifiedMessageRow {
+  return episode.rows.find((row) => row.decision && isDurableKnowledge(row.decision)) ??
+    episode.rows.find((row) => factsFrom(row.memorableFacts).some(isDurableKnowledge)) ??
+    episode.rows[Math.max(0, episode.rows.length - 1)]!;
+}
+
+function isKnowledgeEvidenceRow(row: ClassifiedMessageRow): boolean {
+  if (row.agentMentioned || isAgentCommand(row.content)) return false;
+  if (isSocialOnly(row.content)) return false;
+  if (hasSocialTopic(row.content) && !hasDurableCommitmentSignal(row.content)) return false;
+  return true;
+}
+
+function deterministicEpisodeClassification(episode: KnowledgeEpisode): EpisodeClassification {
+  const transcript = episodeText(episode);
+  const durableDecision = episode.rows
+    .map((row) => row.decision?.trim() ?? '')
+    .find((decision) => decision && isDurableKnowledge(decision));
+  const durableFact = episode.rows
+    .flatMap((row) => factsFrom(row.memorableFacts))
+    .find(isDurableKnowledge);
+  const socialRows = episode.rows.filter((row) => isSocialOnly(row.content)).length;
+  const hasAgentMention = episode.rows.some((row) => row.agentMentioned);
+  const hasDomain = hasDomainWorkSignal(transcript);
+  const hasTask = hasTaskOnlySignal(transcript);
+  const hasDurable = hasDurableSignal(transcript) || Boolean(durableDecision || durableFact);
+  const hasSettledKnowledge = hasSettledKnowledgeSignal(transcript) || Boolean(durableDecision || durableFact);
+
+  if (hasAgentMention) {
+    return {
+      kind: 'task_only',
+      confidence: 0.9,
+      wikiType: 'fact',
+      title: '',
+      summary: '',
+      content: '',
+      reason: 'Episode contains a Defty/agent mention, so task handling stays agent-led.',
+    };
+  }
+  if (socialRows >= Math.ceil(episode.rows.length * 0.55) && !hasDomain) {
+    return {
+      kind: 'social_ephemeral',
+      confidence: 0.9,
+      wikiType: 'fact',
+      title: '',
+      summary: '',
+      content: '',
+      reason: 'Episode is mostly social or ephemeral conversation.',
+    };
+  }
+  if (hasTask && !hasSettledKnowledge) {
+    return {
+      kind: 'task_only',
+      confidence: 0.86,
+      wikiType: 'fact',
+      title: '',
+      summary: '',
+      content: '',
+      reason: 'Episode is blocker/task-shaped but lacks a settled decision or durable process fact.',
+    };
+  }
+  if (!hasDurable || !hasDomain) {
+    return {
+      kind: hasTask ? 'task_only' : 'noise',
+      confidence: hasTask ? 0.82 : 0.72,
+      wikiType: 'fact',
+      title: '',
+      summary: '',
+      content: '',
+      reason: hasTask
+        ? 'Episode is actionable/task-shaped but not durable knowledge.'
+        : 'Episode lacks durable work-memory signals.',
+    };
+  }
+
+  const source = durableDecision || durableFact || truncatePlainText(transcript, 220);
+  const wikiType = durableDecision ? 'decision' : 'fact';
+  const title = truncatePlainText(source.replace(/^[.!?\s]+|[.!?\s]+$/g, ''), 100) ||
+    (wikiType === 'decision' ? 'Decision from discussion' : 'Fact from discussion');
+  const content = [
+    truncatePlainText(source, 600),
+    '',
+    'Discussion evidence:',
+    evidenceContext(episode.rows.filter(isKnowledgeEvidenceRow)).slice(0, 1800),
+  ].join('\n').trim();
+
+  return {
+    kind: 'durable_knowledge',
+    confidence: 0.78,
+    wikiType,
+    title,
+    summary: truncatePlainText(source, 240),
+    content,
+    reason: 'Episode has durable work-memory signals and domain context.',
+  };
+}
+
+function coerceEpisodeClassification(
+  raw: Partial<EpisodeClassification>,
+  fallback: EpisodeClassification,
+  episode: KnowledgeEpisode,
+): EpisodeClassification {
+  const transcript = episodeText(episode);
+  const rawKind = raw.kind;
+  const kind: EpisodeKind = rawKind === 'durable_knowledge' ||
+    rawKind === 'task_only' ||
+    rawKind === 'social_ephemeral' ||
+    rawKind === 'noise'
+    ? rawKind
+    : fallback.kind;
+  const wikiType = raw.wikiType === 'decision' ||
+    raw.wikiType === 'resource' ||
+    raw.wikiType === 'procedure' ||
+    raw.wikiType === 'preference' ||
+    raw.wikiType === 'entity' ||
+    raw.wikiType === 'fact'
+    ? raw.wikiType
+    : fallback.wikiType;
+  const confidence = typeof raw.confidence === 'number'
+    ? Math.max(0, Math.min(1, raw.confidence))
+    : fallback.confidence;
+
+  const candidate: EpisodeClassification = {
+    kind,
+    confidence,
+    wikiType,
+    title: truncatePlainText(raw.title || fallback.title, 100),
+    summary: truncatePlainText(raw.summary || fallback.summary, 280),
+    content: truncatePlainText(raw.content || fallback.content, 2200),
+    reason: truncatePlainText(raw.reason || fallback.reason, 320),
+  };
+
+  // Hard guardrails after the model: social-only episodes and agent-command
+  // episodes must never become passive wiki writes.
+  if (episode.rows.some((row) => row.agentMentioned)) {
+    return { ...fallback, kind: 'task_only', confidence: Math.max(fallback.confidence, 0.9) };
+  }
+  if (hasSocialTopic(transcript) && !hasDomainWorkSignal(transcript)) {
+    return { ...fallback, kind: 'social_ephemeral', confidence: Math.max(fallback.confidence, 0.9) };
+  }
+  if (candidate.kind === 'durable_knowledge' && (!hasDomainWorkSignal(transcript) || !hasDurableSignal(`${candidate.summary}\n${candidate.content}\n${transcript}`))) {
+    return {
+      ...candidate,
+      kind: hasTaskOnlySignal(transcript) ? 'task_only' : 'noise',
+      reason: 'Rejected by deterministic guardrail: not enough domain + durable signals.',
+    };
+  }
+
+  return candidate;
+}
+
+async function classifyEpisode(episode: KnowledgeEpisode, orgId: string): Promise<EpisodeClassification> {
+  const fallback = deterministicEpisodeClassification(episode);
+  if (fallback.kind === 'social_ephemeral' || fallback.kind === 'task_only') {
+    return fallback;
+  }
+
+  if (!(await hasAnyAIProvider(orgId))) {
+    return fallback;
+  }
+
+  try {
+    const orgConfig = await getOrgAIConfig(orgId);
+    const response = await llm({
+      task: 'classify',
+      system: `You classify settled workspace chat episodes for a knowledge wiki.
+
+Return JSON only with:
+{
+  "kind": "durable_knowledge" | "task_only" | "social_ephemeral" | "noise",
+  "confidence": 0-1,
+  "wikiType": "decision" | "fact" | "procedure" | "preference" | "entity" | "resource",
+  "title": "short title if durable, else empty",
+  "summary": "concise summary if durable, else empty",
+  "content": "self-contained wiki text if durable, else empty",
+  "reason": "short reason"
+}
+
+Rules:
+- Durable knowledge means stable company memory: decisions, process changes, client constraints, operating rules, canonical facts, launch commitments.
+- Task-only means actionable work that should wait for Defty/a human to create or update a task, not become wiki by itself.
+- Social/ephemeral includes lunch, pizza, jokes, greetings, personal banter, temporary preferences unrelated to work. Reject these even if someone says "policy" sarcastically.
+- If the episode contains a Defty/agent instruction, classify as task_only unless it also clearly records a separate durable decision.
+- Prefer updating an existing canonical wiki later; here only decide whether the episode deserves memory.
+- Do not include markdown fences.`,
+      messages: [
+        {
+          role: 'user',
+          content: `Episode bucket: ${episode.bucket}\nMessages:\n${episodeText(episode)}`,
+        },
+      ],
+      maxTokens: 700,
+      orgConfig,
+    });
+    const cleaned = response.text
+      .trim()
+      .replace(/^```(?:json)?\s*/i, '')
+      .replace(/\s*```\s*$/, '')
+      .trim();
+    const parsed = JSON.parse(cleaned) as Partial<EpisodeClassification>;
+    return coerceEpisodeClassification(parsed, fallback, episode);
+  } catch (err) {
+    console.warn('[chat-knowledge-batch] Episode classifier failed, using deterministic fallback:', (err as Error).message);
+    return fallback;
+  }
+}
+
+async function buildCandidatesForSpace(rows: ClassifiedMessageRow[]): Promise<KnowledgeCandidate[]> {
+  const candidates: KnowledgeCandidate[] = [];
+  const episodes = segmentRowsIntoEpisodes(rows);
+  for (let index = 0; index < episodes.length; index += 1) {
+    const episode = episodes[index]!;
+    const nextEpisode = episodes[index + 1];
+    const transcript = episodeText(episode);
+    if (episode.rows.every((row) => row.confidence < 0.45) && !hasDomainWorkSignal(transcript) && !hasDurableSignal(transcript)) {
+      continue;
+    }
+    const followedByAgentTaskCommand = Boolean(
+      nextEpisode?.rows.some((row) => row.agentMentioned) &&
+      nextEpisode.rows[0]!.createdAt.getTime() - episode.rows[episode.rows.length - 1]!.createdAt.getTime() < EPISODE_GAP_MS * 2 &&
+      hasTaskOnlySignal(`${episodeText(episode)}\n${episodeText(nextEpisode)}`),
+    );
+    if (followedByAgentTaskCommand) {
+      continue;
+    }
+    const classification = await classifyEpisode(episode, episode.rows[0]!.orgId);
+    if (classification.kind !== 'durable_knowledge' || classification.confidence < 0.62) continue;
+    const evidence = episode.rows.filter(isKnowledgeEvidenceRow);
+    if (evidence.length === 0) continue;
+    const source = chooseSourceRow({ ...episode, rows: evidence });
+    const wikiType = classification.wikiType === 'decision' ? 'decision' : 'fact';
+    candidates.push({
+      kind: wikiType === 'decision' ? 'decision_candidate' : 'note_candidate',
+      wikiType,
+      title: classification.title || (wikiType === 'decision' ? 'Decision from discussion' : 'Fact from discussion'),
+      summary: classification.summary,
+      content: classification.content || classification.summary,
+      source,
+      evidence,
+      episode,
+      classification,
+    });
+  }
+  return dedupeCandidates(candidates).slice(-MAX_CANDIDATES_PER_SPACE);
+}
+
+export async function handleChatKnowledgeBatch(job: JobData): Promise<void> {
+  const data = (job.data ?? {}) as {
+    lookbackMs?: number;
+    quietMs?: number;
+    orgId?: string;
+    spaceId?: string;
+  };
+  const lookbackMs = Math.max(5 * 60 * 1000, data.lookbackMs ?? DEFAULT_LOOKBACK_MS);
+  const quietMs = Math.max(0, data.quietMs ?? DEFAULT_QUIET_MS);
+  const now = new Date();
+  const since = new Date(now.getTime() - lookbackMs);
+  const before = new Date(now.getTime() - quietMs);
+
+  const rawRows = await db
+    .select({
+      messageId: messages.id,
+      spaceId: messages.space_id,
+      spaceName: spaces.name,
+      orgId: messages.org_id,
+      userId: messages.user_id,
+      userName: users.name,
+      content: messages.content,
+      createdAt: messages.created_at,
+      confidence: messageClassifications.confidence,
+      agentMentioned: messageClassifications.agent_mentioned,
+      memorableFacts: messageClassifications.memorable_facts,
+      decision: messageClassifications.decision,
+    })
+    .from(messages)
+    .leftJoin(messageClassifications, and(
+      eq(messages.id, messageClassifications.message_id),
+      eq(messages.org_id, messageClassifications.org_id),
+    ))
+    .innerJoin(spaces, and(
+      eq(spaces.id, messages.space_id),
+      eq(spaces.org_id, messages.org_id),
+    ))
+    .innerJoin(users, eq(users.id, messages.user_id))
+    .where(and(
+      data.orgId ? eq(messages.org_id, data.orgId) : undefined,
+      data.spaceId ? eq(messages.space_id, data.spaceId) : undefined,
+      eq(messages.is_deleted, false),
+      eq(users.is_agent, false),
+      eq(spaces.is_archived, false),
+      gte(messages.created_at, since),
+      lt(messages.created_at, before),
+    ))
+    .orderBy(desc(messages.created_at))
+    .limit(MAX_MESSAGES_PER_RUN);
+
+  const grouped = new Map<string, ClassifiedMessageRow[]>();
+  const rows = (rawRows.reverse() as RawMessageRow[]).map((row) => ({
+    ...row,
+    confidence: typeof row.confidence === 'number'
+      ? row.confidence
+      : hasDurableSignal(row.content) || hasDomainWorkSignal(row.content) ? 0.58 : 0.25,
+    agentMentioned: row.agentMentioned ?? isAgentCommand(row.content),
+    memorableFacts: row.memorableFacts ?? [],
+    decision: row.decision ?? extractInlineDecision(row.content),
+  } satisfies ClassifiedMessageRow));
+
+  for (const row of rows) {
+    const list = grouped.get(row.spaceId) ?? [];
+    list.push(row);
+    grouped.set(row.spaceId, list);
+  }
+
+  let queuedCount = 0;
+  let skippedCount = 0;
+  for (const spaceRows of grouped.values()) {
+    const candidates = await buildCandidatesForSpace(spaceRows);
+    for (const candidate of candidates) {
+      const result = await queueDeftyKnowledgeCapture({
+        orgId: candidate.source.orgId,
+        sourceUserId: candidate.source.userId,
+        spaceId: candidate.source.spaceId,
+        messageId: candidate.source.messageId,
+        content: candidate.content,
+        rawContent: evidenceContext(candidate.evidence),
+        title: candidate.title,
+        summary: candidate.summary,
+        wikiType: candidate.wikiType,
+        captureKind: candidate.kind,
+        captureReason: 'Quiet discussion batch found durable knowledge after the chat settled.',
+        extraction: 'llm',
+        tags: ['chat-batch', 'episode', candidate.wikiType],
+        metadata: {
+          source: 'chat_knowledge_batch',
+          batch_capture: true,
+          episode_capture: true,
+          episode_index: candidate.episode.index,
+          episode_bucket: candidate.episode.bucket,
+          episode_kind: candidate.classification.kind,
+          episode_confidence: candidate.classification.confidence,
+          episode_reason: candidate.classification.reason,
+          episode_message_count: candidate.episode.rows.length,
+          batch_window_start: since.toISOString(),
+          batch_window_end: before.toISOString(),
+          batch_space_id: candidate.source.spaceId,
+          batch_space_name: candidate.source.spaceName,
+          batch_message_ids: candidate.evidence.map((row) => row.messageId),
+          batch_message_previews: candidate.evidence.map((row) => ({
+            message_id: row.messageId,
+            user_name: row.userName,
+            preview: truncatePlainText(toPlainText(row.content), 180),
+          })),
+        },
+        autoApprove: true,
+        preferUpdate: true,
+      });
+      if (result.queued) queuedCount += 1;
+      else skippedCount += 1;
+    }
+  }
+
+  console.log(`[chat-knowledge-batch] processed ${rows.length} messages, queued ${queuedCount}, skipped ${skippedCount}`);
+}

--- a/apps/api/src/workers/handlers/memory-capture.ts
+++ b/apps/api/src/workers/handlers/memory-capture.ts
@@ -4,6 +4,8 @@ import type { JobData } from '../types.js';
 import { queueDeftyKnowledgeCapture } from '../../lib/defty-capture.js';
 import { toPlainText, truncatePlainText } from '../../lib/plain-text.js';
 
+const ENABLE_IMMEDIATE_MEMORY_CAPTURE = process.env.DEFT_ENABLE_IMMEDIATE_MEMORY_CAPTURE === '1';
+
 interface MemoryCaptureJobData {
   messageId: string;
   spaceId: string;
@@ -88,6 +90,12 @@ function dedupeSimilarFacts(facts: string[]): string[] {
 }
 
 export async function handleMemoryCapture(job: JobData) {
+  if (!ENABLE_IMMEDIATE_MEMORY_CAPTURE) {
+    const data = job.data as MemoryCaptureJobData;
+    console.log(`[memory-capture] Immediate chat-to-knowledge capture disabled; skipping ${data.messageId}`);
+    return;
+  }
+
   const data = job.data as MemoryCaptureJobData;
   const {
     messageId,
@@ -106,6 +114,7 @@ export async function handleMemoryCapture(job: JobData) {
       spaceId,
       messageId,
       content: decision,
+      rawContent: content,
       title: decisionTitle(decision, content),
       summary: decision,
       wikiType: 'decision',
@@ -139,6 +148,7 @@ export async function handleMemoryCapture(job: JobData) {
       spaceId,
       messageId,
       content: noteContent,
+      rawContent: content,
       title: factCandidates.length === 1 ? noteTitle(firstFact) : 'Facts and preferences from chat',
       summary: noteContent,
       wikiType: 'fact',
@@ -166,6 +176,7 @@ export async function handleMemoryCapture(job: JobData) {
       spaceId,
       messageId,
       content: resource.content,
+      rawContent: content,
       title: resource.title,
       summary: resource.content,
       wikiType: 'resource',

--- a/apps/api/src/workers/handlers/observe-chat-message.ts
+++ b/apps/api/src/workers/handlers/observe-chat-message.ts
@@ -3,6 +3,7 @@ import {
   messageClassifications,
   messageObservations,
   messages,
+  users,
 } from '@deft/db/schema';
 import type { JobData } from '../types.js';
 import { db } from '../../lib/db.js';
@@ -11,6 +12,8 @@ import { enqueue, QUEUE_NAMES } from '../../lib/queues.js';
 import {
   CHAT_OBSERVATION_VERSION,
   explicitObservationIgnoreReason,
+  hasNoKnowledgeDirective,
+  hasNoTaskDirective,
 } from '../../lib/chat-observation.js';
 import { toPlainText } from '../../lib/plain-text.js';
 
@@ -21,6 +24,8 @@ type ObserveChatMessageJobData = {
   userId: string;
   observationVersion?: number;
 };
+
+const EXPLICIT_KNOWLEDGE_UPDATE_CAPTURE_DELAY_MS = 30_000;
 
 function tokenOverlap(a: string, b: string): number {
   const toTokens = (value: string) => new Set(
@@ -60,13 +65,16 @@ function looksLikeResourceCapture(content: string): boolean {
 
 function hasExplicitTaskSignal(content: string): boolean {
   const plain = toPlainText(content).toLowerCase();
-  return /\b(?:create|add|make|open|track)\b.{0,50}\b(?:task|todo|ticket)\b/i.test(plain) ||
-    /\b(?:task|todo|ticket)\s*:\s*\S+/i.test(plain);
+  return /\b(?:create|add|make|open|track)\b.{0,50}\b(?:tasks?|todos?|tickets?)\b/i.test(plain) ||
+    /\b(?:tasks?|todos?|tickets?)\s*:\s*\S+/i.test(plain);
 }
 
-function hasGeneralActionSignal(content: string): boolean {
+function hasConcreteBlockedSignal(content: string): boolean {
   const plain = toPlainText(content).toLowerCase();
-  return /\b(?:need to|should|please|can someone|follow up|assign|owner)\b/i.test(plain);
+  if (hasNoTaskDirective(content)) return false;
+  return /\b(?:i am|i'm|im|we are|we're|were|team is|team's)\s+(?:blocked|stuck|waiting|held up)\b/i.test(plain) ||
+    /\b(?:blocked|stuck|held up)\s+(?:on|by|because|until)\b/i.test(plain) ||
+    /\b(?:can't|cannot|unable to)\s+(?:ship|finish|complete|start|move|continue|proceed)\b/i.test(plain);
 }
 
 function hasExplicitKnowledgeSignal(content: string): boolean {
@@ -75,9 +83,15 @@ function hasExplicitKnowledgeSignal(content: string): boolean {
     /\b(?:we decided|we agreed|going forward)\b/i.test(plain);
 }
 
+function hasExplicitKnowledgeUpdateSignal(content: string): boolean {
+  const plain = toPlainText(content).trim();
+  return /^(?:(?:decision|fact|resource|note|knowledge|wiki|memory)\s*:\s*)?(?:update|correct|correction|amend|revise|change|replace)\b(?:\s+(?:the\s+)?(?:decision|fact|resource|note|knowledge|wiki|memory))?\b/i.test(plain)
+    || /\b(?:update|correct|correction|amend|revise|change|replace)\b\s+(?:the\s+)?(?:decision|fact|resource|note|knowledge|wiki|memory)\b/i.test(plain);
+}
+
 export function extractExplicitDecision(content: string): string | null {
   const plain = toPlainText(content)
-    .replace(/^[A-Z0-9][A-Z0-9_-]{2,80}:\s*/i, '')
+    .replace(/^[A-Z0-9][A-Z0-9_-]{2,80}:\s*/, '')
     .replace(/\s+/g, ' ')
     .trim();
   const explicit = plain.match(/\bdecision\s*:\s*(.+?)(?:\s+(?:save|keep|capture|remember)\b|$)/i);
@@ -99,6 +113,35 @@ function hasExplicitStatusContextSignal(content: string): boolean {
     /\b(?:keep|save|capture|remember)\b.{0,60}\b(?:context|status|memory|note)\b/i.test(plain);
 }
 
+function looksLikeSocialChatter(content: string): boolean {
+  const plain = toPlainText(content)
+    .toLowerCase()
+    .replace(/\b(?:human|chat|dense|edge)[a-z0-9_-]*-[a-z0-9_-]{6,}\b/g, '');
+  const socialTopic =
+    /\b(?:pizza|deep dish|thin crust|pineapple|jalapeno|mushroom|cheese|lunch|breakfast|dinner|snack|coffee|tea|cake|eat|eating|birthday|party|weekend|movie|music|sports)\b/i.test(plain);
+  if (!socialTopic) return false;
+
+  const explicitCapture =
+    hasExplicitKnowledgeSignal(content) ||
+    hasExplicitKnowledgeUpdateSignal(content) ||
+    hasExplicitTaskSignal(content) ||
+    looksLikeResourceCapture(content);
+  if (explicitCapture) return false;
+
+  const jokingOrPreferenceLanguage =
+    /\b(?:discourse|drama|counterpoint|civilized|absolutely not|fine|deal|move on|unbothered|option|prefer|preference|want|wants|only|never|chaos|democracy)\b/i.test(plain);
+  return jokingOrPreferenceLanguage || plain.length < 220;
+}
+
+function looksLikeSocialTaskJoke(content: string): boolean {
+  const plain = toPlainText(content)
+    .toLowerCase()
+    .replace(/\b(?:human|chat|dense|edge)[a-z0-9_-]*-[a-z0-9_-]{6,}\b/g, '');
+  return hasExplicitTaskSignal(content) &&
+    /\b(?:pizza|pineapple|lunch|coffee|snack|cake|weekend|movie|music|sports)\b/i.test(plain) &&
+    /\b(?:joke|joking|kidding|mostly|ban|constitution|debate|debates|drama)\b/i.test(plain);
+}
+
 function statusContextFact(content: string): string | null {
   const plain = toPlainText(content)
     .replace(/^DENSE-[^:]+:\s*/i, '')
@@ -113,14 +156,13 @@ function shouldQueueTaskExtraction(params: {
   confidence: number;
   blocked: boolean;
   hasMemoryCapture: boolean;
+  agentMentioned: boolean;
 }): boolean {
-  if (params.blocked) return false;
-  const explicitTask = hasExplicitTaskSignal(params.content);
-  if (explicitTask) return params.confidence > 0.7;
-  if (params.hasMemoryCapture && hasExplicitKnowledgeSignal(params.content)) return false;
-  return params.intent === 'actionable' &&
-    params.confidence > 0.78 &&
-    hasGeneralActionSignal(params.content);
+  // Chat-to-task is now intentionally Defty-led. Normal chat can still be
+  // observed and later used as context, but it should not create/update tasks
+  // mechanically in the background.
+  void params;
+  return false;
 }
 
 async function markObservation(params: {
@@ -213,6 +255,29 @@ export async function handleObserveChatMessage(job: JobData): Promise<void> {
     return;
   }
 
+  const [author] = await db
+    .select({ is_agent: users.is_agent })
+    .from(users)
+    .where(eq(users.id, message.user_id))
+    .limit(1);
+  if (author?.is_agent) {
+    await markObservation({
+      orgId,
+      messageId,
+      observationVersion,
+      status: 'ignored',
+      ignoredReason: 'agent_authored_message',
+      classifierResult: {
+        intent: 'none',
+        confidence: 1,
+        ignored_reason: 'agent_authored_message',
+        source: 'deterministic_guardrail',
+      },
+      completed: true,
+    });
+    return;
+  }
+
   await markObservation({
     orgId,
     messageId,
@@ -267,20 +332,34 @@ export async function handleObserveChatMessage(job: JobData): Promise<void> {
 
   const downstreamJobs: Array<Record<string, unknown>> = [];
   const resourceCapture = looksLikeResourceCapture(message.content);
+  const explicitKnowledgeUpdate = hasExplicitKnowledgeUpdateSignal(message.content);
   const explicitDecision = extractExplicitDecision(message.content) || classification.decision;
-  const factCandidates = resourceCapture && !hasExplicitFactSignal(message.content)
+  const classifierFactCandidates = explicitKnowledgeUpdate
+    ? []
+    : resourceCapture && !hasExplicitFactSignal(message.content)
     ? []
     : factsWithoutDecisionEcho(
       classification.memorable_facts,
       explicitDecision,
     );
+  const factCandidates = (looksLikeSocialChatter(message.content) || looksLikeSocialTaskJoke(message.content)) && !hasExplicitFactSignal(message.content)
+    ? []
+    : classifierFactCandidates;
   const deterministicStatusFact = hasExplicitStatusContextSignal(message.content)
     ? statusContextFact(message.content)
     : null;
   if (factCandidates.length === 0 && deterministicStatusFact) {
     factCandidates.push(deterministicStatusFact);
   }
-  const hasMemoryCapture = Boolean(explicitDecision) || factCandidates.length > 0 || resourceCapture;
+  const knowledgeSuppressed =
+    classification.agent_mentioned ||
+    hasNoKnowledgeDirective(message.content) ||
+    looksLikeSocialChatter(message.content) ||
+    looksLikeSocialTaskJoke(message.content);
+  const hasImmediateMemoryCapture = false;
+  const hasMemoryCapture = !knowledgeSuppressed && (
+    Boolean(explicitDecision) || factCandidates.length > 0 || resourceCapture
+  );
 
   if (shouldQueueTaskExtraction({
     content: message.content,
@@ -288,6 +367,7 @@ export async function handleObserveChatMessage(job: JobData): Promise<void> {
     confidence: classification.confidence,
     blocked: classification.blocked,
     hasMemoryCapture,
+    agentMentioned: classification.agent_mentioned,
   })) {
     await enqueue(QUEUE_NAMES.AGENT_JOBS, 'task-extract', {
       messageId,
@@ -300,7 +380,13 @@ export async function handleObserveChatMessage(job: JobData): Promise<void> {
     downstreamJobs.push({ name: 'task-extract', reason: classification.intent });
   }
 
-  if (classification.blocked === true) {
+  if (
+    classification.blocked === true &&
+    !classification.agent_mentioned &&
+    !looksLikeSocialChatter(message.content) &&
+    !looksLikeSocialTaskJoke(message.content) &&
+    hasConcreteBlockedSignal(message.content)
+  ) {
     await enqueue(QUEUE_NAMES.AGENT_JOBS, 'blocked-alert', {
       messageId,
       spaceId: message.space_id,
@@ -311,7 +397,10 @@ export async function handleObserveChatMessage(job: JobData): Promise<void> {
     downstreamJobs.push({ name: 'blocked-alert', reason: 'blocked' });
   }
 
-  if (hasMemoryCapture) {
+  if (hasImmediateMemoryCapture && hasMemoryCapture) {
+    const memoryCaptureOptions = explicitKnowledgeUpdate
+      ? { delay: EXPLICIT_KNOWLEDGE_UPDATE_CAPTURE_DELAY_MS, maxAttempts: 5 }
+      : undefined;
     await enqueue(QUEUE_NAMES.AGENT_JOBS, 'memory-capture', {
       messageId,
       spaceId: message.space_id,
@@ -320,7 +409,7 @@ export async function handleObserveChatMessage(job: JobData): Promise<void> {
       userId,
       decision: explicitDecision || null,
       facts: factCandidates,
-    });
+    }, memoryCaptureOptions);
     downstreamJobs.push({
       name: 'memory-capture',
       reason: explicitDecision
@@ -328,6 +417,9 @@ export async function handleObserveChatMessage(job: JobData): Promise<void> {
         : factCandidates.length > 0
           ? 'facts'
           : 'resource',
+      ...(explicitKnowledgeUpdate
+        ? { delay_ms: EXPLICIT_KNOWLEDGE_UPDATE_CAPTURE_DELAY_MS }
+        : {}),
     });
   }
 

--- a/apps/api/src/workers/handlers/task-extract.ts
+++ b/apps/api/src/workers/handlers/task-extract.ts
@@ -13,8 +13,10 @@ import { enqueue, QUEUE_NAMES } from '../../lib/queues.js';
 import type { TriggerInvocation } from './employee-trigger.js';
 import { toPlainText, truncatePlainText } from '../../lib/plain-text.js';
 import { queueDeftyCreateTaskCapture } from '../../lib/defty-capture.js';
+import { hasNoTaskDirective } from '../../lib/chat-observation.js';
 
 const TASK_EXTRACT_TRIGGER_KIND = 'event:task-extract';
+const ENABLE_BACKGROUND_TASK_CAPTURE = process.env.DEFT_ENABLE_BACKGROUND_TASK_CAPTURE === '1';
 
 async function findTaskExtractEmployee(orgId: string) {
   const [row] = await db
@@ -62,7 +64,7 @@ export function buildDeterministicTaskTitle(content: string): string {
     .replace(/^[A-Z0-9][A-Z0-9_-]{2,80}:\s*/i, '')
     .trim();
   const explicit = plainContent.match(
-    /\b(?:create|add|make|open|track)\b.{0,60}?\b(?:task|todo|ticket)\b\s*:?\s*(.+)$/i,
+    /\b(?:create|add|make|open|track)\b.{0,60}?\b(?:tasks?|todos?|tickets?)\b\s*:?\s*(.+)$/i,
   );
   const candidate = (explicit?.[1]?.trim() || plainContent).replace(/[.!?]+$/g, '');
   return truncatePlainText(candidate.replace(/^please\s+/i, ''), 80) || 'Follow up from chat';
@@ -70,8 +72,8 @@ export function buildDeterministicTaskTitle(content: string): string {
 
 function hasExplicitTaskRequest(content: string): boolean {
   const plainContent = toPlainText(content);
-  return /\b(?:create|add|make|open|track)\b.{0,50}\b(?:task|todo|ticket)\b/i.test(plainContent) ||
-    /\b(?:task|todo|ticket)\s*:\s*\S+/i.test(plainContent);
+  return /\b(?:create|add|make|open|track)\b.{0,50}\b(?:tasks?|todos?|tickets?)\b/i.test(plainContent) ||
+    /\b(?:tasks?|todos?|tickets?)\s*:\s*\S+/i.test(plainContent);
 }
 
 function normalizePriority(priority?: string | null): 'p0' | 'p1' | 'p2' | 'p3' {
@@ -109,9 +111,10 @@ async function queueTaskCreateApproval(params: {
   } = params;
   const plainContent = toPlainText(content);
   if (!plainContent) return false;
+  const explicitTaskRequest = hasExplicitTaskRequest(content);
 
   const deterministicTitle = buildDeterministicTaskTitle(content);
-  const titleSeed = hasExplicitTaskRequest(content)
+  const titleSeed = explicitTaskRequest
     ? deterministicTitle
     : providedTitle || deterministicTitle;
   const title = truncatePlainText(titleSeed, 80);
@@ -129,6 +132,7 @@ async function queueTaskCreateApproval(params: {
     captureKind: 'task_candidate',
     captureReason: 'A chat message looked actionable enough to capture as possible work.',
     extraction,
+    approvalMode: explicitTaskRequest ? 'approval' : 'passive',
   });
 
   if (!queued.queued && queued.skippedReason === 'project_missing') {
@@ -179,6 +183,16 @@ Rules:
 
 export async function handleTaskExtract(job: JobData): Promise<void> {
   const { messageId, spaceId, content, orgId, userId, classification } = job.data as TaskExtractJobData;
+
+  if (!ENABLE_BACKGROUND_TASK_CAPTURE) {
+    console.log(`[task-extract] Background chat-to-task capture disabled; skipping ${messageId}`);
+    return;
+  }
+
+  if (hasNoTaskDirective(content)) {
+    console.log(`[task-extract] Skipped message ${messageId} due to explicit no-task directive`);
+    return;
+  }
 
   // Only process task_create or actionable intents
   if (classification.intent !== 'task_create' && classification.intent !== 'actionable') {

--- a/apps/api/src/workers/index.ts
+++ b/apps/api/src/workers/index.ts
@@ -27,6 +27,7 @@ const CRON_DELAYS: Record<string, number> = {
   // cadence not _fire_ cadence.
   'ics-sync': 60_000,
   'chat-observation-backfill': 5 * 60_000,
+  'chat-knowledge-batch': 30 * 60_000,
 };
 
 const CRON_KEYS: Record<string, string> = {
@@ -44,6 +45,7 @@ const CRON_KEYS: Record<string, string> = {
   'trigger-dispatch': 'cron:trigger-dispatch',
   'ics-sync': 'cron:ics-sync',
   'chat-observation-backfill': 'cron:chat-observation-backfill',
+  'chat-knowledge-batch': 'cron:chat-knowledge-batch',
 };
 
 const JOB_TIMEOUT_MS = Number.parseInt(process.env.DEFT_JOB_TIMEOUT_MS ?? '120000', 10);
@@ -94,6 +96,10 @@ async function getAgentJobHandler(jobName: string): Promise<JobHandler | null> {
     case 'memory-capture': {
       const mod = await import('./handlers/memory-capture.js');
       return mod.handleMemoryCapture;
+    }
+    case 'chat-knowledge-batch': {
+      const mod = await import('./handlers/chat-knowledge-batch.js');
+      return mod.handleChatKnowledgeBatch;
     }
     case 'blocked-alert': {
       const mod = await import('./handlers/blocked-alert.js');

--- a/apps/api/test/agent-actions-routes.test.ts
+++ b/apps/api/test/agent-actions-routes.test.ts
@@ -671,10 +671,11 @@ test('GET /api/agent action surfaces hide Defty captures from private spaces', a
   );
   assert.equal(inlineRes.status, 200);
   const inlineBody = await inlineRes.json();
-  const inlineMatch = inlineBody.find((action: any) => action.id === visible.actionId);
-  assert.ok(inlineMatch, 'visible capture action should appear in inline space approvals');
-  assert.equal(inlineMatch.proposer, 'defty');
-  assert.equal(inlineMatch.params.source_message_content, 'visible capture action source');
+  assert.equal(
+    inlineBody.some((action: any) => action.id === visible.actionId),
+    false,
+    'Defty capture actions should not appear as inline chat approval cards',
+  );
 
   const recentRes = await app().request('/api/agent/actions/recent?limit=50', { method: 'GET' });
   assert.equal(recentRes.status, 200);

--- a/apps/api/test/blocked-task-suggest.test.ts
+++ b/apps/api/test/blocked-task-suggest.test.ts
@@ -1,26 +1,50 @@
 /**
- * Block 2.4 — blocked → task-create proposal test.
+ * Blocked chat governance test.
  *
- * Run: pnpm --filter @deft/api exec tsx --env-file=../../.env --test test/blocked-task-suggest.test.ts
- *
- * The blocked-alert handler now also queues a Defty task_create proposal
- * (approval_status='pending', source='defty_capture') so the user
- * can one-click convert the blocked message into a tracked task.
+ * Blocked messages should alert the right human lead when they relate to
+ * in-progress work, but they must not mechanically create Defty task proposals.
  */
 import { test, before, after, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
 import { eq, and } from 'drizzle-orm';
 import {
-  db, agentActions, agentNudges, spaces, messages,
-  orgs, users, orgMembers, projects, projectSpaces, agentEmployees, workIntents,
+  db,
+  agentActions,
+  agentNudges,
+  messages,
+  notifications,
+  orgMembers,
+  orgs,
+  projects,
+  projectSpaces,
+  spaces,
+  tasks,
+  users,
+  workIntents,
 } from '@deft/db';
 import { handleBlockedAlert } from '../src/workers/handlers/blocked-alert.js';
 
 let testOrgId: string;
-let testUserId: string;
+let blockedUserId: string;
+let leadUserId: string;
 let spaceId: string;
 let msgId: string;
 let projectId: string;
+let taskId: string;
+
+async function runBlockedAlert(content = 'I am completely stuck on the database migration') {
+  await handleBlockedAlert({
+    id: 'job',
+    name: 'blocked-alert',
+    data: {
+      messageId: msgId,
+      spaceId,
+      content,
+      orgId: testOrgId,
+      userId: blockedUserId,
+    },
+  } as any);
+}
 
 before(async () => {
   const suffix = `${Date.now()}-${crypto.randomUUID().slice(0, 8)}`;
@@ -28,37 +52,57 @@ before(async () => {
   testOrgId = crypto.randomUUID();
   await db.insert(orgs).values({
     id: testOrgId,
-    name: `b24-${suffix}`,
-    slug: `b24-${suffix}`,
+    name: `blocked-governance-${suffix}`,
+    slug: `blocked-governance-${suffix}`,
   });
 
-  testUserId = crypto.randomUUID();
-  await db.insert(users).values({
-    id: testUserId,
-    email: `b24-${suffix}@t.local`,
-    name: `b24 ${suffix}`,
-  });
+  blockedUserId = crypto.randomUUID();
+  leadUserId = crypto.randomUUID();
+  await db.insert(users).values([
+    {
+      id: blockedUserId,
+      email: `blocked-${suffix}@t.local`,
+      name: `Blocked User ${suffix}`,
+    },
+    {
+      id: leadUserId,
+      email: `blocked-lead-${suffix}@t.local`,
+      name: `Project Lead ${suffix}`,
+    },
+  ]);
 
-  await db.insert(orgMembers).values({
-    id: crypto.randomUUID(),
-    org_id: testOrgId,
-    user_id: testUserId,
-    role: 'admin',
-  });
+  await db.insert(orgMembers).values([
+    {
+      id: crypto.randomUUID(),
+      org_id: testOrgId,
+      user_id: blockedUserId,
+      role: 'member',
+    },
+    {
+      id: crypto.randomUUID(),
+      org_id: testOrgId,
+      user_id: leadUserId,
+      role: 'admin',
+    },
+  ]);
 
   spaceId = crypto.randomUUID();
   await db.insert(spaces).values({
-    id: spaceId, org_id: testOrgId, name: `b24-space-${Date.now()}`,
-    type: 'public', created_by: testUserId,
+    id: spaceId,
+    org_id: testOrgId,
+    name: `blocked-space-${Date.now()}`,
+    type: 'public',
+    created_by: leadUserId,
   });
 
   projectId = crypto.randomUUID();
   await db.insert(projects).values({
     id: projectId,
     org_id: testOrgId,
-    name: `b24-project-${Date.now()}`,
+    name: `blocked-project-${Date.now()}`,
     prefix: `B${Math.floor(Math.random() * 100000)}`,
-    lead_id: testUserId,
+    lead_id: leadUserId,
+    created_by: leadUserId,
   });
   await db.insert(projectSpaces).values({
     id: crypto.randomUUID(),
@@ -66,15 +110,30 @@ before(async () => {
     space_id: spaceId,
   });
 
+  taskId = crypto.randomUUID();
+  await db.insert(tasks).values({
+    id: taskId,
+    org_id: testOrgId,
+    project_id: projectId,
+    number: 1,
+    title: 'Finish migration plan',
+    status: 'in_progress' as any,
+    assignee_id: blockedUserId,
+    created_by: leadUserId,
+  });
+
   msgId = crypto.randomUUID();
   await db.insert(messages).values({
-    id: msgId, org_id: testOrgId, space_id: spaceId, user_id: testUserId,
+    id: msgId,
+    org_id: testOrgId,
+    space_id: spaceId,
+    user_id: blockedUserId,
     content: 'I am completely stuck on the database migration',
   });
 });
 
 afterEach(async () => {
-  if (!testOrgId || !msgId || !testUserId) return;
+  if (!testOrgId || !msgId || !blockedUserId) return;
 
   await db.delete(agentActions).where(
     and(
@@ -89,11 +148,10 @@ afterEach(async () => {
       eq(workIntents.source_message_id, msgId),
     ),
   );
-  // Clear the dedup nudge too so the next test isn't skipped by the
-  // 4h "already alerted" guard in handleBlockedAlert.
+  await db.delete(notifications).where(eq(notifications.org_id, testOrgId));
   await db.delete(agentNudges).where(
     and(
-      eq(agentNudges.user_id, testUserId),
+      eq(agentNudges.user_id, blockedUserId),
       eq(agentNudges.nudge_type, 'blocked'),
     ),
   );
@@ -103,156 +161,24 @@ after(async () => {
   if (testOrgId) {
     await db.delete(agentActions).where(eq(agentActions.org_id, testOrgId));
     await db.delete(workIntents).where(eq(workIntents.org_id, testOrgId));
+    await db.delete(notifications).where(eq(notifications.org_id, testOrgId));
     await db.delete(agentNudges).where(eq(agentNudges.org_id, testOrgId));
   }
   if (msgId) await db.delete(messages).where(eq(messages.id, msgId));
+  if (taskId) await db.delete(tasks).where(eq(tasks.id, taskId));
   if (projectId) await db.delete(projectSpaces).where(eq(projectSpaces.project_id, projectId));
   if (projectId) await db.delete(projects).where(eq(projects.id, projectId));
   if (spaceId) await db.delete(spaces).where(eq(spaces.id, spaceId));
-  if (testOrgId) await db.delete(agentEmployees).where(eq(agentEmployees.org_id, testOrgId));
   if (testOrgId) await db.delete(orgMembers).where(eq(orgMembers.org_id, testOrgId));
   if (testOrgId) await db.delete(orgs).where(eq(orgs.id, testOrgId));
-  if (testUserId) await db.delete(users).where(eq(users.id, testUserId));
+  if (blockedUserId || leadUserId) {
+    await db.delete(users).where(eq(users.id, blockedUserId));
+    await db.delete(users).where(eq(users.id, leadUserId));
+  }
 });
 
-test('blocked-alert queues a Defty task_create proposal for the blocked user', async () => {
-  await handleBlockedAlert({
-    id: 'job',
-    name: 'blocked-alert',
-    data: {
-      messageId: msgId,
-      spaceId,
-      content: 'I am completely stuck on the database migration',
-      orgId: testOrgId,
-      userId: testUserId,
-    },
-  } as any);
-
-  const rows = await db
-    .select()
-    .from(agentActions)
-    .where(and(
-      eq(agentActions.org_id, testOrgId),
-      eq(agentActions.message_id, msgId),
-      eq(agentActions.source, 'defty_capture'),
-    ));
-  assert.equal(rows.length, 1, `expected 1 proposal, got ${rows.length}`);
-  const row = rows[0]!;
-  assert.equal(row.action, 'task_create');
-  assert.equal(row.approval_tier, 'quick');
-  assert.equal(row.approval_status, 'pending');
-  assert.equal(row.message_id, msgId);
-  assert.ok(row.agent_employee_id, 'Defty capture should execute through a hidden agent employee');
-  const params = row.params as any;
-  assert.equal(params.caller_employee_slug, 'defty-system');
-  assert.ok(typeof params.title === 'string' && params.title.startsWith('Blocker:'));
-  assert.equal(params.project_id, projectId);
-  assert.equal(params.space_id, spaceId);
-  assert.equal(params.source_message_id, msgId);
-  assert.equal(params.source_space_id, spaceId);
-  assert.equal(params.source_user_id, testUserId);
-  assert.equal(params.origin_message_id, msgId);
-  assert.equal(params.origin_space_id, spaceId);
-  assert.equal(params.origin_user_id, testUserId);
-  assert.equal(params.capture_kind, 'blocker_candidate');
-  assert.equal(params.proposed_by, 'defty');
-  assert.equal(params.dedupe_key, `defty_capture:blocker_candidate:task_create:${msgId}`);
-  assert.ok(params.work_intent_id, 'proposal should link back to a work intent');
-  assert.equal(params.work_intent_status, 'proposed');
-
-  const intents = await db
-    .select()
-    .from(workIntents)
-    .where(and(
-      eq(workIntents.org_id, testOrgId),
-      eq(workIntents.source_message_id, msgId),
-    ));
-  assert.equal(intents.length, 1, `expected 1 work intent, got ${intents.length}`);
-  const intent = intents[0]!;
-  assert.equal(intent.id, params.work_intent_id);
-  assert.equal(intent.kind, 'blocker_candidate');
-  assert.equal(intent.status, 'proposed');
-  assert.equal(intent.proposed_action, 'task_create');
-  assert.equal(intent.title, params.title);
-  assert.equal(intent.space_id, spaceId);
-  assert.equal(intent.source_user_id, testUserId);
-  assert.equal((intent.proposed_params as any).source_message_id, msgId);
-});
-
-test('proposal payload description keeps the full message', async () => {
-  await handleBlockedAlert({
-    id: 'job',
-    name: 'blocked-alert',
-    data: {
-      messageId: msgId,
-      spaceId,
-      content: 'I am completely stuck on the database migration',
-      orgId: testOrgId,
-      userId: testUserId,
-    },
-  } as any);
-
-  const [row] = await db
-    .select()
-    .from(agentActions)
-    .where(and(
-      eq(agentActions.org_id, testOrgId),
-      eq(agentActions.message_id, msgId),
-      eq(agentActions.source, 'defty_capture'),
-    ))
-    .limit(1);
-  const params = row!.params as any;
-  assert.equal(params.description, 'I am completely stuck on the database migration');
-});
-
-test('blocked-alert repairs an orphaned Defty work intent by recreating the approval action', async () => {
-  await handleBlockedAlert({
-    id: 'job',
-    name: 'blocked-alert',
-    data: {
-      messageId: msgId,
-      spaceId,
-      content: 'I am completely stuck on the database migration',
-      orgId: testOrgId,
-      userId: testUserId,
-    },
-  } as any);
-
-  const [intent] = await db
-    .select()
-    .from(workIntents)
-    .where(and(
-      eq(workIntents.org_id, testOrgId),
-      eq(workIntents.source_message_id, msgId),
-    ))
-    .limit(1);
-  assert.ok(intent, 'first run should create a work intent');
-
-  await db.delete(agentActions).where(
-    and(
-      eq(agentActions.org_id, testOrgId),
-      eq(agentActions.message_id, msgId),
-      eq(agentActions.source, 'defty_capture'),
-    ),
-  );
-  await db.delete(agentNudges).where(
-    and(
-      eq(agentNudges.user_id, testUserId),
-      eq(agentNudges.nudge_type, 'blocked'),
-    ),
-  );
-
-  await handleBlockedAlert({
-    id: 'job',
-    name: 'blocked-alert',
-    data: {
-      messageId: msgId,
-      spaceId,
-      content: 'I am completely stuck on the database migration',
-      orgId: testOrgId,
-      userId: testUserId,
-    },
-  } as any);
+test('blocked-alert does not create Defty task proposals by itself', async () => {
+  await runBlockedAlert();
 
   const actions = await db
     .select()
@@ -262,8 +188,7 @@ test('blocked-alert repairs an orphaned Defty work intent by recreating the appr
       eq(agentActions.message_id, msgId),
       eq(agentActions.source, 'defty_capture'),
     ));
-  assert.equal(actions.length, 1, 'second run should recreate exactly one approval action');
-  assert.equal((actions[0]!.params as any).work_intent_id, intent.id);
+  assert.equal(actions.length, 0, 'blocked chat should wait for Defty/human task creation');
 
   const intents = await db
     .select()
@@ -272,32 +197,41 @@ test('blocked-alert repairs an orphaned Defty work intent by recreating the appr
       eq(workIntents.org_id, testOrgId),
       eq(workIntents.source_message_id, msgId),
     ));
-  assert.equal(intents.length, 1, 'repair must reuse the existing intent');
+  assert.equal(intents.length, 0, 'blocked chat should not create passive work intents');
 });
 
-test('blocked-alert strips rich text from task proposal fields', async () => {
-  await handleBlockedAlert({
-    id: 'job',
-    name: 'blocked-alert',
-    data: {
-      messageId: msgId,
-      spaceId,
-      content: '<p><strong>I am blocked</strong> on the &amp; vendor export.</p>',
-      orgId: testOrgId,
-      userId: testUserId,
-    },
-  } as any);
+test('blocked-alert still notifies the project lead for real blocked work', async () => {
+  await runBlockedAlert();
+
+  const rows = await db
+    .select()
+    .from(notifications)
+    .where(and(
+      eq(notifications.org_id, testOrgId),
+      eq(notifications.user_id, leadUserId),
+      eq(notifications.title, 'Blocked Team Member'),
+    ));
+
+  assert.equal(rows.length, 1, `expected one lead notification, got ${rows.length}`);
+  assert.equal(rows[0]!.type, 'agent_suggestion');
+  assert.match(rows[0]!.body ?? '', /stuck on the database migration/i);
+  assert.equal((rows[0]!.metadata as any).task_id, taskId);
+});
+
+test('blocked-alert strips rich text from lead notification body', async () => {
+  await runBlockedAlert('<p><strong>I am blocked</strong> on the &amp; vendor export.</p>');
 
   const [row] = await db
     .select()
-    .from(agentActions)
+    .from(notifications)
     .where(and(
-      eq(agentActions.org_id, testOrgId),
-      eq(agentActions.message_id, msgId),
-      eq(agentActions.source, 'defty_capture'),
+      eq(notifications.org_id, testOrgId),
+      eq(notifications.user_id, leadUserId),
+      eq(notifications.title, 'Blocked Team Member'),
     ))
     .limit(1);
-  const params = row!.params as any;
-  assert.equal(params.title, 'Blocker: I am blocked on the & vendor export.');
-  assert.equal(params.description, 'I am blocked on the & vendor export.');
+
+  assert.ok(row, 'expected lead notification');
+  assert.match(row.body ?? '', /I am blocked on the & vendor export\./);
+  assert.doesNotMatch(row.body ?? '', /<strong>|<p>/);
 });

--- a/apps/api/test/chat-knowledge-batch.test.ts
+++ b/apps/api/test/chat-knowledge-batch.test.ts
@@ -1,0 +1,310 @@
+import { after, before, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { and, eq, inArray } from 'drizzle-orm';
+import {
+  agentActions,
+  agentEmployees,
+  actionReceipts,
+  db,
+  messageClassifications,
+  messages,
+  orgMembers,
+  orgs,
+  projects,
+  projectSpaces,
+  spaceMembers,
+  spaces,
+  users,
+  wikiOpsLog,
+  wikiPages,
+  workIntents,
+} from '@deft/db';
+
+const RUN_ID = crypto.randomUUID().slice(0, 8);
+const ORG_ID = `chat-batch-org-${RUN_ID}`;
+const USER_ID = `chat-batch-user-${RUN_ID}`;
+const USER_TWO_ID = `chat-batch-user-two-${RUN_ID}`;
+const PROJECT_ID = `chat-batch-project-${RUN_ID}`;
+const BASE_TIME = Date.now() - 12 * 60 * 1000;
+let handleChatKnowledgeBatch: (job: any) => Promise<void>;
+
+async function createSpace(name: string): Promise<string> {
+  const id = `chat-batch-space-${name}-${crypto.randomUUID()}`;
+  await db.insert(spaces).values({
+    id,
+    org_id: ORG_ID,
+    name,
+    type: 'public',
+    created_by: USER_ID,
+  });
+  await db.insert(spaceMembers).values([
+    {
+      id: crypto.randomUUID(),
+      space_id: id,
+      user_id: USER_ID,
+    },
+    {
+      id: crypto.randomUUID(),
+      space_id: id,
+      user_id: USER_TWO_ID,
+    },
+  ]);
+  await db.insert(projectSpaces).values({
+    id: crypto.randomUUID(),
+    project_id: PROJECT_ID,
+    space_id: id,
+  });
+  return id;
+}
+
+async function seedMessage(
+  spaceId: string,
+  content: string,
+  offsetSeconds: number,
+  userId = USER_ID,
+  classification?: {
+    intent?: string;
+    confidence?: number;
+    agentMentioned?: boolean;
+    facts?: string[];
+    decision?: string | null;
+  },
+): Promise<string> {
+  const id = `chat-batch-msg-${crypto.randomUUID()}`;
+  const createdAt = new Date(BASE_TIME + offsetSeconds * 1000);
+  await db.insert(messages).values({
+    id,
+    org_id: ORG_ID,
+    space_id: spaceId,
+    user_id: userId,
+    content,
+    created_at: createdAt,
+    updated_at: createdAt,
+  });
+  if (classification) {
+    await db.insert(messageClassifications).values({
+      org_id: ORG_ID,
+      message_id: id,
+      intent: classification.intent ?? 'discussion',
+      confidence: classification.confidence ?? 0.8,
+      agent_mentioned: classification.agentMentioned ?? false,
+      blocked: false,
+      task_references: [],
+      entities: {},
+      memorable_facts: classification.facts ?? [],
+      decision: classification.decision ?? null,
+      created_at: createdAt,
+    });
+  }
+  return id;
+}
+
+async function runBatch(spaceId: string) {
+  await handleChatKnowledgeBatch({
+    name: 'chat-knowledge-batch',
+    data: {
+      orgId: ORG_ID,
+      spaceId,
+      lookbackMs: 60 * 60 * 1000,
+      quietMs: 0,
+    },
+  } as any);
+}
+
+async function intentsForMessages(messageIds: string[]) {
+  if (messageIds.length === 0) return [];
+  return db
+    .select({
+      id: workIntents.id,
+      kind: workIntents.kind,
+      proposed_action: workIntents.proposed_action,
+      proposed_params: workIntents.proposed_params,
+      metadata: workIntents.metadata,
+    })
+    .from(workIntents)
+    .where(and(
+      eq(workIntents.org_id, ORG_ID),
+      inArray(workIntents.source_message_id, messageIds),
+    ));
+}
+
+before(async () => {
+  process.env.ANTHROPIC_API_KEY = '';
+  process.env.OPENAI_API_KEY = '';
+  process.env.OPENROUTER_API_KEY = '';
+  process.env.OLLAMA_URL = '';
+  ({ handleChatKnowledgeBatch } = await import('../src/workers/handlers/chat-knowledge-batch.js'));
+
+  await db.insert(orgs).values({
+    id: ORG_ID,
+    name: 'Chat Knowledge Batch Test Org',
+    slug: ORG_ID,
+  });
+  await db.insert(users).values([
+    {
+      id: USER_ID,
+      email: `${USER_ID}@test.local`,
+      name: 'Diego Batch',
+    },
+    {
+      id: USER_TWO_ID,
+      email: `${USER_TWO_ID}@test.local`,
+      name: 'Maya Batch',
+    },
+  ]);
+  await db.insert(orgMembers).values([
+    {
+      id: crypto.randomUUID(),
+      org_id: ORG_ID,
+      user_id: USER_ID,
+      role: 'admin',
+    },
+    {
+      id: crypto.randomUUID(),
+      org_id: ORG_ID,
+      user_id: USER_TWO_ID,
+      role: 'member',
+    },
+  ]);
+  await db.insert(projects).values({
+    id: PROJECT_ID,
+    org_id: ORG_ID,
+    name: 'Chat Batch Launch',
+    prefix: `CB${RUN_ID.toUpperCase().slice(0, 5)}`,
+    lead_id: USER_ID,
+  });
+});
+
+after(async () => {
+  await db.delete(actionReceipts).where(eq(actionReceipts.org_id, ORG_ID));
+  await db.delete(agentActions).where(eq(agentActions.org_id, ORG_ID));
+  await db.delete(workIntents).where(eq(workIntents.org_id, ORG_ID));
+  await db.delete(agentEmployees).where(eq(agentEmployees.org_id, ORG_ID));
+  await db.delete(wikiOpsLog).where(eq(wikiOpsLog.org_id, ORG_ID));
+  await db.delete(wikiPages).where(eq(wikiPages.org_id, ORG_ID));
+  await db.delete(messageClassifications).where(eq(messageClassifications.org_id, ORG_ID));
+  await db.delete(messages).where(eq(messages.org_id, ORG_ID));
+  await db.delete(projectSpaces).where(eq(projectSpaces.project_id, PROJECT_ID));
+  const testSpaces = await db
+    .select({ id: spaces.id })
+    .from(spaces)
+    .where(eq(spaces.org_id, ORG_ID));
+  for (const space of testSpaces) {
+    await db.delete(spaceMembers).where(eq(spaceMembers.space_id, space.id));
+  }
+  await db.delete(spaces).where(eq(spaces.org_id, ORG_ID));
+  await db.delete(projects).where(eq(projects.id, PROJECT_ID));
+  await db.delete(orgMembers).where(eq(orgMembers.org_id, ORG_ID));
+  await db.delete(users).where(inArray(users.id, [USER_ID, USER_TWO_ID]));
+  await db.delete(orgs).where(eq(orgs.id, ORG_ID));
+});
+
+test('chat-knowledge-batch ignores social lunch debate even with fake policy language', async () => {
+  const spaceId = await createSpace('batch-pizza-social');
+  const messageIds = [
+    await seedMessage(spaceId, 'I am opening the floor: thin crust or deep dish for lunch?', 0),
+    await seedMessage(spaceId, 'Decision: pineapple is banned from the pizza policy forever.', 35, USER_TWO_ID, {
+      confidence: 0.95,
+      decision: 'pineapple is banned from the pizza policy forever',
+      facts: ['Pineapple is banned from the pizza policy forever'],
+    }),
+    await seedMessage(spaceId, 'Counterpoint, mushroom people have been silenced for too long.', 70),
+    await seedMessage(spaceId, 'Fine, two pies. One spicy, one boring. This is not company memory.', 105, USER_TWO_ID),
+  ];
+
+  await runBatch(spaceId);
+
+  const intents = await intentsForMessages(messageIds);
+  assert.equal(intents.length, 0, 'social lunch debate must not create wiki work intents');
+  const actions = await db
+    .select({ id: agentActions.id })
+    .from(agentActions)
+    .where(and(
+      eq(agentActions.org_id, ORG_ID),
+      inArray(agentActions.message_id, messageIds),
+    ));
+  assert.equal(actions.length, 0, 'social lunch debate must not queue actions');
+});
+
+test('chat-knowledge-batch captures a settled durable launch decision', async () => {
+  const spaceId = await createSpace('batch-launch-decision');
+  const messageIds = [
+    await seedMessage(spaceId, 'For the Sun Gold launch, the buyer copy is ready but QA still needs label signoff.', 0),
+    await seedMessage(spaceId, 'Maya can own the label signoff before the cold-chain review.', 45, USER_TWO_ID),
+    await seedMessage(spaceId, 'Decision: Sun Gold trial shipments only go out after cold-chain QA confirms labels, and Maya owns buyer confirmation.', 90, USER_ID, {
+      confidence: 0.96,
+      decision: 'Sun Gold trial shipments only go out after cold-chain QA confirms labels, and Maya owns buyer confirmation',
+    }),
+  ];
+
+  await runBatch(spaceId);
+
+  const intents = await intentsForMessages(messageIds);
+  assert.equal(intents.length, 1, 'durable decision should create one knowledge intent');
+  assert.equal(intents[0]?.kind, 'decision_candidate');
+  assert.equal(intents[0]?.proposed_action, 'wiki_create');
+  assert.equal((intents[0]?.metadata as Record<string, unknown>).episode_capture, true);
+});
+
+test('chat-knowledge-batch does not turn blocker discussion into passive wiki or task work', async () => {
+  const spaceId = await createSpace('batch-blocker');
+  const messageIds = [
+    await seedMessage(spaceId, 'I am blocked on the label proof because the QA sheet still has two missing crate checks.', 0),
+    await seedMessage(spaceId, 'Can someone check whether Diego or Maya owns the crate checks?', 40, USER_TWO_ID),
+    await seedMessage(spaceId, 'Let us wait until the handoff is clear before opening another task.', 80),
+  ];
+
+  await runBatch(spaceId);
+
+  const intents = await intentsForMessages(messageIds);
+  assert.equal(intents.length, 0, 'blocker discussion should wait for Defty/task flow, not passive wiki');
+});
+
+test('chat-knowledge-batch skips passive wiki when a resolution is immediately handed to Defty', async () => {
+  const spaceId = await createSpace('batch-defty-task');
+  const messageIds = [
+    await seedMessage(spaceId, 'The label QA handoff is messy. Diego thinks ops owns it, Maya thinks marketing owns it.', 0),
+    await seedMessage(spaceId, 'Resolution: Maya owns label copy, Diego owns cold-chain QA, and Lina checks final crates.', 45, USER_TWO_ID),
+    await seedMessage(spaceId, '@defty create a task from this discussion with the owners and next checks.', 90, USER_ID, {
+      confidence: 0.98,
+      agentMentioned: true,
+    }),
+  ];
+
+  await runBatch(spaceId);
+
+  const intents = await intentsForMessages(messageIds);
+  assert.equal(intents.length, 0, 'Defty-invoked task episodes should not also become passive wiki');
+});
+
+test('chat-knowledge-batch prefers updating related wiki over creating duplicate wiki pages', async () => {
+  const spaceId = await createSpace('batch-related-update');
+  const slug = `brightmart-delivery-window-${RUN_ID}`;
+  await db.insert(wikiPages).values({
+    id: `chat-batch-wiki-${crypto.randomUUID()}`,
+    org_id: ORG_ID,
+    scope: 'org',
+    type: 'decision',
+    title: 'BrightMart delivery window stays Friday',
+    slug,
+    summary: 'BrightMart delivery window stays Friday.',
+    content: 'Decision: BrightMart delivery window stays Friday.',
+    confidence: 0.9,
+  });
+
+  const messageIds = [
+    await seedMessage(spaceId, 'BrightMart asked whether the delivery window is moving because the east route is tight.', 0),
+    await seedMessage(spaceId, 'Decision: BrightMart delivery window stays Friday, and Maya owns buyer confirmation before the route sheet is sent.', 50, USER_TWO_ID, {
+      confidence: 0.95,
+      decision: 'BrightMart delivery window stays Friday, and Maya owns buyer confirmation before the route sheet is sent',
+    }),
+  ];
+
+  await runBatch(spaceId);
+
+  const intents = await intentsForMessages(messageIds);
+  assert.equal(intents.length, 1, 'related durable decision should create one update intent');
+  assert.equal(intents[0]?.proposed_action, 'wiki_update');
+  assert.equal(((intents[0]?.proposed_params as Record<string, any>).slug), slug);
+  assert.equal((intents[0]?.metadata as Record<string, unknown>).related_wiki_update, true);
+});

--- a/apps/api/test/defty-capture-dedupe-update.test.ts
+++ b/apps/api/test/defty-capture-dedupe-update.test.ts
@@ -4,6 +4,7 @@ import { and, eq, sql } from 'drizzle-orm';
 import {
   agentActions,
   agentEmployees,
+  actionReceipts,
   db,
   messages,
   orgMembers,
@@ -14,6 +15,7 @@ import {
   spaces,
   tasks,
   users,
+  wikiOpsLog,
   wikiPages,
   workIntents,
 } from '@deft/db';
@@ -86,9 +88,11 @@ before(async () => {
 });
 
 after(async () => {
+  await db.delete(actionReceipts).where(eq(actionReceipts.org_id, ORG_ID));
   await db.delete(agentActions).where(eq(agentActions.org_id, ORG_ID));
   await db.delete(workIntents).where(eq(workIntents.org_id, ORG_ID));
   await db.delete(agentEmployees).where(eq(agentEmployees.org_id, ORG_ID));
+  await db.delete(wikiOpsLog).where(eq(wikiOpsLog.org_id, ORG_ID));
   await db.delete(wikiPages).where(eq(wikiPages.org_id, ORG_ID));
   await db.delete(tasks).where(eq(tasks.org_id, ORG_ID));
   await db.delete(messages).where(eq(messages.org_id, ORG_ID));
@@ -554,6 +558,71 @@ test('similar knowledge with a different reference code still queues a fresh pro
   assert.ok(action, 'expected a fresh pending approval for TT-4102');
   assert.equal(action.action, 'wiki_create');
   assert.equal((action.params as Record<string, any>).title, 'Use TT-4102 for chef sample boxes');
+});
+
+test('preferUpdate queues wiki_update for related existing knowledge instead of duplicate create', async () => {
+  const slug = `brightmart-delivery-window-${RUN_ID}`;
+  await db.insert(wikiPages).values({
+    id: `defty-capture-wiki-${crypto.randomUUID()}`,
+    org_id: ORG_ID,
+    scope: 'org',
+    type: 'decision',
+    title: 'BrightMart delivery window stays Friday',
+    slug,
+    summary: 'BrightMart delivery window stays Friday.',
+    content: 'Decision: BrightMart delivery window stays Friday.',
+    confidence: 0.9,
+  });
+  const content = 'Decision: BrightMart delivery window stays Friday, and Maya owns buyer confirmation before the route sheet is sent.';
+  const messageId = await seedMessage(content);
+
+  const queued = await queueDeftyKnowledgeCapture({
+    orgId: ORG_ID,
+    sourceUserId: USER_ID,
+    spaceId: SPACE_ID,
+    messageId,
+    content,
+    title: 'BrightMart delivery window stays Friday',
+    wikiType: 'decision',
+    captureKind: 'decision_candidate',
+    captureReason: 'Test related decision update.',
+    extraction: 'classifier',
+    tags: ['decision', 'defty-capture'],
+    preferUpdate: true,
+  });
+
+  assert.equal(queued.queued, true);
+
+  const [intent] = await db
+    .select({
+      proposed_action: workIntents.proposed_action,
+      proposed_params: workIntents.proposed_params,
+      metadata: workIntents.metadata,
+    })
+    .from(workIntents)
+    .where(and(
+      eq(workIntents.org_id, ORG_ID),
+      eq(workIntents.source_message_id, messageId),
+    ))
+    .limit(1);
+
+  assert.ok(intent, 'expected a related knowledge update intent');
+  assert.equal(intent.proposed_action, 'wiki_update');
+  assert.equal((intent.proposed_params as Record<string, any>).slug, slug);
+  assert.equal((intent.metadata as Record<string, any>).related_wiki_update, true);
+
+  const [action] = await db
+    .select({ action: agentActions.action, params: agentActions.params })
+    .from(agentActions)
+    .where(and(
+      eq(agentActions.org_id, ORG_ID),
+      eq(agentActions.message_id, messageId),
+    ))
+    .limit(1);
+
+  assert.ok(action, 'expected a pending wiki_update approval');
+  assert.equal(action.action, 'wiki_update');
+  assert.equal((action.params as Record<string, any>).slug, slug);
 });
 
 test('explicit correction to existing knowledge queues wiki_update instead of duplicate wiki_create', async () => {

--- a/apps/api/test/memory-capture.test.ts
+++ b/apps/api/test/memory-capture.test.ts
@@ -16,7 +16,10 @@ import {
   workIntents,
 } from '@deft/db';
 import { queueDeftyCreateTaskCapture } from '../src/lib/defty-capture.js';
-import { handleMemoryCapture } from '../src/workers/handlers/memory-capture.js';
+import {
+  extractResourceCandidate,
+  handleMemoryCapture,
+} from '../src/workers/handlers/memory-capture.js';
 
 const ORG_ID = `memory-capture-org-${crypto.randomUUID()}`;
 const USER_ID = `memory-capture-user-${crypto.randomUUID()}`;
@@ -55,6 +58,34 @@ async function runMemoryCapture(
       decision,
     },
   } as any);
+}
+
+async function intentsForMessage(messageId: string) {
+  return db
+    .select()
+    .from(workIntents)
+    .where(and(
+      eq(workIntents.org_id, ORG_ID),
+      eq(workIntents.source_message_id, messageId),
+    ));
+}
+
+async function actionsForMessage(messageId: string) {
+  return db
+    .select()
+    .from(agentActions)
+    .where(and(
+      eq(agentActions.org_id, ORG_ID),
+      eq(agentActions.message_id, messageId),
+      eq(agentActions.source, 'defty_capture'),
+    ));
+}
+
+async function assertNoMemoryWork(messageId: string) {
+  const intents = await intentsForMessage(messageId);
+  assert.equal(intents.length, 0, 'immediate memory capture should be quiet by default');
+  const actions = await actionsForMessage(messageId);
+  assert.equal(actions.length, 0, 'immediate memory capture should not queue approvals by default');
 }
 
 before(async () => {
@@ -128,169 +159,50 @@ after(async () => {
   await db.delete(orgs).where(eq(orgs.id, ORG_ID));
 });
 
-test('memory-capture routes explicit facts through a Defty wiki_create approval', async () => {
+test('memory-capture skips explicit facts by default', async () => {
   const content = 'Preference: use concise buyer updates. Policy: never promise same-day delivery after 2pm.';
   const messageId = await seedMessage(content);
 
   await runMemoryCapture(messageId, content, [
     'use concise buyer updates',
     'never promise same-day delivery after 2pm',
-    'never promise same-day delivery after 2pm',
-    'Never promise same day delivery after 2 pm',
   ]);
 
-  const [intent] = await db
-    .select({
-      id: workIntents.id,
-      kind: workIntents.kind,
-      status: workIntents.status,
-      proposed_action: workIntents.proposed_action,
-      proposed_params: workIntents.proposed_params,
-      metadata: workIntents.metadata,
-    })
-    .from(workIntents)
-    .where(and(
-      eq(workIntents.org_id, ORG_ID),
-      eq(workIntents.source_message_id, messageId),
-    ))
-    .limit(1);
-
-  assert.ok(intent, 'expected a proposed work intent');
-  assert.equal(intent.kind, 'note_candidate');
-  assert.equal(intent.status, 'proposed');
-  assert.equal(intent.proposed_action, 'wiki_create');
-
-  const params = intent.proposed_params as Record<string, any>;
-  assert.equal(params.source_message_id, messageId);
-  assert.equal(params.capture_kind, 'note_candidate');
-  assert.equal(params.type, 'fact');
-
-  const metadata = intent.metadata as Record<string, any>;
-  assert.deepEqual(metadata.classifier_facts, [
-    'use concise buyer updates',
-    'never promise same-day delivery after 2pm',
-  ]);
-
-  const [action] = await db
-    .select({
-      id: agentActions.id,
-      action: agentActions.action,
-      approval_status: agentActions.approval_status,
-    })
-    .from(agentActions)
-    .where(and(
-      eq(agentActions.org_id, ORG_ID),
-      eq(agentActions.source, 'defty_capture'),
-      sql`${agentActions.params}->>'work_intent_id' = ${intent.id}`,
-    ))
-    .limit(1);
-
-  assert.ok(action, 'expected a pending approval action');
-  assert.equal(action.action, 'wiki_create');
-  assert.equal(action.approval_status, 'pending');
+  await assertNoMemoryWork(messageId);
 });
 
-test('memory-capture routes explicit decisions through a Defty wiki_create approval', async () => {
+test('memory-capture skips explicit decisions by default', async () => {
   const content = 'Decision: ship the chef-sample bundles in blue crates on Friday.';
   const messageId = await seedMessage(content);
 
   await runMemoryCapture(messageId, content, [], SPACE_ID, 'ship the chef-sample bundles in blue crates on Friday');
 
-  const [intent] = await db
-    .select({
-      kind: workIntents.kind,
-      title: workIntents.title,
-      proposed_action: workIntents.proposed_action,
-      proposed_params: workIntents.proposed_params,
-      metadata: workIntents.metadata,
-    })
-    .from(workIntents)
-    .where(and(
-      eq(workIntents.org_id, ORG_ID),
-      eq(workIntents.source_message_id, messageId),
-    ))
-    .limit(1);
-
-  assert.ok(intent, 'expected a decision work intent');
-  assert.equal(intent.kind, 'decision_candidate');
-  assert.equal(intent.proposed_action, 'wiki_create');
-  assert.match(intent.title, /chef-sample bundles/i);
-  const params = intent.proposed_params as Record<string, any>;
-  assert.equal(params.type, 'decision');
-  assert.equal(params.scope, 'org');
-  assert.equal(params.capture_kind, 'decision_candidate');
-  const metadata = intent.metadata as Record<string, any>;
-  assert.equal(metadata.classifier_decision, 'ship the chef-sample bundles in blue crates on Friday');
+  await assertNoMemoryWork(messageId);
 });
 
-test('memory-capture routes explicit resources but ignores bare links', async () => {
+test('memory-capture resource extraction is strict, but immediate resource writes stay off by default', async () => {
   const resourceContent =
     'Resource: buyer launch checklist https://example.com/testers-tomatoes/buyer-launch';
-  const resourceMessageId = await seedMessage(resourceContent);
-
-  await runMemoryCapture(resourceMessageId, resourceContent);
-
-  const [resourceIntent] = await db
-    .select({
-      kind: workIntents.kind,
-      title: workIntents.title,
-      proposed_action: workIntents.proposed_action,
-      proposed_params: workIntents.proposed_params,
-    })
-    .from(workIntents)
-    .where(and(
-      eq(workIntents.org_id, ORG_ID),
-      eq(workIntents.source_message_id, resourceMessageId),
-    ))
-    .limit(1);
-
-  assert.ok(resourceIntent, 'expected an explicit resource work intent');
-  assert.equal(resourceIntent.kind, 'resource_candidate');
-  assert.equal(resourceIntent.proposed_action, 'wiki_create');
-  const params = resourceIntent.proposed_params as Record<string, any>;
-  assert.equal(params.type, 'resource');
-  assert.equal(params.capture_kind, 'resource_candidate');
-  assert.equal(params.metadata?.url, 'https://example.com/testers-tomatoes/buyer-launch');
+  const resource = extractResourceCandidate(resourceContent);
+  assert.ok(resource, 'explicit resource language should still parse as a resource candidate');
+  assert.equal(resource.url, 'https://example.com/testers-tomatoes/buyer-launch');
 
   const bareLinkContent = 'Saw this pricing deck: https://example.com/random-thread';
-  const bareLinkMessageId = await seedMessage(bareLinkContent);
+  assert.equal(extractResourceCandidate(bareLinkContent), null, 'bare links should not parse as durable resources');
 
-  await runMemoryCapture(bareLinkMessageId, bareLinkContent);
+  const resourceMessageId = await seedMessage(resourceContent);
+  await runMemoryCapture(resourceMessageId, resourceContent);
 
-  const bareLinkRows = await db
-    .select({ id: workIntents.id })
-    .from(workIntents)
-    .where(and(
-      eq(workIntents.org_id, ORG_ID),
-      eq(workIntents.source_message_id, bareLinkMessageId),
-    ));
-
-  assert.equal(bareLinkRows.length, 0, 'bare links should not become durable resources');
+  await assertNoMemoryWork(resourceMessageId);
 });
 
-test('memory-capture keeps private-space knowledge proposals space-scoped', async () => {
+test('memory-capture keeps private-space immediate writes off by default', async () => {
   const content = 'Decision: keep the wholesale pricing rescue plan inside this private launch channel.';
   const messageId = await seedMessage(content, PRIVATE_SPACE_ID);
 
   await runMemoryCapture(messageId, content, [], PRIVATE_SPACE_ID, content);
 
-  const [intent] = await db
-    .select({
-      id: workIntents.id,
-      proposed_params: workIntents.proposed_params,
-    })
-    .from(workIntents)
-    .where(and(
-      eq(workIntents.org_id, ORG_ID),
-      eq(workIntents.source_message_id, messageId),
-    ))
-    .limit(1);
-
-  assert.ok(intent, 'expected a proposed private-space work intent');
-  const params = intent.proposed_params as Record<string, any>;
-  assert.equal(params.scope, 'space');
-  assert.equal(params.space_id, PRIVATE_SPACE_ID);
-  assert.equal(params.source_space_id, PRIVATE_SPACE_ID);
+  await assertNoMemoryWork(messageId);
 });
 
 test('memory-capture does not create approvals for ordinary chatter', async () => {
@@ -299,32 +211,16 @@ test('memory-capture does not create approvals for ordinary chatter', async () =
 
   await runMemoryCapture(messageId, content);
 
-  const rows = await db
-    .select({ id: workIntents.id })
-    .from(workIntents)
-    .where(and(
-      eq(workIntents.org_id, ORG_ID),
-      eq(workIntents.source_message_id, messageId),
-    ));
-
-  assert.equal(rows.length, 0);
+  await assertNoMemoryWork(messageId);
 });
 
-test('memory-capture ignores ambiguous planning chatter unless classifier data is explicit', async () => {
+test('memory-capture ignores ambiguous planning chatter and classifier facts by default', async () => {
   const ambiguousContent =
     'Maybe we should discuss whether the chef sample crates need new labels next week.';
   const ambiguousMessageId = await seedMessage(ambiguousContent);
 
   await runMemoryCapture(ambiguousMessageId, ambiguousContent);
-
-  const ambiguousRows = await db
-    .select({ id: workIntents.id })
-    .from(workIntents)
-    .where(and(
-      eq(workIntents.org_id, ORG_ID),
-      eq(workIntents.source_message_id, ambiguousMessageId),
-    ));
-  assert.equal(ambiguousRows.length, 0);
+  await assertNoMemoryWork(ambiguousMessageId);
 
   const explicitClassifierMessageId = await seedMessage(ambiguousContent);
   await runMemoryCapture(
@@ -333,16 +229,7 @@ test('memory-capture ignores ambiguous planning chatter unless classifier data i
     ['Chef sample crates need new labels next week'],
   );
 
-  const [explicitIntent] = await db
-    .select({ kind: workIntents.kind })
-    .from(workIntents)
-    .where(and(
-      eq(workIntents.org_id, ORG_ID),
-      eq(workIntents.source_message_id, explicitClassifierMessageId),
-    ))
-    .limit(1);
-  assert.ok(explicitIntent, 'explicit classifier facts should still create a reviewable proposal');
-  assert.equal(explicitIntent.kind, 'note_candidate');
+  await assertNoMemoryWork(explicitClassifierMessageId);
 });
 
 test('defty task capture turns explicit action requests into task_create work intents', async () => {

--- a/apps/web/src/app/(app)/inbox/page.tsx
+++ b/apps/web/src/app/(app)/inbox/page.tsx
@@ -270,9 +270,9 @@ function WorkIntentRow({
   const OutcomeIcon = outcomeIcon;
   const statusLabel = intent.status === 'converted'
     ? isConvertedToTask
-      ? 'Converted to task'
+      ? intent.proposed_action === 'task_update' ? 'Task updated' : 'Task created'
       : isConvertedToKnowledge
-        ? 'Saved to knowledge'
+        ? intent.proposed_action === 'wiki_update' ? 'Knowledge updated' : 'Knowledge saved'
         : 'Converted'
     : INTENT_STATUS_LABEL[intent.status];
 

--- a/apps/web/src/components/space-chat.tsx
+++ b/apps/web/src/components/space-chat.tsx
@@ -17,8 +17,6 @@ import {
   X,
   Smile,
   MessageSquare,
-  AlertTriangle,
-  ExternalLink,
   Pin,
   MoreHorizontal,
   Copy,
@@ -111,6 +109,7 @@ type WorkIntentReceipt = {
   status: 'proposed' | 'converted' | 'dismissed' | 'expired' | 'failed';
   title: string | null;
   source_message_id: string | null;
+  proposed_action: string | null;
   converted_task_id: string | null;
   failure_reason: string | null;
   metadata: Record<string, unknown> | null;
@@ -240,67 +239,38 @@ function compactReceiptTitle(title: string) {
 }
 
 function WorkIntentReceiptChips({ intents }: { intents?: WorkIntentReceipt[] }) {
-  if (!intents?.length) return null;
+  const knowledgeReceipts = (intents ?? []).filter((intent) => {
+    const metadata = intent.metadata ?? {};
+    return intent.status === 'converted' && typeof metadata.converted_wiki_slug === 'string';
+  });
+  if (knowledgeReceipts.length === 0) return null;
 
   return (
-    <div className="mt-2 flex flex-wrap gap-1.5">
-      {intents.map((intent) => {
+    <div className="mt-1 flex items-center gap-1.5" aria-label="Knowledge receipts">
+      {knowledgeReceipts.slice(0, 3).map((intent) => {
         const metadata = intent.metadata ?? {};
         const wikiSlug = typeof metadata.converted_wiki_slug === 'string' ? metadata.converted_wiki_slug : null;
         const title = intent.title ?? 'Work capture';
-        const isTask = Boolean(intent.converted_task_id);
-        const isKnowledge = Boolean(wikiSlug);
-        const href = isTask
-          ? `/tasks?task=${encodeURIComponent(intent.converted_task_id!)}`
-          : isKnowledge
-            ? `/knowledge?slug=${encodeURIComponent(wikiSlug!)}`
-            : null;
-        const label = intent.status === 'converted'
-          ? isTask
-            ? `Task: ${compactReceiptTitle(title)}`
-            : isKnowledge
-              ? `Knowledge: ${compactReceiptTitle(title)}`
-              : 'Capture converted'
-          : intent.status === 'dismissed'
-            ? 'Capture dismissed'
-            : intent.status === 'failed'
-              ? 'Capture failed'
-              : 'Capture expired';
-        const Icon = isTask
-          ? CheckSquare
-          : isKnowledge
-            ? BookOpen
-            : intent.status === 'failed'
-              ? AlertTriangle
-              : intent.status === 'dismissed'
-                ? X
-                : Clock;
-        const color = intent.status === 'converted'
-          ? 'var(--success)'
-          : intent.status === 'failed'
-            ? 'var(--status-red)'
-            : 'var(--muted)';
-
-        const chip = (
-          <span
-            className="inline-flex max-w-full min-w-0 items-center gap-1.5 rounded-md px-2 py-1 text-[11px] font-medium"
-            style={{ background: 'var(--surface-container-highest)', border: '1px solid var(--border)', color }}
-            title={intent.failure_reason ? `${title}: ${intent.failure_reason}` : title}
+        const isWikiUpdate = intent.proposed_action === 'wiki_update' || metadata.update_kind === 'wiki_content';
+        const label = `${isWikiUpdate ? 'Knowledge updated' : 'Added to knowledge'}: ${compactReceiptTitle(title)}`;
+        return (
+          <a
+            key={intent.id}
+            href={`/knowledge?slug=${encodeURIComponent(wikiSlug!)}`}
+            className="inline-flex h-4 w-4 items-center justify-center rounded-full opacity-65 transition hover:opacity-100"
+            style={{ color: 'var(--success)', background: 'color-mix(in srgb, var(--success) 11%, transparent)' }}
+            title={label}
+            aria-label={label}
           >
-            <Icon size={12} strokeWidth={1.7} />
-            <span className="min-w-0 truncate">{label}</span>
-            {href && <ExternalLink size={11} strokeWidth={1.7} className="flex-shrink-0" />}
-          </span>
-        );
-
-        return href ? (
-          <a key={intent.id} href={href} className="min-w-0 max-w-full no-underline hover:opacity-80">
-            {chip}
+            <span className="h-1.5 w-1.5 rounded-full" style={{ background: 'var(--success)' }} />
           </a>
-        ) : (
-          <span key={intent.id} className="min-w-0 max-w-full">{chip}</span>
         );
       })}
+      {knowledgeReceipts.length > 3 && (
+        <span className="text-[10px]" style={{ color: 'var(--muted)' }} title={`${knowledgeReceipts.length - 3} more knowledge receipts`}>
+          +{knowledgeReceipts.length - 3}
+        </span>
+      )}
     </div>
   );
 }
@@ -668,6 +638,7 @@ export function SpaceChat({
   // label + dispatched action match what the user actually expects.
   useEffect(() => { setCurrentSpaceMuted(isMuted); }, [isMuted]);
   const [cmdToast, setCmdToast] = useState<string | null>(null);
+  const [capturingDiscussion, setCapturingDiscussion] = useState(false);
 
   // P4-4 — pending agent_actions keyed by message_id for this space.
   // Polled every 5s so inline approval cards appear promptly.
@@ -781,6 +752,19 @@ export function SpaceChat({
       source_message_id: msg.id,
     });
     setCmdToast(res.ok ? 'Saved to knowledge' : 'Failed to save knowledge');
+  };
+
+  const captureRecentDiscussion = async () => {
+    if (capturingDiscussion) return;
+    setCapturingDiscussion(true);
+    try {
+      const res = await api.post(`/api/spaces/${spaceId}/knowledge/capture-discussion`, {
+        lookback_minutes: 120,
+      });
+      setCmdToast(res.ok ? 'Discussion capture queued' : 'Failed to queue discussion capture');
+    } finally {
+      setCapturingDiscussion(false);
+    }
   };
 
   const copyMessageLink = (msg: Message) => {
@@ -1645,6 +1629,17 @@ export function SpaceChat({
                               style={{ color: 'var(--on-surface-variant)' }}>
                               <BookOpen size={13} strokeWidth={1.5} /> Save to Knowledge
                             </button>
+                            <button
+                              onClick={() => {
+                                void captureRecentDiscussion();
+                                setMoreMenuId(null);
+                              }}
+                              disabled={capturingDiscussion}
+                              className="w-full text-left px-3.5 py-2 text-[0.8125rem] flex items-center gap-2.5 disabled:opacity-50"
+                              style={{ color: 'var(--on-surface-variant)' }}
+                            >
+                              <Sparkles size={13} strokeWidth={1.5} /> Capture recent discussion
+                            </button>
                             <div className="relative">
                               <button className="w-full text-left px-3.5 py-2 text-[0.8125rem] flex items-center gap-2.5"
                                 style={{ color: 'var(--on-surface-variant)' }}
@@ -2272,6 +2267,14 @@ export function SpaceChat({
               label="Save to Knowledge"
               onClick={() => {
                 void saveMessageToKnowledge(mobileActionMsg);
+                setMobileActionMsg(null);
+              }}
+            />
+            <MobileMessageAction
+              icon={<Sparkles size={18} strokeWidth={1.7} />}
+              label={capturingDiscussion ? 'Capture queued...' : 'Capture recent discussion'}
+              onClick={() => {
+                void captureRecentDiscussion();
                 setMobileActionMsg(null);
               }}
             />

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "audit:byoa-a": "tsx docs/superpowers/audits/agent-byoa/agent-byoa-layer-a.audit.ts",
     "audit:byoa-b": "tsx docs/superpowers/audits/agent-byoa/agent-byoa-layer-b.audit.ts",
     "build": "pnpm -r build",
+    "chat:mini-batches": "tsx scripts/reports/chat-episode-mini-batches.ts",
     "db:generate": "pnpm --filter @deft/db generate",
     "db:migrate": "pnpm --filter @deft/db migrate",
     "db:push": "pnpm --filter @deft/db push",

--- a/scripts/reports/chat-episode-mini-batches.ts
+++ b/scripts/reports/chat-episode-mini-batches.ts
@@ -1,0 +1,711 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { chromium, type Page } from 'playwright';
+import { and, desc, eq, gte, inArray } from 'drizzle-orm';
+import { agentActions, messageClassifications, wikiPages, workIntents } from '@deft/db/schema';
+import { db } from '../../apps/api/src/lib/db.js';
+
+const WEB_URL = (process.env.DEFT_WEB_URL || 'http://localhost:3000').replace(/\/$/, '');
+const API_URL = (process.env.DEFT_API_URL || process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3301').replace(/\/$/, '');
+const EMAIL = process.env.DEFT_TEST_EMAIL || 'diego@testers-tomatoes.com';
+const PASSWORD = process.env.DEFT_TEST_PASSWORD || 'tomato123';
+const RUN_ID = process.env.DEFT_CHAT_MINI_RUN_ID || new Date().toISOString().replace(/[:.]/g, '-');
+const OUT_DIR = path.resolve('reports', 'chat-episode-mini-batches', RUN_ID);
+const HTML_REPORT = path.resolve('reports', `chat-episode-mini-batches-${RUN_ID}.html`);
+const JSON_REPORT = path.resolve('reports', `chat-episode-mini-batches-${RUN_ID}.json`);
+const CLEANUP_SPACES = process.env.DEFT_CHAT_MINI_CLEANUP === '1';
+
+type Status = 'pass' | 'warn' | 'fail';
+type Auth = {
+  accessToken: string;
+  user: { id: string; email: string; name?: string };
+  orgId: string;
+};
+type Space = { id: string; name: string; type?: string };
+type ScenarioExpectation = {
+  wiki: 'none' | 'some';
+  task: 'none' | 'mention';
+};
+type Scenario = {
+  id: string;
+  title: string;
+  spacePreference: string[];
+  spaceType?: 'public' | 'private';
+  about: string;
+  expectation: ScenarioExpectation;
+  messages: string[];
+};
+type ScenarioResult = {
+  id: string;
+  title: string;
+  space: Space;
+  about: string;
+  expectation: ScenarioExpectation;
+  messageIds: string[];
+  messageCount: number;
+  classifications: Array<Record<string, unknown>>;
+  actions: Array<Record<string, unknown>>;
+  intents: Array<Record<string, unknown>>;
+  wiki: Array<Record<string, unknown>>;
+  screenshots: string[];
+  checks: Array<{ status: Status; name: string; detail?: unknown }>;
+};
+
+const scenarios: Scenario[] = [
+  {
+    id: 'pizza-social',
+    title: 'Lunch Debate Stays Ephemeral',
+    spacePreference: ['general', 'marketing', 'operations'],
+    about: 'A spirited pizza/lunch argument with fake policy language. This should not enter wiki.',
+    expectation: { wiki: 'none', task: 'none' },
+    messages: [
+      'Morning vote: I want thin crust pizza for lunch, and I will emotionally filibuster any deep dish proposal.',
+      'Deep dish is obviously soup with confidence. Still not a company policy, just my personal lunch hill.',
+      'If anyone suggests pineapple I am moving my chair three feet away from the table.',
+      'Counterpoint: jalapenos make every pizza less boring. This is lunch chatter, not an operating rule.',
+      'Fine, we can decide at noon. No one please put this in the workspace memory.',
+    ],
+  },
+  {
+    id: 'launch-decision',
+    title: 'Durable Launch Decision Becomes Knowledge',
+    spacePreference: ['marketing', 'sales-and-buyers', 'general'],
+    about: 'A real launch operating decision with client and route implications. This should become one durable wiki update/create.',
+    expectation: { wiki: 'some', task: 'none' },
+    messages: [
+      'For the Sun Gold launch, buyer copy changes are still coming in too late for route planning.',
+      'I think Friday 3pm should be the cutoff. Anything after that moves into the next delivery window.',
+      'Agreed. Going forward, Friday 3pm is the source of truth cutoff for Sun Gold buyer copy changes.',
+      'That also keeps Tomas from rebuilding the cold-chain route sheet on Saturday morning.',
+      'I will mention this in the launch standup so sales and ops stop negotiating it ad hoc.',
+    ],
+  },
+  {
+    id: 'blocker-no-task',
+    title: 'Blocker Discussion Does Not Auto-Create Task',
+    spacePreference: ['operations', 'field-ops', 'general'],
+    about: 'A blocker conversation without Defty being called. It should remain context, not an automatic task.',
+    expectation: { wiki: 'none', task: 'none' },
+    messages: [
+      'I am blocked on the carton label proof because the nutrition copy is still missing from the packhouse note.',
+      'Can someone confirm whether the old copy is acceptable for the pilot shelf talker?',
+      'Please do not create a task yet. I want to check with Maya first because this may already be covered.',
+      'Maya is checking the last approved PDF now. We should know in ten minutes.',
+      'If the PDF is stale, I will call Defty separately and have it draft the proper task.',
+    ],
+  },
+  {
+    id: 'conflict-defty-task',
+    title: 'Conflict Resolution Becomes Defty-Led Task',
+    spacePreference: ['quality', 'operations', 'general'],
+    about: 'A messy task conflict gets resolved by a manager, then Defty is called to create the clean task.',
+    expectation: { wiki: 'none', task: 'mention' },
+    messages: [
+      'The QA checklist cannot keep changing after labels are already printed. It is causing rework.',
+      'Ops keeps saying it is a tiny change, but the label printer queue is not tiny when it slips.',
+      'Let us cool this down. Maya owns final QA wording, Tomas owns print timing, and both need one handoff point.',
+      'Resolution: Maya will deliver final wording before print release, Tomas will not print until that signoff lands.',
+      '@Defty create a task from this discussion: formalize the label QA handoff between Maya and Tomas, assign it to Maya, due 2026-07-08.',
+    ],
+  },
+  {
+    id: 'mixed-client-social',
+    title: 'Mixed Social Plus Client Decision Captures Only Work Memory',
+    spacePreference: ['sales-and-buyers', 'marketing', 'general'],
+    about: 'Coffee banter surrounds a real client decision. The wiki candidate should ignore the social part.',
+    expectation: { wiki: 'some', task: 'none' },
+    messages: [
+      'I am bringing terrible vending machine coffee to the buyer review, apologies in advance.',
+      'BrightMart confirmed they want the Sun Gold trial pallet photos before Thursday route staging.',
+      'Decision: BrightMart launch QA signoff must happen before pallet staging every Thursday.',
+      'That means buyer-facing photos need to be reviewed before Tomas locks the truck sequence.',
+      'Also, no one should judge the coffee. The coffee is fighting its own battle.',
+    ],
+  },
+  {
+    id: 'sarcastic-task-joke',
+    title: 'Sarcastic Task Joke Stays Out',
+    spacePreference: ['general', 'marketing', 'operations'],
+    about: 'A joking fake task with work-ish words should not create passive wiki or task work.',
+    expectation: { wiki: 'none', task: 'none' },
+    messages: [
+      'Please create a P0 task to nominate the official greenhouse playlist captain. This is a joke, before anyone panics.',
+      'Assign it to the tomato vines, due never.',
+      'The actual launch work is fine; I am only making fun of our task hygiene.',
+      'No Defty action needed here. This thread is comedy plus venting.',
+    ],
+  },
+  {
+    id: 'half-decision',
+    title: 'Half Decision Does Not Become Memory',
+    spacePreference: ['operations', 'marketing', 'general'],
+    about: 'The team floats a possible operating change but never settles it.',
+    expectation: { wiki: 'none', task: 'none' },
+    messages: [
+      'Maybe we should move the cherry tomato harvest review to Wednesdays, but I am not sure yet.',
+      'That might collide with the buyer route call.',
+      'Let us not decide now. I want field numbers first.',
+      'Agreed, park the idea until the morning yield sheet lands.',
+    ],
+  },
+  {
+    id: 'reversed-decision',
+    title: 'Reversed Decision Captures Settled Final Context',
+    spacePreference: ['sales-and-buyers', 'operations', 'general'],
+    about: 'A decision changes during the conversation. The final settled decision is durable; earlier uncertainty should not become a separate task.',
+    expectation: { wiki: 'some', task: 'none' },
+    messages: [
+      'Initial thought: move the Co-op tasting kit to Tuesday because Monday packing is crowded.',
+      'Actually, the buyer just confirmed Tuesday does not work for their chef lead.',
+      'Decision: keep the Co-op tasting kit on Monday, but cap it at 24 sample boxes so packing can finish by noon.',
+      'That final Monday cap is the thing we should remember. Ignore the Tuesday idea.',
+    ],
+  },
+  {
+    id: 'private-space-decision',
+    title: 'Private Space Decision Stays Scoped',
+    spacePreference: ['leadership', 'general'],
+    spaceType: 'private',
+    about: 'A private channel records durable context. It should capture knowledge without becoming a public-space artifact.',
+    expectation: { wiki: 'some', task: 'none' },
+    messages: [
+      'For the pilot customer call, we should keep the pricing concession internal to the leadership thread.',
+      'Decision: the pilot discount is capped at 12 percent and only Maneek can approve exceptions.',
+      'This should be remembered for the customer pilot prep, but it should stay scoped to this space.',
+    ],
+  },
+  {
+    id: 'vague-defty-call',
+    title: 'Vague Defty Call Does Not Create Passive Wiki',
+    spacePreference: ['operations', 'general'],
+    about: 'A vague agent invocation should keep passive knowledge quiet until Defty has a clear action path.',
+    expectation: { wiki: 'none', task: 'none' },
+    messages: [
+      'The morning got messy: cold-chain checks slipped, buyer notes are scattered, and Tomas is annoyed.',
+      'I do not know what the right action is yet.',
+      '@Defty can you look at this later and help us make sense of it?',
+      'Let us wait for the actual route sheet before creating anything.',
+    ],
+  },
+];
+
+const artifact = {
+  run_id: RUN_ID,
+  web_url: WEB_URL,
+  api_url: API_URL,
+  cleanup_spaces: CLEANUP_SPACES,
+  started_at: new Date().toISOString(),
+  finished_at: '',
+  summary: { pass: 0, warn: 0, fail: 0 },
+  results: [] as ScenarioResult[],
+};
+
+function escapeHtml(value: unknown): string {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function toRecord(value: unknown): Record<string, unknown> {
+  return JSON.parse(JSON.stringify(value ?? {})) as Record<string, unknown>;
+}
+
+function asArray<T = any>(value: any, keys: string[] = []): T[] {
+  if (Array.isArray(value)) return value;
+  for (const key of keys) {
+    if (Array.isArray(value?.[key])) return value[key];
+  }
+  return [];
+}
+
+function containsAnyMessageId(value: unknown, ids: string[]): boolean {
+  if (!value) return false;
+  const text = typeof value === 'string' ? value : JSON.stringify(value);
+  return ids.some((id) => text.includes(id));
+}
+
+function hasSocialLeak(value: unknown): boolean {
+  const text = JSON.stringify(value ?? '').toLowerCase();
+  return /\b(?:pizza|deep dish|pineapple|jalapeno|lunch|coffee|vending machine)\b/.test(text);
+}
+
+async function fetchJson<T = any>(url: string, init?: RequestInit): Promise<{ ok: boolean; status: number; body: T; text: string }> {
+  const res = await fetch(url, { ...init, signal: AbortSignal.timeout(30_000) });
+  const text = await res.text();
+  let body: T;
+  try {
+    body = JSON.parse(text) as T;
+  } catch {
+    body = text as T;
+  }
+  return { ok: res.ok, status: res.status, body, text };
+}
+
+async function loginApi(): Promise<Auth> {
+  const res = await fetchJson<Auth>(`${API_URL}/api/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email: EMAIL, password: PASSWORD }),
+  });
+  if (!res.ok || !res.body?.accessToken) {
+    throw new Error(`API login failed: ${res.status} ${res.text.slice(0, 240)}`);
+  }
+  const me = await fetchJson<{ org?: { id?: string } }>(`${API_URL}/api/auth/me`, {
+    headers: { Authorization: `Bearer ${res.body.accessToken}` },
+  });
+  const orgId = me.body?.org?.id;
+  if (!me.ok || !orgId) {
+    throw new Error(`/api/auth/me did not return an org id: ${me.status} ${me.text.slice(0, 240)}`);
+  }
+  return { ...res.body, orgId };
+}
+
+async function api<T = any>(auth: Auth, route: string, init?: RequestInit): Promise<T> {
+  const hasBody = init?.body !== undefined;
+  const res = await fetchJson<T>(`${API_URL}${route}`, {
+    ...init,
+    headers: {
+      ...(hasBody ? { 'Content-Type': 'application/json' } : {}),
+      Authorization: `Bearer ${auth.accessToken}`,
+      ...(init?.headers || {}),
+    },
+  });
+  if (!res.ok) {
+    throw new Error(`${route} returned ${res.status}: ${res.text.slice(0, 500)}`);
+  }
+  return res.body;
+}
+
+async function loginUi(page: Page) {
+  await page.goto(`${WEB_URL}/login`, { waitUntil: 'domcontentloaded' });
+  await page.locator('#login-email').waitFor({ state: 'visible', timeout: 20_000 });
+  await page.locator('#login-email').fill(EMAIL);
+  await page.locator('#login-password').fill(PASSWORD);
+  const responsePromise = page.waitForResponse(
+    (response) => response.request().method() === 'POST' && response.url().includes('/api/auth/login'),
+    { timeout: 15_000 },
+  ).catch(() => null);
+  const shellPromise = page.waitForURL((url) => !url.pathname.includes('/login'), { timeout: 30_000 }).catch(() => null);
+  await page.getByRole('button', { name: /^sign in$/i }).click();
+  const response = await Promise.race([responsePromise, shellPromise]);
+  if (response && 'status' in response && response.status() >= 400) {
+    const body = await response.text().catch(() => '');
+    throw new Error(`UI login failed: ${response.status()} ${body.slice(0, 240)}`);
+  }
+  if (page.url().includes('/login')) {
+    await page.waitForURL((url) => !url.pathname.includes('/login'), { timeout: 30_000 });
+  }
+  await page.locator('main').waitFor({ state: 'visible', timeout: 20_000 });
+}
+
+async function getSpaces(auth: Auth): Promise<Space[]> {
+  const body = await api<any>(auth, '/api/spaces');
+  return asArray<Space>(body, ['spaces']);
+}
+
+async function createScenarioSpace(auth: Auth, scenario: Scenario): Promise<Space> {
+  const suffix = RUN_ID.replace(/[^a-zA-Z0-9]/g, '').slice(-8).toLowerCase();
+  const name = `mini-${scenario.id}-${suffix}`.slice(0, 80);
+  return api<Space>(auth, '/api/spaces', {
+    method: 'POST',
+    body: JSON.stringify({
+      name,
+      type: scenario.spaceType ?? 'public',
+      description: `Temporary mini-batch certification space for ${scenario.title}.`,
+    }),
+  });
+}
+
+async function archiveScenarioSpace(auth: Auth, space: Space) {
+  if (!CLEANUP_SPACES || !space.name?.startsWith('mini-')) return;
+  await api(auth, `/api/spaces/${encodeURIComponent(space.id)}`, { method: 'DELETE' })
+    .catch((err) => {
+      console.warn(`[cleanup] Failed to archive #${space.name}:`, err instanceof Error ? err.message : String(err));
+    });
+}
+
+function pickSpace(spaces: Space[], preference: string[]): Space {
+  const normalized = new Map(spaces.map((space) => [(space.name || '').toLowerCase(), space]));
+  for (const name of preference) {
+    const exact = normalized.get(name.toLowerCase());
+    if (exact) return exact;
+  }
+  return spaces.find((space) => space.type === 'public') ?? spaces[0]!;
+}
+
+async function waitFor<T>(
+  label: string,
+  fn: () => Promise<T | null | undefined | false>,
+  opts: { timeoutMs?: number; intervalMs?: number } = {},
+): Promise<T> {
+  const timeoutMs = opts.timeoutMs ?? 90_000;
+  const intervalMs = opts.intervalMs ?? 1_500;
+  const started = Date.now();
+  let last: unknown = null;
+  while (Date.now() - started < timeoutMs) {
+    try {
+      const value = await fn();
+      if (value) return value as T;
+      last = value;
+    } catch (err) {
+      last = err instanceof Error ? err.message : String(err);
+    }
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+  throw new Error(`Timed out waiting for ${label}. Last: ${JSON.stringify(last)}`);
+}
+
+async function sendChatMessage(page: Page, space: Space, content: string): Promise<string> {
+  await page.goto(`${WEB_URL}/chat?space=${encodeURIComponent(space.id)}`, { waitUntil: 'domcontentloaded' });
+  await page.locator('main').waitFor({ state: 'visible', timeout: 25_000 });
+  const editor = page.locator('[contenteditable="true"].deft-editor').last();
+  await editor.waitFor({ state: 'visible', timeout: 25_000 });
+  await editor.click();
+  await editor.fill(content);
+  const sendButton = page.getByRole('button', { name: /send message/i }).last();
+  await waitFor('send button enabled', async () => {
+    const disabled = await sendButton.evaluate((button) => (button as HTMLButtonElement).disabled).catch(() => true);
+    return disabled ? null : true;
+  }, { timeoutMs: 10_000, intervalMs: 250 });
+  const post = page.waitForResponse(
+    (response) => {
+      if (response.request().method() !== 'POST') return false;
+      try {
+        const url = new URL(response.url());
+        return url.pathname === `/api/messages/${space.id}` || url.pathname.startsWith(`/api/messages/${space.id}/`);
+      } catch {
+        return false;
+      }
+    },
+    { timeout: 30_000 },
+  );
+  await sendButton.click();
+  const response = await post;
+  if (response.status() >= 400) {
+    const body = await response.text().catch(() => '');
+    throw new Error(`Message send failed with ${response.status()}: ${body.slice(0, 240)}`);
+  }
+  const responseBody = await response.json().catch(() => null);
+  if (!responseBody?.id) throw new Error('Message send did not return an id');
+  return responseBody.id;
+}
+
+async function screenshot(page: Page, scenarioId: string, label: string): Promise<string> {
+  await fs.mkdir(OUT_DIR, { recursive: true });
+  const file = path.join(OUT_DIR, `${scenarioId}-${label}.png`);
+  await page.screenshot({ path: file, fullPage: true });
+  return file;
+}
+
+async function waitForClassifications(orgId: string, messageIds: string[]) {
+  return waitFor('message classifications', async () => {
+    const rows = await db
+      .select({
+        message_id: messageClassifications.message_id,
+        intent: messageClassifications.intent,
+        confidence: messageClassifications.confidence,
+        agent_mentioned: messageClassifications.agent_mentioned,
+        blocked: messageClassifications.blocked,
+        memorable_facts: messageClassifications.memorable_facts,
+        decision: messageClassifications.decision,
+      })
+      .from(messageClassifications)
+      .where(and(
+        eq(messageClassifications.org_id, orgId),
+        inArray(messageClassifications.message_id, messageIds),
+      ));
+    return rows.length > 0 ? rows : null;
+  }, { timeoutMs: 35_000, intervalMs: 1_000 }).catch(() => []);
+}
+
+async function collectEffects(orgId: string, messageIds: string[], startedAt: Date) {
+  const [actions, intents, pages] = await Promise.all([
+    db.select({
+      id: agentActions.id,
+      action: agentActions.action,
+      source: agentActions.source,
+      approval_status: agentActions.approval_status,
+      message_id: agentActions.message_id,
+      params: agentActions.params,
+      created_at: agentActions.created_at,
+      executed_at: agentActions.executed_at,
+      error: agentActions.error,
+    })
+      .from(agentActions)
+      .where(and(eq(agentActions.org_id, orgId), gte(agentActions.created_at, startedAt)))
+      .orderBy(desc(agentActions.created_at))
+      .limit(200),
+    db.select({
+      id: workIntents.id,
+      kind: workIntents.kind,
+      status: workIntents.status,
+      proposed_action: workIntents.proposed_action,
+      source_message_id: workIntents.source_message_id,
+      title: workIntents.title,
+      summary: workIntents.summary,
+      metadata: workIntents.metadata,
+      created_at: workIntents.created_at,
+    })
+      .from(workIntents)
+      .where(and(eq(workIntents.org_id, orgId), gte(workIntents.created_at, startedAt)))
+      .orderBy(desc(workIntents.created_at))
+      .limit(200),
+    db.select({
+      id: wikiPages.id,
+      title: wikiPages.title,
+      type: wikiPages.type,
+      scope: wikiPages.scope,
+      origin_message_id: wikiPages.origin_message_id,
+      origin_space_id: wikiPages.origin_space_id,
+      content: wikiPages.content,
+      summary: wikiPages.summary,
+      metadata: wikiPages.metadata,
+      created_at: wikiPages.created_at,
+      updated_at: wikiPages.updated_at,
+    })
+      .from(wikiPages)
+      .where(and(eq(wikiPages.org_id, orgId), eq(wikiPages.is_deleted, false), gte(wikiPages.updated_at, startedAt)))
+      .orderBy(desc(wikiPages.updated_at))
+      .limit(200),
+  ]);
+
+  return {
+    actions: actions.filter((row) => row.message_id && messageIds.includes(row.message_id) || containsAnyMessageId(row.params, messageIds)),
+    intents: intents.filter((row) => row.source_message_id && messageIds.includes(row.source_message_id) || containsAnyMessageId(row.metadata, messageIds)),
+    wiki: pages.filter((row) => row.origin_message_id && messageIds.includes(row.origin_message_id) || containsAnyMessageId(row.metadata, messageIds)),
+  };
+}
+
+function scoreScenario(result: ScenarioResult) {
+  const knowledgeActions = result.actions.filter((action) =>
+    ['wiki_create', 'wiki_update'].includes(String(action.action)) ||
+    JSON.stringify(action).includes('wiki_create') ||
+    JSON.stringify(action).includes('wiki_update')
+  );
+  const taskActions = result.actions.filter((action) =>
+    ['create_task', 'task_create', 'task_update', 'update_task', 'task_transition'].includes(String(action.action))
+  );
+
+  if (result.expectation.wiki === 'none' && (knowledgeActions.length > 0 || result.wiki.length > 0)) {
+    result.checks.push({
+      status: 'fail',
+      name: 'No passive wiki capture expected',
+      detail: { knowledgeActions: knowledgeActions.length, wiki: result.wiki.length },
+    });
+  } else if (result.expectation.wiki === 'some' && knowledgeActions.length === 0 && result.wiki.length === 0) {
+    result.checks.push({ status: 'fail', name: 'Durable wiki capture expected', detail: 'No wiki create/update was traced to this scenario.' });
+  } else {
+    result.checks.push({ status: 'pass', name: `Wiki expectation: ${result.expectation.wiki}` });
+  }
+
+  if (result.expectation.task === 'none' && taskActions.length > 0) {
+    result.checks.push({ status: 'fail', name: 'No task action expected', detail: taskActions.map((item) => item.action) });
+  } else if (result.expectation.task === 'mention' && taskActions.length === 0) {
+    result.checks.push({ status: 'warn', name: 'Defty mention task action expected', detail: 'No create/update task action was found yet.' });
+  } else {
+    result.checks.push({ status: 'pass', name: `Task expectation: ${result.expectation.task}` });
+  }
+
+  const leaked = result.wiki.some(hasSocialLeak) || knowledgeActions.some(hasSocialLeak);
+  if (leaked) {
+    result.checks.push({ status: 'fail', name: 'No social/lunch leakage in knowledge', detail: 'Social terms appeared in traced wiki/action payloads.' });
+  } else {
+    result.checks.push({ status: 'pass', name: 'No social/lunch leakage in traced knowledge payloads' });
+  }
+}
+
+async function runScenario(page: Page, auth: Auth, spaces: Space[], scenario: Scenario): Promise<ScenarioResult> {
+  const space = await createScenarioSpace(auth, scenario).catch(() => pickSpace(spaces, scenario.spacePreference));
+  const startedAt = new Date();
+  const result: ScenarioResult = {
+    id: scenario.id,
+    title: scenario.title,
+    space,
+    about: scenario.about,
+    expectation: scenario.expectation,
+    messageIds: [],
+    messageCount: scenario.messages.length,
+    classifications: [],
+    actions: [],
+    intents: [],
+    wiki: [],
+    screenshots: [],
+    checks: [],
+  };
+
+  console.log(`\n[SCENARIO] ${scenario.title} in #${space.name}`);
+  for (const content of scenario.messages) {
+    const id = await sendChatMessage(page, space, content);
+    result.messageIds.push(id);
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+  result.screenshots.push(await screenshot(page, scenario.id, 'chat'));
+
+  const classifications = await waitForClassifications(auth.orgId, result.messageIds);
+  result.classifications = classifications.map(toRecord);
+
+  await api(auth, `/api/spaces/${encodeURIComponent(space.id)}/knowledge/capture-discussion`, {
+    method: 'POST',
+    body: JSON.stringify({ lookback_minutes: 15 }),
+  });
+
+  const waitMs = scenario.expectation.wiki === 'some' || scenario.expectation.task === 'mention'
+    ? Number.parseInt(process.env.DEFT_CHAT_MINI_EFFECT_WAIT_MS ?? '30000', 10)
+    : Number.parseInt(process.env.DEFT_CHAT_MINI_EFFECT_WAIT_MS ?? '12000', 10);
+  await new Promise((resolve) => setTimeout(resolve, waitMs));
+  const effects = await collectEffects(auth.orgId, result.messageIds, startedAt);
+
+  result.actions = effects.actions.map(toRecord);
+  result.intents = effects.intents.map(toRecord);
+  result.wiki = effects.wiki.map(toRecord);
+  scoreScenario(result);
+  await archiveScenarioSpace(auth, space);
+  result.checks.forEach((check) => console.log(`[${check.status.toUpperCase()}] ${scenario.id}: ${check.name}`));
+  return result;
+}
+
+async function writeReports() {
+  const allChecks = artifact.results.flatMap((result) => result.checks);
+  artifact.summary.pass = allChecks.filter((check) => check.status === 'pass').length;
+  artifact.summary.warn = allChecks.filter((check) => check.status === 'warn').length;
+  artifact.summary.fail = allChecks.filter((check) => check.status === 'fail').length;
+  artifact.finished_at = new Date().toISOString();
+  await fs.writeFile(JSON_REPORT, JSON.stringify(artifact, null, 2), 'utf8');
+  await fs.writeFile(HTML_REPORT, renderReport(), 'utf8');
+}
+
+function renderReport(): string {
+  const cards = artifact.results.map((result) => {
+    const checks = result.checks.map((check) => `
+      <li><span class="pill ${check.status}">${check.status.toUpperCase()}</span> ${escapeHtml(check.name)}${check.detail ? `<pre>${escapeHtml(JSON.stringify(check.detail, null, 2))}</pre>` : ''}</li>
+    `).join('');
+    const shots = result.screenshots.map((shot) => `<img src="${escapeHtml(shot)}" alt="${escapeHtml(result.title)} screenshot" />`).join('');
+    return `
+      <section class="card">
+        <div class="card-head">
+          <div>
+            <p class="eyebrow">${escapeHtml(result.id)} · #${escapeHtml(result.space.name)}</p>
+            <h2>${escapeHtml(result.title)}</h2>
+          </div>
+          <div class="metric">${result.messageCount}<span>messages</span></div>
+        </div>
+        <p>${escapeHtml(result.about)}</p>
+        <ul class="checks">${checks}</ul>
+        <div class="grid">
+          <div><h3>Actions</h3><pre>${escapeHtml(JSON.stringify(result.actions, null, 2))}</pre></div>
+          <div><h3>Wiki</h3><pre>${escapeHtml(JSON.stringify(result.wiki, null, 2))}</pre></div>
+        </div>
+        <div class="screens">${shots}</div>
+      </section>
+    `;
+  }).join('');
+
+  return `<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Chat Episode Mini-Batch Certification - ${escapeHtml(RUN_ID)}</title>
+  <style>
+    :root { color-scheme: dark; --bg:#0f0f12; --panel:#181820; --text:#f3f1f8; --muted:#a7a0b8; --border:#31303b; --pass:#4ade80; --warn:#fbbf24; --fail:#fb7185; --accent:#7c5cff; }
+    * { box-sizing: border-box; }
+    body { margin:0; font-family: Inter, ui-sans-serif, system-ui, -apple-system, Segoe UI, sans-serif; background: radial-gradient(circle at 60% 0%, rgba(124,92,255,.18), transparent 34%), var(--bg); color:var(--text); }
+    main { max-width: 1180px; margin: 0 auto; padding: 44px 28px 80px; }
+    h1 { font-size: 40px; line-height: 1.05; margin: 0 0 12px; letter-spacing: -0.03em; }
+    h2 { font-size: 24px; margin: 0 0 8px; }
+    h3 { margin: 0 0 8px; color: var(--muted); font-size: 13px; text-transform: uppercase; letter-spacing: .08em; }
+    p { color: var(--muted); line-height: 1.6; }
+    .summary { display:flex; gap:12px; flex-wrap:wrap; margin: 24px 0 28px; }
+    .summary div, .card { border:1px solid var(--border); background: rgba(24,24,32,.88); border-radius: 10px; box-shadow: 0 20px 70px rgba(0,0,0,.24); }
+    .summary div { padding:14px 16px; min-width: 130px; }
+    .summary strong { display:block; font-size:28px; }
+    .summary span { color:var(--muted); font-size:13px; }
+    .card { padding: 22px; margin: 18px 0; }
+    .card-head { display:flex; justify-content:space-between; gap:16px; align-items:flex-start; }
+    .eyebrow { margin:0 0 8px; font-size:12px; text-transform:uppercase; letter-spacing:.08em; color:#aaa2bd; }
+    .metric { text-align:right; font-size:30px; font-weight:800; color:var(--text); }
+    .metric span { display:block; font-size:12px; color:var(--muted); font-weight:500; }
+    .pill { display:inline-flex; align-items:center; border-radius:999px; padding:3px 8px; font-size:11px; font-weight:800; margin-right:6px; }
+    .pass { background: rgba(74,222,128,.14); color: var(--pass); }
+    .warn { background: rgba(251,191,36,.14); color: var(--warn); }
+    .fail { background: rgba(251,113,133,.14); color: var(--fail); }
+    .checks { list-style:none; padding:0; margin:16px 0; display:grid; gap:10px; }
+    .grid { display:grid; grid-template-columns: 1fr 1fr; gap:14px; margin-top:16px; }
+    pre { overflow:auto; max-height:360px; border:1px solid var(--border); background:#101017; border-radius:8px; padding:12px; color:#d8d3e6; font-size:12px; white-space:pre-wrap; }
+    .screens { display:grid; gap:12px; margin-top:16px; }
+    img { width:100%; border-radius:8px; border:1px solid var(--border); background:#111; }
+    @media (max-width: 820px) { .grid { grid-template-columns: 1fr; } h1 { font-size:32px; } }
+  </style>
+</head>
+<body>
+<main>
+  <p class="eyebrow">Deft chat governance</p>
+  <h1>Episode-Level Mini-Batch Certification</h1>
+  <p>Fast replacement for the week-long simulation. Each batch uses natural chat, tracks actual message IDs, triggers quiet discussion capture, and validates wiki/task effects.</p>
+  <div class="summary">
+    <div><strong>${artifact.summary.pass}</strong><span>passed checks</span></div>
+    <div><strong>${artifact.summary.warn}</strong><span>warnings</span></div>
+    <div><strong>${artifact.summary.fail}</strong><span>failed checks</span></div>
+    <div><strong>${artifact.results.length}</strong><span>scenarios</span></div>
+    <div><strong>${CLEANUP_SPACES ? 'on' : 'off'}</strong><span>space cleanup</span></div>
+  </div>
+  ${cards}
+</main>
+</body>
+</html>`;
+}
+
+async function main() {
+  await fs.mkdir(OUT_DIR, { recursive: true });
+  const auth = await loginApi();
+  const spaces = await getSpaces(auth);
+  if (spaces.length === 0) throw new Error('No spaces available');
+
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage({ viewport: { width: 1365, height: 900 } });
+  try {
+    await loginUi(page);
+    for (const scenario of scenarios) {
+      try {
+        const result = await runScenario(page, auth, spaces, scenario);
+        artifact.results.push(result);
+      } catch (err) {
+        const space = pickSpace(spaces, scenario.spacePreference);
+        artifact.results.push({
+          id: scenario.id,
+          title: scenario.title,
+          space,
+          about: scenario.about,
+          expectation: scenario.expectation,
+          messageIds: [],
+          messageCount: scenario.messages.length,
+          classifications: [],
+          actions: [],
+          intents: [],
+          wiki: [],
+          screenshots: [],
+          checks: [{
+            status: 'fail',
+            name: 'Scenario runner failed',
+            detail: err instanceof Error ? err.message : String(err),
+          }],
+        });
+      }
+      await writeReports();
+    }
+  } finally {
+    await browser.close();
+  }
+
+  await writeReports();
+  console.log(`\nReport: ${HTML_REPORT}`);
+  if (artifact.summary.fail > 0) {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- Moves passive chat-to-knowledge into a quiet episode batch that rejects social/noise/task-only discussion and prefers updating existing wiki pages.
- Stops background task creation by default; task creation/update now stays Defty-led when someone explicitly asks from recent chat context.
- Adds tiny knowledge receipt dots in chat plus a hidden/manual "capture recent discussion" action.
- Adds focused API coverage and a fast UI-style mini-batch certification harness for realistic chat governance scenarios.

## Why
The earlier chat flow was too noisy: approval cards polluted chat, social/temporary messages could become knowledge, and task capture felt mechanical. This makes knowledge capture quieter and stricter while keeping task creation agentic and reviewable.

## Validation
- `pnpm --filter @deft/api exec tsx --test --test-concurrency=1 test/chat-knowledge-batch.test.ts` ? 5 pass
- `pnpm --filter @deft/api exec tsx --test --test-concurrency=1 test/defty-capture-dedupe-update.test.ts` ? 12 pass
- `pnpm --filter @deft/api typecheck` ? pass
- `pnpm --filter @deft/web typecheck` ? pass
- `pnpm chat:mini-batches` ? 10 scenarios, 30 pass, 0 warn, 0 fail

Latest local certification report:
`reports/chat-episode-mini-batches-2026-07-02T13-12-14-900Z.html`

## Notes
- `DEFT_ENABLE_BACKGROUND_TASK_CAPTURE` remains off by default.
- `DEFT_ENABLE_IMMEDIATE_MEMORY_CAPTURE` remains off by default.
- Older exploratory report scripts were intentionally left out of this PR to keep the review focused.
