### PR TITLE
[codex] Fix mobile sidebar layering

### DIFF
--- a/apps/web/src/components/sidebar.tsx
+++ b/apps/web/src/components/sidebar.tsx
@@ -980,7 +980,7 @@ export function Sidebar({
       {/* Mobile overlay */}
       {mobileOpen && (
         <div
-          className="md:hidden fixed inset-0 z-40 bg-black/40 backdrop-blur-sm"
+          className="md:hidden fixed inset-0 z-[60] bg-black/40 backdrop-blur-sm"
           onClick={() => setMobileOpen(false)}
         />
       )}
@@ -991,7 +991,7 @@ export function Sidebar({
         aria-modal={mobileOpen ? 'true' : undefined}
         aria-label={mobileOpen ? 'Navigation' : undefined}
         className={`
-          fixed md:relative z-50 md:z-auto
+          fixed md:relative z-[70] md:z-auto
           h-full flex flex-col
           md:translate-x-0
           ${mobileOpen ? 'translate-x-0' : '-translate-x-full md:translate-x-0'}


### PR DESCRIPTION
## Summary
- Raise the mobile sidebar backdrop and drawer above page-level controls.
- Fixes the `/tasks` mobile drawer issue where the task project/header layer could paint over the sidebar because both used `z-50`.

## Root Cause
The tasks page project selector/header uses `z-50`. The mobile sidebar drawer also used `z-50`, so on mobile the task header could win the stacking contest and visually bleed through the drawer.

## Validation
- `pnpm --filter @deft/web typecheck`
- `pnpm --filter @deft/web lint`
- Playwright mobile visual/assertion pass at `400x872` on `/tasks`:
  - sidebar z-index: `70`
  - backdrop z-index: `60`
  - all probe points in the former bleed zone resolved inside `aside[role="dialog"][aria-label="Navigation"]`
  - no horizontal overflow
  - screenshots saved under `reports/assets/mobile-task-sidebar-zfix-2026-07-06/`
