### PR TITLE
[codex] Enrich MCP activity receipts

### DIFF
--- a/apps/api/src/lib/mcp-tools/human.ts
+++ b/apps/api/src/lib/mcp-tools/human.ts
@@ -25,6 +25,7 @@ import { visibleTaskCondition } from '../task-visibility.js';
 import { visibleWikiPageCondition } from '../wiki-visibility.js';
 import { errorResult, textResult, type ToolResult } from './types.js';
 import { reserveNextTaskNumber } from '../task-numbering.js';
+import { enrichOAuthAuditActions } from '../oauth-audit-receipts.js';
 
 export type HumanToolContext = {
   org_id: string;
@@ -2569,7 +2570,15 @@ export async function humanActivityQuery(args: { limit?: number; tool_name?: str
     ORDER BY created_at DESC
     LIMIT ${limit}
   `);
-  return textResult((rows as any).rows ?? []);
+  const actions = ((rows as any).rows ?? []) as Array<{
+    id: string;
+    client_id: string;
+    event: string;
+    metadata: Record<string, unknown> | null;
+    created_at: Date;
+  }>;
+  const enriched = await enrichOAuthAuditActions(ctx.org_id, actions);
+  return textResult(enriched);
 }
 
 export async function humanTeamWorkload(args: { days?: number }, ctx: HumanToolContext): Promise<ToolResult> {

--- a/apps/api/test/oauth-mcp.test.ts
+++ b/apps/api/test/oauth-mcp.test.ts
@@ -838,6 +838,13 @@ test('OAuth task-helper profile can comment on and update visible tasks', async 
     activity.some((event: any) => event.event === 'mcp_tool_call' && event.metadata?.tool_name === 'task_create'),
     'activity_query should expose recent task_create audit activity',
   );
+  const taskCreateReceipt = activity.find(
+    (event: any) => event.event === 'mcp_idempotency_result' && event.metadata?.tool_name === 'task_create' && event.receipt?.title === 'Created task',
+  )?.receipt;
+  assert.ok(taskCreateReceipt, 'activity_query should return enriched task_create receipts for MCP clients');
+  assert.equal(taskCreateReceipt.target_kind, 'task');
+  assert.match(taskCreateReceipt.detail, /OMCP-\d+: /);
+  assert.match(taskCreateReceipt.href, /^\/tasks\?task=/);
 
   const blockedRes = await jsonPost('/api/mcp/v1', {
     jsonrpc: '2.0',


### PR DESCRIPTION
## Summary
- Enrich MCP `activity_query` results with the same receipt objects used by the MCP Access UI
- Preserve the existing raw audit fields while adding `receipt.title/detail/href/target_kind`
- Extend the OAuth MCP contract test so external clients get human-readable task receipts

## Why
The public MCP battery showed writes were audited correctly, but Codex-style clients still had to parse raw `mcp_idempotency_result` JSON blobs. This makes the workflow feel less polished even though the underlying actions work.

## Validation
- `pnpm --filter @deft/api exec tsx --test --test-concurrency=1 --test-force-exit test/oauth-mcp.test.ts`
- `pnpm --filter @deft/api typecheck`
