### PR TITLE
Polish settings and people management

### DIFF
--- a/apps/api/src/lib/mcp-tools/team-context.ts
+++ b/apps/api/src/lib/mcp-tools/team-context.ts
@@ -293,8 +293,36 @@ async function enrichResources(access: TeamAccessContext, teamId: string) {
       topic: spaces.topic,
       type: spaces.type,
       is_archived: spaces.is_archived,
-    }).from(spaces).where(and(eq(spaces.org_id, access.org_id), inArray(spaces.id, spaceIds)));
-    rows.forEach((row) => put('space', row.id, row));
+      membership_id: spaceMembers.id,
+    })
+      .from(spaces)
+      .leftJoin(
+        spaceMembers,
+        and(eq(spaceMembers.space_id, spaces.id), eq(spaceMembers.user_id, access.user_id ?? '__no_user__')),
+      )
+      .where(and(eq(spaces.org_id, access.org_id), inArray(spaces.id, spaceIds)));
+    rows.forEach((row) => {
+      const canRead = row.type === 'public' || Boolean(row.membership_id);
+      if (canRead) {
+        put('space', row.id, {
+          id: row.id,
+          name: row.name,
+          description: row.description,
+          topic: row.topic,
+          type: row.type,
+          is_archived: row.is_archived,
+          access: 'visible',
+        });
+        return;
+      }
+      put('space', row.id, {
+        id: row.id,
+        type: row.type,
+        is_archived: row.is_archived,
+        access: 'restricted',
+        restricted_reason: 'space_membership_required',
+      });
+    });
   }
 
   const projectIds = idsByType.get('project') ?? [];
@@ -384,14 +412,20 @@ async function enrichResources(access: TeamAccessContext, teamId: string) {
     rows.forEach((row) => put('agent_employee', row.id, row));
   }
 
-  return resources.map((row) => ({
-    id: row.id,
-    type: row.resource_type,
-    resource_id: row.resource_id,
-    label: row.label,
-    created_at: row.created_at,
-    metadata: metadata.get(`${row.resource_type}:${row.resource_id}`) ?? null,
-  }));
+  return resources.map((row) => {
+    const rowMetadata = metadata.get(`${row.resource_type}:${row.resource_id}`) ?? null;
+    const restricted = row.resource_type === 'space' && rowMetadata?.access === 'restricted';
+    return {
+      id: row.id,
+      type: row.resource_type,
+      resource_id: row.resource_id,
+      label: restricted ? null : row.label,
+      access: restricted ? 'restricted' : 'visible',
+      restricted_reason: restricted ? 'space_membership_required' : null,
+      created_at: row.created_at,
+      metadata: rowMetadata,
+    };
+  });
 }
 
 async function allowedSpaceIds(access: TeamAccessContext, spaceIds: string[]): Promise<string[]> {

--- a/apps/api/src/routes/groups.ts
+++ b/apps/api/src/routes/groups.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono';
 import type { Context } from 'hono';
 import { eq, and, count, inArray } from 'drizzle-orm';
 import { db } from '../lib/db.js';
-import { orgMembers, userGroups, userGroupMembers } from '@deft/db/schema';
+import { orgMembers, userGroups, userGroupMembers, users } from '@deft/db/schema';
 import { OrgMembershipError, requireOrgAdminOrOwner } from '../lib/org-membership.js';
 import type { AuthUser } from '../middleware/auth.js';
 
@@ -51,7 +51,7 @@ async function validateActiveOrgUserIds(orgId: string, userIds: unknown): Promis
   return missing.length === 0 ? (unique as string[]) : null;
 }
 
-// GET /api/groups — list all groups for org (with member count)
+// GET /api/groups - list all groups for org (with member count)
 groupRoutes.get('/', async (c) => {
   const user = c.get('user');
 
@@ -64,17 +64,69 @@ groupRoutes.get('/', async (c) => {
     created_by: userGroups.created_by,
     created_at: userGroups.created_at,
     updated_at: userGroups.updated_at,
-    member_count: count(userGroupMembers.id),
+    member_count: count(orgMembers.user_id),
   })
     .from(userGroups)
     .leftJoin(userGroupMembers, eq(userGroups.id, userGroupMembers.group_id))
+    .leftJoin(orgMembers, and(
+      eq(orgMembers.user_id, userGroupMembers.user_id),
+      eq(orgMembers.org_id, userGroups.org_id),
+      eq(orgMembers.is_active, true),
+    ))
     .where(eq(userGroups.org_id, user.org_id))
     .groupBy(userGroups.id);
 
   return c.json(groups);
 });
 
