### PR TITLE
[codex] Reorder primary sidebar navigation

### DIFF
--- a/apps/web/src/components/sidebar.tsx
+++ b/apps/web/src/components/sidebar.tsx
@@ -31,7 +31,6 @@ import {
   Bell,
   Bookmark,
   FileText,
-  CalendarDays,
   Headphones,
   BookOpen,
   Smile,
@@ -77,10 +76,9 @@ type Project = {
 };
 
 const navItems = [
-  { name: 'Notes', href: '/notes', icon: FileText },
-  { name: 'Calendar', href: '/calendar', icon: CalendarDays },
   { name: 'Chat', href: '/chat', icon: MessageSquare },
   { name: 'Tasks', href: '/tasks', icon: CheckSquare },
+  { name: 'Notes', href: '/notes', icon: FileText },
   { name: 'Knowledge', href: '/knowledge', icon: BookOpen },
   { name: 'Inbox', href: '/inbox', icon: Inbox },
 ];


### PR DESCRIPTION
## Summary
- Reorders the primary left navigation to Chat, Tasks, Notes, Knowledge, Inbox.
- Removes Calendar from the primary left nav list.

## Validation
- `pnpm --filter @deft/web lint`
- `pnpm --filter @deft/web typecheck`
- Local Playwright smoke against `http://localhost:3012/chat` confirmed rendered nav order: Chat, Tasks, Notes, Knowledge, Inbox.
