### PR TITLE
fix: route scheduled chat knowledge batches

### DIFF
--- a/apps/api/src/workers/index.ts
+++ b/apps/api/src/workers/index.ts
@@ -150,6 +150,10 @@ async function getAgentJobHandler(jobName: string): Promise<JobHandler | null> {
 
 async function getScheduledJobHandler(jobName: string): Promise<JobHandler | null> {
   switch (jobName) {
+    case 'chat-knowledge-batch': {
+      const mod = await import('./handlers/chat-knowledge-batch.js');
+      return mod.handleChatKnowledgeBatch;
+    }
     case 'standup-generate': {
       const mod = await import('./handlers/standup-generate.js');
       return mod.handleStandupGenerate;
@@ -220,6 +224,10 @@ async function getScheduledJobHandler(jobName: string): Promise<JobHandler | nul
     default:
       return null;
   }
+}
+
+export async function _getScheduledJobHandlerForTest(jobName: string): Promise<JobHandler | null> {
+  return getScheduledJobHandler(jobName);
 }
 
 async function getHandler(queueName: string, jobName: string): Promise<JobHandler | null> {

--- a/apps/api/test/worker-scheduled-routing.test.ts
+++ b/apps/api/test/worker-scheduled-routing.test.ts
@@ -1,0 +1,9 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+test('scheduled chat-knowledge-batch resolves to a real handler', async () => {
+  const workers = await import('../src/workers/index.js');
+  const handler = await workers._getScheduledJobHandlerForTest('chat-knowledge-batch');
+
+  assert.equal(typeof handler, 'function');
+});


### PR DESCRIPTION
## Summary
- route scheduled \chat-knowledge-batch\ cron jobs to the real batch handler
- add a regression test so scheduled chat memory capture cannot silently no-op again

## Verification
- \pnpm --filter @deft/api typecheck\
- \DATABASE_URL=postgres://postgres:freshrepropass@localhost:55525/deft REDIS_URL=redis://localhost:6385 pnpm --filter @deft/api exec tsx --test --test-concurrency=1 --test-force-exit test/worker-scheduled-routing.test.ts test/chat-knowledge-batch.test.ts\

## Demo deploy
- hotfixed and rebuilt \demo.deft.ing\
- forced a one-time 16h scheduled backfill; processed 48 messages, queued 8 wiki captures, embedded 8 pages