### PR TITLE
[codex] Add calendar to primary sidebar navigation

### DIFF
--- a/apps/web/src/components/sidebar.tsx
+++ b/apps/web/src/components/sidebar.tsx
@@ -31,6 +31,7 @@ import {
   Bell,
   Bookmark,
   FileText,
+  CalendarDays,
   Headphones,
   BookOpen,
   Smile,
@@ -78,8 +79,9 @@ type Project = {
 const navItems = [
   { name: 'Chat', href: '/chat', icon: MessageSquare },
   { name: 'Tasks', href: '/tasks', icon: CheckSquare },
-  { name: 'Notes', href: '/notes', icon: FileText },
   { name: 'Knowledge', href: '/knowledge', icon: BookOpen },
+  { name: 'Calendar', href: '/calendar', icon: CalendarDays },
+  { name: 'Notes', href: '/notes', icon: FileText },
   { name: 'Inbox', href: '/inbox', icon: Inbox },
 ];
 


### PR DESCRIPTION
## Summary
- Adds Calendar back to the primary left navigation.
- Sets the primary left nav order to Chat, Tasks, Knowledge, Calendar, Notes, Inbox.

## Validation
- `pnpm --filter @deft/web typecheck`
- `pnpm --filter @deft/web exec eslint src/components/sidebar.tsx --quiet`
- Local Playwright smoke against `http://localhost:3012/chat` confirmed rendered nav order: Chat, Tasks, Knowledge, Calendar, Notes, Inbox.

## Note
- Full `pnpm --filter @deft/web lint` hung locally without returning a failure, so I used a focused ESLint pass on the touched file plus full web typecheck.
