### PR TITLE
Guide MCP access setup

### DIFF
--- a/apps/web/src/app/(app)/settings/mcp-access/page.tsx
+++ b/apps/web/src/app/(app)/settings/mcp-access/page.tsx
@@ -2,7 +2,27 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
-import { Activity, Bot, Check, ChevronDown, ChevronRight, Copy, FileText, Globe2, History, KeyRound, Loader2, Plug, Terminal, Trash2 } from 'lucide-react';
+import {
+  Activity,
+  Bot,
+  Check,
+  ChevronDown,
+  ChevronRight,
+  Code2,
+  Copy,
+  FileText,
+  Globe2,
+  History,
+  KeyRound,
+  Loader2,
+  Plug,
+  Settings2,
+  ShieldCheck,
+  Sparkles,
+  Terminal,
+  Trash2,
+  Wrench,
+} from 'lucide-react';
 import { api } from '@/lib/api';
 import { PageHeader } from '@/components/page-header';
 import { TabStrip } from '@/components/tab-strip';
@@ -19,33 +39,107 @@ type McpToken = {
 
 const READ_SCOPES = ['read:workspace', 'read:wiki', 'read:tasks', 'read:messages', 'read:calendar'];
 const WRITE_SCOPES = ['write:tasks', 'write:messages', 'write:wiki'];
+const ALL_SCOPES = [...READ_SCOPES, ...WRITE_SCOPES];
 
 const SCOPE_LABELS: Record<string, string> = {
-  'read:workspace': 'Workspace map, teammates, projects, and activity context',
+  'read:workspace': 'Workspace map, teammates, projects, receipts, and activity context',
   'read:wiki': 'Company, channel, and personal memory packets',
   'read:tasks': 'Task lists, task detail, comments, and progress',
-  'read:messages': 'Visible spaces, threads, and chat search',
+  'read:messages': 'Visible spaces, threads, unread work, and chat search',
   'read:calendar': 'Native and ICS calendar context',
   'write:tasks': 'Create, update, transition, and comment on tasks',
-  'write:messages': 'Post messages into spaces you belong to',
+  'write:messages': 'Post messages into spaces and DMs you can access',
   'write:wiki': 'Save or update wiki knowledge as you',
 };
 
-const CLIENT_CARDS = [
+type ClientId = 'codex' | 'claude-code' | 'claude-desktop' | 'remote-web' | 'custom' | 'agent-employee';
+type AccessPreset = 'read' | 'work' | 'custom';
+
+type ClientOption = {
+  id: ClientId;
+  name: string;
+  fit: string;
+  detail: string;
+  setupKind: 'token' | 'oauth' | 'advanced' | 'agent';
+  defaultPreset: AccessPreset;
+  tokenName: string;
+};
+
+const CLIENT_OPTIONS: ClientOption[] = [
   {
-    name: 'Codex / Claude Code',
-    fit: 'Works now',
-    detail: 'Use the streamable HTTP endpoint with a bearer token. Best for task and workspace workflows.',
+    id: 'codex',
+    name: 'Codex',
+    fit: 'Recommended token setup',
+    detail: 'Best for owner-operator workflows: triage messages, read tasks, write wiki, post updates, and leave receipts.',
+    setupKind: 'token',
+    defaultPreset: 'work',
+    tokenName: 'Codex',
   },
   {
+    id: 'claude-code',
+    name: 'Claude Code',
+    fit: 'Token setup',
+    detail: 'Use Deft as the work-record MCP server while Claude Code handles local development and repo work.',
+    setupKind: 'token',
+    defaultPreset: 'work',
+    tokenName: 'Claude Code',
+  },
+  {
+    id: 'claude-desktop',
     name: 'Claude Desktop',
-    fit: 'Works with HTTP MCP config',
-    detail: 'Add Deft as an HTTP MCP server and paste the bearer header from a personal token.',
+    fit: 'Desktop assistant',
+    detail: 'Good for workspace Q&A and light task work from a local desktop app that accepts MCP server JSON.',
+    setupKind: 'token',
+    defaultPreset: 'read',
+    tokenName: 'Claude Desktop',
   },
   {
-    name: 'ChatGPT / Claude web',
-    fit: 'Use OAuth connector path',
-    detail: 'Use the public OAuth metadata below when the client expects a remote connector flow.',
+    id: 'remote-web',
+    name: 'ChatGPT / Claude Web',
+    fit: 'Remote connector path',
+    detail: 'Use OAuth metadata only when the hosted app supports remote MCP connectors for self-hosted servers.',
+    setupKind: 'oauth',
+    defaultPreset: 'read',
+    tokenName: 'Remote AI app',
+  },
+  {
+    id: 'custom',
+    name: 'Custom MCP client',
+    fit: 'Advanced',
+    detail: 'For engineers wiring their own streamable HTTP MCP client, bearer token, or OAuth connector.',
+    setupKind: 'advanced',
+    defaultPreset: 'custom',
+    tokenName: 'Custom MCP client',
+  },
+  {
+    id: 'agent-employee',
+    name: 'Agent employee runtime',
+    fit: 'Different flow',
+    detail: 'Use this when the app should behave like a shared employee instead of acting as your personal user.',
+    setupKind: 'agent',
+    defaultPreset: 'work',
+    tokenName: 'Agent employee',
+  },
+];
+
+const PRESETS: Array<{ id: AccessPreset; title: string; detail: string; scopes: string[] }> = [
+  {
+    id: 'read',
+    title: 'Read-only assistant',
+    detail: 'Can answer questions using visible workspace, task, chat, calendar, and wiki context.',
+    scopes: READ_SCOPES,
+  },
+  {
+    id: 'work',
+    title: 'Work-capable assistant',
+    detail: 'Can read context and do work as you: create tasks, post messages, and update wiki knowledge.',
+    scopes: ALL_SCOPES,
+  },
+  {
+    id: 'custom',
+    title: 'Custom scopes',
+    detail: 'Choose exact MCP scopes. Best for self-hosted admins and unusual clients.',
+    scopes: READ_SCOPES,
   },
 ];
 
@@ -62,6 +156,13 @@ const CONTEXT_PACKET_CARDS = [
     title: 'Personal memory',
     detail: 'Private notes and memories scoped to the connected human user.',
   },
+];
+
+const TEST_PROMPTS = [
+  'Check my unread messages and tell me what needs my attention.',
+  'List my open tasks, find blockers, and suggest the next action.',
+  'Search wiki for launch blockers, then summarize what changed recently.',
+  'Create a follow-up task from this discussion, post an update, and show me the receipt.',
 ];
 
 type RemoteReadiness = {
@@ -137,8 +238,8 @@ function actionTitle(action: OAuthAuditAction) {
     if (toolName === 'task_transition') return 'Changed task status';
     if (toolName === 'task_update') return 'Updated task';
     if (toolName === 'comment_on_task') return 'Commented on task';
-    if (toolName === 'message_post') return 'Posted message';
-    if (toolName === 'memory_write') return 'Saved memory';
+    if (toolName === 'message_post' || toolName === 'send_message') return 'Sent message';
+    if (toolName === 'memory_write' || toolName === 'wiki_upsert') return 'Saved knowledge';
     return toolName ? `${toolName} completed` : 'Write completed';
   }
   return action.event.replaceAll('_', ' ');
@@ -178,7 +279,7 @@ function actionDetail(action: OAuthAuditAction) {
     const taskKey = result.task_key ?? result.number ?? 'task';
     return `${taskKey}: ${transition?.from ?? 'previous'} -> ${transition?.to ?? result.status ?? 'updated'}`;
   }
-  if (toolName === 'message_post' && result) {
+  if ((toolName === 'message_post' || toolName === 'send_message') && result) {
     return `message in ${String(result.space_id ?? 'space').slice(0, 8)}...`;
   }
   const pieces = [
@@ -197,7 +298,7 @@ function actionHref(action: OAuthAuditAction) {
   if ((toolName === 'task_create' || toolName === 'task_transition' || toolName === 'task_update' || toolName === 'comment_on_task') && typeof result.id === 'string') {
     return `/tasks?task=${encodeURIComponent(result.id)}`;
   }
-  if (toolName === 'message_post' && typeof result.id === 'string' && typeof result.space_id === 'string') {
+  if ((toolName === 'message_post' || toolName === 'send_message') && typeof result.id === 'string' && typeof result.space_id === 'string') {
     return `/chat?space=${encodeURIComponent(result.space_id)}&message=${encodeURIComponent(result.id)}`;
   }
   return null;
@@ -206,6 +307,18 @@ function actionHref(action: OAuthAuditAction) {
 function isStale(value: string | null | undefined) {
   if (!value) return true;
   return Date.now() - new Date(value).getTime() > 1000 * 60 * 60 * 24 * 14;
+}
+
+function clientById(id: ClientId) {
+  return CLIENT_OPTIONS.find((client) => client.id === id) ?? CLIENT_OPTIONS[0]!;
+}
+
+function clientIcon(id: ClientId) {
+  if (id === 'codex' || id === 'claude-code') return <Code2 size={16} />;
+  if (id === 'claude-desktop') return <Bot size={16} />;
+  if (id === 'remote-web') return <Globe2 size={16} />;
+  if (id === 'custom') return <Wrench size={16} />;
+  return <Bot size={16} />;
 }
 
 function RecentActionList({ actions }: { actions?: OAuthAuditAction[] }) {
@@ -238,25 +351,38 @@ function RecentActionList({ actions }: { actions?: OAuthAuditAction[] }) {
   );
 }
 
+function ScopePill({ scope }: { scope: string }) {
+  return (
+    <span className="text-[11px] rounded-md px-2 py-1" style={{ background: 'var(--surface-container)', color: 'var(--text-secondary)', border: '1px solid var(--border-default)' }}>
+      {scope}
+    </span>
+  );
+}
+
 export default function McpAccessPage() {
   const [tokens, setTokens] = useState<McpToken[]>([]);
   const [remote, setRemote] = useState<RemoteReadiness | null>(null);
   const [grants, setGrants] = useState<OAuthGrant[]>([]);
   const [history, setHistory] = useState<McpAccessHistory | null>(null);
   const [historyOpen, setHistoryOpen] = useState(false);
+  const [advancedOpen, setAdvancedOpen] = useState(false);
   const [endpoint, setEndpoint] = useState('');
   const [loading, setLoading] = useState(true);
   const [busy, setBusy] = useState(false);
-  const [tokenName, setTokenName] = useState('Personal AI client');
-  const [writeEnabled, setWriteEnabled] = useState(false);
+  const [selectedClient, setSelectedClient] = useState<ClientId>('codex');
+  const [accessPreset, setAccessPreset] = useState<AccessPreset>('work');
+  const [customScopes, setCustomScopes] = useState<string[]>(READ_SCOPES);
+  const [tokenName, setTokenName] = useState('Codex');
   const [newToken, setNewToken] = useState<string | null>(null);
   const [copied, setCopied] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  const selectedScopes = useMemo(
-    () => writeEnabled ? [...READ_SCOPES, ...WRITE_SCOPES] : READ_SCOPES,
-    [writeEnabled],
-  );
+  const selectedClientOption = clientById(selectedClient);
+  const selectedScopes = useMemo(() => {
+    if (accessPreset === 'read') return READ_SCOPES;
+    if (accessPreset === 'work') return ALL_SCOPES;
+    return customScopes;
+  }, [accessPreset, customScopes]);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -293,6 +419,23 @@ export default function McpAccessPage() {
 
   useEffect(() => { void load(); }, [load]);
 
+  function chooseClient(id: ClientId) {
+    const client = clientById(id);
+    setSelectedClient(id);
+    setAccessPreset(client.defaultPreset);
+    setTokenName(client.tokenName);
+    setNewToken(null);
+    if (client.defaultPreset === 'custom') setCustomScopes(READ_SCOPES);
+  }
+
+  function toggleCustomScope(scope: string) {
+    setCustomScopes((current) => (
+      current.includes(scope)
+        ? current.filter((item) => item !== scope)
+        : [...current, scope]
+    ));
+  }
+
   async function copy(label: string, value: string) {
     await navigator.clipboard.writeText(value);
     setCopied(label);
@@ -304,7 +447,7 @@ export default function McpAccessPage() {
     setError(null);
     try {
       const res = await api.post('/api/mcp-access/tokens', {
-        name: tokenName.trim() || 'Personal AI client',
+        name: tokenName.trim() || selectedClientOption.tokenName,
         scopes: selectedScopes,
       });
       if (!res.ok) {
@@ -352,52 +495,64 @@ export default function McpAccessPage() {
 
   const endpointForConfig = endpoint || '<deft-api-url>/api/mcp/v1';
   const tokenForConfig = newToken ?? '<paste-token-here>';
-  const configSnippets = useMemo(() => [
-    {
-      id: 'codex',
-      title: 'Codex config',
-      detail: 'Paste into Codex MCP server config when using streamable HTTP with a personal bearer token.',
-      value: [
-        '[mcp_servers.deft]',
-        `url = "${endpointForConfig}"`,
-        `http_headers = { Authorization = "Bearer ${tokenForConfig}" }`,
-      ].join('\n'),
-    },
-    {
-      id: 'claude-desktop',
-      title: 'Claude Desktop / Claude Code JSON',
-      detail: 'Paste into a client that accepts mcpServers JSON with HTTP headers.',
-      value: JSON.stringify({
-        mcpServers: {
-          deft: {
-            type: 'http',
-            url: endpointForConfig,
-            headers: { Authorization: `Bearer ${tokenForConfig}` },
+
+  const selectedSnippet = useMemo(() => {
+    if (selectedClient === 'codex') {
+      return {
+        title: 'Codex config',
+        detail: 'Paste this into your Codex MCP server config.',
+        value: [
+          '[mcp_servers.deft]',
+          `url = "${endpointForConfig}"`,
+          `http_headers = { Authorization = "Bearer ${tokenForConfig}" }`,
+        ].join('\n'),
+      };
+    }
+    if (selectedClient === 'claude-code' || selectedClient === 'claude-desktop') {
+      return {
+        title: selectedClient === 'claude-code' ? 'Claude Code MCP JSON' : 'Claude Desktop MCP JSON',
+        detail: 'Paste this into a client that accepts mcpServers JSON with HTTP headers.',
+        value: JSON.stringify({
+          mcpServers: {
+            deft: {
+              type: 'http',
+              url: endpointForConfig,
+              headers: { Authorization: `Bearer ${tokenForConfig}` },
+            },
           },
-        },
-      }, null, 2),
-    },
-    {
-      id: 'raw',
-      title: 'Raw endpoint and header',
-      detail: 'Use this when a client asks for the MCP URL and bearer header separately.',
+        }, null, 2),
+      };
+    }
+    return {
+      title: 'Raw endpoint and bearer header',
+      detail: 'Use this when your client asks for the MCP URL and authorization header separately.',
       value: [
         `MCP URL: ${endpointForConfig}`,
         `Authorization: Bearer ${tokenForConfig}`,
       ].join('\n'),
-    },
-  ], [endpointForConfig, tokenForConfig]);
+    };
+  }, [endpointForConfig, selectedClient, tokenForConfig]);
+
+  const tokenSetupClient = selectedClientOption.setupKind === 'token' || selectedClientOption.setupKind === 'advanced';
   const historyCount = (history?.revoked_tokens.length ?? 0) + (history?.revoked_grants.length ?? 0);
+  const remoteRows: Array<[string, string | undefined]> = [
+    ['Connector URL', remote?.mcp_endpoint_url],
+    ['Protected resource metadata', remote?.protected_resource_metadata],
+    ['OAuth metadata', remote?.authorization_server_metadata],
+    ['Authorization endpoint', remote?.authorization_endpoint],
+    ['Token endpoint', remote?.token_endpoint],
+    ['Registration endpoint', remote?.registration_endpoint],
+  ];
 
   return (
     <div className="flex flex-col h-full overflow-y-auto">
       <PageHeader
-        title="MCP Access"
-        description="Connect personal AI clients and agent employees to Deft's workspace tools."
+        title="AI App Connections"
+        description="Connect Codex, Claude, ChatGPT, or any MCP client to your Deft workspace."
         secondary={
           <TabStrip>
             <Link href="/settings/mcp-access" className="px-3 py-2 text-[13px] font-medium" style={{ color: 'var(--accent)', borderBottom: '2px solid var(--accent)' }}>
-              My AI Clients
+              My AI Apps
             </Link>
             <Link href="/settings/agent-employees" className="px-3 py-2 text-[13px] font-medium" style={{ color: 'var(--text-tertiary)', borderBottom: '2px solid transparent' }}>
               Agent Employees
@@ -407,7 +562,7 @@ export default function McpAccessPage() {
         compact
       />
 
-      <div className="max-w-4xl w-full mx-auto px-4 md:px-6 pb-8 space-y-4">
+      <div className="max-w-5xl w-full mx-auto px-4 md:px-6 pb-8 space-y-4">
         {error && (
           <div className="rounded-lg px-3 py-2 text-[13px]" style={{ color: 'var(--danger)', border: '1px solid var(--danger)', background: 'color-mix(in srgb, var(--danger) 8%, transparent)' }}>
             {error}
@@ -420,31 +575,262 @@ export default function McpAccessPage() {
         )}
 
         <section className="rounded-lg p-4" style={{ background: 'var(--surface-container-low)', border: '1px solid var(--border-default)' }}>
-          <div className="flex items-start gap-3">
-            <div className="w-8 h-8 rounded-md flex items-center justify-center shrink-0" style={{ background: 'var(--accent-muted)', color: 'var(--accent)' }}>
-              <Bot size={16} />
+          <div className="flex flex-col gap-4">
+            <div className="flex items-start gap-3">
+              <div className="w-8 h-8 rounded-md flex items-center justify-center shrink-0" style={{ background: 'var(--accent-muted)', color: 'var(--accent)' }}>
+                <Sparkles size={16} />
+              </div>
+              <div>
+                <h2 className="text-[15px] font-semibold" style={{ color: 'var(--text-primary)' }}>What do you want to connect?</h2>
+                <p className="text-[12px] mt-1" style={{ color: 'var(--text-secondary)' }}>
+                  Pick the app first. Deft will show the right connection path instead of making you sort through every MCP detail.
+                </p>
+              </div>
             </div>
-            <div className="flex-1 min-w-0">
-              <h2 className="text-[15px] font-semibold" style={{ color: 'var(--text-primary)' }}>Connect an AI app to Deft</h2>
-              <p className="text-[12px] mt-1" style={{ color: 'var(--text-secondary)' }}>
-                Deft exposes your workspace as MCP tools. A connected app can read the same work record you use in Deft,
-                then write back tasks, messages, or wiki updates only inside the scopes you grant.
-              </p>
-              <div className="grid md:grid-cols-3 gap-3 mt-4">
-                {CLIENT_CARDS.map((card) => (
-                  <div key={card.name} className="rounded-md p-3" style={{ background: 'var(--surface-container)', border: '1px solid var(--border-default)' }}>
-                    <div className="flex items-center justify-between gap-2">
-                      <div className="text-[13px] font-medium" style={{ color: 'var(--text-primary)' }}>{card.name}</div>
-                      <span className="text-[10px] rounded px-1.5 py-0.5 shrink-0" style={{ color: 'var(--accent)', border: '1px solid color-mix(in srgb, var(--accent) 35%, transparent)' }}>{card.fit}</span>
+
+            <div className="grid md:grid-cols-2 xl:grid-cols-3 gap-3">
+              {CLIENT_OPTIONS.map((client) => {
+                const active = client.id === selectedClient;
+                return (
+                  <button
+                    key={client.id}
+                    type="button"
+                    onClick={() => chooseClient(client.id)}
+                    className="rounded-md p-3 text-left transition-colors"
+                    style={{
+                      background: active ? 'color-mix(in srgb, var(--accent) 12%, var(--surface-container))' : 'var(--surface-container)',
+                      border: active ? '1px solid var(--accent)' : '1px solid var(--border-default)',
+                    }}
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="flex items-center gap-2 min-w-0">
+                        <span className="w-7 h-7 rounded-md flex items-center justify-center shrink-0" style={{ background: active ? 'var(--accent-muted)' : 'var(--surface-container-low)', color: active ? 'var(--accent)' : 'var(--text-secondary)' }}>
+                          {clientIcon(client.id)}
+                        </span>
+                        <span className="text-[13px] font-semibold truncate" style={{ color: 'var(--text-primary)' }}>{client.name}</span>
+                      </div>
+                      <span className="text-[10px] rounded px-1.5 py-0.5 shrink-0" style={{ color: active ? 'var(--accent)' : 'var(--text-tertiary)', border: '1px solid var(--border-default)' }}>{client.fit}</span>
                     </div>
-                    <p className="text-[11px] mt-2 leading-relaxed" style={{ color: 'var(--text-secondary)' }}>{card.detail}</p>
+                    <p className="text-[11px] mt-3 leading-relaxed" style={{ color: 'var(--text-secondary)' }}>{client.detail}</p>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        </section>
+
+        <div className="grid lg:grid-cols-[1.05fr_.95fr] gap-4 items-start">
+          <div className="space-y-4">
+            {tokenSetupClient && (
+              <section className="rounded-lg p-4" style={{ background: 'var(--surface-container-low)', border: '1px solid var(--border-default)' }}>
+                <div className="flex items-start gap-3">
+                  <div className="w-8 h-8 rounded-md flex items-center justify-center shrink-0" style={{ background: 'var(--accent-muted)', color: 'var(--accent)' }}>
+                    <ShieldCheck size={16} />
                   </div>
-                ))}
+                  <div className="flex-1 min-w-0">
+                    <h2 className="text-[15px] font-semibold" style={{ color: 'var(--text-primary)' }}>Choose what {selectedClientOption.name} can do</h2>
+                    <p className="text-[12px] mt-1" style={{ color: 'var(--text-secondary)' }}>
+                      Personal MCP tokens act as you. The app can only see what you can see, and every write is recorded under your name.
+                    </p>
+
+                    <div className="grid md:grid-cols-3 gap-3 mt-4">
+                      {PRESETS.map((preset) => {
+                        const active = preset.id === accessPreset;
+                        return (
+                          <button
+                            key={preset.id}
+                            type="button"
+                            onClick={() => setAccessPreset(preset.id)}
+                            className="rounded-md p-3 text-left"
+                            style={{
+                              background: active ? 'color-mix(in srgb, var(--accent) 12%, var(--surface-container))' : 'var(--surface-container)',
+                              border: active ? '1px solid var(--accent)' : '1px solid var(--border-default)',
+                            }}
+                          >
+                            <div className="text-[13px] font-medium" style={{ color: 'var(--text-primary)' }}>{preset.title}</div>
+                            <p className="text-[11px] mt-1 leading-relaxed" style={{ color: 'var(--text-secondary)' }}>{preset.detail}</p>
+                          </button>
+                        );
+                      })}
+                    </div>
+
+                    {accessPreset === 'custom' && (
+                      <div className="grid sm:grid-cols-2 gap-2 mt-3">
+                        {ALL_SCOPES.map((scope) => (
+                          <label key={scope} className="flex items-start gap-2 rounded-md p-2.5 text-[11px]" style={{ background: 'var(--surface-container)', color: 'var(--text-secondary)', border: '1px solid var(--border-default)' }}>
+                            <input
+                              type="checkbox"
+                              checked={customScopes.includes(scope)}
+                              onChange={() => toggleCustomScope(scope)}
+                              className="mt-0.5"
+                            />
+                            <span>
+                              <span className="font-medium" style={{ color: 'var(--text-primary)' }}>{scope}</span>
+                              <span> - {SCOPE_LABELS[scope]}</span>
+                            </span>
+                          </label>
+                        ))}
+                      </div>
+                    )}
+
+                    <div className="flex flex-wrap gap-1.5 mt-3">
+                      {selectedScopes.map((scope) => <ScopePill key={scope} scope={scope} />)}
+                    </div>
+                  </div>
+                </div>
+              </section>
+            )}
+
+            {tokenSetupClient && (
+              <section className="rounded-lg p-4" style={{ background: 'var(--surface-container-low)', border: '1px solid var(--border-default)' }}>
+                <div className="flex items-start gap-3">
+                  <div className="w-8 h-8 rounded-md flex items-center justify-center shrink-0" style={{ background: 'var(--accent-muted)', color: 'var(--accent)' }}>
+                    <KeyRound size={16} />
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <h2 className="text-[15px] font-semibold" style={{ color: 'var(--text-primary)' }}>Create the connection</h2>
+                    <p className="text-[12px] mt-1" style={{ color: 'var(--text-secondary)' }}>
+                      Generate a token, copy the config for {selectedClientOption.name}, then test it from the AI app.
+                    </p>
+                    <div className="grid md:grid-cols-[1fr_auto] gap-3 mt-4">
+                      <input
+                        value={tokenName}
+                        onChange={(e) => setTokenName(e.target.value)}
+                        className="h-10 rounded-md px-3 text-[13px] outline-none"
+                        style={{ background: 'var(--surface-container)', color: 'var(--text-primary)', border: '1px solid var(--border-default)' }}
+                      />
+                      <button
+                        type="button"
+                        disabled={busy || selectedScopes.length === 0}
+                        onClick={createToken}
+                        className="inline-flex items-center justify-center gap-2 rounded-md px-3 py-2 text-[13px] font-medium text-white disabled:opacity-50"
+                        style={{ background: 'var(--accent)' }}
+                      >
+                        {busy ? <Loader2 size={14} className="animate-spin" /> : <Plug size={14} />}
+                        Generate token
+                      </button>
+                    </div>
+
+                    {newToken && (
+                      <div className="mt-4 rounded-md p-3" style={{ background: 'color-mix(in srgb, var(--accent) 8%, var(--surface-container))', border: '1px solid var(--accent)' }}>
+                        <div className="flex items-center justify-between gap-3">
+                          <div>
+                            <div className="text-[13px] font-semibold" style={{ color: 'var(--text-primary)' }}>New token</div>
+                            <p className="text-[11px]" style={{ color: 'var(--text-secondary)' }}>Copy it now. Deft will not show it again.</p>
+                          </div>
+                          <button type="button" onClick={() => copy('token', newToken)} className="inline-flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-[12px]" style={{ border: '1px solid var(--border-default)', color: 'var(--text-primary)' }}>
+                            <Copy size={13} /> Copy
+                          </button>
+                        </div>
+                        <pre className="mt-3 overflow-x-auto rounded-md p-3 text-[11px]" style={{ background: 'var(--surface-container)', color: 'var(--text-primary)' }}>{newToken}</pre>
+                      </div>
+                    )}
+
+                    <div className="mt-4 rounded-md p-3" style={{ background: 'var(--surface-container)', border: '1px solid var(--border-default)' }}>
+                      <div className="flex items-start justify-between gap-3">
+                        <div>
+                          <div className="text-[13px] font-semibold" style={{ color: 'var(--text-primary)' }}>{selectedSnippet.title}</div>
+                          <p className="text-[11px] mt-1" style={{ color: 'var(--text-secondary)' }}>{selectedSnippet.detail}</p>
+                        </div>
+                        <button type="button" onClick={() => copy(selectedSnippet.title.toLowerCase(), selectedSnippet.value)} className="p-1.5 rounded-md shrink-0" style={{ color: 'var(--text-secondary)', border: '1px solid var(--border-default)' }} aria-label={`Copy ${selectedSnippet.title}`}>
+                          <Copy size={13} />
+                        </button>
+                      </div>
+                      <pre className="mt-3 overflow-x-auto rounded-md p-3 text-[11px] max-h-56" style={{ background: 'var(--surface-container-high, var(--surface-container-low))', color: 'var(--text-primary)' }}>{selectedSnippet.value}</pre>
+                    </div>
+                  </div>
+                </div>
+              </section>
+            )}
+
+            {selectedClientOption.setupKind === 'oauth' && (
+              <section className="rounded-lg p-4" style={{ background: 'var(--surface-container-low)', border: '1px solid var(--border-default)' }}>
+                <div className="flex items-start gap-3">
+                  <div className="w-8 h-8 rounded-md flex items-center justify-center shrink-0" style={{ background: 'var(--accent-muted)', color: 'var(--accent)' }}>
+                    <Globe2 size={16} />
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-start justify-between gap-3">
+                      <div>
+                        <h2 className="text-[15px] font-semibold" style={{ color: 'var(--text-primary)' }}>Remote connector setup</h2>
+                        <p className="text-[12px] mt-1" style={{ color: 'var(--text-secondary)' }}>
+                          Use this path only when the hosted AI app asks for a remote MCP connector or OAuth metadata. For Codex and local clients, token setup is more reliable.
+                        </p>
+                      </div>
+                      <span className="text-[11px] rounded-md px-2 py-1 shrink-0" style={{ background: remote?.https_ready ? 'var(--accent-muted)' : 'var(--surface-container)', color: remote?.https_ready ? 'var(--accent)' : 'var(--text-tertiary)', border: '1px solid var(--border-default)' }}>
+                        {remote?.https_ready ? 'HTTPS ready' : 'Needs public HTTPS'}
+                      </span>
+                    </div>
+                    <div className="grid md:grid-cols-2 gap-3 mt-4">
+                      {remoteRows.slice(0, 3).map(([label, value]) => (
+                        <div key={label} className="rounded-md p-3 min-w-0" style={{ background: 'var(--surface-container)', border: '1px solid var(--border-default)' }}>
+                          <div className="text-[11px] font-medium uppercase tracking-wide" style={{ color: 'var(--text-tertiary)' }}>{label}</div>
+                          <div className="mt-1 flex items-center gap-2 min-w-0">
+                            <code className="text-[11px] truncate flex-1" style={{ color: 'var(--text-primary)' }}>{value ?? 'Not loaded'}</code>
+                            {value && (
+                              <button type="button" onClick={() => copy(label.toLowerCase(), value)} className="p-1 rounded-md" style={{ color: 'var(--text-secondary)' }} aria-label={`Copy ${label}`}>
+                                <Copy size={13} />
+                              </button>
+                            )}
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                    <button type="button" onClick={() => setAdvancedOpen(true)} className="mt-3 inline-flex items-center gap-1.5 text-[12px]" style={{ color: 'var(--accent)' }}>
+                      <Settings2 size={13} /> Show all OAuth endpoints
+                    </button>
+                  </div>
+                </div>
+              </section>
+            )}
+
+            {selectedClientOption.setupKind === 'agent' && (
+              <section className="rounded-lg p-4" style={{ background: 'var(--surface-container-low)', border: '1px solid var(--border-default)' }}>
+                <div className="flex items-start gap-3">
+                  <div className="w-8 h-8 rounded-md flex items-center justify-center shrink-0" style={{ background: 'var(--accent-muted)', color: 'var(--accent)' }}>
+                    <Bot size={16} />
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <h2 className="text-[15px] font-semibold" style={{ color: 'var(--text-primary)' }}>Use Agent Employees for shared workers</h2>
+                    <p className="text-[12px] mt-1" style={{ color: 'var(--text-secondary)' }}>
+                      Personal AI app connections act as you. If Hermes, OpenClaw, Codex, or another runtime should be available to the whole company as an employee, onboard it as an Agent Employee instead.
+                    </p>
+                    <Link href="/settings/agent-employees" className="mt-4 inline-flex items-center gap-2 rounded-md px-3 py-2 text-[13px] font-medium text-white" style={{ background: 'var(--accent)' }}>
+                      Open Agent Employees
+                    </Link>
+                  </div>
+                </div>
+              </section>
+            )}
+          </div>
+
+          <aside className="space-y-4">
+            <section className="rounded-lg p-4" style={{ background: 'var(--surface-container-low)', border: '1px solid var(--border-default)' }}>
+              <div className="flex items-start gap-3">
+                <div className="w-8 h-8 rounded-md flex items-center justify-center shrink-0" style={{ background: 'var(--accent-muted)', color: 'var(--accent)' }}>
+                  <Terminal size={16} />
+                </div>
+                <div className="flex-1 min-w-0">
+                  <h2 className="text-[14px] font-semibold" style={{ color: 'var(--text-primary)' }}>Test it from the app</h2>
+                  <p className="text-[12px] mt-1" style={{ color: 'var(--text-secondary)' }}>
+                    After connecting, run one prompt and check that recent activity updates below.
+                  </p>
+                  <div className="mt-3 space-y-2">
+                    {TEST_PROMPTS.map((prompt) => (
+                      <div key={prompt} className="flex items-start gap-2 rounded-md p-2" style={{ background: 'var(--surface-container)', border: '1px solid var(--border-default)' }}>
+                        <FileText size={13} className="mt-0.5 shrink-0" style={{ color: 'var(--text-tertiary)' }} />
+                        <span className="text-[11px] leading-relaxed" style={{ color: 'var(--text-secondary)' }}>{prompt}</span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
               </div>
-              <div className="text-[11px] font-semibold uppercase tracking-[0.08em] mt-4" style={{ color: 'var(--text-tertiary)' }}>
-                Context packets available to clients
-              </div>
-              <div className="grid md:grid-cols-3 gap-3 mt-3">
+            </section>
+
+            <section className="rounded-lg p-4" style={{ background: 'var(--surface-container-low)', border: '1px solid var(--border-default)' }}>
+              <h2 className="text-[14px] font-semibold" style={{ color: 'var(--text-primary)' }}>Context packets available</h2>
+              <p className="text-[12px] mt-1" style={{ color: 'var(--text-secondary)' }}>Connected clients can retrieve the right memory packet for the work they are doing.</p>
+              <div className="space-y-2 mt-3">
                 {CONTEXT_PACKET_CARDS.map((card) => (
                   <div key={card.title} className="rounded-md p-3" style={{ background: 'var(--surface-container)', border: '1px solid var(--border-default)' }}>
                     <div className="flex items-center gap-2 text-[12px] font-medium" style={{ color: 'var(--text-primary)' }}>
@@ -454,239 +840,138 @@ export default function McpAccessPage() {
                   </div>
                 ))}
               </div>
-            </div>
-          </div>
-        </section>
+            </section>
+          </aside>
+        </div>
 
         <section className="rounded-lg p-4" style={{ background: 'var(--surface-container-low)', border: '1px solid var(--border-default)' }}>
-          <div className="flex items-start gap-3">
-            <div className="w-8 h-8 rounded-md flex items-center justify-center" style={{ background: 'var(--accent-muted)', color: 'var(--accent)' }}>
-              <KeyRound size={16} />
-            </div>
-            <div className="flex-1 min-w-0">
-              <h2 className="text-[15px] font-semibold" style={{ color: 'var(--text-primary)' }}>Create a personal MCP token</h2>
-              <p className="text-[12px] mt-1" style={{ color: 'var(--text-secondary)' }}>
-                Personal tokens act as you. Reads follow your workspace access; writes create tasks, messages, and wiki pages under your user.
-              </p>
-              <div className="grid md:grid-cols-[1fr_auto] gap-3 mt-4">
-                <input
-                  value={tokenName}
-                  onChange={(e) => setTokenName(e.target.value)}
-                  className="h-10 rounded-md px-3 text-[13px] outline-none"
-                  style={{ background: 'var(--surface-container)', color: 'var(--text-primary)', border: '1px solid var(--border-default)' }}
-                />
-                <label className="flex items-center gap-2 text-[13px]" style={{ color: 'var(--text-secondary)' }}>
-                  <input type="checkbox" checked={writeEnabled} onChange={(e) => setWriteEnabled(e.target.checked)} />
-                  Allow writes
-                </label>
-              </div>
-              <div className="flex flex-wrap gap-1.5 mt-3">
-                {selectedScopes.map((scope) => (
-                  <span key={scope} className="text-[11px] rounded-md px-2 py-1" style={{ background: 'var(--surface-container)', color: 'var(--text-secondary)', border: '1px solid var(--border-default)' }}>
-                    {scope}
-                  </span>
-                ))}
-              </div>
-              <div className="grid md:grid-cols-2 gap-2 mt-3">
-                {selectedScopes.map((scope) => (
-                  <div key={`${scope}-detail`} className="text-[11px] rounded-md px-2.5 py-2" style={{ background: 'var(--surface-container)', color: 'var(--text-secondary)', border: '1px solid var(--border-default)' }}>
-                    <span className="font-medium" style={{ color: 'var(--text-primary)' }}>{scope}</span>
-                    <span> - {SCOPE_LABELS[scope] ?? 'Scoped MCP permission'}</span>
-                  </div>
-                ))}
-              </div>
-              <button
-                type="button"
-                disabled={busy}
-                onClick={createToken}
-                className="mt-4 inline-flex items-center gap-2 rounded-md px-3 py-2 text-[13px] font-medium text-white disabled:opacity-50"
-                style={{ background: 'var(--accent)' }}
-              >
-                {busy ? <Loader2 size={14} className="animate-spin" /> : <Plug size={14} />}
-                Generate token
-              </button>
-            </div>
+          <div className="flex items-center gap-2 mb-3">
+            <Activity size={15} style={{ color: 'var(--accent)' }} />
+            <h2 className="text-[14px] font-semibold" style={{ color: 'var(--text-primary)' }}>Manage active connections</h2>
           </div>
-        </section>
-
-        {newToken && (
-          <section className="rounded-lg p-4" style={{ background: 'var(--surface-container-low)', border: '1px solid var(--accent)' }}>
-            <div className="flex items-center justify-between gap-3">
-              <div>
-                <h2 className="text-[14px] font-semibold" style={{ color: 'var(--text-primary)' }}>New token</h2>
-                <p className="text-[12px]" style={{ color: 'var(--text-secondary)' }}>Copy it now. Deft will not show it again.</p>
-              </div>
-              <button type="button" onClick={() => copy('token', newToken)} className="inline-flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-[12px]" style={{ border: '1px solid var(--border-default)', color: 'var(--text-primary)' }}>
-                <Copy size={13} /> Copy
-              </button>
-            </div>
-            <pre className="mt-3 overflow-x-auto rounded-md p-3 text-[11px]" style={{ background: 'var(--surface-container)', color: 'var(--text-primary)' }}>{newToken}</pre>
-          </section>
-        )}
-
-        <section className="rounded-lg p-4" style={{ background: 'var(--surface-container-low)', border: '1px solid var(--border-default)' }}>
-          <div className="flex items-start gap-3">
-            <div className="w-8 h-8 rounded-md flex items-center justify-center shrink-0" style={{ background: 'var(--accent-muted)', color: 'var(--accent)' }}>
-              <Terminal size={16} />
-            </div>
-            <div className="flex-1 min-w-0">
-              <h2 className="text-[14px] font-semibold" style={{ color: 'var(--text-primary)' }}>One-click client config</h2>
-              <p className="text-[12px] mt-1" style={{ color: 'var(--text-secondary)' }}>
-                Generate a token above, then copy the snippet that matches your AI client. Each config points at Deft's streamable HTTP MCP endpoint.
-              </p>
-              <div className="grid md:grid-cols-3 gap-3 mt-4">
-                {configSnippets.map((snippet) => (
-                  <div key={snippet.id} className="rounded-md p-3 min-w-0" style={{ background: 'var(--surface-container)', border: '1px solid var(--border-default)' }}>
-                    <div className="flex items-start justify-between gap-2">
-                      <div className="min-w-0">
-                        <div className="text-[13px] font-medium" style={{ color: 'var(--text-primary)' }}>{snippet.title}</div>
-                        <p className="text-[11px] mt-1 leading-relaxed" style={{ color: 'var(--text-secondary)' }}>{snippet.detail}</p>
-                      </div>
-                      <button type="button" onClick={() => copy(snippet.title.toLowerCase(), snippet.value)} className="p-1.5 rounded-md shrink-0" style={{ color: 'var(--text-secondary)', border: '1px solid var(--border-default)' }} aria-label={`Copy ${snippet.title}`}>
-                        <Copy size={13} />
-                      </button>
-                    </div>
-                    <pre className="mt-3 overflow-x-auto rounded-md p-3 text-[11px] max-h-52" style={{ background: 'var(--surface-container-high, var(--surface-container-low))', color: 'var(--text-primary)' }}>{snippet.value}</pre>
-                  </div>
-                ))}
-              </div>
-            </div>
-          </div>
-        </section>
-
-        <section className="rounded-lg p-4" style={{ background: 'var(--surface-container-low)', border: '1px solid var(--border-default)' }}>
-          <div className="flex items-start gap-3">
-            <div className="w-8 h-8 rounded-md flex items-center justify-center" style={{ background: 'var(--accent-muted)', color: 'var(--accent)' }}>
-              <Globe2 size={16} />
-            </div>
-            <div className="flex-1 min-w-0">
-              <div className="flex items-center justify-between gap-3">
-                <div>
-                  <h2 className="text-[15px] font-semibold" style={{ color: 'var(--text-primary)' }}>Connected AI apps</h2>
-                  <p className="text-[12px] mt-1" style={{ color: 'var(--text-secondary)' }}>
-                    For ChatGPT, Claude web, Codex, and OAuth MCP clients. Connected apps act as you, inside the scopes you approve.
-                  </p>
-                </div>
-                <span className="text-[11px] rounded-md px-2 py-1" style={{ background: remote?.https_ready ? 'var(--accent-muted)' : 'var(--surface-container)', color: remote?.https_ready ? 'var(--accent)' : 'var(--text-tertiary)', border: '1px solid var(--border-default)' }}>
-                  {remote?.https_ready ? 'HTTPS ready' : 'Needs public HTTPS'}
-                </span>
-              </div>
-
-              <div className="grid md:grid-cols-2 gap-3 mt-4">
-                {([
-                  ['Connector URL', remote?.mcp_endpoint_url],
-                  ['Protected resource metadata', remote?.protected_resource_metadata],
-                  ['OAuth metadata', remote?.authorization_server_metadata],
-                  ['Authorization endpoint', remote?.authorization_endpoint],
-                  ['Token endpoint', remote?.token_endpoint],
-                  ['Registration endpoint', remote?.registration_endpoint],
-                ] as Array<[string, string | undefined]>).map(([label, value]) => (
-                  <div key={label} className="rounded-md p-3 min-w-0" style={{ background: 'var(--surface-container)', border: '1px solid var(--border-default)' }}>
-                    <div className="text-[11px] font-medium uppercase tracking-wide" style={{ color: 'var(--text-tertiary)' }}>{label}</div>
-                    <div className="mt-1 flex items-center gap-2 min-w-0">
-                      <code className="text-[11px] truncate flex-1" style={{ color: 'var(--text-primary)' }}>{value ?? 'Not loaded'}</code>
-                      {value && (
-                        <button type="button" onClick={() => copy(label.toLowerCase(), value)} className="p-1 rounded-md" style={{ color: 'var(--text-secondary)' }} aria-label={`Copy ${label}`}>
-                          <Copy size={13} />
-                        </button>
-                      )}
-                    </div>
-                  </div>
-                ))}
-              </div>
-
-              <div className="flex flex-wrap gap-1.5 mt-3">
-                {(remote?.scopes ?? READ_SCOPES).map((scope) => (
-                  <span key={scope} className="text-[11px] rounded-md px-2 py-1" style={{ background: 'var(--surface-container)', color: 'var(--text-secondary)', border: '1px solid var(--border-default)' }}>
-                    {scope}
-                  </span>
-                ))}
-              </div>
-
-              <h3 className="text-[13px] font-semibold mt-5 mb-2" style={{ color: 'var(--text-primary)' }}>App connections</h3>
-              {grants.length === 0 ? (
-                <p className="text-[13px]" style={{ color: 'var(--text-secondary)' }}>No ChatGPT or Claude-style OAuth connections yet.</p>
-              ) : (
-                <div className="space-y-3">
-                  {grants.map((grant) => (
-                    <div key={grant.id} className="rounded-md p-3" style={{ background: 'var(--surface-container)', border: '1px solid var(--border-default)' }}>
-                      <div className="flex items-start justify-between gap-3">
-                        <div className="min-w-0">
-                          <div className="text-[13px] font-medium" style={{ color: 'var(--text-primary)' }}>{grant.app_name}</div>
-                          <div className="text-[11px] mt-0.5" style={{ color: 'var(--text-tertiary)' }}>
-                            {grant.connector_profile} / {grant.client_id}
-                          </div>
-                          <div className="text-[11px] mt-1" style={{ color: 'var(--text-tertiary)' }}>
-                            connected {formatDate(grant.created_at)} / last used {formatDate(grant.last_used_at)}
-                          </div>
-                        </div>
-                        <button type="button" disabled={busy} onClick={() => revokeGrant(grant.id)} className="inline-flex items-center gap-1.5 rounded-md px-2 py-1.5 text-[12px] disabled:opacity-50" style={{ color: 'var(--danger)', border: '1px solid color-mix(in srgb, var(--danger) 35%, transparent)' }} aria-label={`Revoke ${grant.app_name}`}>
-                          <Trash2 size={13} /> Revoke
-                        </button>
-                      </div>
-                      <div className="flex flex-wrap gap-1 mt-3">
-                        {isStale(grant.last_used_at) && (
-                          <span className="text-[10px] rounded px-1.5 py-0.5" style={{ color: 'var(--warning, #f59e0b)', border: '1px solid color-mix(in srgb, var(--warning, #f59e0b) 45%, transparent)' }}>
-                            {grant.last_used_at ? 'stale' : 'unused'}
-                          </span>
-                        )}
-                        {grant.scopes.map((scope) => (
-                          <span key={scope} className="text-[10px] rounded px-1.5 py-0.5" style={{ color: 'var(--text-secondary)', border: '1px solid var(--border-default)' }}>{scope}</span>
-                        ))}
-                      </div>
-                      <div className="mt-3 pt-3" style={{ borderTop: '1px solid var(--border-default)' }}>
-                        <div className="text-[11px] font-medium uppercase tracking-wide" style={{ color: 'var(--text-tertiary)' }}>Recent actions</div>
-                        <RecentActionList actions={grant.recent_actions} />
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              )}
-            </div>
-          </div>
-        </section>
-
-        <section className="rounded-lg p-4" style={{ background: 'var(--surface-container-low)', border: '1px solid var(--border-default)' }}>
-          <h2 className="text-[14px] font-semibold mb-3" style={{ color: 'var(--text-primary)' }}>Active personal tokens</h2>
           {loading ? (
             <div className="py-6 flex items-center justify-center"><Loader2 size={18} className="animate-spin" /></div>
-          ) : tokens.length === 0 ? (
-            <p className="text-[13px]" style={{ color: 'var(--text-secondary)' }}>No personal MCP tokens yet.</p>
           ) : (
-            <div className="space-y-2">
-              {tokens.map((token) => (
-                <div key={token.id} className="flex items-start justify-between gap-3 rounded-md p-3" style={{ background: 'var(--surface-container)', border: '1px solid var(--border-default)' }}>
-                  <div className="min-w-0 flex-1">
-                    <div className="flex items-start justify-between gap-3">
-                      <div className="min-w-0">
-                        <div className="text-[13px] font-medium" style={{ color: 'var(--text-primary)' }}>{token.name}</div>
-                        <div className="text-[11px] mt-0.5" style={{ color: 'var(--text-tertiary)' }}>
-                          {token.token_prefix}... / created {formatDate(token.created_at)} / last used {formatDate(token.last_used_at)}
+            <div className="grid lg:grid-cols-2 gap-3">
+              <div className="rounded-md p-3" style={{ background: 'var(--surface-container)', border: '1px solid var(--border-default)' }}>
+                <div className="text-[13px] font-semibold" style={{ color: 'var(--text-primary)' }}>Personal tokens</div>
+                {tokens.length === 0 ? (
+                  <p className="text-[12px] mt-2" style={{ color: 'var(--text-secondary)' }}>No personal MCP tokens yet.</p>
+                ) : (
+                  <div className="space-y-2 mt-3">
+                    {tokens.map((token) => (
+                      <div key={token.id} className="rounded-md p-3" style={{ background: 'var(--surface-container-low)', border: '1px solid var(--border-default)' }}>
+                        <div className="flex items-start justify-between gap-3">
+                          <div className="min-w-0">
+                            <div className="text-[13px] font-medium truncate" style={{ color: 'var(--text-primary)' }}>{token.name}</div>
+                            <div className="text-[11px] mt-0.5" style={{ color: 'var(--text-tertiary)' }}>
+                              {token.token_prefix}... / last used {formatDate(token.last_used_at)}
+                            </div>
+                          </div>
+                          <button type="button" disabled={busy} onClick={() => revoke(token.id)} className="inline-flex items-center gap-1.5 rounded-md px-2 py-1.5 text-[12px] disabled:opacity-50 shrink-0" style={{ color: 'var(--danger)', border: '1px solid color-mix(in srgb, var(--danger) 35%, transparent)' }} aria-label={`Revoke ${token.name}`}>
+                            <Trash2 size={13} /> Revoke
+                          </button>
+                        </div>
+                        <div className="flex flex-wrap gap-1 mt-2">
+                          {isStale(token.last_used_at) && (
+                            <span className="text-[10px] rounded px-1.5 py-0.5" style={{ color: 'var(--warning, #f59e0b)', border: '1px solid color-mix(in srgb, var(--warning, #f59e0b) 45%, transparent)' }}>
+                              {token.last_used_at ? 'stale' : 'unused'}
+                            </span>
+                          )}
+                          {token.scopes.map((scope) => (
+                            <span key={scope} className="text-[10px] rounded px-1.5 py-0.5" style={{ color: 'var(--text-secondary)', border: '1px solid var(--border-default)' }}>{scope}</span>
+                          ))}
+                        </div>
+                        <div className="mt-3 pt-3" style={{ borderTop: '1px solid var(--border-default)' }}>
+                          <div className="text-[11px] font-medium uppercase tracking-wide" style={{ color: 'var(--text-tertiary)' }}>Recent token activity</div>
+                          <RecentActionList actions={token.recent_actions} />
                         </div>
                       </div>
-                      {isStale(token.last_used_at) && (
-                        <span className="text-[10px] rounded px-1.5 py-0.5 shrink-0" style={{ color: 'var(--warning, #f59e0b)', border: '1px solid color-mix(in srgb, var(--warning, #f59e0b) 45%, transparent)' }}>
-                          {token.last_used_at ? 'stale' : 'unused'}
-                        </span>
-                      )}
-                    </div>
-                    <div className="flex flex-wrap gap-1 mt-2">
-                      {token.scopes.map((scope) => (
-                        <span key={scope} className="text-[10px] rounded px-1.5 py-0.5" style={{ color: 'var(--text-secondary)', border: '1px solid var(--border-default)' }}>{scope}</span>
-                      ))}
-                    </div>
-                    <div className="mt-3 pt-3" style={{ borderTop: '1px solid var(--border-default)' }}>
-                      <div className="flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-wide" style={{ color: 'var(--text-tertiary)' }}>
-                        <Activity size={12} /> Recent token activity
-                      </div>
-                      <RecentActionList actions={token.recent_actions} />
-                    </div>
+                    ))}
                   </div>
-                  <button type="button" disabled={busy} onClick={() => revoke(token.id)} className="inline-flex items-center gap-1.5 rounded-md px-2 py-1.5 text-[12px] disabled:opacity-50 shrink-0" style={{ color: 'var(--danger)', border: '1px solid color-mix(in srgb, var(--danger) 35%, transparent)' }} aria-label={`Revoke ${token.name}`}>
-                    <Trash2 size={13} /> Revoke
-                  </button>
+                )}
+              </div>
+
+              <div className="rounded-md p-3" style={{ background: 'var(--surface-container)', border: '1px solid var(--border-default)' }}>
+                <div className="text-[13px] font-semibold" style={{ color: 'var(--text-primary)' }}>OAuth app grants</div>
+                {grants.length === 0 ? (
+                  <p className="text-[12px] mt-2" style={{ color: 'var(--text-secondary)' }}>No ChatGPT or Claude-style OAuth connections yet.</p>
+                ) : (
+                  <div className="space-y-2 mt-3">
+                    {grants.map((grant) => (
+                      <div key={grant.id} className="rounded-md p-3" style={{ background: 'var(--surface-container-low)', border: '1px solid var(--border-default)' }}>
+                        <div className="flex items-start justify-between gap-3">
+                          <div className="min-w-0">
+                            <div className="text-[13px] font-medium truncate" style={{ color: 'var(--text-primary)' }}>{grant.app_name}</div>
+                            <div className="text-[11px] mt-0.5" style={{ color: 'var(--text-tertiary)' }}>
+                              {grant.connector_profile} / last used {formatDate(grant.last_used_at)}
+                            </div>
+                          </div>
+                          <button type="button" disabled={busy} onClick={() => revokeGrant(grant.id)} className="inline-flex items-center gap-1.5 rounded-md px-2 py-1.5 text-[12px] disabled:opacity-50 shrink-0" style={{ color: 'var(--danger)', border: '1px solid color-mix(in srgb, var(--danger) 35%, transparent)' }} aria-label={`Revoke ${grant.app_name}`}>
+                            <Trash2 size={13} /> Revoke
+                          </button>
+                        </div>
+                        <div className="flex flex-wrap gap-1 mt-2">
+                          {isStale(grant.last_used_at) && (
+                            <span className="text-[10px] rounded px-1.5 py-0.5" style={{ color: 'var(--warning, #f59e0b)', border: '1px solid color-mix(in srgb, var(--warning, #f59e0b) 45%, transparent)' }}>
+                              {grant.last_used_at ? 'stale' : 'unused'}
+                            </span>
+                          )}
+                          {grant.scopes.map((scope) => (
+                            <span key={scope} className="text-[10px] rounded px-1.5 py-0.5" style={{ color: 'var(--text-secondary)', border: '1px solid var(--border-default)' }}>{scope}</span>
+                          ))}
+                        </div>
+                        <RecentActionList actions={grant.recent_actions} />
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+        </section>
+
+        <section className="rounded-lg p-4" style={{ background: 'var(--surface-container-low)', border: '1px solid var(--border-default)' }}>
+          <button
+            type="button"
+            onClick={() => setAdvancedOpen((value) => !value)}
+            className="w-full flex items-center justify-between gap-3 text-left"
+          >
+            <div className="flex items-center gap-3 min-w-0">
+              <div className="w-8 h-8 rounded-md flex items-center justify-center shrink-0" style={{ background: 'var(--accent-muted)', color: 'var(--accent)' }}>
+                <Settings2 size={16} />
+              </div>
+              <div className="min-w-0">
+                <h2 className="text-[14px] font-semibold" style={{ color: 'var(--text-primary)' }}>Advanced MCP and OAuth details</h2>
+                <p className="text-[12px] mt-0.5" style={{ color: 'var(--text-secondary)' }}>
+                  Raw endpoint, bearer header shape, and remote connector metadata for custom clients.
+                </p>
+              </div>
+            </div>
+            {advancedOpen ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
+          </button>
+
+          {advancedOpen && (
+            <div className="grid md:grid-cols-2 gap-3 mt-4">
+              {remoteRows.map(([label, value]) => (
+                <div key={label} className="rounded-md p-3 min-w-0" style={{ background: 'var(--surface-container)', border: '1px solid var(--border-default)' }}>
+                  <div className="text-[11px] font-medium uppercase tracking-wide" style={{ color: 'var(--text-tertiary)' }}>{label}</div>
+                  <div className="mt-1 flex items-center gap-2 min-w-0">
+                    <code className="text-[11px] truncate flex-1" style={{ color: 'var(--text-primary)' }}>{value ?? 'Not loaded'}</code>
+                    {value && (
+                      <button type="button" onClick={() => copy(label.toLowerCase(), value)} className="p-1 rounded-md" style={{ color: 'var(--text-secondary)' }} aria-label={`Copy ${label}`}>
+                        <Copy size={13} />
+                      </button>
+                    )}
+                  </div>
                 </div>
               ))}
+              <div className="rounded-md p-3 min-w-0 md:col-span-2" style={{ background: 'var(--surface-container)', border: '1px solid var(--border-default)' }}>
+                <div className="text-[11px] font-medium uppercase tracking-wide" style={{ color: 'var(--text-tertiary)' }}>Supported remote scopes</div>
+                <div className="flex flex-wrap gap-1.5 mt-2">
+                  {(remote?.scopes ?? ALL_SCOPES).map((scope) => <ScopePill key={scope} scope={scope} />)}
+                </div>
+              </div>
             </div>
           )}
         </section>


### PR DESCRIPTION
## Summary
- Reworked Settings -> MCP Access into a guided AI app connection flow.
- Adds app-first selection for Codex, Claude Code, Claude Desktop, ChatGPT/Claude Web, custom MCP clients, and shared agent employee runtimes.
- Shows token setup by default for local/desktop clients, OAuth metadata only for remote connector clients, and Agent Employees as the separate shared-runtime path.
- Keeps active tokens, OAuth grants, recent activity, advanced raw details, and connection history available without making them the first thing users must parse.

## Verification
- `pnpm --filter @deft/web typecheck`
- `git diff --check -- apps/web/src/app/(app)/settings/mcp-access/page.tsx`
- Local browser smoke on `http://localhost:3000/settings/mcp-access` as Diego:
  - default Codex guided token setup renders
  - ChatGPT / Claude Web path switches to remote connector metadata and hides token generation
  - OAuth endpoint details are behind “Show all OAuth endpoints”
  - Custom MCP client path shows raw endpoint/bearer header plus token setup
  - Agent employee runtime path points users to Agent Employees and avoids personal token generation