### PR TITLE
Polish core workspace UI surfaces

### DIFF
--- a/apps/web/src/app/(app)/inbox/page.tsx
+++ b/apps/web/src/app/(app)/inbox/page.tsx
@@ -616,8 +616,7 @@ export default function InboxPage() {
           {unreadCount > 0 && (
             <button
               onClick={() => void markAllRead()}
-              className="text-[12px] px-3 py-1.5 rounded-md"
-              style={{ color: 'var(--primary)', background: 'var(--bg-active)' }}
+              className="deft-pill min-h-[32px]"
             >
               Mark all read
             </button>
@@ -626,19 +625,18 @@ export default function InboxPage() {
 
         {/* Tab strip */}
         <nav
-          className="flex gap-1 mb-5 border-b overflow-x-auto whitespace-nowrap"
-          style={{ borderColor: 'var(--border)' }}
+          className="mb-5 flex gap-1.5 overflow-x-auto whitespace-nowrap"
+          role="tablist"
+          aria-label="Inbox sections"
         >
           {TABS.map((t) => (
             <button
               key={t.id}
               onClick={() => setTab(t.id)}
-              className="text-[13px] px-3 py-2 -mb-px"
-              style={{
-                color: tab === t.id ? 'var(--primary)' : 'var(--muted)',
-                borderBottom: tab === t.id ? '2px solid var(--primary)' : '2px solid transparent',
-                fontWeight: tab === t.id ? 600 : 400,
-              }}
+              className="deft-pill"
+              data-active={tab === t.id}
+              role="tab"
+              aria-selected={tab === t.id}
             >
               {t.label}
             </button>
@@ -657,8 +655,7 @@ export default function InboxPage() {
             <button
               type="button"
               onClick={() => { void refreshCaptureSurfaces(); }}
-              className="mt-3 text-[12px] px-3 py-1.5 rounded-md"
-              style={{ color: 'var(--primary)', background: 'var(--bg-active)' }}
+              className="deft-pill mt-3"
             >
               Retry
             </button>

--- a/apps/web/src/app/(app)/knowledge/page.tsx
+++ b/apps/web/src/app/(app)/knowledge/page.tsx
@@ -761,6 +761,14 @@ export default function KnowledgePage() {
     { value: 'user', label: 'Personal' },
   ];
 
+  const mobileViewFilters: Array<{ value: 'pages' | 'activity' | 'stats' | 'doctor' | 'graph'; label: string }> = [
+    { value: 'pages', label: 'Pages' },
+    { value: 'graph', label: 'Graph' },
+    { value: 'activity', label: 'Activity' },
+    { value: 'stats', label: 'Stats' },
+    { value: 'doctor', label: 'Doctor' },
+  ];
+
   const openKnowledgeView = (next: 'pages' | 'activity' | 'stats' | 'doctor' | 'graph') => {
     if (next === 'graph') {
       setShowGraph(true);
@@ -1126,7 +1134,7 @@ export default function KnowledgePage() {
             {/* + New */}
             <button
               onClick={() => setShowCreate(true)}
-              className="flex items-center gap-1 px-2.5 py-1 rounded-lg text-[11px] font-medium transition-colors"
+              className="hidden md:flex items-center gap-1 px-2.5 py-1 rounded-lg text-[11px] font-medium transition-colors"
               style={{ background: 'var(--accent)', color: 'white' }}
             >
               <Plus size={12} /> New
@@ -1134,7 +1142,7 @@ export default function KnowledgePage() {
             {/* Pages (primary view toggle — always visible) */}
             <button
               onClick={() => { setViewMode('pages'); setShowGraph(false); }}
-              className="flex items-center gap-1 px-2 py-1.5 rounded-lg text-[11px] font-medium transition-colors"
+              className="hidden md:flex items-center gap-1 px-2 py-1.5 rounded-lg text-[11px] font-medium transition-colors"
               style={{
                 background: viewMode === 'pages' && !showGraph ? 'var(--surface-container-high)' : 'transparent',
                 color: viewMode === 'pages' && !showGraph ? 'var(--text-primary)' : 'var(--text-tertiary)',
@@ -1165,7 +1173,7 @@ export default function KnowledgePage() {
               }}
               placeholder="Search wiki..."
               title="Search returns results across all types — clear the search to refine by type."
-              className="w-28 md:w-36 px-3 py-1.5 rounded-lg text-[12px] outline-none"
+              className="hidden md:block md:w-44 px-3 py-1.5 rounded-lg text-[12px] outline-none"
               style={{ background: 'var(--surface-container-low)', border: '1px solid var(--border-default)', color: 'var(--text-primary)' }}
             />
             {/* Overflow menu — Activity, Stats, Graph (mobile), Export */}
@@ -1213,27 +1221,40 @@ export default function KnowledgePage() {
           </>
         }
         secondary={
-          <div className="flex flex-col gap-1 px-1">
-            <div className="md:hidden flex gap-2">
-              <select
-                value={showGraph ? 'graph' : viewMode}
-                onChange={e => openKnowledgeView(e.target.value as 'pages' | 'activity' | 'stats' | 'doctor' | 'graph')}
-                className="flex-1 text-[0.8125rem] rounded-md px-2 py-1 outline-none"
-                style={{
-                  background: 'var(--surface-container-low)',
-                  border: '1px solid var(--border-default)',
-                  color: 'var(--text-primary)',
-                }}
-              >
-                <option value="pages">Pages</option>
-                <option value="activity">Activity</option>
-                <option value="stats">Stats</option>
-                <option value="doctor">Doctor</option>
-                <option value="graph">Graph</option>
-              </select>
+          <div className="flex flex-col gap-1.5 px-1">
+            <input
+              value={searchQuery}
+              onChange={e => {
+                const val = e.target.value;
+                if (val && !searchQuery) setFilter('all');
+                setSearchQuery(val);
+                setPage(1);
+              }}
+              placeholder="Search wiki..."
+              title="Search returns results across all types — clear the search to refine by type."
+              className="md:hidden w-full px-3 py-2 rounded-xl text-[13px] outline-none"
+              style={{ background: 'var(--surface-container-low)', border: '1px solid var(--border-default)', color: 'var(--text-primary)' }}
+            />
+            <div className="md:hidden flex items-center gap-1 overflow-x-auto pb-0.5" style={{ WebkitOverflowScrolling: 'touch', scrollbarWidth: 'none' } as React.CSSProperties}>
+              {mobileViewFilters.map(f => {
+                const active = f.value === 'graph' ? showGraph : !showGraph && viewMode === f.value;
+                return (
+                  <button
+                    key={f.value}
+                    onClick={() => openKnowledgeView(f.value)}
+                    className="flex-shrink-0 rounded-full px-3 py-1.5 text-[12px] font-medium transition-colors"
+                    style={{
+                      background: active ? 'var(--accent)' : 'var(--surface-container-low)',
+                      color: active ? 'white' : 'var(--text-secondary)',
+                    }}
+                  >
+                    {f.label}
+                  </button>
+                );
+              })}
               <button
                 onClick={() => setShowCreate(true)}
-                className="px-3 py-1 rounded-md text-[0.8125rem] font-medium"
+                className="flex-shrink-0 rounded-full px-3 py-1.5 text-[12px] font-medium"
                 style={{ background: 'var(--accent)', color: 'white' }}
               >
                 New
@@ -1241,21 +1262,22 @@ export default function KnowledgePage() {
             </div>
             {/* Scope axis: <select> on mobile, inline tab strip on md+ */}
             <div className="flex gap-1">
-              {/* Mobile: select */}
-              <select
-                value={scopeFilter}
-                onChange={e => { setScopeFilter(e.target.value); setPage(1); }}
-                className="md:hidden text-[0.8125rem] rounded-md px-2 py-1 outline-none"
-                style={{
-                  background: 'var(--surface-container-low)',
-                  border: '1px solid var(--border-default)',
-                  color: 'var(--text-primary)',
-                }}
-              >
+              {/* Mobile: pill strip */}
+              <div className="md:hidden flex min-w-0 gap-1 overflow-x-auto pb-0.5" style={{ WebkitOverflowScrolling: 'touch', scrollbarWidth: 'none' } as React.CSSProperties}>
                 {scopeFilters.map(f => (
-                  <option key={f.value} value={f.value}>{f.label}</option>
+                  <button
+                    key={f.value}
+                    onClick={() => { setScopeFilter(f.value); setPage(1); }}
+                    className="flex-shrink-0 rounded-full px-3 py-1.5 text-[12px] font-medium transition-colors"
+                    style={{
+                      background: scopeFilter === f.value ? 'var(--accent)' : 'var(--surface-container-low)',
+                      color: scopeFilter === f.value ? 'white' : 'var(--text-secondary)',
+                    }}
+                  >
+                    {f.label}
+                  </button>
                 ))}
-              </select>
+              </div>
               {/* Desktop: inline pill buttons */}
               <div className="hidden md:flex gap-1">
                 {scopeFilters.map(f => (
@@ -1275,12 +1297,12 @@ export default function KnowledgePage() {
             </div>
 
             {/* Type axis: scrollable tab strip on both mobile + desktop */}
-            <div className="flex flex-nowrap gap-1 overflow-x-auto">
+            <div className="flex flex-nowrap gap-1 overflow-x-auto pb-1" style={{ WebkitOverflowScrolling: 'touch', scrollbarWidth: 'none' } as React.CSSProperties}>
               {typeFilters.map(f => (
                 <button
                   key={f.value}
                   onClick={() => { setFilter(f.value); setPage(1); }}
-                  className="px-3 py-1.5 rounded-lg text-[12px] font-medium transition-colors flex-shrink-0"
+                  className="px-3 py-1.5 rounded-full text-[12px] font-medium transition-colors flex-shrink-0"
                   style={{
                     background: filter === f.value ? 'var(--accent)' : 'var(--surface-container-low)',
                     color: filter === f.value ? 'white' : 'var(--text-secondary)',
@@ -1297,13 +1319,13 @@ export default function KnowledgePage() {
       {/* Entries */}
       <div className="flex flex-col flex-1 overflow-hidden px-4 md:px-6 pb-4 md:pb-6">
       {viewMode === 'pages' && !showGraph && (
-        <div className="mb-3 rounded-lg p-3 flex-shrink-0"
+        <div className="mb-2 rounded-xl p-2 flex-shrink-0 md:mb-3 md:rounded-lg md:p-3"
           style={{ background: 'var(--surface-container-low)', border: '1px solid var(--border-default)' }}>
-          <div className="flex flex-col md:flex-row md:items-center gap-2">
+          <div className="flex flex-col md:flex-row md:items-center gap-1.5 md:gap-2">
             <div className="flex items-center gap-2 flex-1 min-w-0">
-              <span className="w-8 h-8 rounded-lg flex items-center justify-center flex-shrink-0"
+              <span className="w-7 h-7 rounded-lg flex items-center justify-center flex-shrink-0 md:h-8 md:w-8"
                 style={{ background: 'var(--accent-muted, rgba(91, 143, 168, 0.16))', color: 'var(--accent)' }}>
-                <Sparkles size={15} />
+                <Sparkles size={14} />
               </span>
               <input
                 value={askQuery}
@@ -1315,15 +1337,15 @@ export default function KnowledgePage() {
                   }
                 }}
                 placeholder="Ask what the workspace knows..."
-                className="flex-1 min-w-0 px-3 py-2 rounded-lg text-[13px] outline-none"
+                className="flex-1 min-w-0 px-3 py-1.5 rounded-lg text-[12px] outline-none md:py-2 md:text-[13px]"
                 style={{ background: 'var(--surface-container)', border: '1px solid var(--border-default)', color: 'var(--text-primary)' }}
               />
             </div>
-            <div className="flex items-center gap-2 flex-wrap">
+            <div className="flex items-center gap-1.5 flex-nowrap md:gap-2 md:flex-wrap">
               <select
                 value={askScope}
                 onChange={e => setAskScope(e.target.value as 'company' | 'channel')}
-                className="px-2 py-2 rounded-lg text-[12px] outline-none"
+                className="min-w-0 flex-1 px-2 py-1.5 rounded-lg text-[12px] outline-none md:flex-none md:py-2"
                 style={{ background: 'var(--surface-container)', border: '1px solid var(--border-default)', color: 'var(--text-primary)' }}
               >
                 <option value="company">Company memory</option>
@@ -1360,7 +1382,7 @@ export default function KnowledgePage() {
               <button
                 onClick={() => void askKnowledge()}
                 disabled={askLoading || !askQuery.trim() || (askScope === 'channel' && !graphSpaceId)}
-                className="px-3 py-2 rounded-lg text-[12px] font-medium disabled:opacity-40 flex items-center gap-1.5"
+                className="px-3 py-1.5 rounded-lg text-[12px] font-medium disabled:opacity-40 flex items-center gap-1.5 md:py-2"
                 style={{ background: 'var(--accent)', color: 'white' }}
               >
                 {askLoading ? <Loader2 size={13} className="animate-spin" /> : <Sparkles size={13} />}

--- a/apps/web/src/app/(app)/notes/page.tsx
+++ b/apps/web/src/app/(app)/notes/page.tsx
@@ -38,6 +38,7 @@ import { EmojiPicker } from '@/components/emoji-picker';
 import { PageHeader } from '@/components/page-header';
 import { useSetPageContext } from '@/components/app-header-context';
 import { OverflowMenu } from '@/components/overflow-menu';
+import { AppBottomSheet } from '@/components/overlay-primitives';
 
 // Register built-in slash menu commands (idempotent).
 registerBuiltInCommands();
@@ -151,6 +152,14 @@ function timeAgo(dateStr: string): string {
   return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
 }
 
+function isCompactDisplayIcon(icon?: string | null) {
+  if (!icon) return false;
+  const trimmed = icon.trim();
+  if (!trimmed) return false;
+  if (/^[a-zA-Z][a-zA-Z0-9_-]{2,}$/.test(trimmed)) return false;
+  return trimmed.length <= 8;
+}
+
 // ── Toolbar button ─────────────────────────────────────────
 // onMouseDown + preventDefault keeps editor focus before the TipTap command runs.
 // Using onClick caused a focus race where the editor lost focus before toggleX fired.
@@ -161,7 +170,7 @@ function TBtn({ active, onClick, children, title }: { active?: boolean; onClick:
       aria-label={title}
       title={title}
       onMouseDown={(e) => { e.preventDefault(); onClick(); }}
-      className="inline-flex items-center justify-center min-h-[44px] min-w-[44px] md:min-h-0 md:min-w-0 md:p-1.5 rounded transition-colors"
+      className="inline-flex items-center justify-center min-h-[44px] min-w-[44px] rounded-full transition-colors md:min-h-0 md:min-w-0 md:p-1.5"
       style={{ color: active ? 'var(--accent)' : 'var(--muted)', background: active ? 'var(--accent-subtle)' : 'transparent' }}>
       {children}
     </button>
@@ -172,17 +181,22 @@ function TBtn({ active, onClick, children, title }: { active?: boolean; onClick:
 function NoteCard({ note, onClick }: { note: Note; onClick: () => void }) {
   const preview = getNotePreview(note.content);
   return (
-    <div onClick={onClick}
-      className="group p-4 rounded-lg cursor-pointer transition-all hover:shadow-sm"
-      style={{ background: 'var(--surface-container)', border: '1px solid var(--border)' }}>
+    <button type="button" onClick={onClick}
+      className="group deft-soft-card w-full cursor-pointer p-3.5 text-left transition-all hover:shadow-sm md:p-4">
       <div className="flex items-start gap-2 mb-2">
-        {note.icon && <span className="text-[18px] flex-shrink-0">{note.icon}</span>}
+        {isCompactDisplayIcon(note.icon) ? (
+          <span className="text-[18px] flex-shrink-0">{note.icon}</span>
+        ) : (
+          <span className="mt-0.5 inline-flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-md" style={{ background: 'var(--surface-container-high)', color: 'var(--muted)' }}>
+            <FileText size={13} />
+          </span>
+        )}
         <div className="flex-1 min-w-0">
-          <h3 className="text-[14px] font-semibold line-clamp-2 md:truncate"
+          <h3 className="text-[14px] font-semibold leading-snug line-clamp-2 md:truncate"
             style={{ color: 'var(--foreground)', fontFamily: 'var(--font-heading)' }}>
             {note.title || 'Untitled'}
           </h3>
-          <p className="text-[12px] mt-1 line-clamp-2" style={{ color: 'var(--muted)', lineHeight: '1.5' }}>
+          <p className="text-[12px] mt-1 line-clamp-2" style={{ color: 'var(--muted)', lineHeight: '1.45' }}>
             {preview || 'Empty note'}
           </p>
         </div>
@@ -191,7 +205,7 @@ function NoteCard({ note, onClick }: { note: Note; onClick: () => void }) {
         <span className="text-[11px]" style={{ color: 'var(--muted)' }}>{timeAgo(note.updated_at)}</span>
         {note.is_pinned && <Pin size={11} style={{ color: 'var(--accent)' }} />}
       </div>
-    </div>
+    </button>
   );
 }
 
@@ -543,7 +557,7 @@ function NoteEditor({ noteId, onBack, onDeleted }: { noteId: string; onBack: () 
           <button
             type="button"
             onClick={handleUndoDelete}
-            className="inline-flex items-center justify-center min-h-[44px] min-w-[44px] md:min-h-auto md:min-w-auto md:px-2.5 md:py-1 text-[13px] font-semibold rounded-lg"
+            className="inline-flex items-center justify-center min-h-[44px] min-w-[44px] md:min-h-0 md:min-w-0 md:px-2.5 md:py-1 text-[13px] font-semibold rounded-lg"
             style={{ background: 'var(--accent)', color: 'white' }}>
             Undo
           </button>
@@ -551,7 +565,7 @@ function NoteEditor({ noteId, onBack, onDeleted }: { noteId: string; onBack: () 
       )}
 
       <div
-        className={`max-w-[700px] mx-auto px-6 py-6 ${pendingDelete ? 'opacity-40 pointer-events-none select-none' : ''}`}
+        className={`max-w-[700px] mx-auto px-4 py-4 md:px-6 md:py-6 ${pendingDelete ? 'opacity-40 pointer-events-none select-none' : ''}`}
         aria-hidden={pendingDelete}
       >
         {/* Top bar */}
@@ -747,10 +761,10 @@ function NoteEditor({ noteId, onBack, onDeleted }: { noteId: string; onBack: () 
         </div>
 
         {/* Icon + Title */}
-        <div className="flex items-start gap-2 mb-4">
+        <div className="flex items-start gap-2.5 mb-4 md:gap-3">
           <div className="relative">
             <button ref={iconBtnRef} onClick={() => setIconPickerOpen(!iconPickerOpen)}
-              className="text-[28px] p-1 rounded-lg hover:bg-white/5 transition-colors leading-none"
+              className="text-[25px] md:text-[28px] p-1 rounded-lg hover:bg-[var(--bg-hover)] transition-colors leading-none"
               aria-label="Change icon"
               title="Change icon">
               {icon || '\uD83D\uDCC4'}
@@ -775,15 +789,15 @@ function NoteEditor({ noteId, onBack, onDeleted }: { noteId: string; onBack: () 
           <input value={title} onChange={e => isOwner && handleTitleChange(e.target.value)}
             readOnly={!isOwner}
             placeholder="Untitled"
-            className="flex-1 text-[24px] font-bold bg-transparent outline-none mt-0.5"
-            style={{ color: 'var(--foreground)', fontFamily: 'var(--font-heading)', letterSpacing: '-0.02em', cursor: isOwner ? 'text' : 'default' }} />
+            className="min-w-0 flex-1 bg-transparent text-[22px] font-bold outline-none md:text-[24px]"
+            style={{ color: 'var(--foreground)', fontFamily: 'var(--font-heading)', letterSpacing: 0, cursor: isOwner ? 'text' : 'default' }} />
         </div>
 
         {/* Editor with toolbar */}
-        <div className="rounded-lg overflow-hidden" style={{ background: 'var(--surface-container)' }}>
+        <div className="rounded-xl overflow-hidden" style={{ background: 'var(--surface-container)' }}>
           {editor && (
-            <div className="flex items-center gap-0.5 px-2 py-1.5 overflow-x-auto flex-nowrap"
-              style={{ borderBottom: '1px solid var(--border)' }}>
+            <div className="flex items-center gap-0.5 overflow-x-auto flex-nowrap px-1.5 py-1 md:px-2 md:py-1.5"
+              style={{ borderBottom: '1px solid var(--border)', WebkitOverflowScrolling: 'touch', scrollbarWidth: 'none' } as React.CSSProperties}>
               <TBtn active={editor.isActive('heading', { level: 1 })}
                 onClick={() => editor.chain().focus().toggleHeading({ level: 1 }).run()} title="Heading 1">
                 <Heading1 size={15} />
@@ -853,7 +867,7 @@ function NoteEditor({ noteId, onBack, onDeleted }: { noteId: string; onBack: () 
               </TBtn>
             </div>
           )}
-          <div className="px-4 py-3 min-h-[calc(100vh-350px)]">
+          <div className="min-h-[calc(100vh-350px)] px-3.5 py-3 md:px-4">
             <EditorContent editor={editor} />
           </div>
           {/* Word count footer */}
@@ -1062,7 +1076,7 @@ export default function NotesPage() {
   // Inject mobile-only search input into AppHeader (hidden on desktop via md:hidden)
   useSetPageContext(
     activeId ? null : (
-      <div className="md:hidden flex items-center gap-2 flex-1 h-8 px-2 rounded-md"
+      <div className="md:hidden flex items-center gap-2 flex-1 h-8 px-3 rounded-full"
         style={{ background: 'var(--surface-container)', border: '1px solid var(--border)' }}>
         <Search size={13} style={{ color: 'var(--muted)', flexShrink: 0 }} />
         <input
@@ -1132,7 +1146,7 @@ export default function NotesPage() {
   const newNoteButton = (
     <div className="relative">
       <button onClick={() => setShowTemplates(!showTemplates)}
-        className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-[13px] font-medium text-white"
+        className="deft-pill deft-pill-active min-h-[34px]"
         style={{ background: 'var(--accent)' }}>
         <Plus size={14} /> New Note
       </button>
@@ -1176,7 +1190,7 @@ export default function NotesPage() {
           // Mobile: hidden — search is in AppHeader; folder/icon live in ••• overflow menu
           <div className="hidden md:flex flex-col gap-2">
             {/* Search */}
-            <div className="flex items-center gap-2 px-3 h-9 rounded-lg"
+            <div className="flex items-center gap-2 px-3 h-9 rounded-full"
               style={{ background: 'var(--surface-container)', border: '1px solid var(--border)' }}>
               <Search size={14} style={{ color: 'var(--muted)' }} />
               <input value={search} onChange={e => setSearch(e.target.value)}
@@ -1187,19 +1201,19 @@ export default function NotesPage() {
             {/* Folder bar */}
             <div className="flex items-center gap-1 overflow-x-auto">
               <button onClick={() => setActiveFolderId(null)}
-                className="flex items-center gap-1 px-2.5 py-1 rounded-md text-[11px] font-medium flex-shrink-0 transition-colors"
+                className="deft-pill flex-shrink-0"
+                data-active={!activeFolderId}
                 style={{
                   background: !activeFolderId ? 'var(--accent)' : 'var(--surface-container)',
-                  color: !activeFolderId ? 'white' : 'var(--muted)',
                 }}>
                 All Notes
               </button>
               {folders.map(f => (
                 <button key={f.id} onClick={() => setActiveFolderId(f.id)}
-                  className="flex items-center gap-1 px-2.5 py-1 rounded-md text-[11px] font-medium flex-shrink-0 transition-colors"
+                  className="deft-pill flex-shrink-0"
+                  data-active={activeFolderId === f.id}
                   style={{
                     background: activeFolderId === f.id ? 'var(--accent)' : 'var(--surface-container)',
-                    color: activeFolderId === f.id ? 'white' : 'var(--muted)',
                   }}>
                   <Folder size={11} /> {f.name}
                 </button>
@@ -1217,7 +1231,7 @@ export default function NotesPage() {
                 <button onClick={() => setShowNewFolder(true)}
                   aria-label="New folder"
                   title="New folder"
-                  className="flex items-center gap-1 px-2 py-1 rounded-md text-[11px] flex-shrink-0"
+                  className="deft-pill deft-pill-icon min-h-[30px] flex-shrink-0"
                   style={{ color: 'var(--muted)' }}>
                   <FolderPlus size={11} />
                 </button>
@@ -1226,7 +1240,7 @@ export default function NotesPage() {
               <div className="relative ml-auto">
                 <button ref={defaultIconBtnRef}
                   onClick={() => setDefaultIconPickerOpen(!defaultIconPickerOpen)}
-                  className="flex items-center gap-1.5 px-2 py-1.5 rounded-lg text-[12px]"
+                  className="deft-pill"
                   style={{ color: 'var(--muted)', border: '1px solid var(--border)' }}
                   title="Default icon for new notes">
                   <span className="text-[14px]">{currentDefault}</span>
@@ -1255,19 +1269,19 @@ export default function NotesPage() {
           {/* Compact folder chips — show first 2 + overflow */}
           <div className="flex items-center gap-1 flex-1 overflow-x-auto">
             <button onClick={() => setActiveFolderId(null)}
-              className="flex items-center gap-1 px-2.5 py-1 rounded-md text-[11px] font-medium flex-shrink-0"
+              className="deft-pill flex-shrink-0"
+              data-active={!activeFolderId}
               style={{
                 background: !activeFolderId ? 'var(--accent)' : 'var(--surface-container)',
-                color: !activeFolderId ? 'white' : 'var(--muted)',
               }}>
               All Notes
             </button>
             {folders.map(f => (
               <button key={f.id} onClick={() => setActiveFolderId(f.id)}
-                className="flex items-center gap-1 px-2.5 py-1 rounded-md text-[11px] font-medium flex-shrink-0"
+                className="deft-pill flex-shrink-0"
+                data-active={activeFolderId === f.id}
                 style={{
                   background: activeFolderId === f.id ? 'var(--accent)' : 'var(--surface-container)',
-                  color: activeFolderId === f.id ? 'white' : 'var(--muted)',
                 }}>
                 <Folder size={11} /> {f.name}
               </button>
@@ -1279,60 +1293,56 @@ export default function NotesPage() {
               onClick={() => setShowOverflow(!showOverflow)}
               aria-label="More options"
               title="More options"
-              className="flex items-center justify-center w-8 h-8 rounded-lg"
+              className="deft-pill deft-pill-icon min-h-[32px]"
               style={{ color: 'var(--muted)', border: '1px solid var(--border)' }}>
               <MoreHorizontal size={16} />
             </button>
-            {showOverflow && (
-              <>
-                {/* Backdrop to close */}
-                <div className="fixed inset-0 z-40" onClick={() => setShowOverflow(false)} />
-                <div className="absolute right-0 top-full mt-1 w-52 py-1 rounded-lg z-50"
-                  style={{ background: 'var(--surface-container-highest)', boxShadow: 'var(--glass-shadow)', border: '1px solid var(--border)' }}>
-                  <div className="px-3 py-1.5 text-[10px] font-semibold uppercase tracking-wider" style={{ color: 'var(--muted)' }}>Folders</div>
-                  {showNewFolder ? (
-                    <div className="px-3 py-1.5">
-                      <input value={newFolderName} onChange={e => setNewFolderName(e.target.value)}
-                        onKeyDown={e => { if (e.key === 'Enter') { handleCreateFolder(); setShowOverflow(false); } if (e.key === 'Escape') setShowNewFolder(false); }}
-                        placeholder="Folder name..."
-                        autoFocus
-                        className="w-full px-2 py-1 rounded-md text-[11px] outline-none"
-                        style={{ background: 'var(--surface-container)', border: '1px solid var(--accent)', color: 'var(--foreground)' }} />
-                    </div>
-                  ) : (
-                    <button onClick={() => setShowNewFolder(true)}
-                      className="flex items-center gap-2 px-3 py-2 text-[12px] w-full text-left"
-                      style={{ color: 'var(--foreground)' }}>
-                      <FolderPlus size={13} /> New folder
-                    </button>
-                  )}
-                  <div className="my-1" style={{ borderTop: '1px solid var(--border)' }} />
-                  <div className="px-3 py-1.5 text-[10px] font-semibold uppercase tracking-wider" style={{ color: 'var(--muted)' }}>Default note icon</div>
-                  <div className="px-3 py-1.5 relative">
-                    <button ref={defaultIconBtnRef}
-                      onClick={() => setDefaultIconPickerOpen(!defaultIconPickerOpen)}
-                      className="flex items-center gap-1.5 px-2 py-1.5 rounded-lg text-[12px]"
-                      style={{ color: 'var(--muted)', border: '1px solid var(--border)' }}
-                      title="Default icon for new notes">
-                      <span className="text-[14px]">{currentDefault}</span>
-                      <Settings2 size={12} />
-                    </button>
-                    {defaultIconPickerOpen && (
-                      <EmojiPicker
-                        anchorRef={defaultIconBtnRef}
-                        onSelect={(emoji) => {
-                          setDefaultIcon(emoji);
-                          setCurrentDefault(emoji);
-                          setDefaultIconPickerOpen(false);
-                          setShowOverflow(false);
-                        }}
-                        onClose={() => setDefaultIconPickerOpen(false)}
-                      />
-                    )}
+            <AppBottomSheet open={showOverflow} onClose={() => setShowOverflow(false)} title="Notes options" mobileOnly>
+              <div className="px-2 pb-1">
+                <div className="px-2 py-1.5 text-[10px] font-semibold uppercase tracking-wider" style={{ color: 'var(--muted)' }}>Folders</div>
+                {showNewFolder ? (
+                  <div className="px-2 py-1.5">
+                    <input value={newFolderName} onChange={e => setNewFolderName(e.target.value)}
+                      onKeyDown={e => { if (e.key === 'Enter') { handleCreateFolder(); setShowOverflow(false); } if (e.key === 'Escape') setShowNewFolder(false); }}
+                      placeholder="Folder name..."
+                      autoFocus
+                      className="w-full px-3 py-2 rounded-lg text-[13px] outline-none"
+                      style={{ background: 'var(--surface-container-high)', border: '1px solid var(--accent)', color: 'var(--foreground)' }} />
                   </div>
+                ) : (
+                  <button onClick={() => setShowNewFolder(true)}
+                    className="flex min-h-[44px] w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-[13px]"
+                    style={{ color: 'var(--foreground)' }}>
+                    <FolderPlus size={15} /> New folder
+                  </button>
+                )}
+                <div className="my-1" style={{ borderTop: '1px solid var(--outline-variant)' }} />
+                <div className="px-2 py-1.5 text-[10px] font-semibold uppercase tracking-wider" style={{ color: 'var(--muted)' }}>Default note icon</div>
+                <div className="px-2 py-1.5 relative">
+                  <button ref={defaultIconBtnRef}
+                    onClick={() => setDefaultIconPickerOpen(!defaultIconPickerOpen)}
+                    className="flex min-h-[44px] items-center gap-2 rounded-lg px-3 py-2 text-[13px]"
+                    style={{ color: 'var(--muted)', border: '1px solid var(--outline-variant)' }}
+                    title="Default icon for new notes">
+                    <span className="text-[16px]">{currentDefault}</span>
+                    <Settings2 size={14} />
+                    <span>Choose default icon</span>
+                  </button>
+                  {defaultIconPickerOpen && (
+                    <EmojiPicker
+                      anchorRef={defaultIconBtnRef}
+                      onSelect={(emoji) => {
+                        setDefaultIcon(emoji);
+                        setCurrentDefault(emoji);
+                        setDefaultIconPickerOpen(false);
+                        setShowOverflow(false);
+                      }}
+                      onClose={() => setDefaultIconPickerOpen(false)}
+                    />
+                  )}
                 </div>
-              </>
-            )}
+              </div>
+            </AppBottomSheet>
           </div>
         </div>
       </div>
@@ -1351,7 +1361,7 @@ export default function NotesPage() {
               Create your first note to start capturing ideas.
             </p>
             <button onClick={() => handleCreate()}
-              className="px-4 py-2 rounded-lg text-[13px] font-medium text-white"
+              className="deft-pill deft-pill-active min-h-[36px]"
               style={{ background: 'var(--accent)' }}>
               <Plus size={14} className="inline mr-1" /> Create Note
             </button>

--- a/apps/web/src/app/(app)/tasks/page.tsx
+++ b/apps/web/src/app/(app)/tasks/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback, useMemo, lazy, Suspense } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef, lazy, Suspense } from 'react';
 import { useAuth } from '@/lib/auth-context';
 import { api } from '@/lib/api';
 import { getSocket } from '@/lib/socket';
@@ -33,6 +33,7 @@ import {
   FileText,
 } from 'lucide-react';
 import { TabStrip } from '@/components/tab-strip';
+import { AppMenu } from '@/components/overlay-primitives';
 
 const TaskTimeline = lazy(() => import('./timeline'));
 import { EmptyState } from '@/components/empty-state';
@@ -151,12 +152,25 @@ export default function TasksPage() {
   const [toast, setToast] = useState<string | null>(null);
   const [velocity, setVelocity] = useState<{ average: number } | null>(null);
   const [isMobile, setIsMobile] = useState(false);
+  const viewMenuButtonRef = useRef<HTMLButtonElement | null>(null);
+  const [viewMenuOpen, setViewMenuOpen] = useState(false);
   useEffect(() => {
     const check = () => setIsMobile(window.innerWidth < 768);
     check();
     window.addEventListener('resize', check);
     return () => window.removeEventListener('resize', check);
   }, []);
+
+  const viewOptions = useMemo(() => [
+    { value: 'board' as View, label: 'Board', icon: <LayoutGrid size={14} /> },
+    { value: 'list' as View, label: 'List', icon: <List size={14} /> },
+    { value: 'timeline' as View, label: 'Timeline', icon: <GanttChartSquare size={14} /> },
+    { value: 'calendar' as View, label: 'Calendar', icon: <CalendarDays size={14} /> },
+    { value: 'pipeline' as View, label: 'Pipeline', icon: <GitBranch size={14} /> },
+  ], []);
+
+  const activeViewOption = viewOptions.find((option) => option.value === view) ?? viewOptions[0]!;
+  const mobileViewOptions = viewOptions.filter((option) => option.value !== 'calendar');
 
   // Mobile-spillover P2-2: calendar cells (~55px wide) can't fit task content
   // on mobile. Auto-redirect to list view when width < 768 and calendar is active.
@@ -746,13 +760,13 @@ export default function TasksPage() {
               <div className="relative z-50">
                 <button
                   onClick={() => setProjectDropdownOpen(!projectDropdownOpen)}
-                  className="flex items-center gap-2 px-3 py-1.5 rounded-md"
+                  className="deft-pill min-h-[33px] min-w-0 max-w-[48vw] justify-start px-3 md:max-w-none"
                   style={{
                     color: 'var(--foreground)',
                     fontFamily: 'var(--font-heading)',
                     fontSize: '14px',
                     fontWeight: 600,
-                    background: projectDropdownOpen ? 'var(--hover-tint)' : 'transparent',
+                    background: projectDropdownOpen ? 'var(--accent-subtle)' : 'var(--surface-container-low)',
                     transition: 'background 150ms',
                   }}
                 >
@@ -762,7 +776,7 @@ export default function TasksPage() {
                       style={{ background: selectedProject.color }}
                     />
                   )}
-                  {selectedProject?.name || 'Select project'}
+                  <span className="min-w-0 truncate">{selectedProject?.name || 'Select project'}</span>
                   <ChevronDown size={14} style={{ color: 'var(--muted)' }} />
                 </button>
                 {!isMobile && velocity && velocity.average > 0 && (
@@ -819,14 +833,46 @@ export default function TasksPage() {
             )}
 
             {/* View toggle */}
+            <div className="md:hidden">
+              <button
+                ref={viewMenuButtonRef}
+                onClick={() => setViewMenuOpen((open) => !open)}
+                className="deft-pill min-h-[36px] px-3"
+                style={{
+                  color: 'var(--foreground-secondary)',
+                  fontFamily: 'var(--font-heading)',
+                }}
+                aria-haspopup="menu"
+                aria-expanded={viewMenuOpen}
+              >
+                {activeViewOption.icon}
+                <span>{activeViewOption.label}</span>
+                <ChevronDown size={12} style={{ color: 'var(--muted)' }} />
+              </button>
+              <AppMenu
+                open={viewMenuOpen}
+                onClose={() => setViewMenuOpen(false)}
+                anchorRef={viewMenuButtonRef}
+                ariaLabel="Task view"
+                items={mobileViewOptions.map((option) => ({
+                  label: option.label,
+                  icon: option.icon,
+                  onSelect: () => {
+                    setQuery({ view: option.value });
+                    setUserSelectedView(true);
+                  },
+                }))}
+              />
+            </div>
             <TabStrip
-              className="items-center rounded-md p-0.5"
-              style={{ background: 'var(--surface)', border: '1px solid var(--border)' }}
+              className="hidden md:flex items-center"
+              style={{}}
             >
               <button
                 aria-label="Board view"
                 onClick={() => { setQuery({ view: 'board' }); setUserSelectedView(true); }}
-                className="flex items-center gap-1.5 px-2.5 py-2 md:py-1 min-h-[44px] md:min-h-0 rounded text-[12px] font-medium transition-colors"
+                className="deft-pill"
+                data-active={view === 'board'}
                 style={{
                   background: view === 'board' ? 'var(--accent)' : 'transparent',
                   color: view === 'board' ? 'white' : 'var(--muted)',
@@ -839,7 +885,8 @@ export default function TasksPage() {
               <button
                 aria-label="List view"
                 onClick={() => { setQuery({ view: 'list' }); setUserSelectedView(true); }}
-                className="flex items-center gap-1.5 px-2.5 py-2 md:py-1 min-h-[44px] md:min-h-0 rounded text-[12px] font-medium transition-colors"
+                className="deft-pill"
+                data-active={view === 'list'}
                 style={{
                   background: view === 'list' ? 'var(--accent)' : 'transparent',
                   color: view === 'list' ? 'white' : 'var(--muted)',
@@ -852,7 +899,8 @@ export default function TasksPage() {
               <button
                 aria-label="Timeline view"
                 onClick={() => { setQuery({ view: 'timeline' }); setUserSelectedView(true); }}
-                className="flex items-center gap-1.5 px-2.5 py-2 md:py-1 min-h-[44px] md:min-h-0 rounded text-[12px] font-medium transition-colors"
+                className="deft-pill"
+                data-active={view === 'timeline'}
                 style={{
                   background: view === 'timeline' ? 'var(--accent)' : 'transparent',
                   color: view === 'timeline' ? 'white' : 'var(--muted)',
@@ -865,7 +913,8 @@ export default function TasksPage() {
               <button
                 aria-label="Calendar view"
                 onClick={() => { setQuery({ view: 'calendar' }); setUserSelectedView(true); }}
-                className="flex items-center gap-1.5 px-2.5 py-2 md:py-1 min-h-[44px] md:min-h-0 rounded text-[12px] font-medium transition-colors"
+                className="deft-pill"
+                data-active={view === 'calendar'}
                 style={{
                   background: view === 'calendar' ? 'var(--accent)' : 'transparent',
                   color: view === 'calendar' ? 'white' : 'var(--muted)',
@@ -878,7 +927,8 @@ export default function TasksPage() {
               <button
                 aria-label="Pipeline view"
                 onClick={() => { setQuery({ view: 'pipeline' }); setUserSelectedView(true); }}
-                className="flex items-center gap-1.5 px-2.5 py-2 md:py-1 min-h-[44px] md:min-h-0 rounded text-[12px] font-medium transition-colors"
+                className="deft-pill"
+                data-active={view === 'pipeline'}
                 style={{
                   background: view === 'pipeline' ? 'var(--accent)' : 'transparent',
                   color: view === 'pipeline' ? 'white' : 'var(--muted)',
@@ -894,7 +944,8 @@ export default function TasksPage() {
             {!isMobile && (
               <button
                 onClick={() => setSelectionMode(!selectionMode)}
-                className="flex items-center gap-1.5 px-2.5 py-1 rounded-md text-[12px] font-medium"
+                className="deft-pill"
+                data-active={selectionMode}
                 style={{
                   background: selectionMode ? 'var(--accent-subtle)' : 'transparent',
                   color: selectionMode ? 'var(--accent)' : 'var(--muted)',
@@ -972,7 +1023,7 @@ export default function TasksPage() {
                   setQuickCreateStatus(undefined);
                   setQuickCreateOpen(true);
                 }}
-                className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-[13px] font-medium text-white"
+                className="deft-pill deft-pill-active min-h-[36px] px-4 text-[13px]"
                 style={{
                   background: 'var(--accent)',
                   fontFamily: 'var(--font-heading)',
@@ -1220,6 +1271,8 @@ export default function TasksPage() {
       {isMobile && !isMyTasksView && !selectedTask && (
         <button
           onClick={() => { setQuickCreateStatus(undefined); setQuickCreateOpen(true); }}
+          aria-label="Create task"
+          title="Create task"
           className="fixed z-30 w-12 h-12 rounded-full flex items-center justify-center text-white shadow-lg"
           style={{
             background: 'var(--accent)',

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -55,10 +55,17 @@
   --status-green: #30A46C;
   --status-blue: #3B82F6;
   --status-gray: #5C5C5F;
+  --status-orange: #F97316;
+  --status-purple: #8B5CF6;
+  --status-yellow: #FACC15;
+  --status-teal: #14B8A6;
+  --status-pink: #EC4899;
 
   /* ── Typography ─────────────────────────────────────────────── */
   --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
   --font-mono: 'JetBrains Mono', 'Fira Code', monospace;
+  --font-heading: var(--font-sans);
+  --font-body: var(--font-sans);
 
   /* ── Motion ─────────────────────────────────────────────────── */
   --transition-snappy: 150ms cubic-bezier(0.16, 1, 0.3, 1);
@@ -86,6 +93,7 @@
   --text-tertiary: var(--outline);
   --text-inverse: var(--on-primary-container);
   --accent: var(--primary-container);
+  --accent-light: var(--accent-subtle);
   --accent-hover: #9D8FF7;
   --accent-muted: rgba(144, 128, 250, 0.15);
   --accent-subtle: rgba(144, 128, 250, 0.15);
@@ -111,32 +119,61 @@
   --hover-tint: var(--bg-hover);
   --danger: var(--status-red);
   --danger-subtle: rgba(229,72,77,0.12);
+  --warning: var(--status-amber);
+  --warning-subtle: rgba(245,166,35,0.14);
   --success: var(--status-green);
   --avatar-bg: var(--primary-container);
   --muted-bg: var(--surface-container);
   --shadow-sm: 0 1px 2px rgba(0,0,0,0.2);
   --shadow-md: 0 4px 12px rgba(0,0,0,0.3);
   --shadow-lg: var(--glass-shadow);
+  --bg-primary: var(--surface);
+  --pinned-bg: var(--surface-container-low);
+  --pinned-divider: var(--border-default);
 }
 
 /* ── Light mode — minimal override ───────────────────────────── */
 .light {
-  --surface-lowest: #FAFAFA;
-  --surface-dim: #F5F5F5;
+  --surface-lowest: #FBFBFC;
+  --surface-dim: #F6F6F8;
   --surface: #FFFFFF;
-  --surface-container-low: #F5F5F7;
-  --surface-container: #EFEFEF;
-  --surface-container-high: #E8E8E8;
-  --surface-container-highest: #DEDEDE;
-  --surface-variant: #E0E0E0;
+  --surface-container-low: #F7F7FA;
+  --surface-container: #F1F1F5;
+  --surface-container-high: #E8E8EF;
+  --surface-container-highest: #DDDEE8;
+  --surface-variant: #E5E5EC;
+  --surface-bright: #D7D8E3;
   --on-surface: #1C1C1E;
-  --on-surface-variant: #5C5C5F;
-  --outline: #8E8E93;
-  --outline-variant: #C7C7CC;
+  --on-surface-variant: #555560;
+  --outline: #7E7E8A;
+  --outline-variant: #D5D5DD;
   --primary: #6A59E0;
   --primary-container: #7C6BF0;
   --on-primary-container: #FFFFFF;
-  --ghost-border: rgba(0,0,0,0.06);
+  --ghost-border: rgba(20,20,30,0.08);
+  --border-strong: rgba(20,20,30,0.14);
+  --glass-bg: rgba(255, 255, 255, 0.84);
+  --glass-shadow: 0 18px 44px rgba(20, 20, 30, 0.13);
+  --accent-hover: #6F5EEA;
+  --accent-muted: rgba(124, 107, 240, 0.12);
+  --accent-subtle: rgba(124, 107, 240, 0.12);
+  --danger-subtle: rgba(229,72,77,0.10);
+  --warning-subtle: rgba(183,121,0,0.12);
+  --bg-hover: rgba(20,20,30,0.045);
+  --bg-active: rgba(124, 107, 240, 0.12);
+  --hover-tint: var(--bg-hover);
+  --status-amber: #B77900;
+  --status-green: #168356;
+  --status-orange: #C45A08;
+  --status-purple: #6B4EDB;
+  --status-yellow: #A16207;
+  --status-teal: #0F766E;
+  --status-pink: #BE185D;
+  --shadow-sm: 0 1px 2px rgba(20,20,30,0.08);
+  --shadow-md: 0 8px 20px rgba(20,20,30,0.11);
+  --shadow-lg: var(--glass-shadow);
+  --pinned-bg: var(--surface-container);
+  --pinned-divider: var(--border-default);
 }
 
 /* ── Base Styles ─────────────────────────────────────────────── */
@@ -218,22 +255,13 @@ body {
 
 /* ── Pinned messages ──────────────────────────────────────────── */
 div.pinned-bar {
-  background-color: #1C1B1D !important;
+  background-color: var(--pinned-bg) !important;
 }
 div.pinned-dropdown {
-  background-color: #1C1B1D !important;
+  background-color: var(--pinned-bg) !important;
 }
 div.pinned-dropdown-item + div.pinned-dropdown-item {
-  border-top: 1px solid rgba(255,255,255,0.04);
-}
-.light div.pinned-bar {
-  background-color: #EFEFEF !important;
-}
-.light div.pinned-dropdown {
-  background-color: #EFEFEF !important;
-}
-.light div.pinned-dropdown-item + div.pinned-dropdown-item {
-  border-top: 1px solid rgba(0,0,0,0.06);
+  border-top: 1px solid var(--pinned-divider);
 }
 
 /* ── Scrollbar ───────────────────────────────────────────────── */
@@ -257,6 +285,98 @@ div.pinned-dropdown-item + div.pinned-dropdown-item {
 input:focus, textarea:focus {
   outline: none;
   box-shadow: 0 0 0 2px rgba(144, 128, 250, 0.3) !important;
+}
+
+:where(button, a, input, textarea, select, [role="button"], [role="tab"], [tabindex]):focus-visible {
+  outline: 2px solid var(--primary-container);
+  outline-offset: 2px;
+}
+
+.deft-pill {
+  display: inline-flex;
+  min-height: 30px;
+  align-items: center;
+  justify-content: center;
+  gap: 0.375rem;
+  border-radius: 999px;
+  padding: 0.375rem 0.75rem;
+  color: var(--text-secondary);
+  background: var(--surface-container-low);
+  border: 1px solid var(--border-default);
+  font-size: 0.75rem;
+  font-weight: 600;
+  line-height: 1;
+  white-space: nowrap;
+  transition: opacity 150ms cubic-bezier(0.16, 1, 0.3, 1), background-color 150ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.deft-pill:hover { opacity: 0.88; }
+
+.deft-pill[data-active="true"],
+.deft-pill-active {
+  color: #fff;
+  background: var(--accent);
+  border-color: transparent;
+}
+
+.deft-pill-icon {
+  width: 2.25rem;
+  min-width: 2.25rem;
+  padding-left: 0;
+  padding-right: 0;
+}
+
+.deft-soft-card {
+  border-radius: 1rem;
+  border: 1px solid var(--border-default);
+  background: var(--surface-container);
+}
+
+.deft-icon-button {
+  display: inline-flex;
+  min-width: 2.5rem;
+  min-height: 2.5rem;
+  align-items: center;
+  justify-content: center;
+  border-radius: 0.75rem;
+  color: var(--on-surface-variant);
+  background: transparent;
+  transition: background-color 150ms cubic-bezier(0.16, 1, 0.3, 1),
+              color 150ms cubic-bezier(0.16, 1, 0.3, 1),
+              opacity 150ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.deft-icon-button:hover {
+  background: var(--bg-hover);
+  color: var(--on-surface);
+}
+
+.deft-menu-surface {
+  border-radius: 0.875rem;
+  border: 1px solid var(--border-default);
+  background: var(--glass-bg);
+  box-shadow: var(--glass-shadow);
+  backdrop-filter: var(--glass-blur);
+}
+
+.deft-menu-item {
+  min-height: 2.25rem;
+  border-radius: 0.625rem;
+  color: var(--on-surface-variant);
+}
+
+.deft-menu-item:hover,
+.deft-menu-item:focus-visible {
+  background: var(--bg-hover);
+  color: var(--on-surface);
+}
+
+.deft-muted-label {
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--outline);
 }
 
 /* ── Placeholder ─────────────────────────────────────────────── */

--- a/apps/web/src/components/app-header.tsx
+++ b/apps/web/src/components/app-header.tsx
@@ -35,13 +35,19 @@ export function AppHeader({
     setNotifOpen(!notifOpen);
   };
 
+  const notificationLabel = unreadNotifCount > 0
+    ? `Notifications, ${unreadNotifCount} unread`
+    : 'Notifications';
+
   return (
     <div className="h-12 flex items-center gap-3 px-4 flex-shrink-0" style={{ background: 'transparent' }}>
       {/* Mobile menu button */}
       {onMenuClick && (
         <button
           onClick={onMenuClick}
-          className="md:hidden flex items-center justify-center min-w-[44px] min-h-[44px] -ml-1 rounded-lg"
+          aria-label="Open navigation"
+          title="Open navigation"
+          className="deft-icon-button -ml-1 md:hidden"
           style={{ color: 'var(--on-surface-variant)' }}
         >
           <Menu size={18} strokeWidth={1.5} />
@@ -55,7 +61,9 @@ export function AppHeader({
       {/* Search — full bar on desktop, icon-only on mobile */}
       <button
         onClick={handleSearchClick}
-        className="hidden md:flex items-center gap-2 px-3 h-8 rounded-lg cursor-pointer"
+        aria-label={placeholder.replace('... ⌘K', '')}
+        title={placeholder}
+        className="hidden md:flex items-center gap-2 px-3 h-8 rounded-full cursor-pointer"
         style={{ background: 'var(--surface-container-low)', minWidth: '200px' }}
       >
         <Search size={14} strokeWidth={1.5} style={{ color: 'var(--outline)' }} />
@@ -63,7 +71,9 @@ export function AppHeader({
       </button>
       <button
         onClick={handleSearchClick}
-        className="md:hidden flex items-center justify-center min-w-[44px] min-h-[44px] rounded-lg cursor-pointer"
+        aria-label={placeholder.replace('... ⌘K', '')}
+        title={placeholder}
+        className="deft-icon-button md:hidden cursor-pointer"
         style={{ color: 'var(--outline)' }}
       >
         <Search size={18} strokeWidth={1.5} />
@@ -84,9 +94,11 @@ export function AppHeader({
         <button
           ref={bellRef}
           onClick={handleNotifOpen}
-          aria-label="Notifications"
+          aria-label={notificationLabel}
+          aria-expanded={notifOpen}
+          aria-haspopup="dialog"
           title="Notifications"
-          className="flex items-center justify-center min-w-[44px] min-h-[44px] md:min-w-0 md:min-h-0 md:p-1.5 p-3 rounded-md relative"
+          className="deft-icon-button relative md:min-h-8 md:min-w-8 md:rounded-lg"
           style={{ color: 'var(--outline)' }}
         >
           <Bell size={16} strokeWidth={1.5} />

--- a/apps/web/src/components/board-column.tsx
+++ b/apps/web/src/components/board-column.tsx
@@ -95,6 +95,8 @@ export function BoardColumn({
         </button>
         <button
           onClick={onAdd}
+          aria-label={`Add task to ${label}`}
+          title={`Add task to ${label}`}
           className="p-1 rounded-md"
           style={{ color: 'var(--muted)', transition: 'color 150ms' }}
           onMouseEnter={(e) => (e.currentTarget.style.color = 'var(--foreground)')}

--- a/apps/web/src/components/calendar/calendar-header.tsx
+++ b/apps/web/src/components/calendar/calendar-header.tsx
@@ -24,36 +24,37 @@ export function CalendarHeader({
   const title = getTitle(view, anchor);
 
   return (
-    <div className="flex items-center justify-between px-1 pb-4 gap-3 flex-wrap">
+    <div className="flex flex-col gap-3 px-1 pb-4 md:flex-row md:items-center md:justify-between">
       {/* Left: navigation */}
-      <div className="flex items-center gap-2">
-        <button onClick={onPrev} className="p-1.5 rounded-md hover:opacity-70 transition-colors"
+      <div className="flex w-full min-w-0 items-center gap-2 md:w-auto">
+        <button onClick={onPrev} aria-label="Previous calendar period" title="Previous calendar period" className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full transition-colors hover:opacity-80"
           style={{ color: 'var(--text-secondary)', background: 'var(--surface-container-low)' }}>
           <ChevronLeft size={16} />
         </button>
-        <button onClick={onNext} className="p-1.5 rounded-md hover:opacity-70 transition-colors"
+        <button onClick={onNext} aria-label="Next calendar period" title="Next calendar period" className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full transition-colors hover:opacity-80"
           style={{ color: 'var(--text-secondary)', background: 'var(--surface-container-low)' }}>
           <ChevronRight size={16} />
         </button>
-        <h1 className="text-[16px] font-semibold ml-1" style={{ color: 'var(--text-primary)' }}>
+        <h1 className="ml-1 min-w-0 flex-1 truncate text-[15px] font-semibold md:flex-none md:text-[16px]" style={{ color: 'var(--text-primary)' }}>
           {title}
         </h1>
         <button onClick={onToday}
-          className="text-[11px] font-medium px-2.5 py-1 rounded-md transition-colors hover:opacity-80"
+          className="h-9 flex-shrink-0 rounded-full px-3 text-[12px] font-semibold transition-colors hover:opacity-80 md:h-8"
           style={{ background: 'var(--accent)', color: 'white' }}>
           Today
         </button>
       </div>
 
       {/* Right: actions + view toggle + connection */}
-      <div className="flex items-center gap-3">
+      <div className="flex w-full items-center gap-2 overflow-x-auto pb-0.5 md:w-auto md:justify-start md:gap-2 md:overflow-visible md:pb-0">
         {/* New event button */}
         {onNewEvent && (
           <button onClick={onNewEvent}
-            className="flex items-center gap-1.5 text-[11px] font-medium px-2.5 py-1.5 rounded-md transition-colors hover:opacity-80"
+            className="flex h-9 flex-shrink-0 items-center gap-1.5 rounded-full px-3 text-[12px] font-semibold transition-colors hover:opacity-80 md:h-8"
             style={{ background: 'var(--accent)', color: 'white' }}>
             <Plus size={13} />
-            New event
+            <span className="hidden sm:inline">New event</span>
+            <span className="sm:hidden">New</span>
           </button>
         )}
 
@@ -63,11 +64,10 @@ export function CalendarHeader({
           Calendar feeds
         </Link>
 
-        <div className="flex rounded-lg overflow-hidden"
-          style={{ border: '1px solid var(--border-default)' }}>
+        <div className="flex flex-shrink-0 items-center gap-1">
           {VIEW_LABELS.map(({ value, label }) => (
             <button key={value} onClick={() => onViewChange(value)}
-              className="px-3 py-1.5 text-[11px] font-medium transition-colors"
+              className="h-9 rounded-full px-4 text-[12px] font-semibold transition-colors hover:opacity-80 md:h-8 md:px-3.5"
               style={{
                 background: view === value ? 'var(--accent)' : 'var(--surface-container-low)',
                 color: view === value ? 'white' : 'var(--text-secondary)',

--- a/apps/web/src/components/calendar/day-detail-panel.tsx
+++ b/apps/web/src/components/calendar/day-detail-panel.tsx
@@ -2,11 +2,14 @@
 
 import { CalEvent, DayBucket, ITEM_COLORS, getEventSourceColor, getEventSourceLabel } from '@/lib/calendar';
 import { formatFullDateLong, formatEventTime } from '@/lib/time';
-import { X, ExternalLink, MapPin, Users, CheckCircle2, Circle, FileText } from 'lucide-react';
+import { X, ExternalLink, MapPin, Users, CheckCircle2, Circle, FileText, Bell } from 'lucide-react';
 import Link from 'next/link';
 
 const PRIORITY_COLORS: Record<string, string> = {
-  p0: 'var(--status-red)', p1: 'var(--status-amber)', p2: 'var(--status-blue)', p3: 'var(--status-gray)',
+  p0: 'var(--status-red)',
+  p1: 'var(--status-amber)',
+  p2: 'var(--status-blue)',
+  p3: 'var(--status-gray)',
 };
 
 export function DayDetailPanel({
@@ -28,177 +31,216 @@ export function DayDetailPanel({
   const isEmpty = events.length + tasks.length + notes.length + remindersList.length === 0;
 
   return (
-    <div
-      className="flex-shrink-0 w-[320px] h-full overflow-y-auto border-l"
-      style={{
-        background: 'var(--surface-container-low)',
-        borderColor: 'var(--border-default)',
-      }}
-    >
-      {/* Header */}
-      <div className="flex items-center justify-between p-4 border-b"
-        style={{ borderColor: 'var(--border-default)' }}>
-        <span className="text-[13px] font-semibold" style={{ color: 'var(--text-primary)' }}>
-          {dateLabel}
-        </span>
-        <button onClick={onClose} className="p-1 rounded hover:opacity-70"
-          style={{ color: 'var(--text-tertiary)' }}>
-          <X size={14} />
-        </button>
-      </div>
+    <>
+      <button
+        type="button"
+        aria-label="Close day details"
+        className="fixed inset-0 z-40 bg-black/45 backdrop-blur-[2px] md:hidden"
+        onClick={onClose}
+      />
+      <aside
+        className="fixed inset-x-0 bottom-0 z-50 flex max-h-[82svh] flex-col overflow-hidden rounded-t-[24px] border-t shadow-2xl md:static md:z-auto md:h-full md:max-h-none md:w-[340px] md:flex-shrink-0 md:rounded-none md:border-l md:border-t-0 md:shadow-none"
+        style={{
+          background: 'var(--surface-container-low)',
+          borderColor: 'var(--border-default)',
+        }}
+      >
+        <div className="flex justify-center pt-2 md:hidden">
+          <div className="h-1 w-10 rounded-full" style={{ background: 'var(--border-strong)' }} />
+        </div>
 
-      <div className="p-4 space-y-4">
-        {isEmpty && (
-          <p className="text-[12px] text-center py-6" style={{ color: 'var(--text-tertiary)' }}>
-            Nothing on this day
-          </p>
-        )}
+        <div className="flex items-center justify-between border-b px-4 pb-3 pt-3 md:pt-4"
+          style={{ borderColor: 'var(--border-default)' }}>
+          <div className="min-w-0">
+            <span className="block truncate text-[14px] font-semibold" style={{ color: 'var(--text-primary)' }}>
+              {dateLabel}
+            </span>
+            <span className="text-[11px]" style={{ color: 'var(--text-tertiary)' }}>
+              {events.length} events, {tasks.length} tasks, {notes.length} notes
+            </span>
+          </div>
+          <button
+            onClick={onClose}
+            className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full transition-colors hover:opacity-80"
+            style={{ color: 'var(--text-tertiary)' }}
+          >
+            <X size={14} />
+          </button>
+        </div>
 
-        {/* Events */}
-        {events.length > 0 && (
-          <Section title="Events" color={ITEM_COLORS.event}>
-            {events.map((e) => {
-              const startTime = formatEventTime(e.metadata?.start || e.timestamp);
-              const endTime = e.metadata?.end ? formatEventTime(e.metadata.end) : null;
-              const briefText = briefs?.get(e.id);
-              const eventColor = getEventSourceColor(e.source);
-              return (
-                <div key={e.id}
-                  className="space-y-1 py-2 border-b last:border-b-0 cursor-pointer hover:opacity-80"
-                  style={{ borderColor: 'var(--border-default)' }}
-                  onClick={() => onEventClick?.(e)}>
-                  <div className="flex items-start gap-2">
-                    <div className="w-1.5 h-1.5 rounded-full mt-1.5 flex-shrink-0"
-                      style={{ background: eventColor }} />
-                    <div className="flex-1 min-w-0">
-                      <p className="text-[12px] font-medium" style={{ color: 'var(--text-primary)' }}>
-                        {e.title}
-                      </p>
-                      <p className="text-[11px]" style={{ color: 'var(--text-tertiary)' }}>
-                        {startTime}{endTime ? ` – ${endTime}` : ''}
-                        {e.metadata?.allDay ? ' (All day)' : ''}
-                      </p>
-                      <p className="text-[10px]" style={{ color: 'var(--text-tertiary)' }}>
-                        {getEventSourceLabel(e)}
-                      </p>
+        <div className="min-h-0 flex-1 space-y-4 overflow-y-auto p-4">
+          {isEmpty && (
+            <p className="py-6 text-center text-[12px]" style={{ color: 'var(--text-tertiary)' }}>
+              Nothing on this day
+            </p>
+          )}
+
+          {events.length > 0 && (
+            <Section title="Events" color={ITEM_COLORS.event}>
+              {events.map((e) => {
+                const startTime = formatEventTime(e.metadata?.start || e.timestamp);
+                const endTime = e.metadata?.end ? formatEventTime(e.metadata.end) : null;
+                const briefText = briefs?.get(e.id);
+                const eventColor = getEventSourceColor(e.source);
+                const attendeeCount = e.metadata?.attendees?.length || 0;
+
+                return (
+                  <div
+                    key={e.id}
+                    className="space-y-2 rounded-2xl border p-3 transition-colors hover:opacity-90"
+                    style={{
+                      borderColor: 'var(--border-default)',
+                      background: 'var(--surface-container)',
+                    }}
+                    onClick={() => onEventClick?.(e)}
+                  >
+                    <div className="flex items-start gap-2">
+                      <div className="mt-1.5 h-2 w-2 flex-shrink-0 rounded-full"
+                        style={{ background: eventColor }} />
+                      <div className="min-w-0 flex-1">
+                        <p className="text-[13px] font-semibold leading-snug" style={{ color: 'var(--text-primary)' }}>
+                          {e.title}
+                        </p>
+                        <p className="mt-1 text-[11px]" style={{ color: 'var(--text-tertiary)' }}>
+                          {startTime}{endTime ? ` - ${endTime}` : ''}
+                          {e.metadata?.allDay ? ' (All day)' : ''}
+                        </p>
+                        <p className="text-[10px] font-medium" style={{ color: 'var(--text-tertiary)' }}>
+                          {getEventSourceLabel(e)}
+                        </p>
+                      </div>
+                      {briefText && (
+                        <FileText size={12} className="mt-1 flex-shrink-0" style={{ color: 'var(--accent)' }} />
+                      )}
+                      {e.url && (
+                        <a
+                          href={e.url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="p-0.5 hover:opacity-70"
+                          style={{ color: 'var(--text-tertiary)' }}
+                          onClick={(ev) => ev.stopPropagation()}
+                        >
+                          <ExternalLink size={12} />
+                        </a>
+                      )}
                     </div>
-                    {briefText && (
-                      <FileText size={12} className="flex-shrink-0 mt-1" style={{ color: 'var(--accent)' }} />
+
+                    {e.metadata?.location && (
+                      <div className="ml-4 flex items-center gap-1.5 text-[11px]"
+                        style={{ color: 'var(--text-tertiary)' }}>
+                        <MapPin size={10} />
+                        <span>{e.metadata.location}</span>
+                      </div>
                     )}
-                    {e.url && (
-                      <a href={e.url} target="_blank" rel="noopener noreferrer"
-                        className="p-0.5 hover:opacity-70" style={{ color: 'var(--text-tertiary)' }}
-                        onClick={(ev) => ev.stopPropagation()}>
-                        <ExternalLink size={12} />
-                      </a>
+                    {attendeeCount > 0 && (
+                      <div className="ml-4 flex items-center gap-1.5 text-[11px]"
+                        style={{ color: 'var(--text-tertiary)' }}>
+                        <Users size={10} />
+                        <span>{attendeeCount} attendees</span>
+                      </div>
+                    )}
+                    {briefText && (
+                      <div className="ml-4 mt-1 rounded-xl p-2 text-[10px] leading-relaxed"
+                        style={{ background: 'var(--accent-muted, rgba(99,102,241,0.08))', color: 'var(--text-secondary)' }}>
+                        <div className="mb-1 flex items-center gap-1 text-[9px] font-semibold uppercase tracking-wider"
+                          style={{ color: 'var(--accent)' }}>
+                          <FileText size={9} /> Meeting prep
+                        </div>
+                        {briefText.slice(0, 200)}{briefText.length > 200 ? '...' : ''}
+                      </div>
                     )}
                   </div>
-                  {e.metadata?.location && (
-                    <div className="flex items-center gap-1.5 ml-3.5 text-[10px]"
-                      style={{ color: 'var(--text-tertiary)' }}>
-                      <MapPin size={10} />
-                      <span>{e.metadata.location}</span>
-                    </div>
-                  )}
-                  {e.metadata?.attendees?.length > 0 && (
-                    <div className="flex items-center gap-1.5 ml-3.5 text-[10px]"
-                      style={{ color: 'var(--text-tertiary)' }}>
-                      <Users size={10} />
-                      <span>{e.metadata.attendees.length} attendees</span>
-                    </div>
-                  )}
-                  {briefText && (
-                    <div className="ml-3.5 mt-1 p-2 rounded text-[10px] leading-relaxed"
-                      style={{ background: 'var(--accent-muted, rgba(99,102,241,0.08))', color: 'var(--text-secondary)' }}>
-                      <div className="flex items-center gap-1 mb-1 text-[9px] font-semibold uppercase tracking-wider"
-                        style={{ color: 'var(--accent)' }}>
-                        <FileText size={9} /> Meeting Prep
-                      </div>
-                      {briefText.slice(0, 200)}{briefText.length > 200 ? '...' : ''}
-                    </div>
-                  )}
-                </div>
-              );
-            })}
-          </Section>
-        )}
+                );
+              })}
+            </Section>
+          )}
 
-        {/* Tasks */}
-        {tasks.length > 0 && (
-          <Section title="Tasks" color={ITEM_COLORS.task}>
-            {tasks.map((t) => (
-              <Link key={t.id} href={`/tasks?task=${t.project_prefix}-${t.number}`}
-                className="flex items-center gap-2 py-1.5 hover:opacity-80 border-b last:border-b-0"
-                style={{ borderColor: 'var(--border-default)' }}>
-                {t.status === 'done'
-                  ? <CheckCircle2 size={12} style={{ color: 'var(--status-green)' }} />
-                  : <Circle size={12} style={{ color: PRIORITY_COLORS[t.priority] || 'var(--text-tertiary)' }} />}
-                <span className="text-[12px] truncate flex-1" style={{
-                  color: 'var(--text-primary)',
-                  textDecoration: t.status === 'done' ? 'line-through' : 'none',
-                  opacity: t.status === 'done' ? 0.5 : 1,
-                }}>
-                  {t.title}
-                </span>
-                <span className="text-[9px] font-mono flex-shrink-0" style={{ color: 'var(--text-tertiary)' }}>
-                  {t.project_prefix}-{t.number}
-                </span>
-              </Link>
-            ))}
-          </Section>
-        )}
-
-        {/* Notes */}
-        {notes.length > 0 && (
-          <Section title="Notes" color={ITEM_COLORS.note}>
-            {notes.map((n) => (
-              <Link key={n.id} href={`/notes?id=${n.id}`}
-                className="flex items-center gap-2 py-1.5 hover:opacity-80 border-b last:border-b-0"
-                style={{ borderColor: 'var(--border-default)' }}>
-                <span className="text-[11px]">{n.icon || '\uD83D\uDCC4'}</span>
-                <span className="text-[12px] truncate" style={{ color: 'var(--text-primary)' }}>
-                  {n.title || 'Untitled'}
-                </span>
-              </Link>
-            ))}
-          </Section>
-        )}
-
-        {/* Reminders */}
-        {remindersList.length > 0 && (
-          <Section title="Reminders" color={ITEM_COLORS.reminder}>
-            {remindersList.map((r) => (
-              <div key={r.id} className="flex items-center gap-2 py-1.5 border-b last:border-b-0"
-                style={{ borderColor: 'var(--border-default)' }}>
-                <span className="text-[11px]">⏰</span>
-                <div className="flex-1 min-w-0">
-                  <span className="text-[12px] truncate block" style={{ color: 'var(--text-primary)' }}>
-                    {r.message}
+          {tasks.length > 0 && (
+            <Section title="Tasks" color={ITEM_COLORS.task}>
+              {tasks.map((t) => (
+                <Link
+                  key={t.id}
+                  href={`/tasks?task=${t.project_prefix}-${t.number}`}
+                  className="flex items-center gap-2 rounded-2xl border p-3 transition-colors hover:opacity-90"
+                  style={{ borderColor: 'var(--border-default)', background: 'var(--surface-container)' }}
+                >
+                  {t.status === 'done'
+                    ? <CheckCircle2 size={12} style={{ color: 'var(--status-green)' }} />
+                    : <Circle size={12} style={{ color: PRIORITY_COLORS[t.priority] || 'var(--text-tertiary)' }} />}
+                  <span className="min-w-0 flex-1 truncate text-[12px]" style={{
+                    color: 'var(--text-primary)',
+                    textDecoration: t.status === 'done' ? 'line-through' : 'none',
+                    opacity: t.status === 'done' ? 0.5 : 1,
+                  }}>
+                    {t.title}
                   </span>
-                  <span className="text-[10px]" style={{ color: 'var(--text-tertiary)' }}>
-                    {new Date(r.remind_at).toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' })}
+                  <span className="flex-shrink-0 font-mono text-[9px]" style={{ color: 'var(--text-tertiary)' }}>
+                    {t.project_prefix}-{t.number}
                   </span>
+                </Link>
+              ))}
+            </Section>
+          )}
+
+          {notes.length > 0 && (
+            <Section title="Notes" color={ITEM_COLORS.note}>
+              {notes.map((n) => (
+                <Link
+                  key={n.id}
+                  href={`/notes?id=${n.id}`}
+                  className="flex items-center gap-2 rounded-2xl border p-3 transition-colors hover:opacity-90"
+                  style={{ borderColor: 'var(--border-default)', background: 'var(--surface-container)' }}
+                >
+                  <span className="text-[11px]">{n.icon || '\uD83D\uDCC4'}</span>
+                  <span className="truncate text-[12px]" style={{ color: 'var(--text-primary)' }}>
+                    {n.title || 'Untitled'}
+                  </span>
+                </Link>
+              ))}
+            </Section>
+          )}
+
+          {remindersList.length > 0 && (
+            <Section title="Reminders" color={ITEM_COLORS.reminder}>
+              {remindersList.map((r) => (
+                <div
+                  key={r.id}
+                  className="flex items-center gap-2 rounded-2xl border p-3"
+                  style={{ borderColor: 'var(--border-default)', background: 'var(--surface-container)' }}
+                >
+                  <Bell size={12} style={{ color: ITEM_COLORS.reminder }} />
+                  <div className="min-w-0 flex-1">
+                    <span className="block truncate text-[12px]" style={{ color: 'var(--text-primary)' }}>
+                      {r.message}
+                    </span>
+                    <span className="text-[10px]" style={{ color: 'var(--text-tertiary)' }}>
+                      {new Date(r.remind_at).toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' })}
+                    </span>
+                  </div>
                 </div>
-              </div>
-            ))}
-          </Section>
-        )}
-      </div>
-    </div>
+              ))}
+            </Section>
+          )}
+        </div>
+      </aside>
+    </>
   );
 }
 
 function Section({ title, color, children }: { title: string; color: string; children: React.ReactNode }) {
   return (
-    <div>
-      <div className="flex items-center gap-2 mb-2">
-        <div className="w-2 h-2 rounded-full" style={{ background: color }} />
+    <section>
+      <div className="mb-2 flex items-center gap-2">
+        <div className="h-2 w-2 rounded-full" style={{ background: color }} />
         <span className="text-[11px] font-semibold uppercase tracking-wider"
           style={{ color: 'var(--text-tertiary)' }}>
           {title}
         </span>
       </div>
-      {children}
-    </div>
+      <div className="space-y-2">
+        {children}
+      </div>
+    </section>
   );
 }

--- a/apps/web/src/components/confirm-dialog.tsx
+++ b/apps/web/src/components/confirm-dialog.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
+import { useRef } from 'react';
+import { AppDialog } from './overlay-primitives';
 
 interface ConfirmDialogProps {
   title: string;
@@ -12,48 +13,51 @@ interface ConfirmDialogProps {
   onCancel: () => void;
 }
 
-export default function ConfirmDialog({ title, message, confirmLabel = 'Confirm', cancelLabel = 'Cancel', danger, onConfirm, onCancel }: ConfirmDialogProps) {
+export default function ConfirmDialog({
+  title,
+  message,
+  confirmLabel = 'Confirm',
+  cancelLabel = 'Cancel',
+  danger,
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps) {
   const cancelRef = useRef<HTMLButtonElement>(null);
 
-  useEffect(() => {
-    cancelRef.current?.focus();
-    const handleKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onCancel();
-    };
-    window.addEventListener('keydown', handleKey);
-    return () => window.removeEventListener('keydown', handleKey);
-  }, [onCancel]);
-
   return (
-    <div className="fixed inset-0 z-[100] flex items-center justify-center" style={{ background: 'rgba(0,0,0,0.5)' }} onClick={onCancel}>
-      <div
-        className="w-full max-w-[360px] rounded-xl p-5 flex flex-col gap-4"
-        style={{ background: 'var(--card-bg)', border: '1px solid var(--border)', boxShadow: 'var(--glass-shadow)' }}
-        onClick={e => e.stopPropagation()}
-      >
-        <div className="text-[0.9375rem] font-semibold" style={{ color: 'var(--on-surface)' }}>{title}</div>
-        <div className="text-[0.8125rem]" style={{ color: 'var(--on-surface-variant)' }}>{message}</div>
-        <div className="flex justify-end gap-2 mt-1">
+    <AppDialog
+      open
+      onClose={onCancel}
+      title={title}
+      description={message}
+      danger={danger}
+      width={380}
+      initialFocusRef={cancelRef}
+      footer={
+        <div className="flex justify-end gap-2">
           <button
             ref={cancelRef}
             onClick={onCancel}
-            className="px-4 py-2 text-[0.8125rem] rounded-lg font-medium"
-            style={{ color: 'var(--on-surface-variant)', background: 'var(--surface-container-low)', border: '1px solid var(--outline-variant)' }}
+            className="rounded-lg px-4 py-2 text-[0.8125rem] font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary-container)]"
+            style={{
+              color: 'var(--on-surface-variant)',
+              background: 'var(--surface-container-low)',
+              border: '1px solid var(--outline-variant)',
+            }}
           >
             {cancelLabel}
           </button>
           <button
             onClick={onConfirm}
-            className="px-4 py-2 text-[0.8125rem] rounded-lg font-medium"
-            style={{
-              background: danger ? 'var(--danger)' : 'var(--accent)',
-              color: '#fff',
-            }}
+            className="rounded-lg px-4 py-2 text-[0.8125rem] font-medium text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary-container)]"
+            style={{ background: danger ? 'var(--danger)' : 'var(--accent)' }}
           >
             {confirmLabel}
           </button>
         </div>
-      </div>
-    </div>
+      }
+    >
+      <span className="sr-only">{message}</span>
+    </AppDialog>
   );
 }

--- a/apps/web/src/components/inbox-row.tsx
+++ b/apps/web/src/components/inbox-row.tsx
@@ -31,13 +31,27 @@ export function InboxRow({ item, onClick, onDismiss }: Props) {
   const Icon = KIND_ICON[item.kind] ?? Bell;
   const content = (
     <div
-      className="group flex items-start gap-3 px-4 py-3 rounded-lg cursor-pointer relative"
+      className="group relative flex cursor-pointer items-start gap-3 rounded-xl px-4 py-3 transition-colors hover:bg-[var(--bg-hover)]"
       style={{
-        background: item.read ? 'transparent' : 'var(--bg-active)',
-        borderLeft: item.read ? '2px solid transparent' : '2px solid var(--primary)',
+        border: '1px solid transparent',
       }}
     >
-      <Icon size={16} strokeWidth={1.5} style={{ color: 'var(--primary)', marginTop: 2 }} />
+      {!item.read && (
+        <span
+          aria-hidden="true"
+          className="absolute left-2 top-4 h-2 w-2 rounded-full"
+          style={{ background: 'var(--primary-container)' }}
+        />
+      )}
+      <span
+        className="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-full"
+        style={{
+          background: item.read ? 'transparent' : 'color-mix(in srgb, var(--primary-container) 12%, transparent)',
+          color: item.read ? 'var(--outline)' : 'var(--primary)',
+        }}
+      >
+        <Icon size={15} strokeWidth={1.65} />
+      </span>
       <div className="flex-1 min-w-0 pr-7">
         <div
           className="text-[13px] font-medium truncate"
@@ -63,10 +77,10 @@ export function InboxRow({ item, onClick, onDismiss }: Props) {
             e.stopPropagation();
             onDismiss();
           }}
-          className="absolute top-2.5 right-2.5 p-1 rounded opacity-0 group-hover:opacity-100 transition-opacity hover:bg-[var(--bg-hover)]"
+          className="absolute right-2 top-2 flex h-8 w-8 items-center justify-center rounded-full opacity-100 transition-opacity hover:bg-[var(--bg-hover)] focus-visible:opacity-100 md:h-7 md:w-7 md:opacity-0 md:group-hover:opacity-100 md:group-focus-within:opacity-100"
           style={{ color: 'var(--muted)' }}
-          title="Dismiss"
-          aria-label="Dismiss notification"
+          title="Mark read"
+          aria-label="Mark notification read"
         >
           <X size={13} strokeWidth={1.75} />
         </button>
@@ -81,5 +95,20 @@ export function InboxRow({ item, onClick, onDismiss }: Props) {
       </Link>
     );
   }
-  return <div onClick={onClick}>{content}</div>;
+  return (
+    <div
+      onClick={onClick}
+      role={onClick ? 'button' : undefined}
+      tabIndex={onClick ? 0 : undefined}
+      onKeyDown={(event) => {
+        if (!onClick) return;
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          onClick();
+        }
+      }}
+    >
+      {content}
+    </div>
+  );
 }

--- a/apps/web/src/components/label-picker.tsx
+++ b/apps/web/src/components/label-picker.tsx
@@ -143,7 +143,7 @@ export function LabelPicker({ taskId, appliedLabels, onLabelsChange }: Props) {
               <button
                 key={label.id}
                 onClick={() => { void applyLabel(label); setQuery(''); }}
-                className="w-full flex items-center gap-2 px-3 py-1.5 text-[12px] text-left hover:bg-white/5"
+                className="w-full flex items-center gap-2 px-3 py-1.5 text-[12px] text-left hover:bg-[var(--bg-hover)]"
                 style={{ color: 'var(--foreground-secondary)' }}
               >
                 <div className="w-2.5 h-2.5 rounded-full flex-shrink-0" style={{ background: label.color }} />
@@ -154,7 +154,7 @@ export function LabelPicker({ taskId, appliedLabels, onLabelsChange }: Props) {
             {canCreate && (
               <button
                 onClick={createAndApply}
-                className="w-full flex items-center gap-2 px-3 py-1.5 text-[12px] text-left hover:bg-white/5"
+                className="w-full flex items-center gap-2 px-3 py-1.5 text-[12px] text-left hover:bg-[var(--bg-hover)]"
                 style={{ color: 'var(--accent)' }}
               >
                 <Plus size={12} />

--- a/apps/web/src/components/mobile-action-sheet.tsx
+++ b/apps/web/src/components/mobile-action-sheet.tsx
@@ -1,5 +1,7 @@
 'use client';
-import { ReactNode, useEffect } from 'react';
+
+import { ReactNode } from 'react';
+import { AppBottomSheet } from './overlay-primitives';
 
 type Props = {
   open: boolean;
@@ -9,31 +11,14 @@ type Props = {
 };
 
 /**
- * Bottom sheet for mobile (`< md`) — slides up from the bottom, dismisses on
- * Escape or backdrop tap. Use for formatting toolbars, action lists, or any
- * cluster of buttons too dense for a 48px row at narrow widths.
+ * Bottom sheet for mobile (`< md`). Shared behavior lives in
+ * `overlay-primitives` so every sheet uses the same Escape, focus, backdrop,
+ * safe-area, scroll-lock, and height behavior.
  */
 export function MobileActionSheet({ open, onClose, title, children }: Props) {
-  useEffect(() => {
-    if (!open) return;
-    const handler = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
-    window.addEventListener('keydown', handler);
-    return () => window.removeEventListener('keydown', handler);
-  }, [open, onClose]);
-  if (!open) return null;
   return (
-    <>
-      <div className="md:hidden fixed inset-0 z-40 bg-black/40" onClick={onClose} aria-hidden />
-      <div
-        role="dialog"
-        aria-modal="true"
-        aria-label={title}
-        className="md:hidden fixed bottom-0 left-0 right-0 z-50 rounded-t-2xl pb-[max(env(safe-area-inset-bottom),16px)] pt-3"
-        style={{ background: 'var(--surface)' }}
-      >
-        {title && <div className="px-4 pb-2 text-[0.8125rem] font-semibold opacity-70">{title}</div>}
-        <div className="px-2 pb-2">{children}</div>
-      </div>
-    </>
+    <AppBottomSheet open={open} onClose={onClose} title={title} mobileOnly>
+      {children}
+    </AppBottomSheet>
   );
 }

--- a/apps/web/src/components/notification-panel.tsx
+++ b/apps/web/src/components/notification-panel.tsx
@@ -17,6 +17,7 @@ export function NotificationPanel({ onClose }: Props) {
   const router = useRouter();
   const { items, isLoading, markRead, markAllRead, refresh } = useInbox();
   const ref = useRef<HTMLDivElement>(null);
+  const unreadCount = items.filter((item) => !item.read).length;
 
   useEffect(() => {
     function handleClickOutside(e: MouseEvent) {
@@ -70,6 +71,8 @@ export function NotificationPanel({ onClose }: Props) {
   return (
     <div
       ref={ref}
+      role="dialog"
+      aria-label="Notifications"
       className="fixed bottom-0 left-0 right-0 z-[9999] max-h-[70vh] flex flex-col overflow-hidden rounded-t-2xl md:rounded-xl md:absolute md:bottom-auto md:left-auto md:right-0 md:top-full md:mt-2 md:w-[360px] md:max-h-[520px]"
       style={{
         background: 'var(--surface-container-highest)',
@@ -91,7 +94,8 @@ export function NotificationPanel({ onClose }: Props) {
         </span>
         <button
           onClick={() => void markAllRead()}
-          className="text-[11px] font-medium px-2 py-2 md:py-1 rounded-md min-h-[36px] flex items-center"
+          disabled={isLoading || unreadCount === 0}
+          className="text-[11px] font-medium px-2 py-2 md:py-1 rounded-md min-h-[36px] flex items-center disabled:cursor-not-allowed disabled:opacity-45"
           style={{ color: 'var(--accent)', fontFamily: 'var(--font-body)' }}
         >
           Mark all read

--- a/apps/web/src/components/overflow-menu.tsx
+++ b/apps/web/src/components/overflow-menu.tsx
@@ -1,50 +1,57 @@
 'use client';
-import { useState, useRef, useEffect, ReactNode } from 'react';
+
+import { useRef, useState, ReactNode } from 'react';
 import { MoreHorizontal } from 'lucide-react';
+import { AppMenu, type AppMenuItem } from './overlay-primitives';
 
-type Item = { label: string; onClick: () => void; icon?: ReactNode; danger?: boolean };
+type Item = {
+  label: string;
+  onClick: () => void | Promise<void>;
+  icon?: ReactNode;
+  danger?: boolean;
+  disabled?: boolean;
+};
 
-export function OverflowMenu({ items, className = '' }: { items: Item[]; className?: string }) {
+export function OverflowMenu({
+  items,
+  className = '',
+  label = 'More',
+}: {
+  items: Item[];
+  className?: string;
+  label?: string;
+}) {
   const [open, setOpen] = useState(false);
-  const ref = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (!open) return;
-    const handler = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
-    };
-    window.addEventListener('mousedown', handler);
-    return () => window.removeEventListener('mousedown', handler);
-  }, [open]);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const menuItems: AppMenuItem[] = items.map((item) => ({
+    label: item.label,
+    icon: item.icon,
+    danger: item.danger,
+    disabled: item.disabled,
+    onSelect: item.onClick,
+  }));
 
   return (
-    <div ref={ref} className={`relative ${className}`}>
+    <div className={`relative ${className}`}>
       <button
-        onClick={() => setOpen(!open)}
-        aria-label="More"
-        className="flex items-center justify-center min-w-[44px] min-h-[44px] rounded-md hover:opacity-70"
+        ref={buttonRef}
+        onClick={() => setOpen((current) => !current)}
+        aria-label={label}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded-md hover:opacity-75 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary-container)]"
         style={{ color: 'var(--text-tertiary)' }}
       >
         <MoreHorizontal size={18} />
       </button>
-      {open && (
-        <div
-          className="absolute right-0 top-full mt-1 rounded-md border py-1 z-30 min-w-[180px]"
-          style={{ background: 'var(--surface)', borderColor: 'var(--outline-variant)' }}
-        >
-          {items.map((item) => (
-            <button
-              key={item.label}
-              onClick={() => { item.onClick(); setOpen(false); }}
-              className="flex items-center gap-2 w-full text-left px-3 py-2 text-[0.875rem] hover:bg-[var(--surface-container)]"
-              style={{ color: item.danger ? 'var(--status-red)' : 'var(--text-primary)' }}
-            >
-              {item.icon && <span className="flex-shrink-0">{item.icon}</span>}
-              {item.label}
-            </button>
-          ))}
-        </div>
-      )}
+      <AppMenu
+        open={open}
+        onClose={() => setOpen(false)}
+        anchorRef={buttonRef}
+        items={menuItems}
+        ariaLabel={label}
+        width={200}
+      />
     </div>
   );
 }

--- a/apps/web/src/components/overlay-primitives.tsx
+++ b/apps/web/src/components/overlay-primitives.tsx
@@ -1,0 +1,465 @@
+'use client';
+
+import {
+  ReactNode,
+  RefObject,
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type KeyboardEvent as ReactKeyboardEvent,
+} from 'react';
+import { createPortal } from 'react-dom';
+
+function useMounted() {
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+  return mounted;
+}
+
+function getFocusable(container: HTMLElement | null): HTMLElement[] {
+  if (!container) return [];
+  return Array.from(
+    container.querySelectorAll<HTMLElement>(
+      'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])',
+    ),
+  ).filter((el) => !el.hasAttribute('disabled') && el.getAttribute('aria-hidden') !== 'true');
+}
+
+export function useBodyScrollLock(open: boolean) {
+  useEffect(() => {
+    if (!open || typeof document === 'undefined') return;
+    const previous = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = previous;
+    };
+  }, [open]);
+}
+
+export function useOverlayDismiss({
+  open,
+  onClose,
+  refs,
+  closeOnOutside = true,
+  closeOnEscape = true,
+}: {
+  open: boolean;
+  onClose: () => void;
+  refs: RefObject<HTMLElement | null>[];
+  closeOnOutside?: boolean;
+  closeOnEscape?: boolean;
+}) {
+  useEffect(() => {
+    if (!open) return;
+
+    const handlePointerDown = (event: PointerEvent) => {
+      if (!closeOnOutside) return;
+      const target = event.target as Node;
+      if (refs.some((ref) => ref.current?.contains(target))) return;
+      onClose();
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (closeOnEscape && event.key === 'Escape') {
+        event.preventDefault();
+        onClose();
+      }
+    };
+
+    document.addEventListener('pointerdown', handlePointerDown);
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerDown);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [closeOnEscape, closeOnOutside, onClose, open, refs]);
+}
+
+function useReturnFocus(open: boolean, anchorRef?: RefObject<HTMLElement | null>) {
+  const lastOpen = useRef(false);
+
+  useEffect(() => {
+    if (open) {
+      lastOpen.current = true;
+      return;
+    }
+    if (!lastOpen.current) return;
+    lastOpen.current = false;
+    requestAnimationFrame(() => anchorRef?.current?.focus?.());
+  }, [anchorRef, open]);
+}
+
+function handleFocusTrap(event: ReactKeyboardEvent, panel: HTMLElement | null) {
+  if (event.key !== 'Tab') return;
+  const focusable = getFocusable(panel);
+  if (focusable.length === 0) return;
+
+  const first = focusable[0];
+  const last = focusable[focusable.length - 1];
+  const active = document.activeElement;
+
+  if (event.shiftKey && active === first) {
+    event.preventDefault();
+    last.focus();
+  } else if (!event.shiftKey && active === last) {
+    event.preventDefault();
+    first.focus();
+  }
+}
+
+export function AppBackdrop({
+  onClose,
+  className = '',
+  subtle = false,
+}: {
+  onClose?: () => void;
+  className?: string;
+  subtle?: boolean;
+}) {
+  return (
+    <div
+      aria-hidden
+      className={`fixed inset-0 ${className}`}
+      onClick={onClose}
+      style={{
+        background: subtle ? 'rgba(0,0,0,0.28)' : 'rgba(0,0,0,0.52)',
+        backdropFilter: 'blur(5px)',
+      }}
+    />
+  );
+}
+
+export function AppDialog({
+  open = true,
+  onClose,
+  title,
+  description,
+  children,
+  footer,
+  width = 420,
+  danger = false,
+  initialFocusRef,
+}: {
+  open?: boolean;
+  onClose: () => void;
+  title?: string;
+  description?: string;
+  children: ReactNode;
+  footer?: ReactNode;
+  width?: number;
+  danger?: boolean;
+  initialFocusRef?: RefObject<HTMLElement | null>;
+}) {
+  const mounted = useMounted();
+  const panelRef = useRef<HTMLDivElement>(null);
+  const titleId = useId();
+  const descriptionId = useId();
+
+  useBodyScrollLock(open);
+  useOverlayDismiss({ open, onClose, refs: [panelRef], closeOnOutside: false });
+
+  useEffect(() => {
+    if (!open) return;
+    requestAnimationFrame(() => {
+      if (initialFocusRef?.current) {
+        initialFocusRef.current.focus();
+        return;
+      }
+      getFocusable(panelRef.current)[0]?.focus();
+    });
+  }, [initialFocusRef, open]);
+
+  if (!mounted || !open) return null;
+
+  return createPortal(
+    <div className="fixed inset-0 z-[100] flex items-center justify-center px-4 py-6">
+      <AppBackdrop onClose={onClose} />
+      <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={title ? titleId : undefined}
+        aria-describedby={description ? descriptionId : undefined}
+        className="relative flex max-h-[min(90vh,760px)] w-full flex-col overflow-hidden rounded-2xl outline-none"
+        style={{
+          maxWidth: width,
+          background: 'var(--surface-container)',
+          border: '1px solid var(--outline-variant)',
+          boxShadow: 'var(--glass-shadow)',
+        }}
+        onClick={(event) => event.stopPropagation()}
+        onKeyDown={(event) => handleFocusTrap(event, panelRef.current)}
+      >
+        {(title || description) && (
+          <div className="flex-shrink-0 px-5 pt-5">
+            {title && (
+              <h2 id={titleId} className="text-[0.9375rem] font-semibold" style={{ color: danger ? 'var(--danger)' : 'var(--on-surface)' }}>
+                {title}
+              </h2>
+            )}
+            {description && (
+              <p id={descriptionId} className="mt-2 text-[0.8125rem] leading-relaxed" style={{ color: 'var(--on-surface-variant)' }}>
+                {description}
+              </p>
+            )}
+          </div>
+        )}
+        <div className="min-h-0 flex-1 overflow-y-auto px-5 py-4">{children}</div>
+        {footer && (
+          <div className="flex-shrink-0 px-5 pb-5 pt-1">
+            {footer}
+          </div>
+        )}
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
+export function AppBottomSheet({
+  open,
+  onClose,
+  title,
+  children,
+  footer,
+  mobileOnly = false,
+}: {
+  open: boolean;
+  onClose: () => void;
+  title?: string;
+  children: ReactNode;
+  footer?: ReactNode;
+  mobileOnly?: boolean;
+}) {
+  const mounted = useMounted();
+  const panelRef = useRef<HTMLDivElement>(null);
+  const titleId = useId();
+
+  useBodyScrollLock(open);
+  useOverlayDismiss({ open, onClose, refs: [panelRef], closeOnOutside: false });
+
+  useEffect(() => {
+    if (!open) return;
+    requestAnimationFrame(() => getFocusable(panelRef.current)[0]?.focus());
+  }, [open]);
+
+  if (!mounted || !open) return null;
+
+  return createPortal(
+    <div className={`fixed inset-0 z-[90] flex items-end ${mobileOnly ? 'md:hidden' : ''}`}>
+      <AppBackdrop onClose={onClose} subtle />
+      <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={title ? titleId : undefined}
+        className="relative max-h-[82vh] w-full overflow-hidden rounded-t-2xl outline-none"
+        style={{
+          background: 'var(--surface-container)',
+          borderTop: '1px solid var(--outline-variant)',
+          boxShadow: '0 -18px 44px rgba(0,0,0,0.38)',
+          paddingBottom: 'max(env(safe-area-inset-bottom), 12px)',
+        }}
+        onKeyDown={(event) => handleFocusTrap(event, panelRef.current)}
+      >
+        <div className="mx-auto mt-2 h-1 w-10 rounded-full" style={{ background: 'var(--outline-variant)' }} />
+        {title && (
+          <div id={titleId} className="px-4 pb-2 pt-3 text-[0.8125rem] font-semibold" style={{ color: 'var(--on-surface-variant)' }}>
+            {title}
+          </div>
+        )}
+        <div className="max-h-[60vh] overflow-y-auto px-2 pb-2">{children}</div>
+        {footer && <div className="px-4 pb-2 pt-2">{footer}</div>}
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
+function getAnchoredPosition(anchor: HTMLElement, width: number, side: 'top' | 'bottom', align: 'start' | 'end') {
+  const rect = anchor.getBoundingClientRect();
+  const margin = 10;
+  const viewportWidth = window.innerWidth;
+  const viewportHeight = window.innerHeight;
+  const maxHeight = Math.max(180, viewportHeight - margin * 2);
+  const left = align === 'end' ? rect.right - width : rect.left;
+  const clampedLeft = Math.min(Math.max(margin, left), viewportWidth - width - margin);
+  const spaceBelow = viewportHeight - rect.bottom - margin;
+  const spaceAbove = rect.top - margin;
+  const resolvedSide = side === 'bottom' && spaceBelow < 220 && spaceAbove > spaceBelow ? 'top' : side;
+  const top = resolvedSide === 'top' ? Math.max(margin, rect.top - 8) : Math.min(viewportHeight - margin, rect.bottom + 8);
+
+  return {
+    left: clampedLeft,
+    top,
+    transform: resolvedSide === 'top' ? 'translateY(-100%)' : undefined,
+    maxHeight: Math.min(maxHeight, resolvedSide === 'top' ? spaceAbove - 8 : spaceBelow - 8),
+  };
+}
+
+export function AnchoredOverlay({
+  open,
+  onClose,
+  anchorRef,
+  children,
+  width = 220,
+  side = 'bottom',
+  align = 'end',
+  role = 'dialog',
+  ariaLabel,
+}: {
+  open: boolean;
+  onClose: () => void;
+  anchorRef: RefObject<HTMLElement | null>;
+  children: ReactNode;
+  width?: number;
+  side?: 'top' | 'bottom';
+  align?: 'start' | 'end';
+  role?: string;
+  ariaLabel?: string;
+}) {
+  const mounted = useMounted();
+  const panelRef = useRef<HTMLDivElement>(null);
+  const [style, setStyle] = useState<CSSProperties | null>(null);
+
+  const updatePosition = useCallback(() => {
+    if (!anchorRef.current) return;
+    const next = getAnchoredPosition(anchorRef.current, width, side, align);
+    setStyle({
+      position: 'fixed',
+      width,
+      left: next.left,
+      top: next.top,
+      transform: next.transform,
+      maxHeight: next.maxHeight,
+    });
+  }, [align, anchorRef, side, width]);
+
+  useReturnFocus(open, anchorRef);
+  useOverlayDismiss({ open, onClose, refs: [panelRef, anchorRef], closeOnOutside: true });
+
+  useEffect(() => {
+    if (!open) return;
+    updatePosition();
+    window.addEventListener('resize', updatePosition);
+    window.addEventListener('scroll', updatePosition, true);
+    return () => {
+      window.removeEventListener('resize', updatePosition);
+      window.removeEventListener('scroll', updatePosition, true);
+    };
+  }, [open, updatePosition]);
+
+  if (!mounted || !open || !style) return null;
+
+  return createPortal(
+    <div
+      ref={panelRef}
+      role={role}
+      aria-label={ariaLabel}
+      className="deft-menu-surface z-[95] overflow-y-auto py-1.5 outline-none"
+      style={{
+        ...style,
+      }}
+    >
+      {children}
+    </div>,
+    document.body,
+  );
+}
+
+export type AppMenuItem = {
+  label: string;
+  onSelect: () => void | Promise<void>;
+  icon?: ReactNode;
+  danger?: boolean;
+  disabled?: boolean;
+};
+
+export function AppMenu({
+  open,
+  onClose,
+  anchorRef,
+  items,
+  header,
+  width = 220,
+  ariaLabel = 'Menu',
+}: {
+  open: boolean;
+  onClose: () => void;
+  anchorRef: RefObject<HTMLElement | null>;
+  items: AppMenuItem[];
+  header?: ReactNode;
+  width?: number;
+  ariaLabel?: string;
+}) {
+  const itemRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    const check = () => setIsMobile(window.innerWidth < 768);
+    check();
+    window.addEventListener('resize', check);
+    return () => window.removeEventListener('resize', check);
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    requestAnimationFrame(() => itemRefs.current.find(Boolean)?.focus());
+  }, [open]);
+
+  const content = useMemo(() => (
+    <div role={isMobile ? 'menu' : undefined} aria-label={isMobile ? ariaLabel : undefined}>
+      {header && (
+        <div className="px-3 py-2" style={{ borderBottom: '1px solid var(--outline-variant)' }}>
+          {header}
+        </div>
+      )}
+      {items.map((item, index) => (
+        <button
+          key={item.label}
+          ref={(node) => { itemRefs.current[index] = node; }}
+          role="menuitem"
+          disabled={item.disabled}
+          onClick={async () => {
+            if (item.disabled) return;
+            await item.onSelect();
+            onClose();
+          }}
+          onKeyDown={(event) => {
+            if (event.key === 'ArrowDown') {
+              event.preventDefault();
+              itemRefs.current[(index + 1) % items.length]?.focus();
+            }
+            if (event.key === 'ArrowUp') {
+              event.preventDefault();
+              itemRefs.current[(index - 1 + items.length) % items.length]?.focus();
+            }
+          }}
+          className="deft-menu-item mx-1 flex w-[calc(100%-0.5rem)] items-center gap-2.5 px-3 py-2 text-left text-[0.8125rem] outline-none disabled:cursor-not-allowed disabled:opacity-45"
+          style={item.danger ? { color: 'var(--danger)' } : undefined}
+        >
+          {item.icon && <span className="flex-shrink-0">{item.icon}</span>}
+          <span className="min-w-0 flex-1 truncate">{item.label}</span>
+        </button>
+      ))}
+    </div>
+  ), [ariaLabel, header, isMobile, items, onClose]);
+
+  if (isMobile) {
+    return (
+      <AppBottomSheet open={open} onClose={onClose} title={ariaLabel}>
+        {content}
+      </AppBottomSheet>
+    );
+  }
+
+  return (
+    <AnchoredOverlay open={open} onClose={onClose} anchorRef={anchorRef} width={width} role="menu" ariaLabel={ariaLabel}>
+      {content}
+    </AnchoredOverlay>
+  );
+}

--- a/apps/web/src/components/rich-composer.tsx
+++ b/apps/web/src/components/rich-composer.tsx
@@ -144,8 +144,11 @@ export function RichComposer({
   const [focused, setFocused] = useState(false);
   const [emojiOpen, setEmojiOpen] = useState(false);
   const [scheduleOpen, setScheduleOpen] = useState(false);
+  const [desktopActionsOpen, setDesktopActionsOpen] = useState(false);
   const [customScheduleTime, setCustomScheduleTime] = useState('');
   const scheduleBtnRef = useRef<HTMLButtonElement>(null);
+  const desktopActionBtnRef = useRef<HTMLButtonElement>(null);
+  const desktopActionMenuRef = useRef<HTMLDivElement>(null);
   const [schedulePos, setSchedulePos] = useState<{ top: number; right: number } | null>(null);
   useEffect(() => {
     if (!scheduleOpen) return;
@@ -163,6 +166,17 @@ export function RichComposer({
       window.removeEventListener('scroll', update, true);
     };
   }, [scheduleOpen]);
+  useEffect(() => {
+    if (!desktopActionsOpen) return;
+    const handlePointerDown = (event: MouseEvent) => {
+      const target = event.target;
+      if (!(target instanceof globalThis.Node)) return;
+      if (desktopActionBtnRef.current?.contains(target) || desktopActionMenuRef.current?.contains(target)) return;
+      setDesktopActionsOpen(false);
+    };
+    document.addEventListener('mousedown', handlePointerDown);
+    return () => document.removeEventListener('mousedown', handlePointerDown);
+  }, [desktopActionsOpen]);
   const [linkDialogOpen, setLinkDialogOpen] = useState(false);
   const [formatSheetOpen, setFormatSheetOpen] = useState(false);
   const [linkUrl, setLinkUrl] = useState('');
@@ -399,6 +413,10 @@ export function RichComposer({
     setFormatSheetOpen(false);
     action();
   };
+  const runDesktopAction = (action: () => void) => {
+    setDesktopActionsOpen(false);
+    action();
+  };
 
   return (
     <div className="px-3 md:px-6 py-2 md:py-3 flex-shrink-0 relative" style={{ paddingBottom: 'max(0.75rem, env(safe-area-inset-bottom))' }} ref={composerRef}>
@@ -419,13 +437,16 @@ export function RichComposer({
       )}
       <div
         className={[
-          'bg-transparent md:bg-[var(--surface-container-low)] rounded-none md:rounded-[var(--radius-lg)] overflow-visible md:overflow-hidden transition-[box-shadow] duration-150',
-          focused ? 'md:shadow-[0_0_0_2px_rgba(144,128,250,0.3)]' : '',
+          'bg-transparent md:bg-[var(--surface-container-low)] rounded-none md:rounded-[28px] overflow-visible transition-[border-color,box-shadow,background] duration-150 md:border md:p-1.5',
+          focused
+            ? 'md:shadow-[0_0_0_2px_rgba(144,128,250,0.22)]'
+            : 'md:shadow-[0_10px_30px_rgba(0,0,0,0.08)]',
         ].join(' ')}
+        style={{ borderColor: focused ? '#9080fa' : 'var(--outline-variant)' }}
       >
-        {/* Formatting toolbar - desktop only (hidden on < md) */}
+        {/* Legacy desktop formatting strip is intentionally hidden; desktop now uses the bottom work dock rail. */}
         <div
-          className="hidden md:flex items-center gap-0.5 px-2 pt-1.5 pb-0.5"
+          className="hidden"
         >
           <ToolbarBtn
             active={editor.isActive('bold')}
@@ -505,11 +526,11 @@ export function RichComposer({
           </ToolbarBtn>
         </div>
 
-        {/* Mobile composer action sheet - Insert (attach/emoji/voice) + Format (B/I/...) */}
+        {/* Mobile composer action sheet - work actions first, then insert + format. */}
         <MobileActionSheet
           open={formatSheetOpen}
           onClose={() => setFormatSheetOpen(false)}
-          title="Compose"
+          title="Compose actions"
         >
           <div className="px-1 pb-2 text-[0.6875rem] font-semibold uppercase tracking-wider opacity-50">Work</div>
           <div className="grid grid-cols-1 gap-2 mb-4">
@@ -517,7 +538,7 @@ export function RichComposer({
               <SheetActionButton
                 icon={<Bot size={18} strokeWidth={1.6} />}
                 label="Ask Defty"
-                description="Open the built-in agent DM"
+                description="Pull an agent into the current work context"
                 onClick={() => runSheetAction(onAskDefty)}
               />
             )}
@@ -525,14 +546,14 @@ export function RichComposer({
               <>
                 <SheetActionButton
                   icon={<CheckSquare size={18} strokeWidth={1.6} />}
-                  label="Create task"
-                  description="Start a task from chat"
+                  label="Create task draft"
+                  description="Turn the current discussion into assigned work"
                   onClick={() => runSheetAction(() => onSlashCommand('task', 'New task'))}
                 />
                 <SheetActionButton
                   icon={<FileText size={18} strokeWidth={1.6} />}
                   label="New note"
-                  description="Capture a quick note"
+                  description="Save a structured note from this conversation"
                   onClick={() => runSheetAction(() => onSlashCommand('note', 'Chat note'))}
                 />
               </>
@@ -704,29 +725,44 @@ export function RichComposer({
           </div>
         </MobileActionSheet>
 
-        {/* Editor row - mobile uses single-row layout with [+] and [send] flanking the editor.
+        {emojiOpen && (
+          <EmojiPicker
+            anchorRef={emojiBtnRef}
+            onSelect={handleEmoji}
+            onClose={() => setEmojiOpen(false)}
+          />
+        )}
+
+        {/* Editor row - mobile uses a compact work dock with [+] and [send] flanking the editor.
             Desktop renders only the editor (the +/send below are md:hidden) and uses the
             bottom toolbar for those actions instead. */}
-        <div className="flex items-end gap-2 md:block">
-          {/* Mobile-only "+" - opens unified compose sheet (Insert + Format) */}
+        <div
+          className={[
+            'flex items-center gap-1.5 rounded-[28px] border p-1.5 bg-[var(--surface-container-low)] transition-[border-color,box-shadow,background] md:block md:rounded-none md:border-0 md:bg-transparent md:p-0 md:shadow-none',
+            focused
+              ? 'border-[#9080fa] shadow-[0_0_0_2px_rgba(144,128,250,0.2)]'
+              : 'border-[var(--outline-variant)] shadow-[0_10px_30px_rgba(0,0,0,0.08)]',
+          ].join(' ')}
+        >
+          {/* Mobile-only "+" - opens unified compose sheet (work + insert + format) */}
           <button
             type="button"
             onClick={() => setFormatSheetOpen(true)}
             aria-label="Open composer actions"
-            className="md:hidden flex items-center justify-center w-10 h-10 flex-shrink-0 rounded-full border transition-colors"
+            className="md:hidden flex items-center justify-center w-9 h-9 flex-shrink-0 rounded-full transition-colors active:scale-95 self-center"
             style={{
               color: 'var(--on-surface-variant)',
               background: 'var(--surface-container-high)',
-              borderColor: 'var(--outline-variant)',
+              border: '1px solid var(--outline-variant)',
             }}
           >
-            <Plus size={20} strokeWidth={1.7} />
+            <Plus size={18} strokeWidth={1.8} />
           </button>
 
           <div
             className={[
-              'flex-1 min-w-0 px-3 md:px-4 py-2 min-h-[42px] md:min-h-[40px] max-h-[150px] md:max-h-[200px] overflow-y-auto rounded-[22px] md:rounded-none border md:border-0 bg-[var(--surface-container-low)] md:bg-transparent transition-[border-color,box-shadow,background]',
-              focused ? 'shadow-[0_0_0_2px_rgba(144,128,250,0.22)] md:shadow-none border-[#9080fa]' : 'border-[var(--outline-variant)]',
+              'flex-1 min-w-0 px-2.5 md:px-3 py-2 md:py-2.5 min-h-[38px] md:min-h-[50px] max-h-[150px] md:max-h-[220px] overflow-y-auto rounded-[20px] md:rounded-[20px] border-0 bg-transparent transition-[background]',
+              focused ? 'bg-[var(--surface-container)] md:bg-transparent' : '',
             ].join(' ')}
             onPaste={onPaste as unknown as React.ClipboardEventHandler<HTMLDivElement>}
           >
@@ -739,7 +775,7 @@ export function RichComposer({
             onClick={hasContent ? handleSend : onClipRecord}
             disabled={!hasContent && !onClipRecord}
             aria-label={hasContent ? 'Send message' : 'Record voice memo'}
-            className="md:hidden flex items-center justify-center w-10 h-10 flex-shrink-0 rounded-full text-white disabled:opacity-40 transition-transform active:scale-95"
+            className="md:hidden flex items-center justify-center w-9 h-9 flex-shrink-0 rounded-full text-white disabled:opacity-40 transition-transform active:scale-95 self-center"
             style={{
               background: hasContent ? 'var(--primary-container)' : 'var(--surface-container-high)',
               color: hasContent ? 'white' : 'var(--on-surface-variant)',
@@ -781,10 +817,146 @@ export function RichComposer({
           </div>
         )}
 
-        {/* Bottom toolbar: emoji, attach, send - desktop only.
+        {/* Bottom toolbar: work actions, format, insert, schedule, send - desktop only.
             Mobile consolidates these into the "+" sheet + inline send. */}
-        <div className="hidden md:flex items-center justify-between px-2.5 pb-1.5 pt-0.5">
-          <div className="flex items-center gap-0.5">
+        <div className="hidden md:flex items-center justify-between gap-3 px-2.5 pb-1.5 pt-0.5">
+          <div className="flex min-w-0 items-center gap-1.5">
+            <div className="relative">
+              <button
+                ref={desktopActionBtnRef}
+                type="button"
+                onClick={() => setDesktopActionsOpen((open) => !open)}
+                aria-label="Open compose actions"
+                className="flex h-8 w-8 items-center justify-center rounded-full transition-colors"
+                style={{
+                  color: 'var(--on-surface-variant)',
+                  background: desktopActionsOpen ? 'var(--primary-container)' : 'var(--surface-container-high)',
+                  border: '1px solid var(--outline-variant)',
+                }}
+                title="Compose actions"
+              >
+                <Plus size={15} strokeWidth={1.8} />
+              </button>
+              {desktopActionsOpen && (
+                <div
+                  ref={desktopActionMenuRef}
+                  className="absolute bottom-full left-0 z-50 mb-2 w-72 rounded-2xl p-2"
+                  style={{
+                    background: 'var(--surface-container-high)',
+                    border: '1px solid var(--outline-variant)',
+                    boxShadow: 'var(--glass-shadow)',
+                  }}
+                >
+                  <div
+                    className="px-2 pb-1.5 text-[10px] font-semibold uppercase tracking-wide"
+                    style={{ color: 'var(--outline)', fontFamily: 'var(--font-heading)' }}
+                  >
+                    Work actions
+                  </div>
+                  <div className="space-y-1">
+                    {onAskDefty && (
+                      <DesktopActionButton
+                        icon={<Bot size={16} strokeWidth={1.6} />}
+                        label="Ask Defty"
+                        description="Pull an agent into this context"
+                        onClick={() => runDesktopAction(onAskDefty)}
+                      />
+                    )}
+                    {onSlashCommand && (
+                      <>
+                        <DesktopActionButton
+                          icon={<CheckSquare size={16} strokeWidth={1.6} />}
+                          label="Create task draft"
+                          description="Turn this discussion into work"
+                          onClick={() => runDesktopAction(() => onSlashCommand('task', 'New task'))}
+                        />
+                        <DesktopActionButton
+                          icon={<FileText size={16} strokeWidth={1.6} />}
+                          label="New note"
+                          description="Capture a structured note"
+                          onClick={() => runDesktopAction(() => onSlashCommand('note', 'Chat note'))}
+                        />
+                      </>
+                    )}
+                    <DesktopActionButton
+                      icon={<Paperclip size={16} strokeWidth={1.6} />}
+                      label="Attach file"
+                      description="Add an image, document, or context file"
+                      onClick={() => runDesktopAction(onFileSelect)}
+                    />
+                  </div>
+                </div>
+              )}
+            </div>
+
+            <div className="h-5 w-px" style={{ background: 'var(--outline-variant)', opacity: 0.55 }} />
+
+            <div className="flex items-center gap-0.5">
+              <ToolbarBtn
+                active={editor.isActive('bold')}
+                onClick={() => editor.chain().focus().toggleBold().run()}
+                title="Bold (Cmd+B)"
+              >
+                <Bold size={14} strokeWidth={1.5} />
+              </ToolbarBtn>
+              <ToolbarBtn
+                active={editor.isActive('italic')}
+                onClick={() => editor.chain().focus().toggleItalic().run()}
+                title="Italic (Cmd+I)"
+              >
+                <Italic size={14} strokeWidth={1.5} />
+              </ToolbarBtn>
+              <ToolbarBtn
+                active={editor.isActive('strike')}
+                onClick={() => editor.chain().focus().toggleStrike().run()}
+                title="Strikethrough (Cmd+Shift+X)"
+              >
+                <Strikethrough size={14} strokeWidth={1.5} />
+              </ToolbarBtn>
+              <ToolbarBtn
+                active={editor.isActive('code')}
+                onClick={() => editor.chain().focus().toggleCode().run()}
+                title="Inline code (Cmd+E)"
+              >
+                <Code size={14} strokeWidth={1.5} />
+              </ToolbarBtn>
+              <ToolbarBtn
+                active={editor.isActive('bulletList')}
+                onClick={() => editor.chain().focus().toggleBulletList().run()}
+                title="Bullet list"
+              >
+                <List size={14} strokeWidth={1.5} />
+              </ToolbarBtn>
+              <ToolbarBtn
+                active={editor.isActive('orderedList')}
+                onClick={() => editor.chain().focus().toggleOrderedList().run()}
+                title="Numbered list"
+              >
+                <ListOrdered size={14} strokeWidth={1.5} />
+              </ToolbarBtn>
+              <ToolbarBtn
+                active={editor.isActive('blockquote')}
+                onClick={() => editor.chain().focus().toggleBlockquote().run()}
+                title="Blockquote"
+              >
+                <Quote size={14} strokeWidth={1.5} />
+              </ToolbarBtn>
+              <ToolbarBtn
+                active={editor.isActive('link')}
+                onClick={() => {
+                  const existing = editor.getAttributes('link').href;
+                  setLinkUrl(existing || '');
+                  setLinkDialogOpen(true);
+                }}
+                title="Link (Cmd+K)"
+              >
+                <LinkIcon size={14} strokeWidth={1.5} />
+              </ToolbarBtn>
+            </div>
+
+            <div className="h-5 w-px" style={{ background: 'var(--outline-variant)', opacity: 0.55 }} />
+
+            <div className="flex items-center gap-0.5">
             <button
               className="p-1.5 rounded-md"
               style={{ color: 'var(--muted)' }}
@@ -803,13 +975,6 @@ export function RichComposer({
               >
                 <Smile size={15} strokeWidth={1.5} />
               </button>
-              {emojiOpen && (
-                <EmojiPicker
-                  anchorRef={emojiBtnRef}
-                  onSelect={handleEmoji}
-                  onClose={() => setEmojiOpen(false)}
-                />
-              )}
             </div>
             {onClipRecord && (
               <button
@@ -822,11 +987,12 @@ export function RichComposer({
               </button>
             )}
           </div>
-          <div className="flex items-center gap-1">
+          </div>
+          <div className="flex items-center gap-1.5">
             {hasContent && (
               <div className="relative">
                 <button ref={scheduleBtnRef} onClick={() => setScheduleOpen(!scheduleOpen)}
-                  className="p-1.5 rounded-md" style={{ color: 'var(--outline)' }} title="Schedule send">
+                  className="flex h-8 w-8 items-center justify-center rounded-full" style={{ color: 'var(--outline)', background: 'var(--surface-container-high)' }} title="Schedule send">
                   <Clock size={14} strokeWidth={1.5} />
                 </button>
                 {scheduleOpen && schedulePos && createPortal(
@@ -948,8 +1114,8 @@ export function RichComposer({
               onClick={handleSend}
               disabled={!hasContent}
               aria-label="Send message from composer toolbar"
-              className="flex items-center justify-center min-w-[44px] min-h-[44px] rounded-md text-white disabled:opacity-40 hover:opacity-90 transition-opacity"
-              style={{ background: 'var(--primary-container)', borderRadius: 'var(--radius-md)' }}
+              className="flex h-9 min-w-12 items-center justify-center rounded-full text-white disabled:opacity-40 hover:opacity-90 transition-opacity"
+              style={{ background: 'var(--primary-container)' }}
             >
               <Send size={16} strokeWidth={2} />
             </button>
@@ -1030,6 +1196,40 @@ function SheetActionButton({
       <span className="min-w-0">
         <span className="block text-[0.875rem] font-semibold leading-tight">{label}</span>
         <span className="block text-[0.75rem] leading-snug mt-0.5" style={{ color: 'var(--on-surface-variant)' }}>
+          {description}
+        </span>
+      </span>
+    </button>
+  );
+}
+
+function DesktopActionButton({
+  icon,
+  label,
+  description,
+  onClick,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  description: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="flex w-full items-center gap-2.5 rounded-xl px-2.5 py-2 text-left transition-colors hover:bg-[var(--surface-container)]"
+      style={{ color: 'var(--on-surface)' }}
+    >
+      <span
+        className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full"
+        style={{ background: 'rgba(144,128,250,0.14)', color: 'var(--primary)' }}
+      >
+        {icon}
+      </span>
+      <span className="min-w-0">
+        <span className="block text-[0.8125rem] font-semibold leading-tight">{label}</span>
+        <span className="mt-0.5 block truncate text-[0.72rem] leading-snug" style={{ color: 'var(--on-surface-variant)' }}>
           {description}
         </span>
       </span>

--- a/apps/web/src/components/sidebar.tsx
+++ b/apps/web/src/components/sidebar.tsx
@@ -5,6 +5,7 @@ import { createPortal } from 'react-dom';
 import { useAuth } from '@/lib/auth-context';
 import { useChatContext } from '@/lib/chat-context';
 import { registerOpenCreateSpace } from '@/lib/quick-actions';
+import { isSettingsItemActive, settingsNavGroups } from '@/lib/settings-navigation';
 import { useTheme } from './theme-provider';
 import { Logo } from './brand/logo';
 import { api } from '@/lib/api';
@@ -42,6 +43,7 @@ import { CreateDmModal } from './create-dm-modal';
 import { SavedMessages } from './saved-messages';
 import { CreateProjectModal } from './create-project-modal';
 import { useInboxCount } from '@/hooks/use-inbox-count';
+import { AppMenu, type AppMenuItem } from './overlay-primitives';
 
 type AgentEmployee = {
   id: string;
@@ -169,7 +171,7 @@ function ChatSidebarContent({
                   color: active ? 'var(--on-surface)' : hasUnread ? 'var(--on-surface)' : 'var(--on-surface-variant)',
                   fontWeight: active ? 500 : hasUnread ? 600 : 500,
                   fontSize: '0.8125rem',
-                  borderRadius: 'var(--radius-lg)',
+                  borderRadius: '999px',
                   paddingRight: activeHuddles.has(space.id) ? '3rem' : undefined,
                 }}
               >
@@ -279,7 +281,7 @@ function ChatSidebarContent({
                   color: active ? 'var(--on-surface)' : hasUnread ? 'var(--on-surface)' : 'var(--on-surface-variant)',
                   fontWeight: active ? 500 : hasUnread ? 600 : 500,
                   fontSize: '0.8125rem',
-                  borderRadius: 'var(--radius-lg)',
+                  borderRadius: '999px',
                 }}
               >
                 <div className="relative flex-shrink-0 w-6 h-6">
@@ -402,7 +404,7 @@ function ChatSidebarContent({
                   color: 'var(--on-surface-variant)',
                   fontWeight: 500,
                   fontSize: '0.8125rem',
-                  borderRadius: 'var(--radius-lg)',
+                  borderRadius: '999px',
                 }}
               >
                 <div className="relative flex-shrink-0">
@@ -495,7 +497,7 @@ function TasksSidebarContent({ onNav }: { onNav?: () => void }) {
             color: isMyTasksActive ? 'var(--on-surface)' : 'var(--on-surface-variant)',
             fontWeight: isMyTasksActive ? 500 : 500,
             fontSize: '0.8125rem',
-            borderRadius: 'var(--radius-lg)',
+            borderRadius: '999px',
           }}
         >
           <User size={18} strokeWidth={1.5} className="flex-shrink-0" style={{ opacity: isMyTasksActive ? 0.7 : 0.4 }} />
@@ -533,7 +535,7 @@ function TasksSidebarContent({ onNav }: { onNav?: () => void }) {
                 color: active ? 'var(--on-surface)' : 'var(--on-surface-variant)',
                 fontWeight: active ? 500 : 500,
                 fontSize: '0.8125rem',
-                borderRadius: 'var(--radius-lg)',
+                borderRadius: '999px',
               }}
             >
               <div
@@ -570,24 +572,8 @@ function TasksSidebarContent({ onNav }: { onNav?: () => void }) {
 function SettingsSidebarContent({ onNav }: { onNav?: () => void }) {
   const pathname = usePathname();
 
-  const sections = [
-    { name: 'General', href: '/settings' },
-    { name: 'Profile', href: '/settings/profile' },
-    { name: 'Members', href: '/settings/members' },
-    { name: 'Teams', href: '/settings/teams' },
-    { name: 'Groups', href: '/settings/groups' },
-    { name: 'Projects', href: '/settings/projects' },
-    { name: 'Tags', href: '/settings/tags' },
-    { name: 'Integrations', href: '/settings/integrations' },
-    { name: 'AI Providers', href: '/settings/ai' },
-    { name: 'Agent', href: '/settings/agent' },
-    { name: 'Agent Employees', href: '/settings/agent-employees' },
-    { name: 'MCP Access', href: '/settings/mcp-access' },
-    { name: 'API Access', href: '/settings/api-access' },
-  ];
-
   return (
-    <div className="px-3 pt-5 pb-1">
+    <div className="px-3 pt-5 pb-6 overflow-y-auto">
       <div className="flex items-center px-2 mb-2">
         <span
           className="text-[0.6875rem] font-semibold uppercase tracking-[0.05em]"
@@ -596,27 +582,38 @@ function SettingsSidebarContent({ onNav }: { onNav?: () => void }) {
           Settings
         </span>
       </div>
-      {sections.map((section) => {
-        const active = pathname === section.href;
-        return (
-          <Link
-            key={section.href}
-            href={section.href}
-            onClick={onNav}
-            className="w-full text-left px-2 flex items-center gap-2 block"
-            style={{
-              height: '36px',
-              background: active ? 'var(--bg-active)' : 'transparent',
-              color: active ? 'var(--on-surface)' : 'var(--on-surface-variant)',
-              fontWeight: active ? 500 : 500,
-              fontSize: '0.8125rem',
-              borderRadius: 'var(--radius-lg)',
-            }}
-          >
-            <span className="truncate">{section.name}</span>
-          </Link>
-        );
-      })}
+      <div className="space-y-4">
+        {settingsNavGroups.map((group) => (
+          <div key={group.label}>
+            <div className="px-2 pb-1 text-[0.625rem] font-semibold uppercase tracking-[0.06em]" style={{ color: 'var(--outline)' }}>
+              {group.label}
+            </div>
+            <div className="space-y-0.5">
+              {group.items.map((section) => {
+                const active = isSettingsItemActive(pathname, section.href);
+                return (
+                  <Link
+                    key={section.href}
+                    href={section.href}
+                    onClick={onNav}
+                    className="w-full text-left px-2 flex items-center gap-2 block"
+                    style={{
+                      height: '34px',
+                      background: active ? 'var(--bg-active)' : 'transparent',
+                      color: active ? 'var(--on-surface)' : 'var(--on-surface-variant)',
+                      fontWeight: 500,
+                      fontSize: '0.8125rem',
+                      borderRadius: '999px',
+                    }}
+                  >
+                    <span className="truncate">{section.name}</span>
+                  </Link>
+                );
+              })}
+            </div>
+          </div>
+        ))}
+      </div>
     </div>
   );
 }
@@ -641,6 +638,7 @@ export function Sidebar({
   const { theme, toggleTheme } = useTheme();
   const { unreadCounts } = useChatContext();
   const pathname = usePathname();
+  const router = useRouter();
   const [userMenuOpen, setUserMenuOpen] = useState(false);
   const [statusModalOpen, setStatusModalOpen] = useState(false);
   // Create-space modal lifted from ChatSidebarContent — the parent Sidebar
@@ -651,20 +649,7 @@ export function Sidebar({
   useEffect(() => registerOpenCreateSpace(() => setCreateSpaceOpen(true)), []);
   const [savedOpen, setSavedOpen] = useState(false);
   const [dnd, setDnd] = useState(() => user?.status_text === 'Do Not Disturb');
-  const userMenuRef = useRef<HTMLDivElement>(null);
   const userMenuBtnRef = useRef<HTMLButtonElement>(null);
-
-  // Click-outside handler for three-dot menu
-  useEffect(() => {
-    if (!userMenuOpen) return;
-    const handler = (e: MouseEvent) => {
-      if (userMenuRef.current && !userMenuRef.current.contains(e.target as Node)) {
-        setUserMenuOpen(false);
-      }
-    };
-    document.addEventListener('mousedown', handler);
-    return () => document.removeEventListener('mousedown', handler);
-  }, [userMenuOpen]);
 
   // Escape-key handler for mobile drawer
   useEffect(() => {
@@ -681,6 +666,40 @@ export function Sidebar({
     setDnd(next);
     await api.patch('/api/users/dnd', { enabled: next });
   };
+
+  const userMenuItems: AppMenuItem[] = [
+    {
+      label: 'Set status',
+      icon: <Smile size={14} strokeWidth={1.5} />,
+      onSelect: () => setStatusModalOpen(true),
+    },
+    {
+      label: 'Saved messages',
+      icon: <Bookmark size={14} strokeWidth={1.5} />,
+      onSelect: () => setSavedOpen(true),
+    },
+    {
+      label: dnd ? 'Disable Do Not Disturb' : 'Do Not Disturb',
+      icon: dnd ? <BellOff size={14} strokeWidth={1.5} /> : <Bell size={14} strokeWidth={1.5} />,
+      onSelect: toggleDnd,
+    },
+    {
+      label: theme === 'dark' ? 'Light mode' : 'Dark mode',
+      icon: theme === 'dark' ? <Sun size={14} strokeWidth={1.5} /> : <Moon size={14} strokeWidth={1.5} />,
+      onSelect: toggleTheme,
+    },
+    {
+      label: 'Settings',
+      icon: <Settings size={14} strokeWidth={1.5} />,
+      onSelect: () => router.push('/settings'),
+    },
+    {
+      label: 'Log out',
+      icon: <LogOut size={14} strokeWidth={1.5} />,
+      danger: true,
+      onSelect: logout,
+    },
+  ];
 
   const [collapsed, setCollapsed] = useState(() => {
     if (typeof window !== 'undefined') return localStorage.getItem('deft-sidebar-collapsed') === 'true';
@@ -778,7 +797,7 @@ export function Sidebar({
                 height: '36px',
                 color: active ? 'var(--primary)' : 'var(--on-surface-variant)',
                 background: active ? 'var(--bg-active)' : 'transparent',
-                borderRadius: 'var(--radius-lg)',
+                borderRadius: '999px',
                 fontSize: '0.8125rem',
                 fontWeight: active ? 500 : 400,
               }}
@@ -854,76 +873,42 @@ export function Sidebar({
           </span>
         </button>
 
-        <div ref={userMenuRef}>
+        <div>
           <button
             ref={userMenuBtnRef}
             className="p-1.5 rounded-md"
             style={{ color: 'var(--outline)' }}
             title="More options"
             onClick={(e) => { e.stopPropagation(); setUserMenuOpen(!userMenuOpen); }}
+            aria-haspopup="menu"
+            aria-expanded={userMenuOpen}
           >
             <MoreHorizontal size={15} strokeWidth={1.5} />
           </button>
-          {userMenuOpen && typeof document !== 'undefined' && createPortal(
-            <div
-              className="fixed w-48 py-1 rounded-lg z-[100]"
-              onMouseDown={(e) => e.stopPropagation()}
-              style={{
-                background: 'var(--surface-container-highest)',
-                boxShadow: 'var(--glass-shadow)',
-                bottom: `${window.innerHeight - (userMenuBtnRef.current?.getBoundingClientRect().top ?? 0) + 8}px`,
-                left: `${(userMenuBtnRef.current?.getBoundingClientRect().right ?? 0) + 8}px`,
-              }}
-            >
-              {/* Status display / set */}
-              {user?.status_emoji ? (
-                <div className="px-3 py-1.5 flex items-center gap-2 text-[12px]"
-                  style={{ color: 'var(--on-surface-variant)' }}>
-                  <span>{user.status_emoji}</span>
-                  <span className="flex-1 truncate">{user.status_text || ''}</span>
-                  <button onClick={async () => {
+          <AppMenu
+            open={userMenuOpen}
+            onClose={() => setUserMenuOpen(false)}
+            anchorRef={userMenuBtnRef}
+            items={userMenuItems}
+            ariaLabel="User menu"
+            width={230}
+            header={user?.status_emoji ? (
+              <div className="flex items-center gap-2 text-[12px]" style={{ color: 'var(--on-surface-variant)' }}>
+                <span>{user.status_emoji}</span>
+                <span className="min-w-0 flex-1 truncate">{user.status_text || ''}</span>
+                <button
+                  onClick={async () => {
                     await api.delete('/api/users/status');
                     setUserMenuOpen(false);
-                  }} className="text-[10px] px-1.5 py-0.5 rounded hover:opacity-70"
-                    style={{ color: 'var(--text-tertiary)' }}>Clear</button>
-                </div>
-              ) : null}
-              <button onClick={() => { setUserMenuOpen(false); setStatusModalOpen(true); }}
-                className="flex items-center gap-2 px-3 py-1.5 text-[12px] w-full text-left rounded-md hover:opacity-80"
-                style={{ color: 'var(--on-surface-variant)' }}>
-                <Smile size={14} strokeWidth={1.5} /> Set status
-              </button>
-              <button onClick={() => { setUserMenuOpen(false); setSavedOpen(true); }}
-                className="flex items-center gap-2 px-3 py-1.5 text-[12px] w-full text-left rounded-md hover:opacity-80"
-                style={{ color: 'var(--on-surface-variant)' }}>
-                <Bookmark size={14} strokeWidth={1.5} /> Saved messages
-              </button>
-              <button onClick={() => { toggleDnd(); setUserMenuOpen(false); }}
-                className="flex items-center gap-2 px-3 py-1.5 text-[12px] w-full text-left rounded-md hover:opacity-80"
-                style={{ color: dnd ? 'var(--status-amber)' : 'var(--on-surface-variant)' }}>
-                {dnd ? <BellOff size={14} strokeWidth={1.5} /> : <Bell size={14} strokeWidth={1.5} />}
-                {dnd ? 'Disable Do Not Disturb' : 'Do Not Disturb'}
-              </button>
-              <button onClick={() => { toggleTheme(); setUserMenuOpen(false); }}
-                className="flex items-center gap-2 px-3 py-1.5 text-[12px] w-full text-left rounded-md hover:opacity-80"
-                style={{ color: 'var(--on-surface-variant)' }}>
-                {theme === 'dark' ? <Sun size={14} strokeWidth={1.5} /> : <Moon size={14} strokeWidth={1.5} />}
-                {theme === 'dark' ? 'Light mode' : 'Dark mode'}
-              </button>
-              <div className="my-1" style={{ borderTop: '1px solid var(--ghost-border)' }} />
-              <Link href="/settings" onClick={() => setUserMenuOpen(false)}
-                className="flex items-center gap-2 px-3 py-1.5 text-[12px] w-full text-left rounded-md hover:opacity-80"
-                style={{ color: 'var(--on-surface-variant)' }}>
-                <Settings size={14} strokeWidth={1.5} /> Settings
-              </Link>
-              <button onClick={() => { setUserMenuOpen(false); logout(); }}
-                className="flex items-center gap-2 px-3 py-1.5 text-[12px] w-full text-left rounded-md hover:opacity-80"
-                style={{ color: 'var(--status-red)' }}>
-                <LogOut size={14} strokeWidth={1.5} /> Log out
-              </button>
-            </div>,
-            document.body
-          )}
+                  }}
+                  className="rounded px-1.5 py-0.5 text-[10px] hover:opacity-70"
+                  style={{ color: 'var(--text-tertiary)' }}
+                >
+                  Clear
+                </button>
+              </div>
+            ) : undefined}
+          />
         </div>
       </div>
       {statusModalOpen && <StatusModal onClose={() => setStatusModalOpen(false)} />}
@@ -944,7 +929,7 @@ export function Sidebar({
         const active = pathname.startsWith(item.href);
         return (
           <Link key={item.href} href={item.href} title={item.name}
-            className="w-9 h-9 flex items-center justify-center rounded-lg"
+            className="w-9 h-9 flex items-center justify-center rounded-full"
             style={{
               background: active ? 'var(--bg-active)' : 'transparent',
               color: active ? 'var(--primary)' : 'var(--outline)',

--- a/apps/web/src/components/space-chat.tsx
+++ b/apps/web/src/components/space-chat.tsx
@@ -1212,7 +1212,7 @@ export function SpaceChat({
 
             {/* Pin count */}
             {pinCount > 0 && (
-              <button className="hidden md:flex items-center gap-1 px-3 min-h-[44px] md:min-h-0 md:px-2 h-auto md:h-7 rounded-md text-[11px]"
+              <button className="deft-pill hidden min-h-[30px] items-center gap-1 md:flex"
                 style={{ color: 'var(--on-surface-variant)' }}
                 title={`${pinCount} pinned messages`}>
                 <Pin size={12} strokeWidth={1.5} />
@@ -1223,7 +1223,7 @@ export function SpaceChat({
             {/* Member count */}
             <button
               onClick={() => setShowMembers(true)}
-              className="hidden md:flex items-center gap-1 px-3 min-h-[44px] md:min-h-0 md:px-2 h-auto md:h-7 rounded-md text-[11px] hover:opacity-70"
+              className="deft-pill hidden min-h-[30px] items-center gap-1 md:flex"
               style={{ color: 'var(--on-surface-variant)' }}
               title="View members"
             >
@@ -1238,7 +1238,7 @@ export function SpaceChat({
                 setIsMuted(newMuted);
                 await api.patch(`/api/spaces/${spaceId}/mute`, { muted: newMuted });
               }}
-              className="hidden md:flex items-center justify-center min-w-[44px] min-h-[44px] md:min-w-0 md:min-h-0 md:p-1.5 p-3 rounded-md hover:opacity-70"
+              className="deft-pill deft-pill-icon hidden min-h-[30px] items-center justify-center md:flex"
               style={{ color: isMuted ? 'var(--status-red)' : 'var(--on-surface-variant)' }}
               title={isMuted ? 'Unmute channel' : 'Mute channel'}
             >
@@ -1253,7 +1253,7 @@ export function SpaceChat({
 
               if (inThisHuddle) {
                 return (
-                  <button className="flex items-center gap-1.5 px-3 min-h-[44px] md:min-h-0 md:px-2.5 h-auto md:h-7 rounded-md text-[11px] font-medium"
+                  <button className="deft-pill min-h-[38px] md:min-h-[30px]"
                     style={{ background: '#22c55e', color: 'white' }} title="You're in this huddle">
                     <Mic size={13} strokeWidth={1.5} />
                     <span className="hidden md:inline">In Huddle</span>
@@ -1263,7 +1263,7 @@ export function SpaceChat({
               if (othersInHuddle) {
                 return (
                   <button onClick={() => joinHuddleBySpace?.(spaceId)}
-                    className="flex items-center gap-1.5 px-3 min-h-[44px] md:min-h-0 md:px-2.5 h-auto md:h-7 rounded-md text-[11px] font-medium hover:opacity-80 animate-pulse"
+                    className="deft-pill min-h-[38px] animate-pulse md:min-h-[30px]"
                     style={{ background: 'rgba(34,197,94,0.15)', color: '#22c55e' }}
                     title={`${huddleHere!.participants.length} in huddle — click to join`}>
                     <Mic size={13} strokeWidth={1.5} />
@@ -1273,8 +1273,8 @@ export function SpaceChat({
               }
               return (
                 <button onClick={() => startHuddle?.(spaceId)}
-                  className="flex items-center gap-1.5 px-3 min-h-[44px] md:min-h-0 md:px-2.5 h-auto md:h-7 rounded-md text-[11px] font-medium hover:opacity-80"
-                  style={{ color: 'var(--on-surface-variant)', background: 'var(--surface-container-high, var(--accent-muted))' }}
+                  className="deft-pill min-h-[38px] md:min-h-[30px]"
+                  style={{ color: 'var(--on-surface-variant)' }}
                   title="Start a huddle">
                   <Mic size={13} strokeWidth={1.5} />
                   <span className="hidden md:inline">Huddle</span>
@@ -1296,7 +1296,7 @@ export function SpaceChat({
               }}
               aria-label="Catch up on this space"
               title="Catch Up"
-              className="flex items-center justify-center gap-1 min-w-[44px] min-h-[44px] md:min-h-0 md:min-w-0 md:px-2.5 h-auto md:h-7 rounded-md text-[11px] font-medium"
+              className="deft-pill min-h-[38px] md:min-h-[30px]"
               style={{ background: 'var(--accent-muted)', color: 'var(--primary)' }}
               disabled={recapLoading}
             >
@@ -1308,10 +1308,10 @@ export function SpaceChat({
             <button
               onClick={() => setShowKnowledge(!showKnowledge)}
               aria-label={showKnowledge ? 'Close knowledge panel' : 'Open knowledge panel'}
-              className="flex items-center justify-center min-w-[44px] min-h-[44px] md:min-w-0 md:min-h-0 md:p-1.5 p-3 rounded-md hover:opacity-70"
+              className="deft-pill deft-pill-icon min-h-[38px] md:min-h-[30px]"
               style={{
-                color: showKnowledge ? 'var(--primary)' : 'var(--outline)',
-                background: showKnowledge ? 'var(--accent-muted)' : 'transparent',
+                color: showKnowledge ? 'var(--primary)' : 'var(--on-surface-variant)',
+                background: showKnowledge ? 'var(--accent-muted)' : undefined,
               }}
               title="Knowledge"
             >
@@ -1603,7 +1603,7 @@ export function SpaceChat({
                               const res = await api.post(`/api/spaces/${spaceId}/mark-unread`, { message_id: msg.id });
                               setCmdToast(res.ok ? 'Marked unread' : 'Failed to mark unread');
                               setMoreMenuId(null);
-                            }} className="w-full text-left px-3.5 py-2 text-[0.8125rem] flex items-center gap-2.5 hover:bg-white/5"
+                            }} className="w-full text-left px-3.5 py-2 text-[0.8125rem] flex items-center gap-2.5 hover:bg-[var(--bg-hover)]"
                               style={{ color: 'var(--on-surface-variant)' }}>
                               <MailOpen size={13} strokeWidth={1.5} /> Mark unread
                             </button>
@@ -1618,7 +1618,7 @@ export function SpaceChat({
                             <button onClick={() => {
                               setForwardMsgId(msg.id);
                               setMoreMenuId(null);
-                            }} className="w-full text-left px-3.5 py-2 text-[0.8125rem] flex items-center gap-2.5 hover:bg-white/5"
+                            }} className="w-full text-left px-3.5 py-2 text-[0.8125rem] flex items-center gap-2.5 hover:bg-[var(--bg-hover)]"
                               style={{ color: 'var(--on-surface-variant)' }}>
                               <Forward size={13} strokeWidth={1.5} /> Forward
                             </button>
@@ -2378,7 +2378,7 @@ export function SpaceChat({
                 <button key={s.id} onClick={async () => {
                   await api.post('/api/messages/forward', { message_id: forwardMsgId, target_space_id: s.id });
                   setForwardMsgId(null);
-                }} className="w-full text-left px-3 py-2 rounded-lg text-[13px] flex items-center gap-2 hover:bg-white/5"
+                }} className="w-full text-left px-3 py-2 rounded-lg text-[13px] flex items-center gap-2 hover:bg-[var(--bg-hover)]"
                   style={{ color: 'var(--foreground)' }}>
                   # {s.name}
                 </button>

--- a/apps/web/src/components/tag-picker.tsx
+++ b/apps/web/src/components/tag-picker.tsx
@@ -128,7 +128,7 @@ export function TagPicker({ entityType, entityId, appliedTags, onTagsChange, com
           <div className="max-h-40 overflow-y-auto">
             {filtered.map(tag => (
               <button key={tag.id} onClick={() => { applyTag(tag); setQuery(''); }}
-                className="w-full flex items-center gap-2 px-3 py-1.5 text-[12px] text-left hover:bg-white/5"
+                className="w-full flex items-center gap-2 px-3 py-1.5 text-[12px] text-left hover:bg-[var(--bg-hover)]"
                 style={{ color: 'var(--foreground-secondary)' }}>
                 <div className="w-2.5 h-2.5 rounded-full flex-shrink-0"
                   style={{ background: tag.color || '#6b7280' }} />
@@ -138,7 +138,7 @@ export function TagPicker({ entityType, entityId, appliedTags, onTagsChange, com
 
             {canCreate && (
               <button onClick={createAndApply}
-                className="w-full flex items-center gap-2 px-3 py-1.5 text-[12px] text-left hover:bg-white/5"
+                className="w-full flex items-center gap-2 px-3 py-1.5 text-[12px] text-left hover:bg-[var(--bg-hover)]"
                 style={{ color: 'var(--accent)' }}>
                 <Plus size={12} />
                 Create "#{query.trim().toLowerCase().replace(/\s+/g, '-')}"

--- a/apps/web/src/components/task-detail.tsx
+++ b/apps/web/src/components/task-detail.tsx
@@ -2512,7 +2512,7 @@ export function TaskDetail({ taskId, projectPrefix, onClose, onUpdated, onDuplic
                           router.push(sourceMessageHref);
                         }
                       }}
-                      className="flex items-start gap-2.5 px-3 py-2 rounded-lg cursor-pointer hover:bg-white/[0.03] transition-colors min-w-0"
+                      className="flex items-start gap-2.5 px-3 py-2 rounded-lg cursor-pointer hover:bg-[var(--bg-hover)] transition-colors min-w-0"
                       style={{ background: 'var(--surface-container)' }}
                     >
                       <div className="w-6 h-6 rounded-full flex items-center justify-center text-[9px] font-medium text-white flex-shrink-0 mt-0.5"
@@ -2556,7 +2556,7 @@ export function TaskDetail({ taskId, projectPrefix, onClose, onUpdated, onDuplic
                           router.push(`/chat?space=${ref.message_space_id}&message=${ref.source_id}`);
                         }
                       }}
-                      className="flex items-start gap-2.5 px-3 py-2 rounded-lg cursor-pointer hover:bg-white/[0.03] transition-colors"
+                      className="flex items-start gap-2.5 px-3 py-2 rounded-lg cursor-pointer hover:bg-[var(--bg-hover)] transition-colors"
                       style={{ background: 'var(--surface-container)' }}>
                       <div className="w-6 h-6 rounded-full flex items-center justify-center text-[9px] font-medium text-white flex-shrink-0 mt-0.5"
                         style={{ background: 'var(--primary-container)' }}>

--- a/apps/web/src/components/task-filters.tsx
+++ b/apps/web/src/components/task-filters.tsx
@@ -7,6 +7,7 @@ import { ChevronDown, X, User, AlertTriangle, Calendar, FolderOpen, Bookmark, Sa
 import { STATUS_LABELS, statusLabel } from '@/lib/task-status-labels';
 import type { PriorityVocab, ResolvedStatus, CanonicalPriority } from '@/hooks/use-project-resolved-config';
 import { priorityFullLabel } from '@/hooks/use-project-resolved-config';
+import { AppBottomSheet } from '@/components/overlay-primitives';
 
 export type Filters = {
   assigneeIds: string[];
@@ -190,7 +191,6 @@ export function TaskFilters({ filters, onChange, projects, statuses, priorityVoc
   // Mobile: single "Filters" button with stacked dropdown
   const mobileFilterBar = (
     <>
-      {openDropdown && <div className="fixed inset-0 z-10" onClick={() => { setOpenDropdown(null); setMemberSearch(''); setLabelSearch(''); setShowSaveInput(false); }} />}
       <div
         className="flex items-center gap-2 px-4 py-2 flex-shrink-0"
         style={{ borderBottom: '1px solid var(--border)' }}
@@ -198,7 +198,7 @@ export function TaskFilters({ filters, onChange, projects, statuses, priorityVoc
         <div className="relative">
           <button
             onClick={() => setOpenDropdown(openDropdown === 'mobile-filters' ? null : 'mobile-filters')}
-            className="flex items-center gap-1.5 px-2.5 py-2 min-h-[44px] rounded-md text-[12px] font-medium"
+            className="deft-pill min-h-[38px]"
             style={{
               background: activeFilterCount > 0 ? 'var(--accent-subtle)' : 'transparent',
               color: activeFilterCount > 0 ? 'var(--accent)' : 'var(--foreground-secondary)',
@@ -211,11 +211,12 @@ export function TaskFilters({ filters, onChange, projects, statuses, priorityVoc
             {activeFilterCount > 0 ? `Filters (${activeFilterCount})` : 'Filters'}
             <ChevronDown size={11} />
           </button>
-          {openDropdown === 'mobile-filters' && (
-            <div
-              className="absolute top-full left-0 mt-1 w-72 max-w-[calc(100vw-2rem)] rounded-lg py-1 z-20"
-              style={{ background: 'var(--card-bg)', border: '1px solid var(--border)', boxShadow: 'var(--shadow-lg)' }}
-            >
+          <AppBottomSheet
+            open={openDropdown === 'mobile-filters'}
+            onClose={() => { setOpenDropdown(null); setMemberSearch(''); setLabelSearch(''); setShowSaveInput(false); }}
+            title={`Task filters${activeFilterCount > 0 ? ` (${activeFilterCount})` : ''}`}
+          >
+            <div className="pb-2">
               {/* Assignee section */}
               <div className="px-3 py-1.5">
                 <p className="text-[10px] font-semibold uppercase tracking-wide mb-1.5" style={{ color: 'var(--muted)', fontFamily: 'var(--font-heading)' }}>Assignee</p>
@@ -476,7 +477,7 @@ export function TaskFilters({ filters, onChange, projects, statuses, priorityVoc
                 )}
               </div>
             </div>
-          )}
+          </AppBottomSheet>
         </div>
 
         {activeFilterCount > 0 && (
@@ -511,7 +512,7 @@ export function TaskFilters({ filters, onChange, projects, statuses, priorityVoc
         <div className="relative">
           <button
             onClick={() => setOpenDropdown(openDropdown === 'assignee' ? null : 'assignee')}
-            className="flex items-center gap-1.5 px-2.5 py-2 md:py-1 min-h-[44px] md:min-h-0 rounded-md text-[12px] font-medium"
+            className="deft-pill min-h-[38px] md:min-h-[30px]"
             style={{
               background: filters.assigneeIds.length > 0 ? 'var(--accent-subtle)' : 'transparent',
               color: filters.assigneeIds.length > 0 ? 'var(--accent)' : 'var(--foreground-secondary)',
@@ -600,7 +601,7 @@ export function TaskFilters({ filters, onChange, projects, statuses, priorityVoc
         <div className="relative">
           <button
             onClick={() => setOpenDropdown(openDropdown === 'priority' ? null : 'priority')}
-            className="flex items-center gap-1.5 px-2.5 py-2 md:py-1 min-h-[44px] md:min-h-0 rounded-md text-[12px] font-medium"
+            className="deft-pill min-h-[38px] md:min-h-[30px]"
             style={{
               background: filters.priorities.length > 0 ? 'var(--accent-subtle)' : 'transparent',
               color: filters.priorities.length > 0 ? 'var(--accent)' : 'var(--foreground-secondary)',
@@ -660,7 +661,7 @@ export function TaskFilters({ filters, onChange, projects, statuses, priorityVoc
         <div className="relative">
           <button
             onClick={() => setOpenDropdown(openDropdown === 'status' ? null : 'status')}
-            className="flex items-center gap-1.5 px-2.5 py-2 md:py-1 min-h-[44px] md:min-h-0 rounded-md text-[12px] font-medium"
+            className="deft-pill min-h-[38px] md:min-h-[30px]"
             style={{
               background: filters.status.length > 0 ? 'var(--accent-subtle)' : 'transparent',
               color: filters.status.length > 0 ? 'var(--accent)' : 'var(--foreground-secondary)',
@@ -719,7 +720,7 @@ export function TaskFilters({ filters, onChange, projects, statuses, priorityVoc
         <div className="relative">
           <button
             onClick={() => setOpenDropdown(openDropdown === 'labels' ? null : 'labels')}
-            className="flex items-center gap-1.5 px-2.5 py-2 md:py-1 min-h-[44px] md:min-h-0 rounded-md text-[12px] font-medium"
+            className="deft-pill min-h-[38px] md:min-h-[30px]"
             style={{
               background: filters.labels.length > 0 ? 'var(--accent-subtle)' : 'transparent',
               color: filters.labels.length > 0 ? 'var(--accent)' : 'var(--foreground-secondary)',
@@ -806,7 +807,7 @@ export function TaskFilters({ filters, onChange, projects, statuses, priorityVoc
           <div className="relative">
             <button
               onClick={() => setOpenDropdown(openDropdown === 'project' ? null : 'project')}
-              className="flex items-center gap-1.5 px-2.5 py-2 md:py-1 min-h-[44px] md:min-h-0 rounded-md text-[12px] font-medium"
+              className="deft-pill min-h-[38px] md:min-h-[30px]"
               style={{
                 background: filters.projectId ? 'var(--accent-subtle)' : 'transparent',
                 color: filters.projectId ? 'var(--accent)' : 'var(--foreground-secondary)',
@@ -858,7 +859,7 @@ export function TaskFilters({ filters, onChange, projects, statuses, priorityVoc
         <div className="relative">
           <button
             onClick={() => setOpenDropdown(openDropdown === 'dueDate' ? null : 'dueDate')}
-            className="flex items-center gap-1.5 px-2.5 py-2 md:py-1 min-h-[44px] md:min-h-0 rounded-md text-[12px] font-medium"
+            className="deft-pill min-h-[38px] md:min-h-[30px]"
             style={{
               background: (filters.dueDate || filters.dateFrom) ? 'var(--accent-subtle)' : 'transparent',
               color: (filters.dueDate || filters.dateFrom) ? 'var(--accent)' : 'var(--foreground-secondary)',
@@ -1022,7 +1023,7 @@ export function TaskFilters({ filters, onChange, projects, statuses, priorityVoc
         <div className="relative ml-auto">
           <button
             onClick={() => setOpenDropdown(openDropdown === 'views' ? null : 'views')}
-            className="flex items-center gap-1.5 px-2.5 py-2 md:py-1 min-h-[44px] md:min-h-0 rounded-md text-[12px] font-medium"
+            className="deft-pill min-h-[38px] md:min-h-[30px]"
             style={{
               background: 'transparent',
               color: 'var(--foreground-secondary)',

--- a/apps/web/src/lib/settings-navigation.ts
+++ b/apps/web/src/lib/settings-navigation.ts
@@ -1,0 +1,67 @@
+export type SettingsNavItem = {
+  name: string;
+  href: string;
+  description: string;
+};
+
+export type SettingsNavGroup = {
+  label: string;
+  description: string;
+  items: SettingsNavItem[];
+};
+
+export const settingsNavGroups: SettingsNavGroup[] = [
+  {
+    label: 'Personal',
+    description: 'Your profile, identity, availability, and display preferences.',
+    items: [
+      { name: 'General', href: '/settings', description: 'Theme and top-level settings overview.' },
+      { name: 'Profile', href: '/settings/profile', description: 'Work identity, avatar, status, notifications, and password.' },
+    ],
+  },
+  {
+    label: 'Workspace',
+    description: 'People, teams, mention groups, and shared workspace context.',
+    items: [
+      { name: 'Members', href: '/settings/members', description: 'Invite people, recover accounts, and manage access.' },
+      { name: 'Teams', href: '/settings/teams', description: 'Organize people around operating teams and linked work.' },
+      { name: 'Groups', href: '/settings/groups', description: 'Lightweight mention lists for chat coordination.' },
+      { name: 'Calendar', href: '/settings/calendar', description: 'Connect calendars with self-hostable ICS feeds.' },
+      { name: 'Tags', href: '/settings/tags', description: 'Review workspace labels and usage counts.' },
+    ],
+  },
+  {
+    label: 'Work System',
+    description: 'Reusable work patterns, archived projects, and workflow automation.',
+    items: [
+      { name: 'Deleted projects', href: '/settings/projects', description: 'Restore recently deleted projects during the recovery window.' },
+      { name: 'Workflows', href: '/settings/workflows', description: 'Automate simple task status-change rules.' },
+      { name: 'Templates', href: '/settings/library', description: 'Reusable task templates and work packs.' },
+      { name: 'Integrations', href: '/settings/integrations', description: 'Connect tool servers and supported workspace feeds.' },
+    ],
+  },
+  {
+    label: 'Agents & AI',
+    description: 'AI providers, shared agent employees, and personal AI app access.',
+    items: [
+      { name: 'AI Providers', href: '/settings/ai', description: 'Bring your own model providers or local endpoints.' },
+      { name: 'Agent Employees', href: '/settings/agent-employees', description: 'Manage shared agents that act as workspace employees.' },
+      { name: 'MCP Access', href: '/settings/mcp-access', description: 'Connect Codex, Claude, ChatGPT, or any MCP client as you.' },
+      { name: 'Agent governance', href: '/settings/agent', description: 'Review agent trust level, activity, and pending action history.' },
+    ],
+  },
+  {
+    label: 'Developer',
+    description: 'Programmatic access for custom tools and internal systems.',
+    items: [
+      { name: 'API Access', href: '/settings/api-access', description: 'Create API keys for external services and scripts.' },
+    ],
+  },
+];
+
+export const settingsNavItems = settingsNavGroups.flatMap((group) => group.items);
+
+export function isSettingsItemActive(pathname: string, href: string) {
+  if (href === '/settings') return pathname === href;
+  return pathname === href || pathname.startsWith(`${href}/`);
+}


### PR DESCRIPTION
﻿## What changed

- Polishes the core workspace surfaces: chat, tasks, knowledge, calendar, notes, and inbox.
- Adds shared overlay primitives for dialogs, menus, and bottom sheets so mobile and desktop interactions behave consistently.
- Refines pill-shaped active states, search controls, action buttons, inbox rows, calendar day drawer, task filters, and chat composer behavior.
- Adds shared settings navigation metadata used by the sidebar without including the full settings-page follow-up work.

## Why

The recent UI pass moved Deft toward a calmer, more consistent product language across the high-traffic surfaces. This PR packages the core surface polish separately from the settings/team-management and API/notification work so it is easier to review and merge.

## Validation

- `pnpm --filter @deft/web typecheck`
- `pnpm --filter @deft/web lint`

Both were run after temporarily stashing unrelated local changes, so the checks covered this PR slice in isolation.

## Notes

Unrelated settings-page and API/notification changes remain local and will be handled in follow-up PRs.