-// POST /api/groups — create group
+// GET /api/groups/:id - fetch a group with member details
+groupRoutes.get('/:id', async (c) => {
+  const user = c.get('user');
+  const id = c.req.param('id');
+
+  const [group] = await db
+    .select({
+      id: userGroups.id,
+      org_id: userGroups.org_id,
+      name: userGroups.name,
+      handle: userGroups.handle,
+      description: userGroups.description,
+      created_by: userGroups.created_by,
+      created_at: userGroups.created_at,
+      updated_at: userGroups.updated_at,
+    })
+    .from(userGroups)
+    .where(and(eq(userGroups.id, id), eq(userGroups.org_id, user.org_id)))
+    .limit(1);
+
+  if (!group) {
+    return c.json({ error: 'Group not found', code: 'NOT_FOUND' }, 404);
+  }
+
+  const members = await db
+    .select({
+      user_id: userGroupMembers.user_id,
+      name: users.name,
+      email: users.email,
+      avatar_url: users.avatar_url,
+    })
+    .from(userGroupMembers)
+    .innerJoin(users, eq(users.id, userGroupMembers.user_id))
+    .innerJoin(orgMembers, and(
+      eq(orgMembers.user_id, userGroupMembers.user_id),
+      eq(orgMembers.org_id, group.org_id),
+      eq(orgMembers.is_active, true),
+    ))
+    .where(eq(userGroupMembers.group_id, id));
+
+  return c.json({
+    ...group,
+    member_count: members.length,
+    members,
+  });
+});
+
+// POST /api/groups - create group
 groupRoutes.post('/', async (c) => {
   const user = c.get('user');
   try {
@@ -131,7 +183,7 @@ groupRoutes.post('/', async (c) => {
   return c.json(group, 201);
 });
 
-// PATCH /api/groups/:id — update group
+// PATCH /api/groups/:id - update group
 groupRoutes.patch('/:id', async (c) => {
   const user = c.get('user');
   try {
@@ -195,7 +247,7 @@ groupRoutes.patch('/:id', async (c) => {
   return c.json(updated);
 });
 
-// DELETE /api/groups/:id — delete group + members
+// DELETE /api/groups/:id - delete group + members
 groupRoutes.delete('/:id', async (c) => {
   const user = c.get('user');
   try {
@@ -223,7 +275,7 @@ groupRoutes.delete('/:id', async (c) => {
   return c.json({ success: true });
 });
 
-// POST /api/groups/:id/members — add members
+// POST /api/groups/:id/members - add members
 groupRoutes.post('/:id/members', async (c) => {
   const user = c.get('user');
   try {
@@ -261,7 +313,7 @@ groupRoutes.post('/:id/members', async (c) => {
   return c.json(members, 201);
 });
 
-// DELETE /api/groups/:id/members/:userId — remove member
+// DELETE /api/groups/:id/members/:userId - remove member
 groupRoutes.delete('/:id/members/:userId', async (c) => {
   const user = c.get('user');
   try {

--- a/apps/api/src/routes/members.ts
+++ b/apps/api/src/routes/members.ts
@@ -3,6 +3,7 @@ import type { Context } from 'hono';
 import { z } from 'zod';
 import { eq, and, desc, inArray, sql } from 'drizzle-orm';
 import jwt from 'jsonwebtoken';
+import crypto from 'node:crypto';
 import { db } from '../lib/db.js';
 import {
   users,
@@ -18,6 +19,11 @@ import {
   oauthRefreshTokens,
   projects,
   tasks,
+  taskAssignees,
+  teamMembers,
+  teams,
+  userGroupMembers,
+  userGroups,
   wikiPages,
 } from '@deft/db/schema';
 import { env } from '../lib/env.js';
@@ -26,6 +32,10 @@ import { OrgMembershipError, requireOrgAdminOrOwner } from '../lib/org-membershi
 
 const INVITE_TTL = '7d';
 const RECOVERY_TTL = '24h';
+
+const offboardingPayloadSchema = z.object({
+  replacement_user_id: z.string().min(1).optional().nullable(),
+});
 
 function buildInviteUrl(token: string): string {
   return `${env.NEXT_PUBLIC_APP_URL}/invite/${token}`;
@@ -115,6 +125,29 @@ async function revokeMemberWorkspaceAccess(orgId: string, memberId: string, deac
       )
   `);
 
+  await db.delete(teamMembers)
+    .where(and(eq(teamMembers.org_id, orgId), eq(teamMembers.user_id, memberId)));
+
+  await db.execute(sql`
+    DELETE FROM ${userGroupMembers}
+    WHERE ${userGroupMembers.user_id} = ${memberId}
+      AND ${userGroupMembers.group_id} IN (
+        SELECT ${userGroups.id}
+        FROM ${userGroups}
+        WHERE ${userGroups.org_id} = ${orgId}
+      )
+  `);
+
+  await db.execute(sql`
+    DELETE FROM ${taskAssignees}
+    WHERE ${taskAssignees.user_id} = ${memberId}
+      AND ${taskAssignees.task_id} IN (
+        SELECT ${tasks.id}
+        FROM ${tasks}
+        WHERE ${tasks.org_id} = ${orgId}
+      )
+  `);
+
   await db.update(mcpTokens)
     .set({ revoked_at: revokedAt, updated_at: revokedAt })
     .where(and(
@@ -156,6 +189,243 @@ async function revokeMemberWorkspaceAccess(orgId: string, memberId: string, deac
           AND user_id = ${memberId}
       )
   `);
+}
+
+async function reassignMemberOwnership(orgId: string, memberId: string, replacementUserId: string) {
+  if (memberId === replacementUserId) {
+    throw new Error('Replacement cannot be the member being removed');
+  }
+
+  const replacement = await getCurrentMembership(orgId, replacementUserId);
+  if (!replacement) {
+    throw new Error('Replacement must be an active member of this organization');
+  }
+
+  const reassignedAt = new Date();
+  const ledTeamRows = await db
+    .select({ id: teams.id })
+    .from(teams)
+    .where(and(
+      eq(teams.org_id, orgId),
+      eq(teams.lead_user_id, memberId),
+      eq(teams.is_archived, false),
+    ));
+
+  const reassignedTasks = await db
+    .update(tasks)
+    .set({ assignee_id: replacementUserId, updated_at: reassignedAt })
+    .where(and(
+      eq(tasks.org_id, orgId),
+      eq(tasks.assignee_id, memberId),
+      eq(tasks.is_deleted, false),
+      sql`${tasks.status} NOT IN ('done', 'cancelled')`,
+    ))
+    .returning({ id: tasks.id });
+
+  const reassignedProjects = await db
+    .update(projects)
+    .set({ lead_id: replacementUserId, updated_at: reassignedAt })
+    .where(and(
+      eq(projects.org_id, orgId),
+      eq(projects.lead_id, memberId),
+      eq(projects.is_deleted, false),
+    ))
+    .returning({ id: projects.id });
+
+  const reassignedTeams = await db
+    .update(teams)
+    .set({ lead_user_id: replacementUserId, updated_at: reassignedAt })
+    .where(and(
+      eq(teams.org_id, orgId),
+      eq(teams.lead_user_id, memberId),
+      eq(teams.is_archived, false),
+    ))
+    .returning({ id: teams.id });
+
+  for (const team of ledTeamRows) {
+    await db
+      .insert(teamMembers)
+      .values({
+        id: crypto.randomUUID(),
+        org_id: orgId,
+        team_id: team.id,
+        user_id: replacementUserId,
+        role: 'lead',
+      })
+      .onConflictDoUpdate({
+        target: [teamMembers.team_id, teamMembers.user_id],
+        set: { role: 'lead', updated_at: reassignedAt },
+      });
+  }
+
+  return {
+    replacement_user_id: replacementUserId,
+    primary_open_tasks: reassignedTasks.length,
+    led_projects: reassignedProjects.length,
+    led_teams: reassignedTeams.length,
+  };
+}
+
+async function buildOffboardingPreview(orgId: string, memberId: string) {
+  const [
+    spaceRows,
+    teamRows,
+    groupRows,
+    primaryTasks,
+    secondaryTaskRows,
+    ledProjects,
+    ledTeams,
+    mcpRows,
+    apiRows,
+    oauthRows,
+    spaceCountRows,
+    teamCountRows,
+    groupCountRows,
+    primaryTaskCountRows,
+    ledProjectCountRows,
+    ledTeamCountRows,
+  ] = await Promise.all([
+    db.select({
+      id: spaces.id,
+      name: spaces.name,
+      type: spaces.type,
+    })
+      .from(spaceMembers)
+      .innerJoin(spaces, eq(spaces.id, spaceMembers.space_id))
+      .where(and(eq(spaces.org_id, orgId), eq(spaceMembers.user_id, memberId)))
+      .orderBy(spaces.name)
+      .limit(12),
+    db.select({
+      id: teams.id,
+      name: teams.name,
+      handle: teams.handle,
+      role: teamMembers.role,
+    })
+      .from(teamMembers)
+      .innerJoin(teams, eq(teams.id, teamMembers.team_id))
+      .where(and(eq(teamMembers.org_id, orgId), eq(teamMembers.user_id, memberId)))
+      .orderBy(teams.name)
+      .limit(12),
+    db.select({
+      id: userGroups.id,
+      name: userGroups.name,
+      handle: userGroups.handle,
+    })
+      .from(userGroupMembers)
+      .innerJoin(userGroups, eq(userGroups.id, userGroupMembers.group_id))
+      .where(and(eq(userGroups.org_id, orgId), eq(userGroupMembers.user_id, memberId)))
+      .orderBy(userGroups.name)
+      .limit(12),
+    db.select({
+      id: tasks.id,
+      title: tasks.title,
+      status: tasks.status,
+      priority: tasks.priority,
+      project_id: tasks.project_id,
+    })
+      .from(tasks)
+      .where(and(
+        eq(tasks.org_id, orgId),
+        eq(tasks.assignee_id, memberId),
+        eq(tasks.is_deleted, false),
+        sql`${tasks.status} NOT IN ('done', 'cancelled')`,
+      ))
+      .orderBy(desc(tasks.updated_at))
+      .limit(12),
+    db.select({
+      count: sql<number>`count(*)::int`,
+    })
+      .from(taskAssignees)
+      .innerJoin(tasks, eq(tasks.id, taskAssignees.task_id))
+      .where(and(
+        eq(tasks.org_id, orgId),
+        eq(taskAssignees.user_id, memberId),
+        eq(tasks.is_deleted, false),
+        sql`${tasks.status} NOT IN ('done', 'cancelled')`,
+      )),
+    db.select({
+      id: projects.id,
+      name: projects.name,
+      prefix: projects.prefix,
+    })
+      .from(projects)
+      .where(and(eq(projects.org_id, orgId), eq(projects.lead_id, memberId), eq(projects.is_deleted, false)))
+      .orderBy(projects.name)
+      .limit(12),
+    db.select({
+      id: teams.id,
+      name: teams.name,
+      handle: teams.handle,
+    })
+      .from(teams)
+      .where(and(eq(teams.org_id, orgId), eq(teams.lead_user_id, memberId), eq(teams.is_archived, false)))
+      .orderBy(teams.name)
+      .limit(12),
+    db.select({ count: sql<number>`count(*)::int` })
+      .from(mcpTokens)
+      .where(and(eq(mcpTokens.org_id, orgId), eq(mcpTokens.user_id, memberId), sql`${mcpTokens.revoked_at} IS NULL`)),
+    db.select({ count: sql<number>`count(*)::int` })
+      .from(apiKeys)
+      .where(and(eq(apiKeys.org_id, orgId), eq(apiKeys.created_by, memberId), eq(apiKeys.is_active, true))),
+    db.select({ count: sql<number>`count(*)::int` })
+      .from(oauthGrants)
+      .where(and(eq(oauthGrants.org_id, orgId), eq(oauthGrants.user_id, memberId), sql`${oauthGrants.revoked_at} IS NULL`)),
+    db.select({ count: sql<number>`count(*)::int` })
+      .from(spaceMembers)
+      .innerJoin(spaces, eq(spaces.id, spaceMembers.space_id))
+      .where(and(eq(spaces.org_id, orgId), eq(spaceMembers.user_id, memberId))),
+    db.select({ count: sql<number>`count(*)::int` })
+      .from(teamMembers)
+      .innerJoin(teams, eq(teams.id, teamMembers.team_id))
+      .where(and(eq(teamMembers.org_id, orgId), eq(teamMembers.user_id, memberId))),
+    db.select({ count: sql<number>`count(*)::int` })
+      .from(userGroupMembers)
+      .innerJoin(userGroups, eq(userGroups.id, userGroupMembers.group_id))
+      .where(and(eq(userGroups.org_id, orgId), eq(userGroupMembers.user_id, memberId))),
+    db.select({ count: sql<number>`count(*)::int` })
+      .from(tasks)
+      .where(and(
+        eq(tasks.org_id, orgId),
+        eq(tasks.assignee_id, memberId),
+        eq(tasks.is_deleted, false),
+        sql`${tasks.status} NOT IN ('done', 'cancelled')`,
+      )),
+    db.select({ count: sql<number>`count(*)::int` })
+      .from(projects)
+      .where(and(eq(projects.org_id, orgId), eq(projects.lead_id, memberId), eq(projects.is_deleted, false))),
+    db.select({ count: sql<number>`count(*)::int` })
+      .from(teams)
+      .where(and(eq(teams.org_id, orgId), eq(teams.lead_user_id, memberId), eq(teams.is_archived, false))),
+  ]);
+
+  return {
+    revoke_now: {
+      spaces: spaceRows,
+      teams: teamRows,
+      groups: groupRows,
+      secondary_task_assignments: Number(secondaryTaskRows[0]?.count ?? 0),
+      active_mcp_tokens: Number(mcpRows[0]?.count ?? 0),
+      active_api_keys: Number(apiRows[0]?.count ?? 0),
+      active_oauth_grants: Number(oauthRows[0]?.count ?? 0),
+    },
+    needs_reassignment: {
+      primary_open_tasks: primaryTasks,
+      led_projects: ledProjects,
+      led_teams: ledTeams,
+    },
+    counts: {
+      spaces: Number(spaceCountRows[0]?.count ?? 0),
+      teams: Number(teamCountRows[0]?.count ?? 0),
+      groups: Number(groupCountRows[0]?.count ?? 0),
+      primary_open_tasks: Number(primaryTaskCountRows[0]?.count ?? 0),
+      secondary_task_assignments: Number(secondaryTaskRows[0]?.count ?? 0),
+      led_projects: Number(ledProjectCountRows[0]?.count ?? 0),
+      led_teams: Number(ledTeamCountRows[0]?.count ?? 0),
+      active_mcp_tokens: Number(mcpRows[0]?.count ?? 0),
+      active_api_keys: Number(apiRows[0]?.count ?? 0),
+      active_oauth_grants: Number(oauthRows[0]?.count ?? 0),
+    },
+  };
 }
 
 async function listOrgInvites(orgId: string) {
@@ -704,6 +974,41 @@ memberRoutes.get('/:id/detail', async (c) => {
   }
 });
 
+memberRoutes.get('/:id/offboarding-preview', async (c) => {
+  try {
+    const currentUser = c.get('user');
+    const memberId = c.req.param('id');
+
+    try {
+      await requireOrgAdminOrOwner(currentUser.org_id, currentUser.id);
+    } catch (err) {
+      return adminForbidden(c, err);
+    }
+
+    const [targetMembership] = await db.select({ role: orgMembers.role })
+      .from(orgMembers)
+      .where(and(
+        eq(orgMembers.org_id, currentUser.org_id),
+        eq(orgMembers.user_id, memberId),
+        eq(orgMembers.is_active, true),
+      ))
+      .limit(1);
+
+    if (!targetMembership) {
+      return c.json({ error: 'Member not found', code: 'NOT_FOUND' }, 404);
+    }
+
+    if (targetMembership.role === 'owner') {
+      return c.json({ error: 'Cannot remove the org owner', code: 'FORBIDDEN' }, 403);
+    }
+
+    return c.json(await buildOffboardingPreview(currentUser.org_id, memberId));
+  } catch (err) {
+    console.error('Failed to build offboarding preview:', err);
+    return c.json({ error: 'Failed to build offboarding preview', code: 'INTERNAL_ERROR' }, 500);
+  }
+});
+
 memberRoutes.get('/:id', async (c) => {
   try {
     const user = c.get('user');
@@ -830,6 +1135,7 @@ memberRoutes.post('/invite', async (c) => {
         email,
         inviter_id: currentUser.id,
         role,
+        nonce: crypto.randomUUID(),
       },
       env.JWT_SECRET,
       { expiresIn: INVITE_TTL },
@@ -921,6 +1227,7 @@ memberRoutes.post('/invites/:id/reissue', async (c) => {
         email,
         inviter_id: currentUser.id,
         role: role ?? 'member',
+        nonce: crypto.randomUUID(),
       },
       env.JWT_SECRET,
       { expiresIn: INVITE_TTL },
@@ -1103,10 +1410,20 @@ memberRoutes.delete('/:id', async (c) => {
   try {
     const currentUser = c.get('user');
     const memberId = c.req.param('id');
+    const rawBody = await c.req.json().catch(() => ({}));
+    const parsedBody = offboardingPayloadSchema.safeParse(rawBody);
+    if (!parsedBody.success) {
+      return c.json({ error: 'Invalid offboarding payload', code: 'VALIDATION_ERROR' }, 400);
+    }
+    const replacementUserId = parsedBody.data.replacement_user_id?.trim() || null;
 
     // Can't remove yourself
     if (memberId === currentUser.id) {
       return c.json({ error: 'Cannot remove yourself', code: 'FORBIDDEN' }, 403);
+    }
+
+    if (replacementUserId === memberId) {
+      return c.json({ error: 'Replacement cannot be the removed member', code: 'VALIDATION_ERROR' }, 400);
     }
 
     try {
@@ -1129,9 +1446,40 @@ memberRoutes.delete('/:id', async (c) => {
       return c.json({ error: 'Cannot remove the org owner', code: 'FORBIDDEN' }, 403);
     }
 
+    const preview = await buildOffboardingPreview(currentUser.org_id, memberId);
+    let reassigned = {
+      replacement_user_id: replacementUserId,
+      primary_open_tasks: 0,
+      led_projects: 0,
+      led_teams: 0,
+    };
+    if (replacementUserId) {
+      try {
+        reassigned = await reassignMemberOwnership(currentUser.org_id, memberId, replacementUserId);
+      } catch (error) {
+        return c.json({
+          error: error instanceof Error ? error.message : 'Failed to reassign member ownership',
+          code: 'VALIDATION_ERROR',
+        }, 400);
+      }
+    }
     await revokeMemberWorkspaceAccess(currentUser.org_id, memberId, true);
+    const remaining = await buildOffboardingPreview(currentUser.org_id, memberId);
 
-    return c.json({ success: true });
+    return c.json({
+      success: true,
+      receipt: {
+        revoked_at: new Date().toISOString(),
+        revoked: preview.revoke_now,
+        reassigned,
+        remaining_reassignment: remaining.needs_reassignment,
+        remaining_counts: {
+          primary_open_tasks: remaining.counts.primary_open_tasks,
+          led_projects: remaining.counts.led_projects,
+          led_teams: remaining.counts.led_teams,
+        },
+      },
+    });
   } catch (err) {
     console.error('Failed to remove member:', err);
     return c.json({ error: 'Failed to remove member', code: 'INTERNAL_ERROR' }, 500);

--- a/apps/api/src/routes/teams.ts
+++ b/apps/api/src/routes/teams.ts
@@ -9,6 +9,7 @@ import {
   notes,
   orgMembers,
   projects,
+  spaceMembers,
   spaces,
   taskTemplates,
   teamDashboardSnapshots,
@@ -216,6 +217,48 @@ async function resourceBelongsToOrg(orgId: string, type: ResourceType, id: strin
   }
 }
 
+async function decorateResourcesForUser(
+  orgId: string,
+  userId: string,
+  resources: Array<typeof teamResources.$inferSelect>,
+) {
+  const spaceIds = resources
+    .filter((resource) => resource.resource_type === 'space')
+    .map((resource) => resource.resource_id);
+
+  if (spaceIds.length === 0) {
+    return resources.map((resource) => ({ ...resource, access: 'visible' as const }));
+  }
+
+  const visibleSpaces = await db
+    .select({ id: spaces.id })
+    .from(spaces)
+    .leftJoin(
+      spaceMembers,
+      and(eq(spaceMembers.space_id, spaces.id), eq(spaceMembers.user_id, userId)),
+    )
+    .where(
+      and(
+        eq(spaces.org_id, orgId),
+        inArray(spaces.id, Array.from(new Set(spaceIds))),
+        or(eq(spaces.type, 'public'), sql`${spaceMembers.id} is not null`),
+      ),
+    );
+  const visibleSpaceIds = new Set(visibleSpaces.map((space) => space.id));
+
+  return resources.map((resource) => {
+    if (resource.resource_type !== 'space' || visibleSpaceIds.has(resource.resource_id)) {
+      return { ...resource, access: 'visible' as const };
+    }
+    return {
+      ...resource,
+      label: null,
+      access: 'restricted' as const,
+      restricted_reason: 'space_membership_required',
+    };
+  });
+}
+
 async function buildTeamSummary(orgId: string, teamId: string) {
   const [memberCount] = await db
     .select({ count: count(teamMembers.id) })
@@ -371,6 +414,19 @@ async function buildTeamDashboard(orgId: string, teamId: string) {
 
   return {
     generated_at: now.toISOString(),
+    data_quality: {
+      mode: 'live_summary' as const,
+      history_available: Boolean(summary.latest_snapshot),
+      snapshot_status: summary.latest_snapshot ? 'snapshot_available' as const : 'no_snapshot_worker_data' as const,
+      source_scope: 'linked_team_resources' as const,
+      notes: [
+        'Open task counts are computed live from linked projects.',
+        'Context counts are computed from linked team resources.',
+        summary.latest_snapshot
+          ? 'A dashboard snapshot is available, but trend rendering is still intentionally limited.'
+          : 'No historical dashboard snapshot exists yet; treat this as a current-state summary, not trend analytics.',
+      ],
+    },
     summary,
     attention: {
       overdue_tasks: overdueTaskCount[0]?.count ?? 0,
@@ -565,6 +621,8 @@ teamRoutes.get('/:id', async (c) => {
     .where(and(eq(teamResources.org_id, user.org_id), eq(teamResources.team_id, visible.team.id)))
     .orderBy(teamResources.resource_type, teamResources.created_at);
 
+  const decoratedResources = await decorateResourcesForUser(user.org_id, user.id, resources);
+
   return c.json({
     team: visible.team,
     lead,
@@ -572,7 +630,7 @@ teamRoutes.get('/:id', async (c) => {
       ...member,
       kind: member.kind === 'agent' || member.agent_employee_id ? 'agent' : member.kind,
     })),
-    resources,
+    resources: decoratedResources,
     summary: await buildTeamSummary(user.org_id, visible.team.id),
   });
 });

--- a/apps/web/src/app/(app)/settings/agent/page.tsx
+++ b/apps/web/src/app/(app)/settings/agent/page.tsx
@@ -298,12 +298,17 @@ export default function AgentSettingsPage() {
   return (
     <div className="h-full overflow-y-auto">
     <div className="p-6 max-w-[900px]">
-      <h2
-        className="text-[18px] font-semibold mb-6"
-        style={{ color: 'var(--foreground)', fontFamily: 'var(--font-heading)' }}
-      >
-        Agent Settings
-      </h2>
+      <div className="mb-6">
+        <h2
+          className="text-[18px] font-semibold"
+          style={{ color: 'var(--foreground)', fontFamily: 'var(--font-heading)' }}
+        >
+          Agent governance
+        </h2>
+        <p className="text-[12px] mt-1 max-w-[640px]" style={{ color: 'var(--muted)' }}>
+          Set global trust rails for Defty and shared agent employees, then review approvals, receipts, and agent health from one place.
+        </p>
+      </div>
 
       {/* Approvals moved banner */}
       <div

--- a/apps/web/src/app/(app)/settings/ai/page.tsx
+++ b/apps/web/src/app/(app)/settings/ai/page.tsx
@@ -114,7 +114,7 @@ export default function AISettingsPage() {
 
   return (
     <div className="h-full overflow-y-auto">
-      <div className="p-6 max-w-[720px]">
+      <div className="p-6 max-w-[860px]">
         <div className="mb-6">
           <h2
             className="text-[18px] font-semibold"
@@ -135,6 +135,24 @@ export default function AISettingsPage() {
               features wake up after you configure any supported provider.
             </div>
           )}
+        </div>
+
+        <div className="grid gap-3 md:grid-cols-3 mb-8">
+          <AIContractNote
+            icon={Sparkles}
+            title="Optional by design"
+            body="Chat, tasks, calendar, notes, and wiki stay usable without provider keys."
+          />
+          <AIContractNote
+            icon={Server}
+            title="Self-hostable path"
+            body="Use Ollama or OpenAI-compatible local endpoints where possible."
+          />
+          <AIContractNote
+            icon={Database}
+            title="Workspace-scoped"
+            body="Keys and routing choices belong to this org, not every Deft install."
+          />
         </div>
 
         <section className="mb-8">
@@ -396,6 +414,27 @@ function ProviderCard({
           </div>
         </div>
       )}
+    </div>
+  );
+}
+
+function AIContractNote({
+  icon: Icon,
+  title,
+  body,
+}: {
+  icon: typeof Sparkles;
+  title: string;
+  body: string;
+}) {
+  return (
+    <div
+      className="rounded-xl p-4"
+      style={{ background: 'var(--surface-container-low)', border: '1px solid var(--border-default, var(--outline-variant))' }}
+    >
+      <Icon size={16} strokeWidth={1.75} style={{ color: 'var(--accent)' }} />
+      <p className="text-[13px] font-semibold mt-3" style={{ color: 'var(--foreground)' }}>{title}</p>
+      <p className="text-[12px] leading-relaxed mt-1" style={{ color: 'var(--muted)' }}>{body}</p>
     </div>
   );
 }

--- a/apps/web/src/app/(app)/settings/api-access/page.tsx
+++ b/apps/web/src/app/(app)/settings/api-access/page.tsx
@@ -2,7 +2,8 @@
 
 import { useState, useEffect } from 'react';
 import { api } from '@/lib/api';
-import { Trash2, X, Plus, Copy, Check, Key } from 'lucide-react';
+import Link from 'next/link';
+import { Trash2, X, Plus, Copy, Check, Key, Bot, Server, ShieldCheck } from 'lucide-react';
 
 type ApiKey = {
   id: string;
@@ -129,7 +130,7 @@ export default function ApiAccessPage() {
 
   if (loading) {
     return (
-      <div className="p-6 max-w-[700px]">
+      <div className="p-6 max-w-[820px]">
         <p className="text-[13px]" style={{ color: 'var(--muted)' }}>Loading...</p>
       </div>
     );
@@ -137,14 +138,19 @@ export default function ApiAccessPage() {
 
   return (
     <div className="h-full overflow-y-auto">
-    <div className="p-6 max-w-[700px]">
+    <div className="p-6 max-w-[820px]">
       <div className="flex items-center justify-between mb-4">
-        <h2
-          className="text-[18px] font-semibold"
-          style={{ color: 'var(--foreground)', fontFamily: 'var(--font-heading)' }}
-        >
-          API Access
-        </h2>
+        <div>
+          <h2
+            className="text-[18px] font-semibold"
+            style={{ color: 'var(--foreground)', fontFamily: 'var(--font-heading)' }}
+          >
+            API Access
+          </h2>
+          <p className="text-[12px] mt-1 max-w-[560px]" style={{ color: 'var(--muted)' }}>
+            Create service keys for API and MCP runtimes. Personal AI apps are usually easier from MCP Access.
+          </p>
+        </div>
         <button
           onClick={() => setShowCreate(!showCreate)}
           className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-[12px] font-medium"
@@ -157,6 +163,26 @@ export default function ApiAccessPage() {
           <Plus size={13} />
           Create API Key
         </button>
+      </div>
+
+      <div className="grid gap-3 md:grid-cols-3 mb-5">
+        <AccessNote
+          icon={Bot}
+          title="Personal AI apps"
+          body="Use MCP Access for Claude, Codex, ChatGPT, and human-owned tokens."
+          href="/settings/mcp-access"
+          cta="Open MCP Access"
+        />
+        <AccessNote
+          icon={Server}
+          title="Service runtimes"
+          body="Use API keys for background services, custom runtimes, or automation bridges."
+        />
+        <AccessNote
+          icon={ShieldCheck}
+          title="Rotate on exposure"
+          body="Keys are only shown once. Delete and recreate anything pasted into an unsafe place."
+        />
       </div>
 
       {/* One-time key display modal */}
@@ -323,10 +349,10 @@ export default function ApiAccessPage() {
         >
           <Key size={32} style={{ color: 'var(--muted)', margin: '0 auto 12px' }} />
           <p className="text-[14px] font-medium mb-1" style={{ color: 'var(--foreground)' }}>
-            No API keys yet
+            No service keys yet
           </p>
           <p className="text-[12px]" style={{ color: 'var(--muted)' }}>
-            Create a key to let external agents connect.
+            Create one when a service or agent runtime needs long-lived access.
           </p>
         </div>
       ) : (
@@ -433,4 +459,35 @@ export default function ApiAccessPage() {
     </div>
     </div>
   );
+}
+
+function AccessNote({
+  icon: Icon,
+  title,
+  body,
+  href,
+  cta,
+}: {
+  icon: typeof Bot;
+  title: string;
+  body: string;
+  href?: string;
+  cta?: string;
+}) {
+  const content = (
+    <>
+      <Icon size={16} strokeWidth={1.75} style={{ color: 'var(--accent)' }} />
+      <p className="text-[13px] font-semibold mt-3" style={{ color: 'var(--foreground)' }}>{title}</p>
+      <p className="text-[12px] leading-relaxed mt-1" style={{ color: 'var(--muted)' }}>{body}</p>
+      {cta && (
+        <p className="text-[11px] font-medium mt-3" style={{ color: 'var(--accent)' }}>{cta}</p>
+      )}
+    </>
+  );
+  const className = "rounded-xl p-4 text-left";
+  const style = { background: 'var(--surface-container-low)', border: '1px solid var(--border-default, var(--outline-variant))' };
+  if (href) {
+    return <Link href={href} className={className} style={style}>{content}</Link>;
+  }
+  return <div className={className} style={style}>{content}</div>;
 }

--- a/apps/web/src/app/(app)/settings/groups/page.tsx
+++ b/apps/web/src/app/(app)/settings/groups/page.tsx
@@ -1,97 +1,367 @@
 'use client';
-import { useState, useEffect } from 'react';
-import { api } from '@/lib/api';
-import { Plus, Trash2, Users } from 'lucide-react';
 
-type Group = { id: string; name: string; handle: string; description: string | null; member_count?: number };
-type Member = { id: string; name: string; email: string };
+import { useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import { AtSign, Check, MessageSquare, Plus, Trash2, Users, X } from 'lucide-react';
+import { api } from '@/lib/api';
+
+type GroupMember = {
+  user_id: string;
+  name: string;
+  email?: string | null;
+  avatar_url?: string | null;
+};
+
+type Group = {
+  id: string;
+  name: string;
+  handle: string;
+  description: string | null;
+  member_count?: number;
+  members?: GroupMember[];
+};
+
+type Member = {
+  id: string;
+  user_id?: string;
+  name: string;
+  email: string;
+  avatar_url?: string | null;
+};
+
+function normalizeMembers(value: any): Member[] {
+  const rows = Array.isArray(value) ? value : value?.members ?? value?.data ?? [];
+  return rows
+    .map((row: any) => ({
+      id: row.user_id ?? row.id,
+      user_id: row.user_id ?? row.id,
+      name: row.name ?? row.user_name ?? row.email ?? 'Unknown',
+      email: row.email ?? '',
+      avatar_url: row.avatar_url ?? null,
+    }))
+    .filter((row: Member) => !!row.id);
+}
+
+function initials(name: string) {
+  return name
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase())
+    .join('') || '?';
+}
 
 export default function GroupsPage() {
   const [groups, setGroups] = useState<Group[]>([]);
   const [members, setMembers] = useState<Member[]>([]);
   const [creating, setCreating] = useState(false);
+  const [expandedGroupId, setExpandedGroupId] = useState<string | null>(null);
+  const [memberPicker, setMemberPicker] = useState<Record<string, string>>({});
   const [name, setName] = useState('');
   const [handle, setHandle] = useState('');
+  const [description, setDescription] = useState('');
   const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+
+  async function loadGroups() {
+    const res = await api.get('/api/groups');
+    if (!res.ok) return;
+    const body = await res.json();
+    setGroups(Array.isArray(body) ? body : body.groups ?? body.data ?? []);
+  }
+
+  async function loadGroupDetails(groupId: string) {
+    const res = await api.get(`/api/groups/${groupId}`);
+    if (!res.ok) return;
+    const body = await res.json();
+    setGroups((prev) => prev.map((group) => group.id === groupId ? body : group));
+  }
 
   useEffect(() => {
     Promise.all([
-      api.get('/api/groups').then(async r => r.ok ? r.json() : []),
-      api.get('/api/members').then(async r => r.ok ? r.json() : []),
-    ]).then(([g, m]) => { setGroups(g); setMembers(m); setLoading(false); });
+      api.get('/api/groups').then(async (r) => r.ok ? r.json() : []),
+      api.get('/api/members').then(async (r) => r.ok ? r.json() : []),
+    ]).then(([groupRows, memberRows]) => {
+      setGroups(Array.isArray(groupRows) ? groupRows : groupRows.groups ?? groupRows.data ?? []);
+      setMembers(normalizeMembers(memberRows));
+      setLoading(false);
+    });
   }, []);
+
+  const expandedGroup = useMemo(
+    () => groups.find((group) => group.id === expandedGroupId) ?? null,
+    [expandedGroupId, groups],
+  );
+
+  const addableMembers = useMemo(() => {
+    if (!expandedGroup) return [];
+    const existing = new Set((expandedGroup.members ?? []).map((member) => member.user_id));
+    return members.filter((member) => !existing.has(member.id));
+  }, [expandedGroup, members]);
+
+  const totalMemberships = groups.reduce((sum, group) => sum + (group.member_count ?? group.members?.length ?? 0), 0);
 
   const handleCreate = async () => {
     if (!name.trim() || !handle.trim()) return;
-    const res = await api.post('/api/groups', { name, handle: handle.toLowerCase().replace(/[^a-z0-9-]/g, '') });
-    if (res.ok) {
-      const group = await res.json();
-      setGroups(prev => [...prev, group]);
-      setName(''); setHandle(''); setCreating(false);
+    setSaving(true);
+    try {
+      const res = await api.post('/api/groups', {
+        name,
+        handle: handle.toLowerCase().replace(/[^a-z0-9-]/g, ''),
+        description: description.trim() || null,
+      });
+      if (res.ok) {
+        const group = await res.json();
+        setGroups((prev) => [...prev, { ...group, member_count: 0, members: [] }]);
+        setName('');
+        setHandle('');
+        setDescription('');
+        setCreating(false);
+        setExpandedGroupId(group.id);
+        await loadGroupDetails(group.id);
+      }
+    } finally {
+      setSaving(false);
     }
   };
 
   const handleDelete = async (id: string) => {
     if (!confirm('Delete this group?')) return;
-    await api.delete(`/api/groups/${id}`);
-    setGroups(prev => prev.filter(g => g.id !== id));
+    const res = await api.delete(`/api/groups/${id}`);
+    if (res.ok) {
+      setGroups((prev) => prev.filter((group) => group.id !== id));
+      if (expandedGroupId === id) setExpandedGroupId(null);
+    }
+  };
+
+  const handleExpand = async (groupId: string) => {
+    const next = expandedGroupId === groupId ? null : groupId;
+    setExpandedGroupId(next);
+    if (next) await loadGroupDetails(next);
+  };
+
+  const handleAddMember = async (groupId: string) => {
+    const userId = memberPicker[groupId];
+    if (!userId) return;
+    const res = await api.post(`/api/groups/${groupId}/members`, { user_ids: [userId] });
+    if (res.ok) {
+      setMemberPicker((prev) => ({ ...prev, [groupId]: '' }));
+      await loadGroupDetails(groupId);
+      await loadGroups();
+    }
+  };
+
+  const handleRemoveMember = async (groupId: string, userId: string) => {
+    const res = await api.delete(`/api/groups/${groupId}/members/${userId}`);
+    if (res.ok) {
+      await loadGroupDetails(groupId);
+      await loadGroups();
+    }
   };
 
   return (
     <div className="h-full overflow-y-auto">
-    <div className="p-6 max-w-[640px]">
-      <div className="flex items-center justify-between mb-6">
-        <div>
-          <h2 className="text-[1.125rem] font-semibold" style={{ color: 'var(--on-surface)' }}>User Groups</h2>
-          <p className="text-[0.8125rem] mt-0.5" style={{ color: 'var(--outline)' }}>
-            Create groups to mention multiple people at once with @handle
-          </p>
-        </div>
-        <button onClick={() => setCreating(true)}
-          className="px-3 py-1.5 text-[0.75rem] font-medium text-white rounded-md"
-          style={{ background: 'var(--primary-container)' }}>
-          <Plus size={12} strokeWidth={2} className="inline mr-1" /> Create Group
-        </button>
-      </div>
-
-      {creating && (
-        <div className="p-4 rounded-lg mb-4" style={{ background: 'var(--surface-container)' }}>
-          <div className="flex gap-2 mb-3">
-            <input value={name} onChange={e => { setName(e.target.value); setHandle(e.target.value.toLowerCase().replace(/[^a-z0-9]+/g, '-')); }}
-              placeholder="Group name" className="flex-1 h-9 px-3 text-[0.8125rem] rounded-md outline-none"
-              style={{ background: 'var(--surface-container-high)', color: 'var(--on-surface)' }} />
-            <input value={handle} onChange={e => setHandle(e.target.value)}
-              placeholder="handle" className="w-32 h-9 px-3 text-[0.8125rem] rounded-md outline-none"
-              style={{ background: 'var(--surface-container-high)', color: 'var(--on-surface)', fontFamily: 'var(--font-mono)' }} />
+      <div className="mx-auto max-w-[860px] p-4 sm:p-6">
+        <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h2 className="text-[1.125rem] font-semibold" style={{ color: 'var(--on-surface)' }}>Groups</h2>
+            <p className="mt-0.5 text-[0.8125rem]" style={{ color: 'var(--outline)' }}>
+              Lightweight mention lists for chat. Use teams when you need ownership, leads, resources, and operating context.
+            </p>
           </div>
-          <div className="flex gap-2">
-            <button onClick={handleCreate} className="px-3 py-1.5 text-[0.75rem] font-medium text-white rounded-md"
-              style={{ background: 'var(--primary-container)' }}>Create</button>
-            <button onClick={() => setCreating(false)} className="px-3 py-1.5 text-[0.75rem] rounded-md"
-              style={{ color: 'var(--outline)' }}>Cancel</button>
-          </div>
+          <button
+            onClick={() => setCreating(true)}
+            className="inline-flex h-9 items-center justify-center gap-2 rounded-md px-3 text-[0.75rem] font-medium text-white"
+            style={{ background: 'var(--primary-container)' }}
+          >
+            <Plus size={14} strokeWidth={2} /> Create
+          </button>
         </div>
-      )}
 
-      <div className="space-y-2">
-        {groups.map(g => (
-          <div key={g.id} className="flex items-center gap-3 p-3 rounded-lg"
-            style={{ background: 'var(--surface-container)' }}>
-            <Users size={16} strokeWidth={1.5} style={{ color: 'var(--outline)' }} />
-            <div className="flex-1">
-              <span className="text-[0.8125rem] font-medium" style={{ color: 'var(--on-surface)' }}>{g.name}</span>
-              <span className="text-[0.6875rem] ml-2" style={{ color: 'var(--outline)', fontFamily: 'var(--font-mono)' }}>@{g.handle}</span>
+        <div className="grid gap-3 md:grid-cols-3 mb-5">
+          <GroupNote icon={AtSign} title="Mention lists" body="Groups exist so people can notify a set of coworkers with one handle." />
+          <GroupNote icon={MessageSquare} title="Chat-first" body="Use @handle in chat; it does not grant private space access by itself." />
+          <Link
+            href="/settings/teams"
+            className="rounded-xl p-4"
+            style={{ background: 'var(--surface-container-low)', border: '1px solid var(--outline-variant)' }}
+          >
+            <Users size={16} strokeWidth={1.75} style={{ color: 'var(--accent)' }} />
+            <p className="text-[13px] font-semibold mt-3" style={{ color: 'var(--on-surface)' }}>Need structure?</p>
+            <p className="text-[12px] leading-relaxed mt-1" style={{ color: 'var(--outline)' }}>Use Teams for leads, membership, linked work, and team dashboards.</p>
+          </Link>
+        </div>
+
+        <div className="grid grid-cols-2 gap-2 mb-5">
+          <GroupStat label="Groups" value={groups.length} />
+          <GroupStat label="Memberships" value={totalMemberships} />
+        </div>
+
+        {creating && (
+          <div className="mb-4 rounded-lg border p-4" style={{ background: 'var(--surface-container)', borderColor: 'var(--outline-variant)' }}>
+            <div className="grid gap-3 sm:grid-cols-[1fr_180px]">
+              <input
+                value={name}
+                onChange={(event) => {
+                  setName(event.target.value);
+                  setHandle(event.target.value.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, ''));
+                }}
+                placeholder="Group name"
+                className="h-10 rounded-md px-3 text-[0.8125rem] outline-none"
+                style={{ background: 'var(--surface-container-high)', color: 'var(--on-surface)' }}
+              />
+              <input
+                value={handle}
+                onChange={(event) => setHandle(event.target.value.toLowerCase().replace(/[^a-z0-9-]/g, ''))}
+                placeholder="handle"
+                className="h-10 rounded-md px-3 text-[0.8125rem] outline-none"
+                style={{ background: 'var(--surface-container-high)', color: 'var(--on-surface)', fontFamily: 'var(--font-mono)' }}
+              />
+              <input
+                value={description}
+                onChange={(event) => setDescription(event.target.value)}
+                placeholder="What this group is for"
+                className="h-10 rounded-md px-3 text-[0.8125rem] outline-none sm:col-span-2"
+                style={{ background: 'var(--surface-container-high)', color: 'var(--on-surface)' }}
+              />
             </div>
-            <button onClick={() => handleDelete(g.id)} className="p-1" style={{ color: 'var(--outline)' }}>
-              <Trash2 size={13} strokeWidth={1.5} />
-            </button>
+            <div className="mt-3 flex gap-2">
+              <button
+                onClick={handleCreate}
+                disabled={saving}
+                className="inline-flex h-8 items-center gap-2 rounded-md px-3 text-[0.75rem] font-medium text-white disabled:opacity-60"
+                style={{ background: 'var(--primary-container)' }}
+              >
+                <Check size={13} strokeWidth={2} /> Create group
+              </button>
+              <button
+                onClick={() => setCreating(false)}
+                className="inline-flex h-8 items-center gap-2 rounded-md px-3 text-[0.75rem]"
+                style={{ color: 'var(--outline)' }}
+              >
+                <X size={13} strokeWidth={2} /> Cancel
+              </button>
+            </div>
           </div>
-        ))}
-        {!loading && groups.length === 0 && !creating && (
-          <p className="text-center py-8 text-[0.75rem]" style={{ color: 'var(--outline)' }}>No groups yet</p>
         )}
+
+        <div className="space-y-3">
+          {groups.map((group) => {
+            const expanded = expandedGroupId === group.id;
+            return (
+              <div key={group.id} className="rounded-lg border" style={{ background: 'var(--surface-container)', borderColor: 'var(--outline-variant)' }}>
+                <div className="flex items-center gap-3 p-3">
+                  <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md" style={{ background: 'var(--surface-container-high)', color: 'var(--outline)' }}>
+                    <Users size={16} strokeWidth={1.5} />
+                  </div>
+                  <button onClick={() => handleExpand(group.id)} className="min-w-0 flex-1 text-left">
+                    <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+                      <span className="text-[0.8125rem] font-medium" style={{ color: 'var(--on-surface)' }}>{group.name}</span>
+                      <span className="text-[0.6875rem]" style={{ color: 'var(--outline)', fontFamily: 'var(--font-mono)' }}>@{group.handle}</span>
+                    </div>
+                    <div className="mt-0.5 truncate text-[0.6875rem]" style={{ color: 'var(--outline)' }}>
+                      {group.member_count ?? group.members?.length ?? 0} members{group.description ? ` - ${group.description}` : ''}
+                    </div>
+                  </button>
+                  <button onClick={() => handleDelete(group.id)} className="rounded-md p-2" style={{ color: 'var(--outline)' }} aria-label={`Delete ${group.name}`}>
+                    <Trash2 size={14} strokeWidth={1.5} />
+                  </button>
+                </div>
+
+                {expanded && (
+                  <div className="border-t p-3" style={{ borderColor: 'var(--outline-variant)' }}>
+                    <div className="mb-3 flex flex-col gap-2 sm:flex-row">
+                      <select
+                        value={memberPicker[group.id] ?? ''}
+                        onChange={(event) => setMemberPicker((prev) => ({ ...prev, [group.id]: event.target.value }))}
+                        className="h-9 min-w-0 flex-1 rounded-md px-3 text-[0.75rem] outline-none"
+                        style={{ background: 'var(--surface-container-high)', color: 'var(--on-surface)' }}
+                      >
+                        <option value="">Add a member</option>
+                        {addableMembers.map((member) => (
+                          <option key={member.id} value={member.id}>{member.name} - {member.email}</option>
+                        ))}
+                      </select>
+                      <button
+                        onClick={() => handleAddMember(group.id)}
+                        disabled={!memberPicker[group.id]}
+                        className="inline-flex h-9 items-center justify-center gap-2 rounded-md px-3 text-[0.75rem] font-medium disabled:opacity-50"
+                        style={{ background: 'var(--surface-container-high)', color: 'var(--on-surface)' }}
+                      >
+                        <Plus size={13} strokeWidth={2} /> Add
+                      </button>
+                    </div>
+
+                    <div className="flex flex-wrap gap-2">
+                      {(group.members ?? []).map((member) => (
+                        <div key={member.user_id} className="inline-flex max-w-full items-center gap-2 rounded-full border px-2 py-1" style={{ borderColor: 'var(--outline-variant)', color: 'var(--on-surface)' }}>
+                          {member.avatar_url ? (
+                            <img src={member.avatar_url} alt="" className="h-6 w-6 rounded-full object-cover" />
+                          ) : (
+                            <span className="flex h-6 w-6 items-center justify-center rounded-full text-[0.625rem] font-semibold" style={{ background: 'var(--primary-container)', color: 'white' }}>
+                              {initials(member.name)}
+                            </span>
+                          )}
+                          <span className="max-w-[180px] truncate text-[0.75rem]">{member.name}</span>
+                          <button onClick={() => handleRemoveMember(group.id, member.user_id)} className="rounded-full p-1" style={{ color: 'var(--outline)' }} aria-label={`Remove ${member.name}`}>
+                            <X size={12} strokeWidth={2} />
+                          </button>
+                        </div>
+                      ))}
+                      {(group.members ?? []).length === 0 && (
+                        <span className="text-[0.75rem]" style={{ color: 'var(--outline)' }}>No members yet.</span>
+                      )}
+                    </div>
+                  </div>
+                )}
+              </div>
+            );
+          })}
+          {!loading && groups.length === 0 && !creating && (
+            <div
+              className="py-12 px-6 text-center rounded-xl"
+              style={{ background: 'var(--surface-container-low)', border: '1px dashed var(--outline-variant)' }}
+            >
+              <AtSign size={28} className="mx-auto mb-3" style={{ color: 'var(--outline)' }} />
+              <p className="text-[13px] font-medium" style={{ color: 'var(--on-surface)' }}>No mention groups yet.</p>
+              <p className="text-[12px] mt-1" style={{ color: 'var(--outline)' }}>Create a group when the same people are repeatedly mentioned together.</p>
+            </div>
+          )}
+        </div>
       </div>
     </div>
+  );
+}
+
+function GroupNote({
+  icon: Icon,
+  title,
+  body,
+}: {
+  icon: typeof AtSign;
+  title: string;
+  body: string;
+}) {
+  return (
+    <div
+      className="rounded-xl p-4"
+      style={{ background: 'var(--surface-container-low)', border: '1px solid var(--outline-variant)' }}
+    >
+      <Icon size={16} strokeWidth={1.75} style={{ color: 'var(--accent)' }} />
+      <p className="text-[13px] font-semibold mt-3" style={{ color: 'var(--on-surface)' }}>{title}</p>
+      <p className="text-[12px] leading-relaxed mt-1" style={{ color: 'var(--outline)' }}>{body}</p>
+    </div>
+  );
+}
+
+function GroupStat({ label, value }: { label: string; value: number }) {
+  return (
+    <div
+      className="rounded-xl px-3 py-3"
+      style={{ background: 'var(--surface-container-low)', border: '1px solid var(--outline-variant)' }}
+    >
+      <p className="text-[20px] font-semibold tabular-nums" style={{ color: 'var(--on-surface)', fontFamily: 'var(--font-heading)' }}>{value}</p>
+      <p className="text-[11px] mt-0.5" style={{ color: 'var(--outline)' }}>{label}</p>
     </div>
   );
 }

--- a/apps/web/src/app/(app)/settings/integrations/page.tsx
+++ b/apps/web/src/app/(app)/settings/integrations/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { api } from '@/lib/api';
 import Link from 'next/link';
-import { CalendarDays, ChevronDown, ChevronRight, Globe, RefreshCw, Trash2, Zap, Plug } from 'lucide-react';
+import { Bot, CalendarDays, ChevronDown, ChevronRight, Globe, RefreshCw, Trash2, Zap, Plug, Users } from 'lucide-react';
 import McpConnectionForm from '@/components/mcp-connection-form';
 
 
@@ -175,6 +175,12 @@ export default function IntegrationsPage() {
       <p className="text-[0.8125rem] mb-6" style={{ color: 'var(--outline)' }}>
         Connect calendar feeds and MCP-compatible tool servers. Agent employees can bring their own external tools through MCP.
       </p>
+
+      <div className="grid gap-3 md:grid-cols-3 mb-6">
+        <IntegrationRoute icon={CalendarDays} title="Calendar feeds" body="Subscribe to ICS calendars and publish your Deft task feed." href="/settings/calendar" />
+        <IntegrationRoute icon={Bot} title="Personal AI apps" body="Connect Claude, Codex, and other MCP clients as yourself." href="/settings/mcp-access" />
+        <IntegrationRoute icon={Users} title="Shared agents" body="Onboard agent employees for the whole workspace." href="/settings/agent-employees" />
+      </div>
 
       {/* Calendar feeds */}
       <div className="mb-6 p-4 rounded-lg"
@@ -500,5 +506,29 @@ export default function IntegrationsPage() {
       )}
     </div>
     </div>
+  );
+}
+
+function IntegrationRoute({
+  icon: Icon,
+  title,
+  body,
+  href,
+}: {
+  icon: typeof CalendarDays;
+  title: string;
+  body: string;
+  href: string;
+}) {
+  return (
+    <Link
+      href={href}
+      className="rounded-xl p-4"
+      style={{ background: 'var(--surface-container-low)', border: '1px solid var(--border-default, var(--outline-variant))' }}
+    >
+      <Icon size={16} strokeWidth={1.75} style={{ color: 'var(--accent)' }} />
+      <p className="text-[13px] font-semibold mt-3" style={{ color: 'var(--foreground)' }}>{title}</p>
+      <p className="text-[12px] leading-relaxed mt-1" style={{ color: 'var(--muted)' }}>{body}</p>
+    </Link>
   );
 }

--- a/apps/web/src/app/(app)/settings/library/page.tsx
+++ b/apps/web/src/app/(app)/settings/library/page.tsx
@@ -2,10 +2,9 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import useSWR from 'swr';
-import { Loader2, Layers, FileStack, X, ChevronRight, CheckCircle2 } from 'lucide-react';
+import { Loader2, Layers, FileStack, X, ChevronRight, CheckCircle2, Sparkles } from 'lucide-react';
 import { api } from '@/lib/api';
 import { PageHeader } from '@/components/page-header';
-import { TabStrip } from '@/components/tab-strip';
 
 const fetcher = async (url: string) => {
   const res = await api.get(url);
@@ -601,8 +600,8 @@ export default function LibraryPage() {
   return (
     <div className="flex flex-col h-full overflow-hidden">
       <PageHeader
-        title="Task Templates"
-        description="Browse repeatable task templates and apply them to projects."
+        title="Templates"
+        description="Turn repeatable work into ready-made task sets that can be applied to any project."
         compact
       />
 
@@ -692,6 +691,22 @@ export default function LibraryPage() {
       {/* Templates tab */}
       {tab === 'templates' && (
         <div className="flex-1 overflow-y-auto space-y-2 px-4 md:px-6 pb-4">
+          <div
+            className="rounded-xl p-4 mb-3"
+            style={{ background: 'var(--surface-container-low)', border: '1px solid var(--border-default)' }}
+          >
+            <div className="flex items-start gap-3">
+              <Sparkles size={16} strokeWidth={1.75} className="mt-0.5" style={{ color: 'var(--accent)' }} />
+              <div>
+                <p className="text-[13px] font-semibold" style={{ color: 'var(--foreground)' }}>
+                  Templates create normal tasks
+                </p>
+                <p className="text-[12px] leading-relaxed mt-1" style={{ color: 'var(--text-secondary)' }}>
+                  Apply a template to a project, then manage the created tasks through the regular board, list, and workflow surfaces.
+                </p>
+              </div>
+            </div>
+          </div>
           {templatesErr && (
             <p className="text-[13px]" style={{ color: '#EF4444' }}>
               Failed to load templates.

--- a/apps/web/src/app/(app)/settings/members/page.tsx
+++ b/apps/web/src/app/(app)/settings/members/page.tsx
@@ -117,6 +117,35 @@ type ShareLink = {
   context: string;
 };
 
+type OffboardingPreview = {
+  revoke_now: {
+    spaces: Array<{ id: string; name: string; type: string }>;
+    teams: Array<{ id: string; name: string; handle: string; role: string }>;
+    groups: Array<{ id: string; name: string; handle: string }>;
+    secondary_task_assignments: number;
+    active_mcp_tokens: number;
+    active_api_keys: number;
+    active_oauth_grants: number;
+  };
+  needs_reassignment: {
+    primary_open_tasks: Array<{ id: string; title: string; status: string; priority: string; project_id: string | null }>;
+    led_projects: Array<{ id: string; name: string; prefix: string }>;
+    led_teams: Array<{ id: string; name: string; handle: string }>;
+  };
+  counts: {
+    spaces: number;
+    teams: number;
+    groups: number;
+    primary_open_tasks: number;
+    secondary_task_assignments: number;
+    led_projects: number;
+    led_teams: number;
+    active_mcp_tokens: number;
+    active_api_keys: number;
+    active_oauth_grants: number;
+  };
+};
+
 function formatExpiry(iso: string | null): string {
   if (!iso) return '';
   const d = new Date(iso);
@@ -229,6 +258,11 @@ export default function MembersPage() {
   const [copied, setCopied] = useState(false);
   const [roleDropdown, setRoleDropdown] = useState<string | null>(null);
   const [confirmRemove, setConfirmRemove] = useState<string | null>(null);
+  const [offboardingPreview, setOffboardingPreview] = useState<OffboardingPreview | null>(null);
+  const [offboardingReplacementId, setOffboardingReplacementId] = useState('');
+  const [offboardingLoading, setOffboardingLoading] = useState(false);
+  const [offboardingError, setOffboardingError] = useState('');
+  const [removingId, setRemovingId] = useState<string | null>(null);
   const [workingInviteId, setWorkingInviteId] = useState<string | null>(null);
   const [recoveringId, setRecoveringId] = useState<string | null>(null);
 
@@ -287,6 +321,17 @@ export default function MembersPage() {
   }, [members, filter, search]);
 
   const pendingInvites = invites.filter((invite) => invite.status === 'pending');
+  const offboardingReplacementOptions = useMemo(() => {
+    const removedId = detail?.member.id ?? confirmRemove;
+    return members.filter((member) => (
+      member.id !== removedId &&
+      member.lifecycle_status === 'active'
+    ));
+  }, [members, detail?.member.id, confirmRemove]);
+
+  const offboardingHandoffCount = offboardingPreview
+    ? offboardingPreview.counts.primary_open_tasks + offboardingPreview.counts.led_projects + offboardingPreview.counts.led_teams
+    : 0;
 
   const handleInvite = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -322,13 +367,53 @@ export default function MembersPage() {
     setRoleDropdown(null);
   };
 
+  const openRemovePreview = async (memberId: string) => {
+    setConfirmRemove(memberId);
+    setOffboardingPreview(null);
+    const defaultReplacement = members.find((member) => (
+      member.id !== memberId &&
+      member.lifecycle_status === 'active'
+    ));
+    setOffboardingReplacementId(defaultReplacement?.id ?? '');
+    setOffboardingError('');
+    setOffboardingLoading(true);
+    try {
+      const res = await api.get(`/api/members/${memberId}/offboarding-preview`);
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(data.error || 'Failed to load offboarding preview');
+      setOffboardingPreview(data);
+    } catch (err: any) {
+      setOffboardingError(err.message);
+    } finally {
+      setOffboardingLoading(false);
+    }
+  };
+
+  const closeRemovePreview = () => {
+    setConfirmRemove(null);
+    setOffboardingPreview(null);
+    setOffboardingReplacementId('');
+    setOffboardingError('');
+  };
+
   const handleRemove = async (memberId: string) => {
-    const res = await api.delete(`/api/members/${memberId}`);
-    if (res.ok) {
+    setRemovingId(memberId);
+    setOffboardingError('');
+    try {
+      const res = await api.delete(`/api/members/${memberId}`, {
+        replacement_user_id: offboardingReplacementId || null,
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        setOffboardingError(data.error || 'Failed to remove member');
+        return;
+      }
       await fetchDirectory(null);
       setDetail(null);
+      closeRemovePreview();
+    } finally {
+      setRemovingId(null);
     }
-    setConfirmRemove(null);
   };
 
   const handleRecoveryLink = async (m: DirectoryMember) => {
@@ -509,7 +594,7 @@ export default function MembersPage() {
 
         <div className="grid gap-4 lg:grid-cols-[minmax(360px,1fr)_360px] xl:grid-cols-[minmax(0,1fr)_390px]">
           <section className="min-w-0 overflow-hidden rounded-lg" style={{ background: 'var(--card-bg)', border: '1px solid var(--border)' }}>
-            <div className="border-b p-3" style={{ borderColor: 'rgba(255,255,255,0.08)' }}>
+            <div className="border-b p-3" style={{ borderColor: 'var(--border-default)' }}>
               <div className="space-y-2">
                 <div className="relative min-w-0">
                   <Search size={15} className="absolute left-3 top-1/2 -translate-y-1/2" style={{ color: 'var(--muted)' }} />
@@ -551,8 +636,8 @@ export default function MembersPage() {
                   <button
                     key={m.id}
                     onClick={() => setSelectedId(m.id)}
-                    className="group flex w-full min-w-0 items-start gap-3 border-b px-3 py-2 text-left transition last:border-b-0 hover:bg-white/[0.025]"
-                    style={{ background: selected ? 'var(--hover-tint)' : 'transparent', borderColor: 'rgba(255,255,255,0.08)' }}
+                    className="group flex w-full min-w-0 items-start gap-3 border-b px-3 py-2 text-left transition last:border-b-0 hover:bg-[var(--bg-hover)]"
+                    style={{ background: selected ? 'var(--hover-tint)' : 'transparent', borderColor: 'var(--border-default)' }}
                   >
                     <Avatar member={m} />
                     <div className="min-w-0 flex-1">
@@ -740,21 +825,84 @@ export default function MembersPage() {
 
                       {detail.member.role !== 'owner' && detail.member.id !== user?.id && detail.member.is_active && (
                         confirmRemove === detail.member.id ? (
-                          <div className="flex items-center gap-1">
-                            <button
-                              onClick={() => handleRemove(detail.member.id)}
-                              className="h-8 rounded-md px-2 text-[11px] font-semibold"
-                              style={{ background: 'var(--error)', color: 'white' }}
-                            >
-                              Confirm remove
-                            </button>
-                            <button onClick={() => setConfirmRemove(null)} style={{ color: 'var(--muted)' }}>
-                              <X size={14} />
-                            </button>
+                          <div
+                            className="w-full rounded-lg p-3 sm:w-[420px]"
+                            style={{ background: 'var(--surface)', border: '1px solid var(--border)' }}
+                          >
+                            <div className="flex items-start justify-between gap-3">
+                              <div>
+                                <p className="text-[12px] font-semibold" style={{ color: 'var(--foreground)' }}>Remove {detail.member.name}?</p>
+                                <p className="mt-1 text-[11px] leading-relaxed" style={{ color: 'var(--muted)' }}>
+                                  Deft will revoke workspace access, tokens, app grants, team memberships, group mentions, and secondary task assignments.
+                                </p>
+                              </div>
+                              <button onClick={closeRemovePreview} style={{ color: 'var(--muted)' }} aria-label="Cancel removal">
+                                <X size={14} />
+                              </button>
+                            </div>
+
+                            {offboardingLoading ? (
+                              <p className="mt-3 text-[12px]" style={{ color: 'var(--muted)' }}>Loading offboarding preview...</p>
+                            ) : offboardingError ? (
+                              <p className="mt-3 rounded px-2 py-1.5 text-[12px]" style={{ color: 'var(--error)', background: 'rgba(147,0,10,0.16)' }}>{offboardingError}</p>
+                            ) : offboardingPreview && (
+                              <div className="mt-3 grid gap-2">
+                                <div className="grid grid-cols-3 gap-2">
+                                  <StatCard icon={Users} label="Spaces" value={offboardingPreview.counts.spaces} />
+                                  <StatCard icon={Briefcase} label="Teams" value={offboardingPreview.counts.teams} />
+                                  <StatCard icon={Activity} label="Groups" value={offboardingPreview.counts.groups} />
+                                </div>
+                                <div className="rounded-md px-2 py-2 text-[11px]" style={{ background: 'var(--card-bg)', color: 'var(--muted)' }}>
+                                  Also revokes {offboardingPreview.counts.active_mcp_tokens} MCP token(s), {offboardingPreview.counts.active_api_keys} API key(s), {offboardingPreview.counts.active_oauth_grants} app grant(s), and {offboardingPreview.counts.secondary_task_assignments} secondary task assignment(s).
+                                </div>
+                                {offboardingHandoffCount > 0 && (
+                                  <div className="grid gap-2 rounded-md px-2 py-2 text-[11px]" style={{ background: 'rgba(234,179,8,0.12)', color: 'var(--warning)' }}>
+                                    <p>
+                                      Transfer ownership for {offboardingPreview.counts.primary_open_tasks} open primary task(s), {offboardingPreview.counts.led_projects} led project(s), and {offboardingPreview.counts.led_teams} team lead role(s).
+                                    </p>
+                                    <select
+                                      data-testid="offboarding-replacement-select"
+                                      value={offboardingReplacementId}
+                                      onChange={(e) => setOffboardingReplacementId(e.target.value)}
+                                      className="h-8 rounded-md px-2 text-[12px] outline-none"
+                                      style={{ background: 'var(--card-bg)', border: '1px solid var(--border)', color: 'var(--foreground)' }}
+                                      disabled={offboardingReplacementOptions.length === 0}
+                                    >
+                                      {offboardingReplacementOptions.length === 0 ? (
+                                        <option value="">No active replacement available</option>
+                                      ) : offboardingReplacementOptions.map((member) => (
+                                        <option key={member.id} value={member.id}>
+                                          {member.name}{member.title ? ` - ${member.title}` : ''}
+                                        </option>
+                                      ))}
+                                    </select>
+                                  </div>
+                                )}
+                              </div>
+                            )}
+
+                            <div className="mt-3 grid grid-cols-2 gap-2">
+                              <button
+                                type="button"
+                                onClick={closeRemovePreview}
+                                className="h-8 rounded-md px-2 text-[11px] font-semibold"
+                                style={{ color: 'var(--muted)', border: '1px solid var(--border)' }}
+                              >
+                                Cancel
+                              </button>
+                              <button
+                                onClick={() => handleRemove(detail.member.id)}
+                                disabled={offboardingLoading || removingId === detail.member.id || (offboardingHandoffCount > 0 && !offboardingReplacementId)}
+                                className="h-8 rounded-md px-2 text-[11px] font-semibold disabled:opacity-50"
+                                style={{ background: 'var(--error)', color: 'white' }}
+                              >
+                                {removingId === detail.member.id ? 'Removing...' : offboardingHandoffCount > 0 ? 'Transfer and remove' : 'Confirm remove'}
+                              </button>
+                            </div>
                           </div>
                         ) : (
                           <button
-                            onClick={() => setConfirmRemove(detail.member.id)}
+                            onClick={() => openRemovePreview(detail.member.id)}
                             className="inline-flex h-8 items-center gap-1.5 rounded-md px-2 text-[11px] font-semibold"
                             style={{ color: 'var(--error)', border: '1px solid var(--border)' }}
                           >

--- a/apps/web/src/app/(app)/settings/page.tsx
+++ b/apps/web/src/app/(app)/settings/page.tsx
@@ -1,151 +1,136 @@
 'use client';
 
 import Link from 'next/link';
-import { usePathname } from 'next/navigation';
 import { useTheme } from '@/components/theme-provider';
 import { useAuth } from '@/lib/auth-context';
-import { Sun, Moon } from 'lucide-react';
-import { TabStrip } from '@/components/tab-strip';
+import { settingsNavGroups } from '@/lib/settings-navigation';
+import { Bot, CalendarDays, Code2, Moon, Settings2, Sun, User, Users, Workflow } from 'lucide-react';
 
-const settingsSections = [
-  { name: 'General', href: '/settings' },
-  { name: 'Profile', href: '/settings/profile' },
-  { name: 'Members', href: '/settings/members' },
-  { name: 'Teams', href: '/settings/teams' },
-  { name: 'Groups', href: '/settings/groups' },
-  { name: 'Projects', href: '/settings/projects' },
-  { name: 'Tags', href: '/settings/tags' },
-  { name: 'Integrations', href: '/settings/integrations' },
-  { name: 'AI', href: '/settings/ai' },
-  { name: 'Calendar', href: '/settings/calendar' },
-  { name: 'Agent', href: '/settings/agent' },
-  { name: 'Agent Employees', href: '/settings/agent-employees' },
-  { name: 'MCP Access', href: '/settings/mcp-access' },
-  { name: 'API Access', href: '/settings/api-access' },
-];
+const groupIcons = {
+  Personal: User,
+  Workspace: Users,
+  'Work System': Workflow,
+  'Agents & AI': Bot,
+  Developer: Code2,
+} as const;
 
 export default function SettingsPage() {
   const { theme, toggleTheme } = useTheme();
-  const { user } = useAuth();
-  const pathname = usePathname();
+  const { user, org } = useAuth();
 
-  const themes: { value: 'light' | 'dark'; label: string; icon: React.ReactNode }[] = [
-    { value: 'light', label: 'Light', icon: <Sun size={18} strokeWidth={1.5} /> },
-    { value: 'dark', label: 'Dark', icon: <Moon size={18} strokeWidth={1.5} /> },
-  ];
-
-  const currentTheme = theme; // 'light' or 'dark' from the provider
+  const currentTheme = theme;
 
   return (
     <div className="h-full overflow-y-auto">
-      {/* Mobile sub-navigation — only visible below md breakpoint */}
-      <div className="md:hidden px-4 pt-4 pb-0">
-        <TabStrip>
-          {settingsSections.map((section) => {
-            const active = pathname === section.href;
+      <div className="mx-auto max-w-6xl px-5 py-8 md:px-8 md:py-10">
+        <header className="mb-8 flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+          <div>
+            <div className="mb-3 inline-flex items-center gap-2 rounded-full px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.06em]" style={{ background: 'var(--surface-container-low)', color: 'var(--text-secondary)' }}>
+              <Settings2 size={13} />
+              Workspace controls
+            </div>
+            <h1 className="text-[30px] font-semibold tracking-tight md:text-[36px]" style={{ color: 'var(--foreground)', fontFamily: 'var(--font-heading)' }}>
+              Settings
+            </h1>
+            <p className="mt-2 max-w-2xl text-[15px] leading-6" style={{ color: 'var(--text-secondary)' }}>
+              Manage your profile, people, teams, agents, calendar feeds, templates, and developer access from one place.
+            </p>
+          </div>
+
+          <div className="deft-soft-card p-4 lg:min-w-[280px]">
+            <div className="flex items-center gap-3">
+              {user?.avatar_url ? (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img src={user.avatar_url} alt="" className="h-11 w-11 rounded-full object-cover" />
+              ) : (
+                <div className="flex h-11 w-11 items-center justify-center rounded-full text-[15px] font-semibold text-white" style={{ background: 'var(--accent)' }}>
+                  {user?.name?.charAt(0).toUpperCase() || '?'}
+                </div>
+              )}
+              <div className="min-w-0">
+                <div className="truncate text-[14px] font-semibold" style={{ color: 'var(--foreground)' }}>{user?.name || 'Unknown user'}</div>
+                <div className="truncate text-[12px]" style={{ color: 'var(--text-tertiary)' }}>{org?.name || user?.email || 'Workspace'}</div>
+              </div>
+            </div>
+            <Link href="/settings/profile" className="deft-pill mt-3" style={{ color: 'var(--accent)' }}>
+              Edit profile
+            </Link>
+          </div>
+        </header>
+
+        <section className="mb-8 grid gap-3 md:grid-cols-2">
+          <button
+            type="button"
+            onClick={() => {
+              if (currentTheme !== 'light') toggleTheme();
+            }}
+            className="deft-soft-card flex items-center gap-3 p-4 text-left transition-colors"
+            style={{
+              background: currentTheme === 'light' ? 'var(--accent-subtle)' : 'var(--card-bg)',
+              border: `1px solid ${currentTheme === 'light' ? 'var(--accent)' : 'var(--border)'}`,
+            }}
+          >
+            <Sun size={18} style={{ color: currentTheme === 'light' ? 'var(--accent)' : 'var(--text-secondary)' }} />
+            <div>
+              <div className="text-[13px] font-semibold" style={{ color: 'var(--foreground)' }}>Light mode</div>
+              <div className="text-[12px]" style={{ color: 'var(--text-tertiary)' }}>Use a brighter interface.</div>
+            </div>
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              if (currentTheme !== 'dark') toggleTheme();
+            }}
+            className="deft-soft-card flex items-center gap-3 p-4 text-left transition-colors"
+            style={{
+              background: currentTheme === 'dark' ? 'var(--accent-subtle)' : 'var(--card-bg)',
+              border: `1px solid ${currentTheme === 'dark' ? 'var(--accent)' : 'var(--border)'}`,
+            }}
+          >
+            <Moon size={18} style={{ color: currentTheme === 'dark' ? 'var(--accent)' : 'var(--text-secondary)' }} />
+            <div>
+              <div className="text-[13px] font-semibold" style={{ color: 'var(--foreground)' }}>Dark mode</div>
+              <div className="text-[12px]" style={{ color: 'var(--text-tertiary)' }}>Use the focused workspace theme.</div>
+            </div>
+          </button>
+        </section>
+
+        <div className="grid gap-4 lg:grid-cols-2">
+          {settingsNavGroups.map((group) => {
+            const Icon = groupIcons[group.label as keyof typeof groupIcons] || CalendarDays;
             return (
-              <Link
-                key={section.href}
-                href={section.href}
-                className="px-3 py-1.5 rounded-lg text-[12px] font-medium transition-colors flex-shrink-0"
-                style={{
-                  background: active ? 'var(--accent)' : 'var(--surface-container-low)',
-                  color: active ? 'white' : 'var(--text-secondary)',
-                }}
-              >
-                {section.name}
-              </Link>
+              <section key={group.label} className="deft-soft-card p-5">
+                <div className="mb-4 flex items-start gap-3">
+                  <div className="flex h-9 w-9 items-center justify-center rounded-lg" style={{ background: 'var(--surface-container-low)', color: 'var(--accent)' }}>
+                    <Icon size={17} />
+                  </div>
+                  <div>
+                    <h2 className="text-[15px] font-semibold" style={{ color: 'var(--foreground)', fontFamily: 'var(--font-heading)' }}>{group.label}</h2>
+                    <p className="mt-1 text-[12px] leading-5" style={{ color: 'var(--text-secondary)' }}>{group.description}</p>
+                  </div>
+                </div>
+                <div>
+                  {group.items.map((item, index) => (
+                    <Link
+                      key={item.href}
+                      href={item.href}
+                      className="group flex items-center justify-between gap-4 py-3"
+                      style={{ borderTop: index === 0 ? 'none' : '1px solid var(--outline-variant)' }}
+                    >
+                      <div className="min-w-0">
+                        <div className="text-[13px] font-medium" style={{ color: 'var(--foreground)' }}>{item.name}</div>
+                        <div className="mt-0.5 text-[12px] leading-5" style={{ color: 'var(--text-tertiary)' }}>{item.description}</div>
+                      </div>
+                      <span className="text-[12px] transition-transform group-hover:translate-x-0.5" style={{ color: 'var(--accent)' }}>
+                        Open
+                      </span>
+                    </Link>
+                  ))}
+                </div>
+              </section>
             );
           })}
-        </TabStrip>
-      </div>
-
-      <div className="max-w-2xl mx-auto px-6 py-10">
-        {/* Profile Section */}
-        <section className="mb-10">
-          <h2 className="eyebrow mb-4" style={{ fontFamily: 'var(--font-heading)' }}>
-            Profile
-          </h2>
-          <div
-            className="rounded-xl p-5"
-            style={{ background: 'var(--card-bg)', border: '1px solid var(--border)' }}
-          >
-            <div className="flex items-center gap-4">
-              <div
-                className="w-12 h-12 rounded-full flex items-center justify-center text-lg font-medium text-white"
-                style={{ background: 'var(--accent)' }}
-              >
-                {user?.name?.charAt(0).toUpperCase() || '?'}
-              </div>
-              <div>
-                <p
-                  className="text-[15px] font-medium"
-                  style={{ color: 'var(--foreground)', fontFamily: 'var(--font-heading)' }}
-                >
-                  {user?.name || 'Unknown'}
-                </p>
-                <p className="text-[13px] mt-0.5" style={{ color: 'var(--muted)' }}>
-                  {user?.email || 'No email'}
-                </p>
-                <Link
-                  href="/settings/profile"
-                  className="inline-flex mt-2 text-[12px] font-medium"
-                  style={{ color: 'var(--accent)' }}
-                >
-                  Edit profile
-                </Link>
-              </div>
-            </div>
-          </div>
-        </section>
-
-        {/* Appearance Section */}
-        <section className="mb-10">
-          <h2 className="eyebrow mb-4" style={{ fontFamily: 'var(--font-heading)' }}>
-            Appearance
-          </h2>
-          <div
-            className="rounded-xl p-5"
-            style={{ background: 'var(--card-bg)', border: '1px solid var(--border)' }}
-          >
-            <p className="text-[14px] mb-4" style={{ color: 'var(--foreground-secondary)' }}>
-              Choose your preferred theme
-            </p>
-            <div className="flex gap-3">
-              {themes.map((t) => {
-                const isActive = t.value === currentTheme;
-
-                return (
-                  <button
-                    key={t.value}
-                    onClick={() => {
-                      if (currentTheme !== t.value) {
-                        toggleTheme();
-                      }
-                    }}
-                    className="flex flex-col items-center gap-2 px-5 py-4 rounded-xl transition-colors"
-                    style={{
-                      background: isActive ? 'var(--accent-light, rgba(124,107,79,0.12))' : 'var(--surface)',
-                      border: `1.5px solid ${isActive ? 'var(--accent)' : 'var(--border)'}`,
-                      color: isActive ? 'var(--accent)' : 'var(--muted)',
-                    }}
-                  >
-                    {t.icon}
-                    <span
-                      className="text-[13px] font-medium"
-                      style={{
-                        color: isActive ? 'var(--accent)' : 'var(--foreground-secondary)',
-                        fontFamily: 'var(--font-heading)',
-                      }}
-                    >
-                      {t.label}
-                    </span>
-                  </button>
-                );
-              })}
-            </div>
-          </div>
-        </section>
+        </div>
       </div>
     </div>
   );

--- a/apps/web/src/app/(app)/settings/projects/page.tsx
+++ b/apps/web/src/app/(app)/settings/projects/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import { api } from '@/lib/api';
-import { Archive, RotateCcw, Loader2, FolderX } from 'lucide-react';
+import { Archive, RotateCcw, Loader2, FolderX, Clock3, ShieldCheck } from 'lucide-react';
 import { formatRelative } from '@/lib/time';
 
 type DeletedProject = {
@@ -64,14 +64,26 @@ export default function ProjectsRecoveryPage() {
 
   return (
     <div className="h-full min-h-0 overflow-y-auto overflow-x-hidden">
-    <div className="max-w-3xl">
-      <div className="mb-6">
-        <h1 className="text-[20px] font-semibold" style={{ color: 'var(--foreground)', fontFamily: 'var(--font-heading)' }}>
+    <div className="max-w-4xl mx-auto px-6 py-8">
+      <div className="mb-5">
+        <span
+          className="text-[10px] font-semibold uppercase tracking-[0.16em]"
+          style={{ color: 'var(--muted)' }}
+        >
+          Recovery
+        </span>
+        <h1 className="text-[22px] font-semibold mt-2" style={{ color: 'var(--foreground)', fontFamily: 'var(--font-heading)' }}>
           Deleted projects
         </h1>
-        <p className="text-[13px] mt-1" style={{ color: 'var(--muted)' }}>
-          Soft-deleted projects within the last 7 days. After 7 days they&apos;re purged and can no longer be restored.
+        <p className="text-[13px] mt-1 max-w-[620px]" style={{ color: 'var(--muted)' }}>
+          Restore recently deleted projects without losing tasks, comments, or audit history. After 7 days, deleted projects are purged permanently.
         </p>
+      </div>
+
+      <div className="grid gap-3 md:grid-cols-3 mb-6">
+        <RecoveryNote icon={Clock3} title="7-day window" body="Soft-deleted projects remain recoverable for one week." />
+        <RecoveryNote icon={RotateCcw} title="Restore in place" body="Tasks, project metadata, and history come back together." />
+        <RecoveryNote icon={ShieldCheck} title="Audit-safe" body="Deletion and restore events stay visible for review." />
       </div>
 
       {error && (
@@ -90,9 +102,9 @@ export default function ProjectsRecoveryPage() {
           style={{ background: 'var(--surface-container-low)', border: '1px dashed var(--border-default, var(--outline-variant))' }}
         >
           <FolderX size={32} strokeWidth={1.25} style={{ color: 'var(--muted)' }} />
-          <p className="text-[13px] mt-3" style={{ color: 'var(--foreground)' }}>No recently deleted projects.</p>
+          <p className="text-[13px] mt-3 font-medium" style={{ color: 'var(--foreground)' }}>Nothing is in recovery.</p>
           <p className="text-[12px] mt-1" style={{ color: 'var(--muted)' }}>
-            Anything deleted in the last 7 days shows up here.
+            Projects deleted in the last 7 days will appear here with a restore button.
           </p>
         </div>
       ) : (
@@ -131,6 +143,27 @@ export default function ProjectsRecoveryPage() {
         </div>
       )}
     </div>
+    </div>
+  );
+}
+
+function RecoveryNote({
+  icon: Icon,
+  title,
+  body,
+}: {
+  icon: typeof Clock3;
+  title: string;
+  body: string;
+}) {
+  return (
+    <div
+      className="rounded-xl p-4"
+      style={{ background: 'var(--surface-container-low)', border: '1px solid var(--border-default, var(--outline-variant))' }}
+    >
+      <Icon size={16} strokeWidth={1.75} style={{ color: 'var(--accent)' }} />
+      <p className="text-[13px] font-semibold mt-3" style={{ color: 'var(--foreground)' }}>{title}</p>
+      <p className="text-[12px] leading-relaxed mt-1" style={{ color: 'var(--muted)' }}>{body}</p>
     </div>
   );
 }

--- a/apps/web/src/app/(app)/settings/tags/page.tsx
+++ b/apps/web/src/app/(app)/settings/tags/page.tsx
@@ -64,6 +64,8 @@ export default function TagsPage() {
   const [selectedTag, setSelectedTag] = useState<Tag | null>(null);
   const [entities, setEntities] = useState<ResolvedEntity[]>([]);
   const [loadingEntities, setLoadingEntities] = useState(false);
+  const totalTaggedItems = tags.reduce((sum, tag) => sum + tag.count, 0);
+  const activeTags = tags.filter((tag) => tag.count > 0).length;
 
   const loadTags = useCallback(async () => {
     const res = await api.get('/api/tags');
@@ -133,7 +135,7 @@ export default function TagsPage() {
               Tags
             </h1>
             <p className="text-[13px] mt-0.5" style={{ color: 'var(--muted)' }}>
-              {tags.length} tag{tags.length !== 1 ? 's' : ''} across your workspace
+              Keep cross-surface labels consistent across tasks, messages, and notes.
             </p>
           </div>
           {!creating && (
@@ -143,6 +145,12 @@ export default function TagsPage() {
               <Plus size={14} /> New Tag
             </button>
           )}
+        </div>
+
+        <div className="grid grid-cols-3 gap-2 mb-6">
+          <TagStat label="Tags" value={tags.length} />
+          <TagStat label="Tagged items" value={totalTaggedItems} />
+          <TagStat label="In use" value={activeTags} />
         </div>
 
         {/* Create tag */}
@@ -180,7 +188,7 @@ export default function TagsPage() {
             <TagIcon size={36} style={{ color: 'var(--muted)', opacity: 0.3 }} className="mx-auto mb-3" />
             <p className="text-[14px] mb-1" style={{ color: 'var(--muted)' }}>No tags yet</p>
             <p className="text-[12px]" style={{ color: 'var(--muted)', opacity: 0.7 }}>
-              Create tags to organize tasks, messages, and notes across your workspace.
+              Start with a few durable labels like launch, customer, blocked, or urgent.
             </p>
           </div>
         ) : (
@@ -202,10 +210,11 @@ export default function TagsPage() {
                       <span className="text-[13px] font-medium block truncate"
                         style={{ color: 'var(--foreground)' }}>#{tag.name}</span>
                     </div>
-                    <span className="text-[11px] tabular-nums flex-shrink-0 group-hover:hidden"
+                    <span className="text-[11px] tabular-nums flex-shrink-0"
                       style={{ color: 'var(--muted)' }}>{tag.count}</span>
                     <button onClick={(e) => handleDelete(tag.id, e)}
-                      className="p-0.5 rounded opacity-0 group-hover:opacity-100 transition-opacity flex-shrink-0"
+                      aria-label={`Delete tag ${tag.name}`}
+                      className="p-0.5 rounded opacity-60 hover:opacity-100 transition-opacity flex-shrink-0"
                       style={{ color: 'var(--muted)' }}>
                       <X size={13} />
                     </button>
@@ -251,7 +260,7 @@ export default function TagsPage() {
                       return (
                         <div key={entity.id}
                           onClick={() => navigateToEntity(entity)}
-                          className="flex items-center gap-3 px-4 py-2.5 cursor-pointer hover:bg-white/[0.03] transition-colors"
+                          className="flex items-center gap-3 px-4 py-2.5 cursor-pointer hover:bg-[var(--bg-hover)] transition-colors"
                           style={{ borderBottom: '1px solid var(--border)' }}>
                           {entity.entity_type === 'task' && entity.status ? (
                             entity.status === 'done' ? (
@@ -286,6 +295,20 @@ export default function TagsPage() {
           </>
         )}
       </div>
+    </div>
+  );
+}
+
+function TagStat({ label, value }: { label: string; value: number }) {
+  return (
+    <div
+      className="rounded-xl px-3 py-3"
+      style={{ background: 'var(--surface-container-low)', border: '1px solid var(--border-default, var(--outline-variant))' }}
+    >
+      <p className="text-[20px] font-semibold tabular-nums" style={{ color: 'var(--foreground)', fontFamily: 'var(--font-heading)' }}>
+        {value}
+      </p>
+      <p className="text-[11px] mt-0.5" style={{ color: 'var(--muted)' }}>{label}</p>
     </div>
   );
 }

--- a/apps/web/src/app/(app)/settings/teams/page.tsx
+++ b/apps/web/src/app/(app)/settings/teams/page.tsx
@@ -69,6 +69,8 @@ type TeamResource = {
   resource_type: string;
   resource_id: string;
   label: string | null;
+  access?: 'visible' | 'restricted';
+  restricted_reason?: string | null;
   created_at: string;
 };
 
@@ -95,6 +97,13 @@ type TeamDetail = {
 
 type TeamDashboard = {
   generated_at: string;
+  data_quality: {
+    mode: 'live_summary';
+    history_available: boolean;
+    snapshot_status: 'snapshot_available' | 'no_snapshot_worker_data';
+    source_scope: 'linked_team_resources';
+    notes: string[];
+  };
   summary: TeamSummary;
   attention: {
     overdue_tasks: number;
@@ -207,7 +216,7 @@ function Avatar({ name, avatarUrl, kind, size = 'md' }: { name: string; avatarUr
 function Pill({ children, tone = 'neutral' }: { children: React.ReactNode; tone?: 'neutral' | 'accent' | 'warning' | 'success' }) {
   const styles = {
     neutral: { color: 'var(--foreground-secondary)', background: 'var(--surface)' },
-    accent: { color: 'var(--accent)', background: 'var(--accent-light, rgba(124,107,79,0.12))' },
+    accent: { color: 'white', background: 'var(--accent)' },
     warning: { color: 'var(--warning)', background: 'rgba(234,179,8,0.12)' },
     success: { color: 'var(--success)', background: 'rgba(34,197,94,0.12)' },
   }[tone];
@@ -663,7 +672,7 @@ export default function TeamsSettingsPage() {
 
         <div className="grid gap-4 lg:grid-cols-[360px_minmax(0,1fr)]">
           <section className="min-w-0 overflow-hidden rounded-lg" style={{ background: 'var(--card-bg)', border: '1px solid var(--border)' }}>
-            <div className="border-b p-3" style={{ borderColor: 'rgba(255,255,255,0.08)' }}>
+            <div className="border-b p-3" style={{ borderColor: 'var(--border-default)' }}>
               <div className="relative">
                 <Search size={15} className="absolute left-3 top-1/2 -translate-y-1/2" style={{ color: 'var(--muted)' }} />
                 <input
@@ -691,8 +700,8 @@ export default function TeamsSettingsPage() {
                   <button
                     key={team.id}
                     onClick={() => setSelectedId(team.id)}
-                    className="flex w-full min-w-0 items-start gap-3 border-b px-3 py-3 text-left transition last:border-b-0 hover:bg-white/[0.025]"
-                    style={{ background: selected ? 'var(--hover-tint)' : 'transparent', borderColor: 'rgba(255,255,255,0.08)' }}
+                    className="flex w-full min-w-0 items-start gap-3 border-b px-3 py-3 text-left transition last:border-b-0 hover:bg-[var(--bg-hover)]"
+                    style={{ background: selected ? 'var(--hover-tint)' : 'transparent', borderColor: 'var(--border-default)' }}
                   >
                     <div
                       className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg text-[13px] font-semibold text-white"
@@ -817,6 +826,31 @@ export default function TeamsSettingsPage() {
                   <MetricCard icon={CheckCircle2} label="In review" value={dashboard?.attention.in_review_tasks ?? 0} />
                   <MetricCard icon={Sparkles} label="Approvals" value={dashboard?.attention.pending_agent_actions ?? 0} />
                 </div>
+
+                {dashboard?.data_quality && (
+                  <div
+                    data-testid="team-dashboard-truth-label"
+                    className="rounded-lg p-3"
+                    style={{ background: 'var(--surface)', border: '1px solid var(--border)' }}
+                  >
+                    <div className="flex flex-wrap items-start gap-3">
+                      <div className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md" style={{ background: 'rgba(139, 92, 246, 0.16)', color: 'var(--accent)' }}>
+                        <Shield size={15} />
+                      </div>
+                      <div className="min-w-0 flex-1">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <p className="text-[13px] font-semibold" style={{ color: 'var(--foreground)' }}>Live team summary</p>
+                          <Pill tone={dashboard.data_quality.history_available ? 'success' : 'neutral'}>
+                            {dashboard.data_quality.history_available ? 'Snapshot available' : 'No trend snapshot'}
+                          </Pill>
+                        </div>
+                        <p className="mt-1 text-[12px] leading-relaxed" style={{ color: 'var(--muted)' }}>
+                          These numbers are computed from linked team resources right now. Historical trends are shown only after snapshot data exists.
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                )}
 
                 {actionError && (
                   <div className="rounded-lg px-3 py-2 text-[12px]" style={{ background: 'rgba(147,0,10,0.2)', color: 'var(--error)', border: '1px solid rgba(147,0,10,0.25)' }}>
@@ -960,11 +994,15 @@ export default function TeamsSettingsPage() {
                       </div>
                       <p className="mt-3 text-[12px]" style={{ color: 'var(--muted)' }}>
                         Snapshot freshness: {relativeTime(dashboard?.context.latest_snapshot?.generated_at)}
+                        {dashboard?.data_quality.snapshot_status === 'no_snapshot_worker_data' ? ' - live summary only' : ''}
                       </p>
                     </div>
 
                     <div className="rounded-lg p-4" style={{ background: 'var(--card-bg)', border: '1px solid var(--border)' }}>
                       <SectionTitle icon={Link2} title="Linked Resources" eyebrow="Operating map" />
+                      <p className="mb-3 text-[12px] leading-relaxed" style={{ color: 'var(--muted)' }}>
+                        Teams organize context. They do not grant private space access; restricted links stay hidden until you are a member of that space.
+                      </p>
                       {canManageSelectedTeam && (
                         <form onSubmit={handleLinkResource} className="mb-3 grid gap-2 rounded-lg p-2" style={{ background: 'var(--surface)' }}>
                           <div className="grid gap-2 sm:grid-cols-[120px_minmax(0,1fr)]">
@@ -1019,28 +1057,40 @@ export default function TeamsSettingsPage() {
                       <div className="flex flex-wrap gap-1.5">
                         {detail.resources.length === 0 ? (
                           <p className="text-[13px]" style={{ color: 'var(--muted)' }}>No linked resources yet.</p>
-                        ) : detail.resources.map((resource) => (
-                          <span
-                            key={resource.id}
-                            className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-medium"
-                            style={{ color: 'var(--accent)', background: 'var(--accent-light, rgba(124,107,79,0.12))' }}
-                          >
-                            {resourceSingularLabel(resource.resource_type)}: {resource.label || resource.resource_id.slice(0, 8)}
-                            {canManageSelectedTeam && (
-                              <button
-                                data-testid={`team-resource-detach-${resource.resource_type}-${resource.resource_id}`}
-                                type="button"
-                                onClick={() => handleDetachResource(resource)}
-                                disabled={workingKey === `detach-${resource.id}`}
-                                aria-label={`Detach ${resource.label || resource.resource_type}`}
-                                className="ml-0.5 inline-flex h-4 w-4 items-center justify-center rounded-full disabled:opacity-50"
-                                style={{ color: 'var(--muted)' }}
-                              >
-                                <Trash2 size={10} />
-                              </button>
-                            )}
-                          </span>
-                        ))}
+                        ) : detail.resources.map((resource) => {
+                          const restricted = resource.access === 'restricted';
+                          const label = restricted
+                            ? 'Restricted private space'
+                            : (resource.label || resource.resource_id.slice(0, 8));
+                          return (
+                            <span
+                              key={resource.id}
+                              className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-medium"
+                              title={restricted ? 'You need to be a member of this private space to see its name and messages.' : undefined}
+                              style={{
+                                color: restricted ? 'var(--muted)' : 'white',
+                                background: restricted ? 'var(--surface)' : 'var(--accent)',
+                                border: restricted ? '1px solid var(--border)' : '1px solid transparent',
+                              }}
+                            >
+                              {restricted && <Lock size={10} />}
+                              {resourceSingularLabel(resource.resource_type)}: {label}
+                              {canManageSelectedTeam && (
+                                <button
+                                  data-testid={`team-resource-detach-${resource.resource_type}-${resource.resource_id}`}
+                                  type="button"
+                                  onClick={() => handleDetachResource(resource)}
+                                  disabled={workingKey === `detach-${resource.id}`}
+                                  aria-label={`Detach ${label}`}
+                                  className="ml-0.5 inline-flex h-4 w-4 items-center justify-center rounded-full disabled:opacity-50"
+                                  style={{ color: restricted ? 'var(--muted)' : 'rgba(255,255,255,0.72)' }}
+                                >
+                                  <Trash2 size={10} />
+                                </button>
+                              )}
+                            </span>
+                          );
+                        })}
                       </div>
                     </div>
                   </div>

--- a/apps/web/src/app/(app)/settings/workflows/page.tsx
+++ b/apps/web/src/app/(app)/settings/workflows/page.tsx
@@ -5,7 +5,7 @@
 // and action checkboxes (add_comment / assign_to / add_label / notify).
 import { useCallback, useEffect, useState } from 'react';
 import { api } from '@/lib/api';
-import { Loader2, Plus, Trash2, Zap, X } from 'lucide-react';
+import { Bell, CheckSquare, Loader2, MessageSquare, Plus, Tags, Trash2, Zap, X } from 'lucide-react';
 
 type WorkflowRule = {
   id: string;
@@ -146,7 +146,7 @@ export default function WorkflowsPage() {
               Workflows
             </h1>
             <p className="lede mt-0.5">
-              Automate simple rules like "when a task moves to Done, add the <em>shipped</em> label."
+              Run deterministic task automations for simple, repeatable handoffs.
             </p>
           </div>
           {!creating && (
@@ -156,6 +156,12 @@ export default function WorkflowsPage() {
               <Plus size={14} /> New workflow
             </button>
           )}
+        </div>
+
+        <div className="grid gap-3 md:grid-cols-3 mb-6">
+          <WorkflowNote icon={CheckSquare} title="Task-triggered" body="Rules run when task status changes to a selected state." />
+          <WorkflowNote icon={MessageSquare} title="Native actions" body="Add comments, labels, assignees, or notifications without leaving Deft." />
+          <WorkflowNote icon={Bell} title="Quiet automation" body="Best for small operational nudges, not complex agent plans." />
         </div>
 
         {creating && (
@@ -258,8 +264,15 @@ export default function WorkflowsPage() {
             <Loader2 size={22} className="animate-spin" style={{ color: 'var(--muted)' }} />
           </div>
         ) : rules.length === 0 ? (
-          <div className="py-16 text-center text-[13px]" style={{ color: 'var(--muted)' }}>
-            No workflows yet. Create one to automate simple status-change actions.
+          <div
+            className="py-14 px-6 text-center rounded-xl"
+            style={{ background: 'var(--surface-container-low)', border: '1px dashed var(--border-default, var(--outline-variant))' }}
+          >
+            <Zap size={28} className="mx-auto mb-3" style={{ color: 'var(--muted)' }} />
+            <p className="text-[13px] font-medium" style={{ color: 'var(--foreground)' }}>No workflows yet.</p>
+            <p className="text-[12px] mt-1" style={{ color: 'var(--muted)' }}>
+              Start with a small rule like adding a label or notifying a lead when work moves to review.
+            </p>
           </div>
         ) : (
           <div className="space-y-2">
@@ -301,6 +314,27 @@ export default function WorkflowsPage() {
           </div>
         )}
       </div>
+    </div>
+  );
+}
+
+function WorkflowNote({
+  icon: Icon,
+  title,
+  body,
+}: {
+  icon: typeof Tags;
+  title: string;
+  body: string;
+}) {
+  return (
+    <div
+      className="rounded-xl p-4"
+      style={{ background: 'var(--surface-container-low)', border: '1px solid var(--border-default, var(--outline-variant))' }}
+    >
+      <Icon size={16} strokeWidth={1.75} style={{ color: 'var(--accent)' }} />
+      <p className="text-[13px] font-semibold mt-3" style={{ color: 'var(--foreground)' }}>{title}</p>
+      <p className="text-[12px] leading-relaxed mt-1" style={{ color: 'var(--muted)' }}>{body}</p>
     </div>
   );
 }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -153,8 +153,11 @@ class ApiClient {
     });
   }
 
-  async delete(path: string) {
-    return this.fetch(path, { method: 'DELETE' });
+  async delete(path: string, body?: unknown) {
+    return this.fetch(path, {
+      method: 'DELETE',
+      body: body ? JSON.stringify(body) : undefined,
+    });
   }
 
   async upload(path: string, file: File): Promise<Response> {


### PR DESCRIPTION
﻿## What changed

- Polishes the Settings landing page and settings sub-pages for a calmer, more consistent workspace control surface.
- Upgrades Members, Groups, and Teams settings flows with richer people/team management affordances.
- Adds group detail/member APIs, safer member offboarding/reassignment behavior, and team resource access decoration so restricted linked spaces do not leak labels.
- Extends the web API client so settings flows can send optional DELETE request bodies.

## Why

The people/team management build made Settings a real operating surface instead of a loose collection of admin pages. This PR packages the UI and the directly required API support together, while keeping unrelated notification-policy/job-priority hardening for a separate PR.

## Validation

- `pnpm --filter @deft/web typecheck`
- `pnpm --filter @deft/api typecheck`
- `pnpm --filter @deft/web lint`
- `pnpm --filter @deft/api exec tsx src/scripts/seed-test-fixtures.ts`
- `pnpm --filter @deft/api exec tsx --test --test-concurrency=1 --test-force-exit test/mcp-team-context.test.ts test/members-kind-field.test.ts test/members-directory.test.ts test/teams.test.ts`

Focused API result: 27 tests passed.

## Notes

Remaining local changes are intentionally excluded and will be handled as a backend notification/job hardening PR.
