### PR TITLE
Allow remote OAuth wiki writes

### DIFF
--- a/apps/api/src/lib/oauth-mcp.ts
+++ b/apps/api/src/lib/oauth-mcp.ts
@@ -23,6 +23,7 @@ export const REMOTE_MCP_READ_SCOPES = [
 export const REMOTE_MCP_WRITE_SCOPES = [
   'write:tasks',
   'write:messages',
+  'write:wiki',
 ] as const;
 
 export const REMOTE_MCP_SCOPES = [

--- a/apps/api/test/oauth-mcp.test.ts
+++ b/apps/api/test/oauth-mcp.test.ts
@@ -331,16 +331,28 @@ test('OAuth metadata and dynamic client registration describe the remote MCP con
   const protectedBody = (await protectedResource.json()) as any;
   assert.equal(protectedBody.resource, 'http://localhost:3301/api/mcp/v1');
   assert.ok(protectedBody.authorization_servers.includes('http://localhost:3301'));
+  assert.ok(protectedBody.scopes_supported.includes('write:wiki'));
 
   const authServer = await testApp.request('/.well-known/oauth-authorization-server');
   assert.equal(authServer.status, 200);
   const authBody = (await authServer.json()) as any;
   assert.equal(authBody.registration_endpoint, 'http://localhost:3301/oauth/register');
   assert.equal(authBody.authorization_endpoint, 'http://localhost:3012/oauth/authorize');
+  assert.ok(authBody.scopes_supported.includes('write:wiki'));
 
   const client = await registerClient();
   assert.ok(client.client_id.startsWith('deft_dcr_'));
   assert.equal(client.scope, 'read:workspace read:wiki write:tasks');
+
+  const wikiClientRes = await jsonPost('/oauth/register', {
+    client_name: `OAuth MCP Wiki Writer ${TEST_ID}`,
+    redirect_uris: ['http://localhost:3999/callback'],
+    scope: 'read:workspace read:wiki write:wiki',
+  });
+  assert.equal(wikiClientRes.status, 201);
+  const wikiClient = (await wikiClientRes.json()) as { client_id: string; scope: string };
+  assert.ok(wikiClient.client_id.startsWith('deft_dcr_'));
+  assert.equal(wikiClient.scope, 'read:workspace read:wiki write:wiki');
 });
 
 test('OAuth PKCE token exchange resolves to a scoped human MCP principal', async () => {

--- a/apps/web/src/app/oauth/authorize/page.tsx
+++ b/apps/web/src/app/oauth/authorize/page.tsx
@@ -106,7 +106,8 @@ function OAuthAuthorizeContent() {
 
   const canWriteTasks = preview?.scopes.includes('write:tasks') ?? false;
   const canWriteMessages = preview?.scopes.includes('write:messages') ?? false;
-  const hasWriteAccess = canWriteTasks || canWriteMessages;
+  const canWriteWiki = preview?.scopes.includes('write:wiki') ?? false;
+  const hasWriteAccess = canWriteTasks || canWriteMessages || canWriteWiki;
   const accessLabel = hasWriteAccess ? 'Workspace helper access' : 'Knowledge access';
 
   return (
@@ -175,7 +176,11 @@ function OAuthAuthorizeContent() {
                     ) : (
                       <li className="flex gap-2"><X size={16} style={{ color: 'var(--danger)' }} /> Post chat messages</li>
                     )}
-                    <li className="flex gap-2"><X size={16} style={{ color: 'var(--danger)' }} /> Edit wiki pages</li>
+                    {canWriteWiki ? (
+                      <li className="flex gap-2"><Check size={16} style={{ color: 'var(--accent)' }} /> Create and update wiki knowledge pages</li>
+                    ) : (
+                      <li className="flex gap-2"><X size={16} style={{ color: 'var(--danger)' }} /> Edit wiki pages</li>
+                    )}
                   </>
                 ) : (
                   <>


### PR DESCRIPTION
## Summary
- Allow remote OAuth MCP connectors, including Claude, to request `write:wiki`.
- Update the OAuth consent screen so wiki writes show as allowed when that scope is present.
- Add OAuth MCP contract coverage for metadata and dynamic client registration with `write:wiki`.

## Root cause
Personal MCP tokens already supported wiki writes, and the MCP server already enforced `write:wiki` for `wiki_upsert` / `memory_write`. The remote OAuth connector scope allowlist omitted `write:wiki`, so Claude could not request or display that permission.

## Validation
- `pnpm --filter @deft/api exec tsx --test --test-concurrency=1 --test-force-exit test/oauth-mcp.test.ts`
- `pnpm --filter @deft/api typecheck`
- `pnpm --filter @deft/web typecheck`
