### PR TITLE
[codex] Harden org membership and API safety gates

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
     "dev": "tsx watch src/server.ts",
     "build": "tsx src/server.ts",
     "typecheck": "tsc --noEmit",
-    "test": "tsx --test --test-concurrency=1 --test-force-exit test/*.test.ts",
+    "test": "tsx src/scripts/seed-test-fixtures.ts && tsx --test --test-concurrency=1 --test-force-exit test/*.test.ts",
     "start": "node dist/server.js"
   },
   "dependencies": {

--- a/apps/api/src/lib/agent-approval-resolver.ts
+++ b/apps/api/src/lib/agent-approval-resolver.ts
@@ -102,7 +102,11 @@ async function assertUserInOrg(
     .select({ id: orgMembers.id })
     .from(orgMembers)
     .where(
-      and(eq(orgMembers.user_id, userId), eq(orgMembers.org_id, orgId)),
+      and(
+        eq(orgMembers.user_id, userId),
+        eq(orgMembers.org_id, orgId),
+        eq(orgMembers.is_active, true),
+      ),
     )
     .limit(1);
   return !!row;

--- a/apps/api/src/lib/org-membership.ts
+++ b/apps/api/src/lib/org-membership.ts
@@ -1,0 +1,65 @@
+import { and, eq } from 'drizzle-orm';
+import { orgMembers } from '@deft/db/schema';
+import { db } from './db.js';
+
+export type OrgRole = 'owner' | 'admin' | 'member' | 'guest';
+
+export type ActiveOrgMembership = {
+  id: string;
+  role: OrgRole;
+};
+
+export async function getActiveOrgMembership(
+  orgId: string,
+  userId: string,
+): Promise<ActiveOrgMembership | null> {
+  const [membership] = await db
+    .select({
+      id: orgMembers.id,
+      role: orgMembers.role,
+    })
+    .from(orgMembers)
+    .where(
+      and(
+        eq(orgMembers.org_id, orgId),
+        eq(orgMembers.user_id, userId),
+        eq(orgMembers.is_active, true),
+      ),
+    )
+    .limit(1);
+
+  return membership ? { id: membership.id, role: membership.role as OrgRole } : null;
+}
+
+export async function requireActiveOrgMembership(
+  orgId: string,
+  userId: string,
+): Promise<ActiveOrgMembership> {
+  const membership = await getActiveOrgMembership(orgId, userId);
+  if (!membership) {
+    throw new OrgMembershipError('User is not an active member of this organization');
+  }
+  return membership;
+}
+
+export async function requireOrgAdminOrOwner(
+  orgId: string,
+  userId: string,
+): Promise<ActiveOrgMembership> {
+  const membership = await requireActiveOrgMembership(orgId, userId);
+  if (membership.role !== 'owner' && membership.role !== 'admin') {
+    throw new OrgMembershipError('Owner or admin role required', 'FORBIDDEN', 403);
+  }
+  return membership;
+}
+
+export class OrgMembershipError extends Error {
+  constructor(
+    message: string,
+    public readonly code = 'ORG_MEMBERSHIP_INACTIVE',
+    public readonly status = 403,
+  ) {
+    super(message);
+    this.name = 'OrgMembershipError';
+  }
+}

--- a/apps/api/src/lib/resolve-assignee.ts
+++ b/apps/api/src/lib/resolve-assignee.ts
@@ -49,8 +49,9 @@ export async function resolveAssignee(
       or(
         // Human member of this org
         sql`EXISTS (SELECT 1 FROM ${orgMembers} WHERE ${orgMembers.user_id} = ${users.id} AND ${orgMembers.org_id} = ${orgId} AND ${orgMembers.is_active} = true)`,
-        // Agent employee of this org
-        sql`EXISTS (SELECT 1 FROM ${agentEmployees} WHERE ${agentEmployees.user_id} = ${users.id} AND ${agentEmployees.org_id} = ${orgId} AND ${agentEmployees.is_active} = true)`,
+        // Agent employee of this org. Paused, deleted, or unhealthy
+        // employees are not assignable until an admin clears the state.
+        sql`EXISTS (SELECT 1 FROM ${agentEmployees} WHERE ${agentEmployees.user_id} = ${users.id} AND ${agentEmployees.org_id} = ${orgId} AND ${agentEmployees.is_active} = true AND ${agentEmployees.is_deleted} = false AND ${agentEmployees.unhealthy} = false)`,
       ),
     );
 
@@ -117,7 +118,7 @@ export async function resolveAssigneeWithMatches(
     .where(
       or(
         sql`EXISTS (SELECT 1 FROM ${orgMembers} WHERE ${orgMembers.user_id} = ${users.id} AND ${orgMembers.org_id} = ${orgId} AND ${orgMembers.is_active} = true)`,
-        sql`EXISTS (SELECT 1 FROM ${agentEmployees} WHERE ${agentEmployees.user_id} = ${users.id} AND ${agentEmployees.org_id} = ${orgId} AND ${agentEmployees.is_active} = true)`,
+        sql`EXISTS (SELECT 1 FROM ${agentEmployees} WHERE ${agentEmployees.user_id} = ${users.id} AND ${agentEmployees.org_id} = ${orgId} AND ${agentEmployees.is_active} = true AND ${agentEmployees.is_deleted} = false AND ${agentEmployees.unhealthy} = false)`,
       ),
     );
 
@@ -144,6 +145,14 @@ export async function resolveAssigneeWithMatches(
   }
 
   return { ok: false, ambiguous: false, matches: [] };
+}
+
+export async function resolveAssignableAssigneeId(
+  userId: string,
+  orgId: string,
+): Promise<ResolvedAssignee | null> {
+  const resolved = await resolveAssignee(userId, orgId);
+  return resolved?.id === userId ? resolved : null;
 }
 
 function toResolved(row: { id: string; name: string; is_agent: boolean }): ResolvedAssignee {

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -1,11 +1,13 @@
 import { createMiddleware } from 'hono/factory';
 import jwt from 'jsonwebtoken';
 import { env } from '../lib/env.js';
+import { OrgMembershipError, requireActiveOrgMembership, type OrgRole } from '../lib/org-membership.js';
 
 export type AuthUser = {
   id: string;
   email: string;
   org_id: string;
+  role?: OrgRole;
 };
 
 declare module 'hono' {
@@ -29,9 +31,13 @@ export const authMiddleware = createMiddleware(async (c, next) => {
   const token = authHeader.slice(7);
   try {
     const payload = jwt.verify(token, env.JWT_SECRET) as AuthUser;
-    c.set('user', payload);
+    const membership = await requireActiveOrgMembership(payload.org_id, payload.id);
+    c.set('user', { ...payload, role: membership.role });
     return next();
-  } catch {
+  } catch (err) {
+    if (err instanceof OrgMembershipError) {
+      return c.json({ error: err.message, code: err.code }, err.status as 403);
+    }
     return c.json({ error: 'Invalid or expired token', code: 'INVALID_TOKEN' }, 401);
   }
 });

--- a/apps/api/src/routes/api-keys.ts
+++ b/apps/api/src/routes/api-keys.ts
@@ -4,6 +4,7 @@ import { eq, and } from 'drizzle-orm';
 import bcrypt from 'bcryptjs';
 import { db } from '../lib/db.js';
 import { apiKeys } from '@deft/db/schema';
+import { OrgMembershipError, requireOrgAdminOrOwner } from '../lib/org-membership.js';
 
 export const apiKeyRoutes = new Hono();
 
@@ -23,6 +24,19 @@ const updateKeySchema = z.object({
   rate_limit_per_day: z.number().int().positive().optional(),
   is_active: z.boolean().optional(),
   expires_at: z.string().nullable().optional(),
+});
+
+apiKeyRoutes.use('*', async (c, next) => {
+  const user = c.get('user');
+  try {
+    await requireOrgAdminOrOwner(user.org_id, user.id);
+  } catch (err) {
+    if (err instanceof OrgMembershipError) {
+      return c.json({ error: err.message, code: err.code }, err.status as 403);
+    }
+    return c.json({ error: 'Forbidden', code: 'FORBIDDEN' }, 403);
+  }
+  return next();
 });
 
 // GET / — List org's API keys (excluding key_hash)

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -9,6 +9,7 @@ import { users, orgs, orgMembers, spaces, spaceMembers, onboardingState, revoked
 import { env } from '../lib/env.js';
 import { countOrgs, SINGLE_ORG_ERROR } from '../lib/single-org-guard.js';
 import { ensureDeftyMembership, ensureDeftyDm } from '../lib/ensure-defty-membership.js';
+import { OrgMembershipError, requireActiveOrgMembership } from '../lib/org-membership.js';
 
 export const authRoutes = new Hono();
 
@@ -170,9 +171,13 @@ authRoutes.post('/login', async (c) => {
   }
 
   // Get user's org
-  const [membership] = await db.select().from(orgMembers).where(eq(orgMembers.user_id, user.id)).limit(1);
+  const [membership] = await db
+    .select()
+    .from(orgMembers)
+    .where(and(eq(orgMembers.user_id, user.id), eq(orgMembers.is_active, true)))
+    .limit(1);
   if (!membership) {
-    return c.json({ error: 'No organization found', code: 'NO_ORG' }, 404);
+    return c.json({ error: 'No active organization membership found', code: 'ORG_MEMBERSHIP_INACTIVE' }, 403);
   }
 
   const tokens = generateTokens({ id: user.id, email: user.email!, org_id: membership.org_id });
@@ -202,9 +207,13 @@ authRoutes.post('/refresh', async (c) => {
 
   try {
     const payload = jwt.verify(refreshToken, env.JWT_REFRESH_SECRET) as { id: string; email: string; org_id: string };
+    await requireActiveOrgMembership(payload.org_id, payload.id);
     const tokens = generateTokens({ id: payload.id, email: payload.email, org_id: payload.org_id });
     return c.json(tokens);
-  } catch {
+  } catch (err) {
+    if (err instanceof OrgMembershipError) {
+      return c.json({ error: err.message, code: err.code }, err.status as 403);
+    }
     return c.json({ error: 'Invalid refresh token', code: 'INVALID_TOKEN' }, 401);
   }
 });
@@ -255,21 +264,19 @@ authRoutes.get('/me', async (c) => {
       return c.json({ error: 'User not found', code: 'NOT_FOUND' }, 404);
     }
 
+    const membership = await requireActiveOrgMembership(payload.org_id, payload.id);
+
     const [org] = await db.select({
       id: orgs.id,
       name: orgs.name,
       slug: orgs.slug,
     }).from(orgs).where(eq(orgs.id, payload.org_id)).limit(1);
 
-    // Get user's role in the org
-    const [membership] = await db.select({
-      role: orgMembers.role,
-    }).from(orgMembers).where(
-      and(eq(orgMembers.user_id, payload.id), eq(orgMembers.org_id, payload.org_id)),
-    ).limit(1);
-
-    return c.json({ user: { ...user, role: membership?.role ?? 'member' }, org });
-  } catch {
+    return c.json({ user: { ...user, role: membership.role }, org });
+  } catch (err) {
+    if (err instanceof OrgMembershipError) {
+      return c.json({ error: err.message, code: err.code }, err.status as 403);
+    }
     return c.json({ error: 'Invalid token', code: 'INVALID_TOKEN' }, 401);
   }
 });
@@ -331,14 +338,18 @@ authRoutes.get('/onboarding', async (c) => {
   }
   const token = authHeader.slice(7);
   try {
-    const payload = jwt.verify(token, env.JWT_SECRET) as { id: string };
+    const payload = jwt.verify(token, env.JWT_SECRET) as { id: string; org_id: string };
+    await requireActiveOrgMembership(payload.org_id, payload.id);
     let [state] = await db.select().from(onboardingState).where(eq(onboardingState.user_id, payload.id)).limit(1);
     if (!state) {
       const [created] = await db.insert(onboardingState).values({ user_id: payload.id }).returning();
       state = created!;
     }
     return c.json(state);
-  } catch {
+  } catch (err) {
+    if (err instanceof OrgMembershipError) {
+      return c.json({ error: err.message, code: err.code }, err.status as 403);
+    }
     return c.json({ error: 'Invalid token', code: 'INVALID_TOKEN' }, 401);
   }
 });
@@ -361,7 +372,8 @@ authRoutes.patch('/onboarding', async (c) => {
   }
   const token = authHeader.slice(7);
   try {
-    const payload = jwt.verify(token, env.JWT_SECRET) as { id: string };
+    const payload = jwt.verify(token, env.JWT_SECRET) as { id: string; org_id: string };
+    await requireActiveOrgMembership(payload.org_id, payload.id);
     const body = await c.req.json().catch(() => ({}));
     const parsed = onboardingUpdateSchema.safeParse(body);
     if (!parsed.success) {
@@ -378,7 +390,10 @@ authRoutes.patch('/onboarding', async (c) => {
 
     const [refreshed] = await db.select().from(onboardingState).where(eq(onboardingState.user_id, payload.id)).limit(1);
     return c.json(refreshed);
-  } catch {
+  } catch (err) {
+    if (err instanceof OrgMembershipError) {
+      return c.json({ error: err.message, code: err.code }, err.status as 403);
+    }
     return c.json({ error: 'Invalid token', code: 'INVALID_TOKEN' }, 401);
   }
 });
@@ -392,6 +407,7 @@ authRoutes.patch('/me', async (c) => {
   const token = authHeader.slice(7);
   try {
     const payload = jwt.verify(token, env.JWT_SECRET) as { id: string; email: string; org_id: string };
+    await requireActiveOrgMembership(payload.org_id, payload.id);
     const body = await c.req.json();
     const parsed = profileUpdateSchema.safeParse(body);
     if (!parsed.success) {
@@ -410,7 +426,10 @@ authRoutes.patch('/me', async (c) => {
     await db.update(users).set(updates).where(eq(users.id, payload.id));
 
     return c.json({ success: true });
-  } catch {
+  } catch (err) {
+    if (err instanceof OrgMembershipError) {
+      return c.json({ error: err.message, code: err.code }, err.status as 403);
+    }
     return c.json({ error: 'Invalid token', code: 'INVALID_TOKEN' }, 401);
   }
 });

--- a/apps/api/src/routes/groups.ts
+++ b/apps/api/src/routes/groups.ts
@@ -1,11 +1,55 @@
 import { Hono } from 'hono';
-import { eq, and, sql, count } from 'drizzle-orm';
+import type { Context } from 'hono';
+import { eq, and, count, inArray } from 'drizzle-orm';
 import { db } from '../lib/db.js';
-import { userGroups, userGroupMembers } from '@deft/db/schema';
+import { orgMembers, userGroups, userGroupMembers } from '@deft/db/schema';
+import { OrgMembershipError, requireOrgAdminOrOwner } from '../lib/org-membership.js';
+import type { AuthUser } from '../middleware/auth.js';
 
 export const groupRoutes = new Hono();
 
 const HANDLE_REGEX = /^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$/;
+
+function forbidden(c: Context, err: unknown) {
+  if (err instanceof OrgMembershipError) {
+    return c.json({ error: err.message, code: err.code }, err.status as 403);
+  }
+  return c.json({ error: 'Forbidden', code: 'FORBIDDEN' }, 403);
+}
+
+async function requireGroupManager(user: AuthUser) {
+  return requireOrgAdminOrOwner(user.org_id, user.id);
+}
+
+async function getGroupForOrg(orgId: string, groupId: string) {
+  const [group] = await db
+    .select({ id: userGroups.id })
+    .from(userGroups)
+    .where(and(eq(userGroups.id, groupId), eq(userGroups.org_id, orgId)))
+    .limit(1);
+  return group ?? null;
+}
+
+async function validateActiveOrgUserIds(orgId: string, userIds: unknown): Promise<string[] | null> {
+  if (!Array.isArray(userIds)) return null;
+  const unique = Array.from(new Set(userIds));
+  if (unique.some((id) => typeof id !== 'string' || id.trim().length === 0)) return null;
+  if (unique.length === 0) return [];
+
+  const activeRows = await db
+    .select({ user_id: orgMembers.user_id })
+    .from(orgMembers)
+    .where(
+      and(
+        eq(orgMembers.org_id, orgId),
+        eq(orgMembers.is_active, true),
+        inArray(orgMembers.user_id, unique as string[]),
+      ),
+    );
+  const active = new Set(activeRows.map((row) => row.user_id));
+  const missing = (unique as string[]).filter((id) => !active.has(id));
+  return missing.length === 0 ? (unique as string[]) : null;
+}
 
 // GET /api/groups — list all groups for org (with member count)
 groupRoutes.get('/', async (c) => {
@@ -33,16 +77,27 @@ groupRoutes.get('/', async (c) => {
 // POST /api/groups — create group
 groupRoutes.post('/', async (c) => {
   const user = c.get('user');
+  try {
+    await requireGroupManager(user);
+  } catch (err) {
+    return forbidden(c, err);
+  }
+
   const body = await c.req.json();
   const { name, handle, description, member_ids } = body;
 
-  if (!name || !handle) {
+  if (typeof name !== 'string' || name.trim().length === 0 || typeof handle !== 'string' || handle.trim().length === 0) {
     return c.json({ error: 'name and handle are required', code: 'VALIDATION_ERROR' }, 400);
   }
 
-  const normalizedHandle = handle.toLowerCase();
+  const normalizedHandle = handle.trim().toLowerCase();
   if (!HANDLE_REGEX.test(normalizedHandle)) {
     return c.json({ error: 'Handle must be lowercase alphanumeric with hyphens only', code: 'VALIDATION_ERROR' }, 400);
+  }
+
+  const memberIds = member_ids === undefined ? [] : await validateActiveOrgUserIds(user.org_id, member_ids);
+  if (!memberIds) {
+    return c.json({ error: 'Group members must be active users in this organization', code: 'INVALID_MEMBERS' }, 400);
   }
 
   // Check uniqueness within org
@@ -57,16 +112,16 @@ groupRoutes.post('/', async (c) => {
 
   const [group] = await db.insert(userGroups).values({
     org_id: user.org_id,
-    name,
+    name: name.trim(),
     handle: normalizedHandle,
-    description: description || null,
+    description: typeof description === 'string' && description.trim().length > 0 ? description.trim() : null,
     created_by: user.id,
   }).returning();
 
   // Add initial members if provided
-  if (member_ids && Array.isArray(member_ids) && member_ids.length > 0) {
+  if (memberIds.length > 0) {
     await db.insert(userGroupMembers).values(
-      member_ids.map((userId: string) => ({
+      memberIds.map((userId: string) => ({
         group_id: group!.id,
         user_id: userId,
       }))
@@ -79,16 +134,35 @@ groupRoutes.post('/', async (c) => {
 // PATCH /api/groups/:id — update group
 groupRoutes.patch('/:id', async (c) => {
   const user = c.get('user');
+  try {
+    await requireGroupManager(user);
+  } catch (err) {
+    return forbidden(c, err);
+  }
+
   const id = c.req.param('id');
   const body = await c.req.json();
   const { name, handle, description } = body;
 
   const updates: Record<string, unknown> = { updated_at: new Date() };
-  if (name !== undefined) updates.name = name;
-  if (description !== undefined) updates.description = description;
+  if (name !== undefined) {
+    if (typeof name !== 'string' || name.trim().length === 0) {
+      return c.json({ error: 'name must be a non-empty string', code: 'VALIDATION_ERROR' }, 400);
+    }
+    updates.name = name.trim();
+  }
+  if (description !== undefined) {
+    if (description !== null && typeof description !== 'string') {
+      return c.json({ error: 'description must be a string or null', code: 'VALIDATION_ERROR' }, 400);
+    }
+    updates.description = typeof description === 'string' && description.trim().length > 0 ? description.trim() : null;
+  }
 
   if (handle !== undefined) {
-    const normalizedHandle = handle.toLowerCase();
+    if (typeof handle !== 'string' || handle.trim().length === 0) {
+      return c.json({ error: 'handle must be a non-empty string', code: 'VALIDATION_ERROR' }, 400);
+    }
+    const normalizedHandle = handle.trim().toLowerCase();
     if (!HANDLE_REGEX.test(normalizedHandle)) {
       return c.json({ error: 'Handle must be lowercase alphanumeric with hyphens only', code: 'VALIDATION_ERROR' }, 400);
     }
@@ -124,11 +198,20 @@ groupRoutes.patch('/:id', async (c) => {
 // DELETE /api/groups/:id — delete group + members
 groupRoutes.delete('/:id', async (c) => {
   const user = c.get('user');
+  try {
+    await requireGroupManager(user);
+  } catch (err) {
+    return forbidden(c, err);
+  }
+
   const id = c.req.param('id');
 
-  // Delete members first
-  await db.delete(userGroupMembers).where(eq(userGroupMembers.group_id, id));
+  const group = await getGroupForOrg(user.org_id, id);
+  if (!group) {
+    return c.json({ error: 'Group not found', code: 'NOT_FOUND' }, 404);
+  }
 
+  await db.delete(userGroupMembers).where(eq(userGroupMembers.group_id, id));
   const [deleted] = await db.delete(userGroups)
     .where(and(eq(userGroups.id, id), eq(userGroups.org_id, user.org_id)))
     .returning();
@@ -142,6 +225,13 @@ groupRoutes.delete('/:id', async (c) => {
 
 // POST /api/groups/:id/members — add members
 groupRoutes.post('/:id/members', async (c) => {
+  const user = c.get('user');
+  try {
+    await requireGroupManager(user);
+  } catch (err) {
+    return forbidden(c, err);
+  }
+
   const id = c.req.param('id');
   const body = await c.req.json();
   const { user_ids } = body;
@@ -150,8 +240,18 @@ groupRoutes.post('/:id/members', async (c) => {
     return c.json({ error: 'user_ids array required', code: 'VALIDATION_ERROR' }, 400);
   }
 
+  const group = await getGroupForOrg(user.org_id, id);
+  if (!group) {
+    return c.json({ error: 'Group not found', code: 'NOT_FOUND' }, 404);
+  }
+
+  const userIds = await validateActiveOrgUserIds(user.org_id, user_ids);
+  if (!userIds) {
+    return c.json({ error: 'Group members must be active users in this organization', code: 'INVALID_MEMBERS' }, 400);
+  }
+
   const members = await db.insert(userGroupMembers)
-    .values(user_ids.map((userId: string) => ({
+    .values(userIds.map((userId: string) => ({
       group_id: id,
       user_id: userId,
     })))
@@ -163,8 +263,20 @@ groupRoutes.post('/:id/members', async (c) => {
 
 // DELETE /api/groups/:id/members/:userId — remove member
 groupRoutes.delete('/:id/members/:userId', async (c) => {
+  const user = c.get('user');
+  try {
+    await requireGroupManager(user);
+  } catch (err) {
+    return forbidden(c, err);
+  }
+
   const groupId = c.req.param('id');
   const userId = c.req.param('userId');
+
+  const group = await getGroupForOrg(user.org_id, groupId);
+  if (!group) {
+    return c.json({ error: 'Group not found', code: 'NOT_FOUND' }, 404);
+  }
 
   await db.delete(userGroupMembers)
     .where(and(

--- a/apps/api/src/routes/invites.ts
+++ b/apps/api/src/routes/invites.ts
@@ -4,7 +4,7 @@ import bcrypt from 'bcryptjs';
 import jwt from 'jsonwebtoken';
 import { eq, and } from 'drizzle-orm';
 import { db } from '../lib/db.js';
-import { users, orgs, orgMembers } from '@deft/db/schema';
+import { users, orgs, orgMembers, invites } from '@deft/db/schema';
 import { env } from '../lib/env.js';
 import { ensureDeftyMembership, ensureDeftyDm } from '../lib/ensure-defty-membership.js';
 
@@ -51,6 +51,23 @@ inviteRoutes.get('/preview/:token', async (c) => {
     return c.json({ error: 'invalid', code: 'INVITE_INVALID' }, 400);
   }
 
+  const [invite] = await db
+    .select({
+      id: invites.id,
+      accepted_at: invites.accepted_at,
+      expires_at: invites.expires_at,
+    })
+    .from(invites)
+    .where(and(eq(invites.token, token), eq(invites.org_id, payload.org_id)))
+    .limit(1);
+
+  if (!invite) {
+    return c.json({ error: 'invalid', code: 'INVITE_INVALID' }, 400);
+  }
+  if (invite.expires_at && invite.expires_at < new Date()) {
+    return c.json({ error: 'expired', code: 'INVITE_EXPIRED' }, 400);
+  }
+
   const [user] = await db
     .select({ id: users.id, email: users.email, name: users.name, password_hash: users.password_hash })
     .from(users)
@@ -79,8 +96,8 @@ inviteRoutes.get('/preview/:token', async (c) => {
     inviter_name: inviter?.name ?? 'an admin',
     email: payload.email,
     role: payload.role,
-    already_accepted: Boolean(user.password_hash),
-    expires_at: payload.exp ? new Date(payload.exp * 1000).toISOString() : null,
+    already_accepted: Boolean(invite.accepted_at ?? user.password_hash),
+    expires_at: invite.expires_at?.toISOString() ?? (payload.exp ? new Date(payload.exp * 1000).toISOString() : null),
   });
 });
 
@@ -110,6 +127,26 @@ inviteRoutes.post('/accept', async (c) => {
     return c.json({ error: 'invalid', code: 'INVITE_INVALID' }, 400);
   }
 
+  const [invite] = await db
+    .select({
+      id: invites.id,
+      accepted_at: invites.accepted_at,
+      expires_at: invites.expires_at,
+    })
+    .from(invites)
+    .where(and(eq(invites.token, parsed.data.token), eq(invites.org_id, payload.org_id)))
+    .limit(1);
+
+  if (!invite) {
+    return c.json({ error: 'invalid', code: 'INVITE_INVALID' }, 400);
+  }
+  if (invite.accepted_at) {
+    return c.json({ error: 'already accepted', code: 'INVITE_ALREADY_ACCEPTED' }, 400);
+  }
+  if (invite.expires_at && invite.expires_at < new Date()) {
+    return c.json({ error: 'expired', code: 'INVITE_EXPIRED' }, 400);
+  }
+
   // Verify user + membership still exist (admin may have removed them)
   const [user] = await db
     .select()
@@ -137,6 +174,10 @@ inviteRoutes.post('/accept', async (c) => {
   if (parsed.data.name) updates.name = parsed.data.name;
 
   await db.update(users).set(updates).where(eq(users.id, payload.user_id));
+  await db
+    .update(invites)
+    .set({ accepted_by: payload.user_id, accepted_at: new Date() })
+    .where(eq(invites.id, invite.id));
 
   // Ensure Defty is in the org and materialize the 1:1 DM so the new
   // member sees it in their sidebar immediately. Both are idempotent;

--- a/apps/api/src/routes/members.ts
+++ b/apps/api/src/routes/members.ts
@@ -1,11 +1,25 @@
 import { Hono } from 'hono';
+import type { Context } from 'hono';
 import { z } from 'zod';
 import { eq, and, sql } from 'drizzle-orm';
 import jwt from 'jsonwebtoken';
 import { db } from '../lib/db.js';
-import { users, orgMembers, spaces, spaceMembers, agentEmployees } from '@deft/db/schema';
+import {
+  users,
+  orgMembers,
+  spaces,
+  spaceMembers,
+  agentEmployees,
+  mcpTokens,
+  invites,
+  apiKeys,
+  oauthGrants,
+  oauthAccessTokens,
+  oauthRefreshTokens,
+} from '@deft/db/schema';
 import { env } from '../lib/env.js';
 import { DEFTY_EMAIL } from '../lib/ensure-defty-membership.js';
+import { OrgMembershipError, requireOrgAdminOrOwner } from '../lib/org-membership.js';
 
 const INVITE_TTL = '7d';
 const RECOVERY_TTL = '24h';
@@ -19,6 +33,13 @@ function buildRecoveryUrl(token: string): string {
 }
 
 export const memberRoutes = new Hono();
+
+function adminForbidden(c: Context, err: unknown) {
+  if (err instanceof OrgMembershipError) {
+    return c.json({ error: err.message, code: err.code }, err.status as 403);
+  }
+  return c.json({ error: 'Only admins can perform this action', code: 'FORBIDDEN' }, 403);
+}
 
 function visibleLiveMemberForOrg(orgIdRef: unknown) {
   return sql`
@@ -132,14 +153,10 @@ memberRoutes.post('/invite', async (c) => {
   try {
     const currentUser = c.get('user');
 
-    // Only owner/admin can invite
-    const [membership] = await db.select({ role: orgMembers.role })
-      .from(orgMembers)
-      .where(and(eq(orgMembers.org_id, currentUser.org_id), eq(orgMembers.user_id, currentUser.id)))
-      .limit(1);
-
-    if (!membership || !['owner', 'admin'].includes(membership.role)) {
-      return c.json({ error: 'Only admins can invite members', code: 'FORBIDDEN' }, 403);
+    try {
+      await requireOrgAdminOrOwner(currentUser.org_id, currentUser.id);
+    } catch (err) {
+      return adminForbidden(c, err);
     }
 
     const body = await c.req.json();
@@ -153,6 +170,7 @@ memberRoutes.post('/invite', async (c) => {
     // Check if user already exists
     let [existingUser] = await db.select().from(users).where(eq(users.email, email)).limit(1);
 
+    let membershipExists = false;
     if (existingUser) {
       const [existingMembership] = await db.select()
         .from(orgMembers)
@@ -160,13 +178,13 @@ memberRoutes.post('/invite', async (c) => {
         .limit(1);
 
       if (existingMembership) {
-        if (!existingMembership.is_active) {
-          await db.update(orgMembers)
-            .set({ is_active: true, role })
-            .where(eq(orgMembers.id, existingMembership.id));
-          return c.json({ success: true, message: 'Member reactivated', user_id: existingUser.id });
+        membershipExists = true;
+        if (existingMembership.is_active) {
+          return c.json({ error: 'User is already a member', code: 'ALREADY_MEMBER' }, 409);
         }
-        return c.json({ error: 'User is already a member', code: 'ALREADY_MEMBER' }, 409);
+        await db.update(orgMembers)
+          .set({ is_active: true, role })
+          .where(eq(orgMembers.id, existingMembership.id));
       }
     } else {
       // Create the user with no password — they'll set one when accepting.
@@ -179,11 +197,13 @@ memberRoutes.post('/invite', async (c) => {
     }
 
     // Add to org
-    await db.insert(orgMembers).values({
-      org_id: currentUser.org_id,
-      user_id: existingUser.id,
-      role,
-    });
+    if (!membershipExists) {
+      await db.insert(orgMembers).values({
+        org_id: currentUser.org_id,
+        user_id: existingUser.id,
+        role,
+      });
+    }
 
     // Add to all default (public) spaces
     const defaultSpaces = await db.select({ id: spaces.id })
@@ -214,7 +234,17 @@ memberRoutes.post('/invite', async (c) => {
     );
 
     const decoded = jwt.decode(inviteToken) as { exp?: number } | null;
-    const expiresAt = decoded?.exp ? new Date(decoded.exp * 1000).toISOString() : null;
+    const expiresAtDate = decoded?.exp ? new Date(decoded.exp * 1000) : null;
+    const expiresAt = expiresAtDate?.toISOString() ?? null;
+
+    await db.insert(invites).values({
+      org_id: currentUser.org_id,
+      email,
+      token: inviteToken,
+      type: 'email',
+      invited_by: currentUser.id,
+      expires_at: expiresAtDate ?? undefined,
+    });
 
     return c.json(
       {
@@ -240,13 +270,10 @@ memberRoutes.post('/:id/recovery-url', async (c) => {
     const currentUser = c.get('user');
     const memberId = c.req.param('id');
 
-    const [currentMembership] = await db.select({ role: orgMembers.role })
-      .from(orgMembers)
-      .where(and(eq(orgMembers.org_id, currentUser.org_id), eq(orgMembers.user_id, currentUser.id)))
-      .limit(1);
-
-    if (!currentMembership || !['owner', 'admin'].includes(currentMembership.role)) {
-      return c.json({ error: 'Only admins can generate recovery links', code: 'FORBIDDEN' }, 403);
+    try {
+      await requireOrgAdminOrOwner(currentUser.org_id, currentUser.id);
+    } catch (err) {
+      return adminForbidden(c, err);
     }
 
     const [target] = await db
@@ -289,20 +316,16 @@ memberRoutes.patch('/:id', async (c) => {
     const currentUser = c.get('user');
     const memberId = c.req.param('id');
 
-    // Only owner/admin can change roles
-    const [currentMembership] = await db.select({ role: orgMembers.role })
-      .from(orgMembers)
-      .where(and(eq(orgMembers.org_id, currentUser.org_id), eq(orgMembers.user_id, currentUser.id)))
-      .limit(1);
-
-    if (!currentMembership || !['owner', 'admin'].includes(currentMembership.role)) {
-      return c.json({ error: 'Only admins can change roles', code: 'FORBIDDEN' }, 403);
+    try {
+      await requireOrgAdminOrOwner(currentUser.org_id, currentUser.id);
+    } catch (err) {
+      return adminForbidden(c, err);
     }
 
     // Can't change owner role
     const [targetMembership] = await db.select({ role: orgMembers.role, id: orgMembers.id })
       .from(orgMembers)
-      .where(and(eq(orgMembers.org_id, currentUser.org_id), eq(orgMembers.user_id, memberId)))
+      .where(and(eq(orgMembers.org_id, currentUser.org_id), eq(orgMembers.user_id, memberId), eq(orgMembers.is_active, true)))
       .limit(1);
 
     if (!targetMembership) {
@@ -341,20 +364,16 @@ memberRoutes.delete('/:id', async (c) => {
       return c.json({ error: 'Cannot remove yourself', code: 'FORBIDDEN' }, 403);
     }
 
-    // Only owner/admin can remove
-    const [currentMembership] = await db.select({ role: orgMembers.role })
-      .from(orgMembers)
-      .where(and(eq(orgMembers.org_id, currentUser.org_id), eq(orgMembers.user_id, currentUser.id)))
-      .limit(1);
-
-    if (!currentMembership || !['owner', 'admin'].includes(currentMembership.role)) {
-      return c.json({ error: 'Only admins can remove members', code: 'FORBIDDEN' }, 403);
+    try {
+      await requireOrgAdminOrOwner(currentUser.org_id, currentUser.id);
+    } catch (err) {
+      return adminForbidden(c, err);
     }
 
     // Can't remove owner
     const [targetMembership] = await db.select({ role: orgMembers.role })
       .from(orgMembers)
-      .where(and(eq(orgMembers.org_id, currentUser.org_id), eq(orgMembers.user_id, memberId)))
+      .where(and(eq(orgMembers.org_id, currentUser.org_id), eq(orgMembers.user_id, memberId), eq(orgMembers.is_active, true)))
       .limit(1);
 
     if (!targetMembership) {
@@ -369,6 +388,63 @@ memberRoutes.delete('/:id', async (c) => {
     await db.update(orgMembers)
       .set({ is_active: false })
       .where(and(eq(orgMembers.org_id, currentUser.org_id), eq(orgMembers.user_id, memberId)));
+
+    // Remove chat access in this org and revoke personal MCP tokens. Access
+    // tokens are short-lived; the active-membership auth guard blocks them
+    // immediately on the next request/refresh/socket auth.
+    await db.execute(sql`
+      DELETE FROM ${spaceMembers}
+      WHERE ${spaceMembers.user_id} = ${memberId}
+        AND ${spaceMembers.space_id} IN (
+          SELECT ${spaces.id}
+          FROM ${spaces}
+          WHERE ${spaces.org_id} = ${currentUser.org_id}
+        )
+    `);
+
+    const revokedAt = new Date();
+
+    await db.update(mcpTokens)
+      .set({ revoked_at: new Date() })
+      .where(and(
+        eq(mcpTokens.org_id, currentUser.org_id),
+        eq(mcpTokens.user_id, memberId),
+        sql`${mcpTokens.revoked_at} IS NULL`,
+      ));
+
+    await db.update(apiKeys)
+      .set({ is_active: false, updated_at: revokedAt })
+      .where(and(
+        eq(apiKeys.org_id, currentUser.org_id),
+        eq(apiKeys.created_by, memberId),
+        eq(apiKeys.is_active, true),
+      ));
+
+    await db.update(oauthGrants)
+      .set({ revoked_at: revokedAt, updated_at: revokedAt })
+      .where(and(
+        eq(oauthGrants.org_id, currentUser.org_id),
+        eq(oauthGrants.user_id, memberId),
+        sql`${oauthGrants.revoked_at} IS NULL`,
+      ));
+    await db.update(oauthAccessTokens)
+      .set({ revoked_at: revokedAt, updated_at: revokedAt })
+      .where(and(
+        eq(oauthAccessTokens.org_id, currentUser.org_id),
+        eq(oauthAccessTokens.user_id, memberId),
+        sql`${oauthAccessTokens.revoked_at} IS NULL`,
+      ));
+    await db.execute(sql`
+      UPDATE ${oauthRefreshTokens}
+      SET revoked_at = ${revokedAt}, updated_at = ${revokedAt}
+      WHERE revoked_at IS NULL
+        AND grant_id IN (
+          SELECT id
+          FROM ${oauthGrants}
+          WHERE org_id = ${currentUser.org_id}
+            AND user_id = ${memberId}
+        )
+    `);
 
     return c.json({ success: true });
   } catch (err) {

--- a/apps/api/src/routes/messages.ts
+++ b/apps/api/src/routes/messages.ts
@@ -431,6 +431,12 @@ messageRoutes.post('/:spaceId', async (c) => {
       if (mentionedUserId === user.id) continue;
 
       try {
+        const [mentionedUser] = await db.select({ id: users.id })
+          .from(users)
+          .where(eq(users.id, mentionedUserId))
+          .limit(1);
+        if (!mentionedUser) continue;
+
         const [notification] = await db.insert(notifications).values({
           org_id: user.org_id,
           user_id: mentionedUserId,

--- a/apps/api/src/routes/projects.ts
+++ b/apps/api/src/routes/projects.ts
@@ -10,6 +10,7 @@ import {
   getProjectResolvedConfig,
 } from '../lib/project-resolved-config.js';
 import { reserveNextTaskNumber } from '../lib/task-numbering.js';
+import { resolveAssignableAssigneeId } from '../lib/resolve-assignee.js';
 
 export const projectRoutes = new Hono();
 
@@ -454,6 +455,15 @@ const createTaskSchema = z.object({
   parent_task_id: z.string().nullable().optional(),
 });
 
+async function validateAssignableAssigneeId(assigneeId: unknown, orgId: string): Promise<string | null | undefined> {
+  if (assigneeId === undefined) return undefined;
+  if (assigneeId === null || assigneeId === '') return null;
+  if (typeof assigneeId !== 'string' || assigneeId.trim().length === 0) return null;
+  const trimmed = assigneeId.trim();
+  const resolved = await resolveAssignableAssigneeId(trimmed, orgId);
+  return resolved ? resolved.id : undefined;
+}
+
 // GET /api/projects/:id/tasks — list all tasks for a project
 async function listProjectTasks(c: any) {
   try {
@@ -594,6 +604,11 @@ projectRoutes.post('/:id/tasks', async (c) => {
       return c.json({ error: 'Project not found', code: 'NOT_FOUND' }, 404);
     }
 
+    const assigneeId = await validateAssignableAssigneeId(parsed.data.assignee_id, user.org_id);
+    if (parsed.data.assignee_id !== undefined && assigneeId === undefined) {
+      return c.json({ error: 'Assignee must be an active user or healthy agent in this organization', code: 'INVALID_ASSIGNEE' }, 400);
+    }
+
     const taskNumber = await reserveNextTaskNumber({
       projectId,
       orgId: user.org_id,
@@ -607,7 +622,7 @@ projectRoutes.post('/:id/tasks', async (c) => {
       description: parsed.data.description || undefined,
       status: (parsed.data.status || 'backlog') as any,
       priority: (parsed.data.priority || 'p2') as any,
-      assignee_id: parsed.data.assignee_id || undefined,
+      assignee_id: assigneeId ?? undefined,
       created_by: user.id,
       due_date: parsed.data.due_date ? new Date(parsed.data.due_date) : undefined,
       sort_order: parsed.data.sort_order ?? 0,

--- a/apps/api/src/routes/tasks.ts
+++ b/apps/api/src/routes/tasks.ts
@@ -14,6 +14,7 @@ import { detectBlocksCycle } from '../lib/task-dependency.js';
 import { dispatchAgentEmployeeTask } from '../lib/dispatch-agent-task.js';
 import { publishAgentChannelEvent, type AgentChannelEventKind } from '../lib/agent-channel.js';
 import { reserveNextTaskNumber } from '../lib/task-numbering.js';
+import { resolveAssignableAssigneeId } from '../lib/resolve-assignee.js';
 
 export const taskRoutes = new Hono();
 
@@ -57,6 +58,15 @@ const updateTaskSchema = z.object({
   // Task 4.11 — partial-update of skill-defined custom fields.
   metadata: z.record(z.string(), z.any()).nullable().optional(),
 });
+
+async function validateAssignableAssigneeId(assigneeId: unknown, orgId: string): Promise<string | null | undefined> {
+  if (assigneeId === undefined) return undefined;
+  if (assigneeId === null || assigneeId === '') return null;
+  if (typeof assigneeId !== 'string' || assigneeId.trim().length === 0) return null;
+  const trimmed = assigneeId.trim();
+  const resolved = await resolveAssignableAssigneeId(trimmed, orgId);
+  return resolved ? resolved.id : undefined;
+}
 
 const createDependencySchema = z.object({
   target_task_id: z.string().min(1),
@@ -524,9 +534,14 @@ taskRoutes.patch('/bulk', async (c) => {
       return c.json({ error: 'updates required', code: 'VALIDATION_ERROR' }, 400);
     }
 
+    const nextAssigneeId = await validateAssignableAssigneeId(updates.assignee_id, user.org_id);
+    if (updates.assignee_id !== undefined && nextAssigneeId === undefined) {
+      return c.json({ error: 'Assignee must be an active user or healthy agent in this organization', code: 'INVALID_ASSIGNEE' }, 400);
+    }
+
     const updateData: Record<string, any> = { updated_at: new Date() };
     if (updates.status) updateData.status = updates.status;
-    if (updates.assignee_id !== undefined) updateData.assignee_id = updates.assignee_id || null;
+    if (updates.assignee_id !== undefined) updateData.assignee_id = nextAssigneeId;
     if (updates.priority) updateData.priority = updates.priority;
 
     await db.update(tasks)
@@ -556,7 +571,7 @@ taskRoutes.patch('/bulk', async (c) => {
           user_id: user.id,
           action: 'assigned',
           field: 'assignee_id',
-          new_value: updates.assignee_id || null,
+          new_value: nextAssigneeId,
         });
       }
       if (updates.priority) {
@@ -576,18 +591,18 @@ taskRoutes.patch('/bulk', async (c) => {
     // actor), write one notification (type=task_assigned) with
     // metadata.task_ids so the client can render a grouped chip +
     // deep-link to the filtered list.
-    if (updates.assignee_id && updates.assignee_id !== user.id && task_ids.length >= 3) {
+    if (nextAssigneeId && nextAssigneeId !== user.id && task_ids.length >= 3) {
       try {
         await db.insert(notifications).values({
           org_id: user.org_id,
-          user_id: updates.assignee_id,
+          user_id: nextAssigneeId,
           type: 'task_assigned',
           title: `You were assigned ${task_ids.length} tasks`,
           body: null,
           link: `/tasks?mine=1`,
           metadata: { task_ids, grouped: true, kind: 'bulk_assign' },
         });
-        emitToUser(updates.assignee_id, 'notification:new', {
+        emitToUser(nextAssigneeId, 'notification:new', {
           type: 'task_assigned',
           title: `You were assigned ${task_ids.length} tasks`,
         });
@@ -796,13 +811,15 @@ taskRoutes.post('/:id/assignees', async (c) => {
     const { user_id } = await c.req.json();
     if (!user_id) return c.json({ error: 'user_id required', code: 'VALIDATION_ERROR' }, 400);
 
+    const assigneeId = await validateAssignableAssigneeId(user_id, user.org_id);
+    if (!assigneeId) {
+      return c.json({ error: 'Assignee must be an active user or healthy agent in this organization', code: 'INVALID_ASSIGNEE' }, 400);
+    }
+
     // Look up the task's primary assignee to enforce "no duplication" invariant.
-    const [taskRow] = await db.select({ assignee_id: tasks.assignee_id })
-      .from(tasks)
-      .where(eq(tasks.id, taskId))
-      .limit(1);
+    const taskRow = await getVisibleTaskForOrg(taskId, user.org_id, user.id);
     if (!taskRow) return c.json({ error: 'Task not found', code: 'NOT_FOUND' }, 404);
-    if (taskRow.assignee_id && taskRow.assignee_id === user_id) {
+    if (taskRow.assignee_id && taskRow.assignee_id === assigneeId) {
       return c.json({
         error: 'User is already the primary assignee for this task',
         code: 'ALREADY_PRIMARY_ASSIGNEE',
@@ -811,7 +828,7 @@ taskRoutes.post('/:id/assignees', async (c) => {
 
     await db.insert(taskAssignees).values({
       task_id: taskId,
-      user_id,
+      user_id: assigneeId,
     }).onConflictDoNothing();
     return c.json({ success: true });
   } catch (err) {
@@ -825,8 +842,12 @@ taskRoutes.post('/:id/assignees', async (c) => {
 // tasks.assignee_id and cannot be removed via this endpoint — see Phase 0.3 plan.
 taskRoutes.delete('/:id/assignees/:userId', async (c) => {
   try {
+    const user = c.get('user');
     const taskId = c.req.param('id');
     const userId = c.req.param('userId');
+    const taskRow = await getVisibleTaskForOrg(taskId, user.org_id, user.id);
+    if (!taskRow) return c.json({ error: 'Task not found', code: 'NOT_FOUND' }, 404);
+
     const deleted = await db.delete(taskAssignees)
       .where(and(eq(taskAssignees.task_id, taskId), eq(taskAssignees.user_id, userId)))
       .returning({ id: taskAssignees.id });
@@ -1542,6 +1563,11 @@ async function createTaskForProject(
     throw Object.assign(new Error('Project not found'), { code: 'NOT_FOUND' });
   }
 
+  const assigneeId = await validateAssignableAssigneeId(data.assignee_id, orgId);
+  if (data.assignee_id !== undefined && assigneeId === undefined) {
+    throw Object.assign(new Error('Invalid assignee'), { code: 'INVALID_ASSIGNEE' });
+  }
+
   const taskNumber = await reserveNextTaskNumber({ projectId, orgId });
 
   const [task] = await db.insert(tasks).values({
@@ -1552,7 +1578,7 @@ async function createTaskForProject(
     description: data.description || undefined,
     status: (data.status || 'backlog') as any,
     priority: (data.priority || 'p2') as any,
-    assignee_id: data.assignee_id || undefined,
+    assignee_id: assigneeId ?? undefined,
     created_by: userId,
     due_date: data.due_date ? new Date(data.due_date) : undefined,
     sort_order: data.sort_order ?? 0,
@@ -1657,6 +1683,9 @@ taskRoutes.post('/', async (c) => {
       if (err?.code === 'NOT_FOUND') {
         return c.json({ error: 'Project not found', code: 'NOT_FOUND' }, 404);
       }
+      if (err?.code === 'INVALID_ASSIGNEE') {
+        return c.json({ error: 'Assignee must be an active user or healthy agent in this organization', code: 'INVALID_ASSIGNEE' }, 400);
+      }
       throw err;
     }
   } catch (err) {
@@ -1760,7 +1789,10 @@ taskRoutes.patch('/:id', async (c) => {
     }
 
     if (parsed.data.assignee_id !== undefined) {
-      const newAssignee = parsed.data.assignee_id || null; // Convert empty string to null
+      const newAssignee = await validateAssignableAssigneeId(parsed.data.assignee_id, user.org_id);
+      if (newAssignee === undefined) {
+        return c.json({ error: 'Assignee must be an active user or healthy agent in this organization', code: 'INVALID_ASSIGNEE' }, 400);
+      }
       if (newAssignee !== existingTask.assignee_id) {
         updateData.assignee_id = newAssignee;
         activityEntries.push({ action: 'assigned', field: 'assignee_id', old_value: existingTask.assignee_id ?? null, new_value: newAssignee });

--- a/apps/api/src/socket.ts
+++ b/apps/api/src/socket.ts
@@ -6,6 +6,7 @@ import { db } from './lib/db.js';
 import { users, spaceMembers, spaces, notifications } from '@deft/db/schema';
 import { eq, and, ne } from 'drizzle-orm';
 import * as huddle from './huddle-rooms.js';
+import { requireActiveOrgMembership } from './lib/org-membership.js';
 
 function updateLastSeen(userId: string) {
   db.update(users).set({ last_seen_at: new Date() }).where(eq(users.id, userId)).catch(() => {});
@@ -53,14 +54,15 @@ export function setupSocket(server: HTTPServer) {
   });
 
   // Auth middleware
-  io.use((socket, next) => {
+  io.use(async (socket, next) => {
     const token = socket.handshake.auth.token;
     if (!token) {
       return next(new Error('Authentication required'));
     }
     try {
       const payload = jwt.verify(token, env.JWT_SECRET) as { id: string; email: string; org_id: string };
-      (socket as any).user = payload;
+      const membership = await requireActiveOrgMembership(payload.org_id, payload.id);
+      (socket as any).user = { ...payload, role: membership.role };
       next();
     } catch {
       next(new Error('Invalid token'));

--- a/apps/api/test/agent-tools-task-mutations.test.ts
+++ b/apps/api/test/agent-tools-task-mutations.test.ts
@@ -115,37 +115,70 @@ before(async () => {
 
 after(async () => {
   await withClient(async (c) => {
-    if (PROJECT_ID) {
+    const projectRows = await c.query<{ id: string }>(
+      `SELECT id
+       FROM projects
+       WHERE org_id = $1
+         AND (
+           id = $2
+           OR lead_id IN ($3, $4)
+           OR name LIKE 'Mutation Tools %'
+           OR prefix LIKE 'MUT%'
+         )`,
+      [ORG_ID, PROJECT_ID ?? '', CALLER_USER_ID, EMP_SHADOW_USER_ID],
+    );
+    const projectIds = projectRows.rows.map((row) => row.id);
+
+    if (projectIds.length > 0) {
       await c.query(
         `DELETE FROM task_relationships
-         WHERE source_task_id IN (SELECT id FROM tasks WHERE project_id = $1)
-            OR target_task_id IN (SELECT id FROM tasks WHERE project_id = $1)`,
-        [PROJECT_ID],
+         WHERE source_task_id IN (SELECT id FROM tasks WHERE project_id = ANY($1::text[]))
+            OR target_task_id IN (SELECT id FROM tasks WHERE project_id = ANY($1::text[]))`,
+        [projectIds],
       );
       await c.query(
         `DELETE FROM task_labels
-         WHERE task_id IN (SELECT id FROM tasks WHERE project_id = $1)`,
-        [PROJECT_ID],
+         WHERE task_id IN (SELECT id FROM tasks WHERE project_id = ANY($1::text[]))`,
+        [projectIds],
       );
       await c.query(
         `DELETE FROM labels WHERE org_id = $1 AND name LIKE 'mut-%'`,
         [ORG_ID],
       );
       await c.query(
-        `DELETE FROM task_comments WHERE task_id IN (SELECT id FROM tasks WHERE project_id = $1)`,
-        [PROJECT_ID],
+        `DELETE FROM task_comments WHERE task_id IN (SELECT id FROM tasks WHERE project_id = ANY($1::text[]))`,
+        [projectIds],
       );
       await c.query(
-        `DELETE FROM task_activity WHERE task_id IN (SELECT id FROM tasks WHERE project_id = $1)`,
-        [PROJECT_ID],
+        `DELETE FROM task_activity WHERE task_id IN (SELECT id FROM tasks WHERE project_id = ANY($1::text[]))`,
+        [projectIds],
       );
       await c.query(
-        `DELETE FROM task_assignees WHERE task_id IN (SELECT id FROM tasks WHERE project_id = $1)`,
-        [PROJECT_ID],
+        `DELETE FROM task_assignees WHERE task_id IN (SELECT id FROM tasks WHERE project_id = ANY($1::text[]))`,
+        [projectIds],
       );
-      await c.query(`DELETE FROM tasks WHERE project_id = $1`, [PROJECT_ID]);
-      await c.query(`DELETE FROM projects WHERE id = $1`, [PROJECT_ID]);
+      await c.query(
+        `DELETE FROM agent_nudges WHERE task_id IN (SELECT id FROM tasks WHERE project_id = ANY($1::text[]))`,
+        [projectIds],
+      );
+      await c.query(`DELETE FROM tasks WHERE project_id = ANY($1::text[])`, [projectIds]);
+      await c.query(`DELETE FROM projects WHERE id = ANY($1::text[])`, [projectIds]);
     }
+    await c.query(`DELETE FROM notifications WHERE org_id = $1 AND user_id IN ($2, $3)`, [ORG_ID, CALLER_USER_ID, EMP_SHADOW_USER_ID]);
+    await c.query(`DELETE FROM people_expertise WHERE org_id = $1 AND user_id IN ($2, $3)`, [ORG_ID, CALLER_USER_ID, EMP_SHADOW_USER_ID]);
+    await c.query(`DELETE FROM people_influence WHERE org_id = $1 AND user_id IN ($2, $3)`, [ORG_ID, CALLER_USER_ID, EMP_SHADOW_USER_ID]);
+    await c.query(`DELETE FROM people_patterns WHERE org_id = $1 AND user_id IN ($2, $3)`, [ORG_ID, CALLER_USER_ID, EMP_SHADOW_USER_ID]);
+    await c.query(
+      `DELETE FROM people_relationships
+       WHERE org_id = $1 AND (user_a_id IN ($2, $3) OR user_b_id IN ($2, $3))`,
+      [ORG_ID, CALLER_USER_ID, EMP_SHADOW_USER_ID],
+    );
+    await c.query(
+      `DELETE FROM people_interactions
+       WHERE org_id = $1 AND (user_a_id IN ($2, $3) OR user_b_id IN ($2, $3))`,
+      [ORG_ID, CALLER_USER_ID, EMP_SHADOW_USER_ID],
+    );
+    await c.query(`DELETE FROM agent_nudges WHERE org_id = $1 AND user_id IN ($2, $3)`, [ORG_ID, CALLER_USER_ID, EMP_SHADOW_USER_ID]);
     await c.query(`DELETE FROM agent_actions WHERE org_id = $1 AND user_id IN ($2, $3)`, [ORG_ID, CALLER_USER_ID, EMP_SHADOW_USER_ID]);
     await c.query(`DELETE FROM agent_employees WHERE id = $1`, [EMP_ID]);
     await c.query(`DELETE FROM org_members WHERE user_id = $1`, [CALLER_USER_ID]);

--- a/apps/api/test/apply-template-from-table.test.ts
+++ b/apps/api/test/apply-template-from-table.test.ts
@@ -10,7 +10,7 @@ import { app } from '../src/index.js';
 async function authHeaders() {
   const res = await app.request('/api/auth/login', {
     method: 'POST',
-    body: JSON.stringify({ email: 'maneek@test.com', password: 'test1234' }),
+    body: JSON.stringify({ email: 'diego@testers-tomatoes.com', password: 'tomato123' }),
     headers: { 'content-type': 'application/json' },
   });
   const body = (await res.json()) as { accessToken: string };

--- a/apps/api/test/identity-hardening.test.ts
+++ b/apps/api/test/identity-hardening.test.ts
@@ -1,0 +1,455 @@
+/**
+ * Loop 0 identity hardening tests.
+ *
+ * Covers:
+ * - inactive org members cannot keep using JWT access/refresh tokens
+ * - groups are admin-managed and org-scoped
+ * - group members must be active org members
+ * - org API keys are owner/admin-managed
+ * - task assignees must be active users or healthy agents in-org
+ * - member removal revokes obvious workspace access
+ */
+import { after, before, describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
+import pg from 'pg';
+import jwt from 'jsonwebtoken';
+import { Hono } from 'hono';
+import { authRoutes } from '../src/routes/auth.js';
+import { authMiddleware } from '../src/middleware/auth.js';
+import { groupRoutes } from '../src/routes/groups.js';
+import { apiKeyRoutes } from '../src/routes/api-keys.js';
+import { memberRoutes } from '../src/routes/members.js';
+import { taskRoutes } from '../src/routes/tasks.js';
+import { inviteRoutes } from '../src/routes/invites.js';
+import { env } from '../src/lib/env.js';
+
+const DATABASE_URL =
+  process.env.DATABASE_URL || 'postgres://postgres:postgres@localhost:5432/deft';
+
+async function withClient<T>(fn: (c: pg.Client) => Promise<T>): Promise<T> {
+  const c = new pg.Client({ connectionString: DATABASE_URL });
+  await c.connect();
+  try {
+    return await fn(c);
+  } finally {
+    await c.end();
+  }
+}
+
+const app = new Hono();
+app.route('/api/auth', authRoutes);
+app.route('/api/invites', inviteRoutes);
+app.use('/api/*', authMiddleware);
+app.route('/api/groups', groupRoutes);
+app.route('/api/api-keys', apiKeyRoutes);
+app.route('/api/members', memberRoutes);
+app.route('/api/tasks', taskRoutes);
+
+const RUN_ID = crypto.randomUUID();
+const ORG_ID = crypto.randomUUID();
+const OTHER_ORG_ID = crypto.randomUUID();
+const ADMIN_ID = crypto.randomUUID();
+const MEMBER_ID = crypto.randomUUID();
+const TARGET_ID = crypto.randomUUID();
+const INACTIVE_ID = crypto.randomUUID();
+const OTHER_USER_ID = crypto.randomUUID();
+const SPACE_ID = crypto.randomUUID();
+const PROJECT_ID = crypto.randomUUID();
+const OTHER_PROJECT_ID = crypto.randomUUID();
+const TASK_ID = crypto.randomUUID();
+const OTHER_TASK_ID = crypto.randomUUID();
+const OTHER_GROUP_ID = crypto.randomUUID();
+const OTHER_GROUP_MEMBER_ID = crypto.randomUUID();
+const OTHER_TASK_ASSIGNEE_ID = crypto.randomUUID();
+const MCP_TOKEN_ID = crypto.randomUUID();
+const TARGET_API_KEY_ID = crypto.randomUUID();
+const TARGET_OAUTH_GRANT_ID = crypto.randomUUID();
+const TARGET_OAUTH_ACCESS_ID = crypto.randomUUID();
+const TARGET_OAUTH_REFRESH_ID = crypto.randomUUID();
+const INVITED_EMAIL = `invite-${RUN_ID}@test.local`;
+
+function accessToken(userId: string, orgId = ORG_ID, email = `${userId}@test.local`) {
+  return jwt.sign({ id: userId, email, org_id: orgId }, env.JWT_SECRET, { expiresIn: '15m' });
+}
+
+function refreshToken(userId: string, orgId = ORG_ID, email = `${userId}@test.local`) {
+  return jwt.sign({ id: userId, email, org_id: orgId }, env.JWT_REFRESH_SECRET, { expiresIn: '30d' });
+}
+
+async function authed(path: string, userId: string, init: RequestInit = {}) {
+  return app.fetch(
+    new Request(`http://localhost${path}`, {
+      ...init,
+      headers: {
+        Authorization: `Bearer ${accessToken(userId)}`,
+        'Content-Type': 'application/json',
+        ...(init.headers ?? {}),
+      },
+    }),
+  );
+}
+
+before(async () => {
+  await withClient(async (c) => {
+    await c.query(
+      `INSERT INTO orgs (id, name, slug)
+       VALUES ($1, 'Identity Hardening Org', $2), ($3, 'Other Identity Org', $4)`,
+      [ORG_ID, `identity-hardening-${RUN_ID.slice(0, 8)}`, OTHER_ORG_ID, `identity-other-${RUN_ID.slice(0, 8)}`],
+    );
+
+    await c.query(
+      `INSERT INTO users (id, email, name, email_verified)
+       VALUES
+        ($1, $2, 'Admin User', true),
+        ($3, $4, 'Member User', true),
+        ($5, $6, 'Target User', true),
+        ($7, $8, 'Inactive User', true),
+        ($9, $10, 'Other Org User', true)`,
+      [
+        ADMIN_ID,
+        `admin-${RUN_ID}@test.local`,
+        MEMBER_ID,
+        `member-${RUN_ID}@test.local`,
+        TARGET_ID,
+        `target-${RUN_ID}@test.local`,
+        INACTIVE_ID,
+        `inactive-${RUN_ID}@test.local`,
+        OTHER_USER_ID,
+        `other-${RUN_ID}@test.local`,
+      ],
+    );
+
+    await c.query(
+      `INSERT INTO org_members (id, org_id, user_id, role, is_active)
+       VALUES
+        ($1, $2, $3, 'admin', true),
+        ($4, $2, $5, 'member', true),
+        ($6, $2, $7, 'member', true),
+        ($8, $2, $9, 'member', false),
+        ($10, $11, $12, 'admin', true)`,
+      [
+        crypto.randomUUID(),
+        ORG_ID,
+        ADMIN_ID,
+        crypto.randomUUID(),
+        MEMBER_ID,
+        crypto.randomUUID(),
+        TARGET_ID,
+        crypto.randomUUID(),
+        INACTIVE_ID,
+        crypto.randomUUID(),
+        OTHER_ORG_ID,
+        OTHER_USER_ID,
+      ],
+    );
+
+    await c.query(
+      `INSERT INTO spaces (id, org_id, name, created_by, is_default)
+       VALUES ($1, $2, 'identity-hardening', $3, true)`,
+      [SPACE_ID, ORG_ID, ADMIN_ID],
+    );
+    await c.query(
+      `INSERT INTO space_members (id, space_id, user_id) VALUES ($1, $2, $3)`,
+      [crypto.randomUUID(), SPACE_ID, TARGET_ID],
+    );
+
+    await c.query(
+      `INSERT INTO projects (id, org_id, name, prefix, lead_id, task_counter)
+       VALUES
+        ($1, $2, 'Identity Project', 'IDH', $3, 0),
+        ($4, $5, 'Other Identity Project', 'OID', $6, 0)`,
+      [PROJECT_ID, ORG_ID, ADMIN_ID, OTHER_PROJECT_ID, OTHER_ORG_ID, OTHER_USER_ID],
+    );
+    await c.query(
+      `INSERT INTO tasks (id, org_id, project_id, number, title, status, priority, assignee_id, created_by, is_deleted)
+       VALUES
+        ($1, $2, $3, 1, 'Identity task', 'backlog', 'p2', $4, $5, false),
+        ($6, $7, $8, 1, 'Other identity task', 'backlog', 'p2', $9, $9, false)`,
+      [TASK_ID, ORG_ID, PROJECT_ID, MEMBER_ID, ADMIN_ID, OTHER_TASK_ID, OTHER_ORG_ID, OTHER_PROJECT_ID, OTHER_USER_ID],
+    );
+    await c.query(
+      `INSERT INTO task_assignees (id, task_id, user_id)
+       VALUES ($1, $2, $3)`,
+      [OTHER_TASK_ASSIGNEE_ID, OTHER_TASK_ID, OTHER_USER_ID],
+    );
+
+    await c.query(
+      `INSERT INTO mcp_tokens (id, org_id, user_id, principal_kind, name, token_hash, token_prefix, scopes, created_by)
+       VALUES ($1, $2, $3, 'human', 'Target token', 'dummy-hash', 'dummy-prefix', ARRAY['read:workspace'], $4)`,
+      [MCP_TOKEN_ID, ORG_ID, TARGET_ID, TARGET_ID],
+    );
+    await c.query(
+      `INSERT INTO api_keys (id, org_id, name, key_hash, key_prefix, permissions, is_active, created_by)
+       VALUES ($1, $2, 'Target owned key', 'target-key-hash', 'target-prefix', ARRAY['read:workspace'], true, $3)`,
+      [TARGET_API_KEY_ID, ORG_ID, TARGET_ID],
+    );
+    await c.query(
+      `INSERT INTO oauth_grants (id, org_id, user_id, client_id, app_name, connector_profile, scopes)
+       VALUES ($1, $2, $3, 'identity-client', 'Identity Client', 'workspace_helper', ARRAY['read:workspace'])`,
+      [TARGET_OAUTH_GRANT_ID, ORG_ID, TARGET_ID],
+    );
+    await c.query(
+      `INSERT INTO oauth_access_tokens (id, token_hash, grant_id, org_id, user_id, client_id, resource, scopes, expires_at)
+       VALUES ($1, 'target-access-hash', $2, $3, $4, 'identity-client', 'https://example.test/mcp', ARRAY['read:workspace'], NOW() + INTERVAL '1 hour')`,
+      [TARGET_OAUTH_ACCESS_ID, TARGET_OAUTH_GRANT_ID, ORG_ID, TARGET_ID],
+    );
+    await c.query(
+      `INSERT INTO oauth_refresh_tokens (id, token_hash, grant_id, expires_at)
+       VALUES ($1, 'target-refresh-hash', $2, NOW() + INTERVAL '30 days')`,
+      [TARGET_OAUTH_REFRESH_ID, TARGET_OAUTH_GRANT_ID],
+    );
+
+    await c.query(
+      `INSERT INTO user_groups (id, org_id, name, handle, created_by)
+       VALUES ($1, $2, 'Other Group', 'other-group', $3)`,
+      [OTHER_GROUP_ID, OTHER_ORG_ID, OTHER_USER_ID],
+    );
+    await c.query(
+      `INSERT INTO user_group_members (id, group_id, user_id)
+       VALUES ($1, $2, $3)`,
+      [OTHER_GROUP_MEMBER_ID, OTHER_GROUP_ID, OTHER_USER_ID],
+    );
+  });
+});
+
+after(async () => {
+  await withClient(async (c) => {
+    await c.query(`DELETE FROM invites WHERE org_id IN ($1, $2)`, [ORG_ID, OTHER_ORG_ID]);
+    await c.query(`DELETE FROM oauth_access_tokens WHERE org_id IN ($1, $2)`, [ORG_ID, OTHER_ORG_ID]);
+    await c.query(`DELETE FROM oauth_refresh_tokens WHERE grant_id IN (SELECT id FROM oauth_grants WHERE org_id IN ($1, $2))`, [ORG_ID, OTHER_ORG_ID]);
+    await c.query(`DELETE FROM oauth_grants WHERE org_id IN ($1, $2)`, [ORG_ID, OTHER_ORG_ID]);
+    await c.query(`DELETE FROM mcp_tokens WHERE org_id IN ($1, $2)`, [ORG_ID, OTHER_ORG_ID]);
+    await c.query(`DELETE FROM api_keys WHERE org_id IN ($1, $2)`, [ORG_ID, OTHER_ORG_ID]);
+    await c.query(`DELETE FROM user_group_members WHERE group_id IN (SELECT id FROM user_groups WHERE org_id IN ($1, $2))`, [ORG_ID, OTHER_ORG_ID]);
+    await c.query(`DELETE FROM user_groups WHERE org_id IN ($1, $2)`, [ORG_ID, OTHER_ORG_ID]);
+    await c.query(`DELETE FROM task_assignees WHERE task_id IN (SELECT id FROM tasks WHERE project_id IN ($1, $2))`, [PROJECT_ID, OTHER_PROJECT_ID]);
+    await c.query(`DELETE FROM task_activity WHERE task_id IN (SELECT id FROM tasks WHERE project_id IN ($1, $2))`, [PROJECT_ID, OTHER_PROJECT_ID]);
+    await c.query(`DELETE FROM notifications WHERE org_id IN ($1, $2)`, [ORG_ID, OTHER_ORG_ID]);
+    await c.query(`DELETE FROM tasks WHERE project_id IN ($1, $2)`, [PROJECT_ID, OTHER_PROJECT_ID]);
+    await c.query(`DELETE FROM projects WHERE id IN ($1, $2)`, [PROJECT_ID, OTHER_PROJECT_ID]);
+    await c.query(`DELETE FROM space_members WHERE space_id = $1`, [SPACE_ID]);
+    await c.query(`DELETE FROM spaces WHERE id = $1`, [SPACE_ID]);
+    await c.query(`DELETE FROM org_members WHERE org_id IN ($1, $2)`, [ORG_ID, OTHER_ORG_ID]);
+    await c.query(`DELETE FROM users WHERE email = $1`, [INVITED_EMAIL]);
+    await c.query(`DELETE FROM users WHERE id = ANY($1::text[])`, [[ADMIN_ID, MEMBER_ID, TARGET_ID, INACTIVE_ID, OTHER_USER_ID]]);
+    await c.query(`DELETE FROM orgs WHERE id IN ($1, $2)`, [ORG_ID, OTHER_ORG_ID]);
+  });
+});
+
+describe('Loop 0 identity hardening', () => {
+  test('inactive org members cannot use protected JWT routes', async () => {
+    const res = await authed('/api/groups', INACTIVE_ID);
+    assert.equal(res.status, 403);
+    const body = await res.json() as Record<string, unknown>;
+    assert.equal(body.code, 'ORG_MEMBERSHIP_INACTIVE');
+  });
+
+  test('inactive org members cannot refresh tokens', async () => {
+    const res = await app.fetch(new Request('http://localhost/api/auth/refresh', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ refreshToken: refreshToken(INACTIVE_ID) }),
+    }));
+    assert.equal(res.status, 403);
+    const body = await res.json() as Record<string, unknown>;
+    assert.equal(body.code, 'ORG_MEMBERSHIP_INACTIVE');
+  });
+
+  test('non-admin members cannot create groups', async () => {
+    const res = await authed('/api/groups', MEMBER_ID, {
+      method: 'POST',
+      body: JSON.stringify({ name: 'Ops', handle: 'ops' }),
+    });
+    assert.equal(res.status, 403);
+  });
+
+  test('admins cannot add inactive or cross-org users to groups', async () => {
+    const res = await authed('/api/groups', ADMIN_ID, {
+      method: 'POST',
+      body: JSON.stringify({
+        name: 'Bad Group',
+        handle: 'bad-group',
+        member_ids: [MEMBER_ID, INACTIVE_ID],
+      }),
+    });
+    assert.equal(res.status, 400);
+    const body = await res.json() as Record<string, unknown>;
+    assert.equal(body.code, 'INVALID_MEMBERS');
+  });
+
+  test('admins can create groups with active org members', async () => {
+    const res = await authed('/api/groups', ADMIN_ID, {
+      method: 'POST',
+      body: JSON.stringify({
+        name: 'Launch Team',
+        handle: 'launch-team',
+        member_ids: [MEMBER_ID],
+      }),
+    });
+    assert.equal(res.status, 201);
+    const group = await res.json() as { id: string };
+
+    await withClient(async (c) => {
+      const { rows } = await c.query(
+        `SELECT count(*)::int AS count FROM user_group_members WHERE group_id = $1 AND user_id = $2`,
+        [group.id, MEMBER_ID],
+      );
+      assert.equal(rows[0].count, 1);
+    });
+  });
+
+  test('cross-org group delete returns 404 without deleting member rows first', async () => {
+    const res = await authed(`/api/groups/${OTHER_GROUP_ID}`, ADMIN_ID, { method: 'DELETE' });
+    assert.equal(res.status, 404);
+
+    await withClient(async (c) => {
+      const { rows } = await c.query(
+        `SELECT count(*)::int AS count FROM user_group_members WHERE id = $1`,
+        [OTHER_GROUP_MEMBER_ID],
+      );
+      assert.equal(rows[0].count, 1);
+    });
+  });
+
+  test('org API keys are admin-managed', async () => {
+    const memberRes = await authed('/api/api-keys', MEMBER_ID);
+    assert.equal(memberRes.status, 403);
+
+    const adminRes = await authed('/api/api-keys', ADMIN_ID, {
+      method: 'POST',
+      body: JSON.stringify({ name: 'Admin key', permissions: ['read:workspace'] }),
+    });
+    assert.equal(adminRes.status, 201);
+    const body = await adminRes.json() as Record<string, unknown>;
+    assert.equal(typeof body.raw_key, 'string');
+  });
+
+  test('member invite creates a durable invite row used by preview', async () => {
+    const res = await authed('/api/members/invite', ADMIN_ID, {
+      method: 'POST',
+      body: JSON.stringify({ email: INVITED_EMAIL, role: 'member' }),
+    });
+    const body = await res.json() as { invite_url: string; expires_at: string };
+    assert.equal(res.status, 201, JSON.stringify(body));
+    const token = new URL(body.invite_url).pathname.split('/').pop();
+    assert.ok(token, 'expected invite token in URL');
+
+    await withClient(async (c) => {
+      const { rows } = await c.query(
+        `SELECT count(*)::int AS count FROM invites WHERE org_id = $1 AND email = $2 AND token = $3 AND accepted_at IS NULL`,
+        [ORG_ID, INVITED_EMAIL, token],
+      );
+      assert.equal(rows[0].count, 1);
+    });
+
+    const preview = await app.fetch(new Request(`http://localhost/api/invites/preview/${encodeURIComponent(token)}`));
+    const previewBody = await preview.json() as Record<string, unknown>;
+    assert.equal(preview.status, 200, JSON.stringify(previewBody));
+    assert.equal(previewBody.email, INVITED_EMAIL);
+    assert.equal(previewBody.already_accepted, false);
+  });
+
+  test('task writes reject inactive or cross-org assignees', async () => {
+    const inactiveRes = await authed('/api/tasks', ADMIN_ID, {
+      method: 'POST',
+      body: JSON.stringify({
+        project_id: PROJECT_ID,
+        title: 'Should not assign inactive user',
+        assignee_id: INACTIVE_ID,
+      }),
+    });
+    assert.equal(inactiveRes.status, 400);
+    assert.equal((await inactiveRes.json() as Record<string, unknown>).code, 'INVALID_ASSIGNEE');
+
+    const crossOrgRes = await authed('/api/tasks', ADMIN_ID, {
+      method: 'POST',
+      body: JSON.stringify({
+        project_id: PROJECT_ID,
+        title: 'Should not assign cross-org user',
+        assignee_id: OTHER_USER_ID,
+      }),
+    });
+    assert.equal(crossOrgRes.status, 400);
+    assert.equal((await crossOrgRes.json() as Record<string, unknown>).code, 'INVALID_ASSIGNEE');
+
+    const validRes = await authed('/api/tasks', ADMIN_ID, {
+      method: 'POST',
+      body: JSON.stringify({
+        project_id: PROJECT_ID,
+        title: 'Can assign active user',
+        assignee_id: MEMBER_ID,
+      }),
+    });
+    assert.equal(validRes.status, 201, await validRes.text());
+  });
+
+  test('additional assignee routes enforce org visibility and active members', async () => {
+    const inactiveRes = await authed(`/api/tasks/${TASK_ID}/assignees`, ADMIN_ID, {
+      method: 'POST',
+      body: JSON.stringify({ user_id: INACTIVE_ID }),
+    });
+    assert.equal(inactiveRes.status, 400);
+    assert.equal((await inactiveRes.json() as Record<string, unknown>).code, 'INVALID_ASSIGNEE');
+
+    const deleteOtherOrgRes = await authed(`/api/tasks/${OTHER_TASK_ID}/assignees/${OTHER_USER_ID}`, ADMIN_ID, { method: 'DELETE' });
+    assert.equal(deleteOtherOrgRes.status, 404);
+
+    await withClient(async (c) => {
+      const { rows } = await c.query(
+        `SELECT count(*)::int AS count FROM task_assignees WHERE id = $1`,
+        [OTHER_TASK_ASSIGNEE_ID],
+      );
+      assert.equal(rows[0].count, 1);
+    });
+  });
+
+  test('member removal revokes space access and personal MCP tokens', async () => {
+    const res = await authed(`/api/members/${TARGET_ID}`, ADMIN_ID, { method: 'DELETE' });
+    assert.equal(res.status, 200, await res.text());
+
+    await withClient(async (c) => {
+      const membership = await c.query(
+        `SELECT is_active FROM org_members WHERE org_id = $1 AND user_id = $2`,
+        [ORG_ID, TARGET_ID],
+      );
+      assert.equal(membership.rows[0].is_active, false);
+
+      const spaceRows = await c.query(
+        `SELECT count(*)::int AS count FROM space_members WHERE space_id = $1 AND user_id = $2`,
+        [SPACE_ID, TARGET_ID],
+      );
+      assert.equal(spaceRows.rows[0].count, 0);
+
+      const tokenRows = await c.query(
+        `SELECT revoked_at IS NOT NULL AS revoked FROM mcp_tokens WHERE id = $1`,
+        [MCP_TOKEN_ID],
+      );
+      assert.equal(tokenRows.rows[0].revoked, true);
+
+      const apiKeyRows = await c.query(
+        `SELECT is_active FROM api_keys WHERE id = $1`,
+        [TARGET_API_KEY_ID],
+      );
+      assert.equal(apiKeyRows.rows[0].is_active, false);
+
+      const oauthGrantRows = await c.query(
+        `SELECT revoked_at IS NOT NULL AS revoked FROM oauth_grants WHERE id = $1`,
+        [TARGET_OAUTH_GRANT_ID],
+      );
+      assert.equal(oauthGrantRows.rows[0].revoked, true);
+
+      const oauthAccessRows = await c.query(
+        `SELECT revoked_at IS NOT NULL AS revoked FROM oauth_access_tokens WHERE id = $1`,
+        [TARGET_OAUTH_ACCESS_ID],
+      );
+      assert.equal(oauthAccessRows.rows[0].revoked, true);
+
+      const oauthRefreshRows = await c.query(
+        `SELECT revoked_at IS NOT NULL AS revoked FROM oauth_refresh_tokens WHERE id = $1`,
+        [TARGET_OAUTH_REFRESH_ID],
+      );
+      assert.equal(oauthRefreshRows.rows[0].revoked, true);
+    });
+  });
+});

--- a/apps/api/test/nudge-proactive-comment.test.ts
+++ b/apps/api/test/nudge-proactive-comment.test.ts
@@ -119,6 +119,12 @@ async function teardownFixture(c: pg.Client, f: Fixture): Promise<void> {
   await c.query(`DELETE FROM agent_nudges WHERE org_id = $1`, [f.orgId]);
   await c.query(`DELETE FROM notifications WHERE org_id = $1`, [f.orgId]);
   await c.query(`DELETE FROM job_queue WHERE data->>'employee_id' = $1`, [f.employeeId]);
+  await c.query(
+    `DELETE FROM action_receipts
+     WHERE action_id IN (SELECT id FROM agent_actions WHERE org_id = $1)`,
+    [f.orgId],
+  );
+  await c.query(`DELETE FROM agent_actions WHERE org_id = $1`, [f.orgId]);
   await c.query(`DELETE FROM tasks WHERE org_id = $1`, [f.orgId]);
   await c.query(`DELETE FROM projects WHERE org_id = $1`, [f.orgId]);
   await c.query(`DELETE FROM agent_employees WHERE org_id = $1`, [f.orgId]);

--- a/apps/api/test/oneone-prep-commitments.test.ts
+++ b/apps/api/test/oneone-prep-commitments.test.ts
@@ -48,6 +48,15 @@ async function withClient<T>(fn: (c: pg.Client) => Promise<T>): Promise<T> {
 
 let originalFetch: typeof globalThis.fetch;
 
+const MOCK_PREP_JSON = JSON.stringify({
+  summary: 'Test summary.',
+  wins: [],
+  currentFocus: [],
+  concerns: [],
+  talkingPoints: ['How are things going?'],
+  commitments: [COMMITMENT_SUMMARY],
+});
+
 function makeFakeAnthropicResponse(jsonPayload: string) {
   const body = JSON.stringify({
     id: 'msg_test_mock_oneone',
@@ -68,6 +77,28 @@ function makeFakeAnthropicResponse(jsonPayload: string) {
   };
 }
 
+function makeFakeOpenAIResponse(jsonPayload: string) {
+  const body = JSON.stringify({
+    id: 'chatcmpl_test_mock_oneone',
+    object: 'chat.completion',
+    choices: [
+      {
+        index: 0,
+        message: { role: 'assistant', content: jsonPayload },
+        finish_reason: 'stop',
+      },
+    ],
+    usage: { prompt_tokens: 20, completion_tokens: 30, total_tokens: 50 },
+  });
+  return {
+    ok: true,
+    status: 200,
+    headers: new Headers({ 'content-type': 'application/json' }),
+    text: async () => body,
+    json: async () => JSON.parse(body),
+  };
+}
+
 before(() => {
   originalFetch = globalThis.fetch;
   globalThis.fetch = async (url: string | URL | Request, opts?: RequestInit) => {
@@ -75,16 +106,10 @@ before(() => {
       typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url;
     if (urlStr.includes('anthropic.com')) {
       // Return a minimal valid prep JSON so generateOneOnePrep doesn't throw.
-      return makeFakeAnthropicResponse(
-        JSON.stringify({
-          summary: 'Test summary.',
-          wins: [],
-          currentFocus: [],
-          concerns: [],
-          talkingPoints: ['How are things going?'],
-          commitments: [COMMITMENT_SUMMARY],
-        }),
-      ) as unknown as Response;
+      return makeFakeAnthropicResponse(MOCK_PREP_JSON) as unknown as Response;
+    }
+    if (urlStr.includes('api.openai.com') || urlStr.includes('openrouter.ai')) {
+      return makeFakeOpenAIResponse(MOCK_PREP_JSON) as unknown as Response;
     }
     return originalFetch(url as any, opts);
   };

--- a/apps/api/test/task-assignee-model.test.ts
+++ b/apps/api/test/task-assignee-model.test.ts
@@ -61,12 +61,14 @@ async function seedFixtures() {
         [id, email, name],
       );
     }
-    await c.query(
-      `INSERT INTO org_members (id, org_id, user_id, role, is_active)
-       VALUES (gen_random_uuid()::text, $1, $2, 'member', true)
-       ON CONFLICT (org_id, user_id) DO NOTHING`,
-      [ORG_ID, MEMBER_USER_ID],
-    );
+    for (const id of [MEMBER_USER_ID, PRIMARY_USER_ID, EXTRA_USER_ID, PROMOTE_USER_ID]) {
+      await c.query(
+        `INSERT INTO org_members (id, org_id, user_id, role, is_active)
+         VALUES (gen_random_uuid()::text, $1, $2, 'member', true)
+         ON CONFLICT (org_id, user_id) DO NOTHING`,
+        [ORG_ID, id],
+      );
+    }
 
     const proj = await c.query(
       `SELECT id FROM projects WHERE org_id = $1 ORDER BY created_at ASC LIMIT 1`,

--- a/apps/api/test/task-dependency-cycles.test.ts
+++ b/apps/api/test/task-dependency-cycles.test.ts
@@ -86,17 +86,58 @@ async function seedFixtures() {
 
 async function teardownFixtures() {
   await withClient(async (c) => {
-    if (projectId) {
-      await c.query(
-        `DELETE FROM task_relationships
-         WHERE source_task_id IN (SELECT id FROM tasks WHERE project_id = $1)
-            OR target_task_id IN (SELECT id FROM tasks WHERE project_id = $1)`,
-        [projectId],
-      );
-      await c.query(`DELETE FROM task_activity WHERE task_id IN (SELECT id FROM tasks WHERE project_id = $1)`, [projectId]);
-      await c.query(`DELETE FROM tasks WHERE project_id = $1`, [projectId]);
-      await c.query(`DELETE FROM projects WHERE id = $1`, [projectId]);
-    }
+    const fixtureProjectFilter = `
+      SELECT id FROM projects
+      WHERE lead_id = $1 AND name LIKE 'Dep Cycles %'
+    `;
+    const fixtureTaskFilter = `
+      SELECT id FROM tasks WHERE project_id IN (${fixtureProjectFilter})
+    `;
+
+    await c.query(
+      `DELETE FROM task_relationships
+       WHERE source_task_id IN (${fixtureTaskFilter})
+          OR target_task_id IN (${fixtureTaskFilter})`,
+      [MEMBER_USER_ID],
+    );
+    await c.query(`DELETE FROM task_reactions WHERE task_id IN (${fixtureTaskFilter})`, [MEMBER_USER_ID]);
+    await c.query(`DELETE FROM task_labels WHERE task_id IN (${fixtureTaskFilter})`, [MEMBER_USER_ID]);
+    await c.query(`DELETE FROM task_comments WHERE task_id IN (${fixtureTaskFilter})`, [MEMBER_USER_ID]);
+    await c.query(`DELETE FROM task_activity WHERE task_id IN (${fixtureTaskFilter})`, [MEMBER_USER_ID]);
+    await c.query(`DELETE FROM task_watchers WHERE task_id IN (${fixtureTaskFilter})`, [MEMBER_USER_ID]);
+    await c.query(`DELETE FROM task_assignees WHERE task_id IN (${fixtureTaskFilter})`, [MEMBER_USER_ID]);
+    await c.query(`DELETE FROM tasks WHERE id IN (${fixtureTaskFilter})`, [MEMBER_USER_ID]);
+    await c.query(`DELETE FROM projects WHERE id IN (${fixtureProjectFilter})`, [MEMBER_USER_ID]);
+    await c.query(
+      `DELETE FROM action_receipts
+       WHERE action_id IN (
+         SELECT id FROM agent_actions WHERE user_id = $1
+       )`,
+      [MEMBER_USER_ID],
+    );
+    await c.query(`DELETE FROM agent_actions WHERE user_id = $1`, [MEMBER_USER_ID]);
+    await c.query(
+      `DELETE FROM people_expertise WHERE user_id = $1`,
+      [MEMBER_USER_ID],
+    );
+    await c.query(
+      `DELETE FROM people_influence WHERE user_id = $1`,
+      [MEMBER_USER_ID],
+    );
+    await c.query(
+      `DELETE FROM people_patterns WHERE user_id = $1`,
+      [MEMBER_USER_ID],
+    );
+    await c.query(
+      `DELETE FROM people_relationships
+       WHERE user_a_id = $1 OR user_b_id = $1`,
+      [MEMBER_USER_ID],
+    );
+    await c.query(
+      `DELETE FROM people_interactions
+       WHERE user_a_id = $1 OR user_b_id = $1`,
+      [MEMBER_USER_ID],
+    );
     await c.query(`DELETE FROM org_members WHERE user_id = $1`, [MEMBER_USER_ID]);
     await c.query(`DELETE FROM users WHERE id = $1`, [MEMBER_USER_ID]);
   });

--- a/apps/api/test/task-templates-list.test.ts
+++ b/apps/api/test/task-templates-list.test.ts
@@ -1,7 +1,6 @@
 /**
  * Shape test for the new list/get endpoints. Exercises route wiring
- * against an in-process Hono app. Uses the seeded dev user
- * (maneek@test.com / test1234) per repo convention.
+ * against an in-process Hono app. Uses the seeded pilot user.
  */
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
@@ -10,7 +9,7 @@ import { app } from '../src/index.js';
 async function authHeaders(): Promise<Record<string, string>> {
   const res = await app.request('/api/auth/login', {
     method: 'POST',
-    body: JSON.stringify({ email: 'maneek@test.com', password: 'test1234' }),
+    body: JSON.stringify({ email: 'diego@testers-tomatoes.com', password: 'tomato123' }),
     headers: { 'content-type': 'application/json' },
   });
   const body = (await res.json()) as { accessToken: string };

--- a/apps/api/test/tasks-bulk-grouped-notify.test.ts
+++ b/apps/api/test/tasks-bulk-grouped-notify.test.ts
@@ -98,17 +98,64 @@ before(async () => {
 
 after(async () => {
   await withClient(async (c) => {
-    if (taskIds.length) {
-      await c.query(`DELETE FROM task_comments WHERE task_id = ANY($1)`, [taskIds]);
-      await c.query(`DELETE FROM task_activity WHERE task_id = ANY($1)`, [taskIds]);
-      await c.query(`DELETE FROM tasks WHERE id = ANY($1)`, [taskIds]);
-    }
-    if (projectId) {
-      await c.query(`DELETE FROM projects WHERE id = $1`, [projectId]);
-    }
+    const fixtureProjectFilter = `
+      SELECT id FROM projects
+      WHERE lead_id = $1 AND name LIKE 'Bulk Notify %'
+    `;
+    const fixtureTaskFilter = `
+      SELECT id FROM tasks WHERE project_id IN (${fixtureProjectFilter})
+    `;
+
+    await c.query(
+      `DELETE FROM task_relationships
+       WHERE source_task_id IN (${fixtureTaskFilter})
+          OR target_task_id IN (${fixtureTaskFilter})`,
+      [ACTOR_ID],
+    );
+    await c.query(`DELETE FROM task_reactions WHERE task_id IN (${fixtureTaskFilter})`, [ACTOR_ID]);
+    await c.query(`DELETE FROM task_labels WHERE task_id IN (${fixtureTaskFilter})`, [ACTOR_ID]);
+    await c.query(`DELETE FROM task_comments WHERE task_id IN (${fixtureTaskFilter})`, [ACTOR_ID]);
+    await c.query(`DELETE FROM task_activity WHERE task_id IN (${fixtureTaskFilter})`, [ACTOR_ID]);
+    await c.query(`DELETE FROM task_watchers WHERE task_id IN (${fixtureTaskFilter})`, [ACTOR_ID]);
+    await c.query(`DELETE FROM task_assignees WHERE task_id IN (${fixtureTaskFilter})`, [ACTOR_ID]);
+    await c.query(`DELETE FROM tasks WHERE id IN (${fixtureTaskFilter})`, [ACTOR_ID]);
+    await c.query(`DELETE FROM projects WHERE id IN (${fixtureProjectFilter})`, [ACTOR_ID]);
     await c.query(
       `DELETE FROM notifications WHERE user_id IN ($1, $2)`,
       [ACTOR_ID, ASSIGNEE_ID],
+    );
+    await c.query(
+      `DELETE FROM action_receipts
+       WHERE action_id IN (
+         SELECT id FROM agent_actions WHERE org_id = $1 AND user_id IN ($2, $3)
+       )`,
+      [ORG_ID, ACTOR_ID, ASSIGNEE_ID],
+    );
+    await c.query(
+      `DELETE FROM agent_actions WHERE org_id = $1 AND user_id IN ($2, $3)`,
+      [ORG_ID, ACTOR_ID, ASSIGNEE_ID],
+    );
+    await c.query(
+      `DELETE FROM people_expertise WHERE org_id = $1 AND user_id IN ($2, $3)`,
+      [ORG_ID, ACTOR_ID, ASSIGNEE_ID],
+    );
+    await c.query(
+      `DELETE FROM people_influence WHERE org_id = $1 AND user_id IN ($2, $3)`,
+      [ORG_ID, ACTOR_ID, ASSIGNEE_ID],
+    );
+    await c.query(
+      `DELETE FROM people_patterns WHERE org_id = $1 AND user_id IN ($2, $3)`,
+      [ORG_ID, ACTOR_ID, ASSIGNEE_ID],
+    );
+    await c.query(
+      `DELETE FROM people_relationships
+       WHERE org_id = $1 AND (user_a_id IN ($2, $3) OR user_b_id IN ($2, $3))`,
+      [ORG_ID, ACTOR_ID, ASSIGNEE_ID],
+    );
+    await c.query(
+      `DELETE FROM people_interactions
+       WHERE org_id = $1 AND (user_a_id IN ($2, $3) OR user_b_id IN ($2, $3))`,
+      [ORG_ID, ACTOR_ID, ASSIGNEE_ID],
     );
     await c.query(
       `DELETE FROM org_members WHERE user_id IN ($1, $2)`,


### PR DESCRIPTION
﻿## Summary

This PR lands the foundation slice from the profile/team management plan before the richer profile and team UI loops.

It hardens org membership semantics across API surfaces, makes inactive membership a real enforcement state, tightens member/group/invite/API-key/assignment paths, and makes the API test suite a reliable local gate.

## What changed

- Added shared active org membership helpers for route-level enforcement.
- Enforced active membership in auth, refresh, `/me`, onboarding, socket, approval, project, task, member, invite, group, and API-key flows.
- Hardened group/member/invite routes around org scope, admin/owner gates, invite lifecycle, and stale credential revocation.
- Unified safer assignment behavior for inactive/cross-org humans and unavailable agent employees.
- Skipped mention notifications for legacy non-user mention ids while preserving Defty legacy dispatch.
- Made the API package test command seed required fixed fixtures before running the suite.
- Updated stale seeded credentials in template route tests.
- Hardened teardown for newer audit, people-graph, nudge, and receipt tables so repeated full-suite runs stay clean.
- Mocked OpenAI/OpenRouter-compatible 1:1 prep responses to avoid live-provider flakiness.

## Why

The profile/team work depends on a trustworthy people layer. Before adding richer profile pages, directories, teams, and widgets, deactivated members, cross-org references, stale credentials, and mixed fixture state need to fail predictably.

## Validation

- `pnpm --filter @deft/api test` -> 626 pass, 0 fail
- `pnpm --filter @deft/api typecheck` -> pass
- `git diff --check` -> pass
- Verified no lingering Node test runners after the full suite

## Notes

Unrelated report scripts and generated web artifacts were intentionally left out of this PR.
