### PR TITLE
Harden notification policy and job priority

### DIFF
--- a/apps/api/src/lib/notification-policy.ts
+++ b/apps/api/src/lib/notification-policy.ts
@@ -1,0 +1,182 @@
+import { and, eq } from 'drizzle-orm';
+import {
+  DEFAULT_NOTIFICATION_PREFERENCES,
+  notifications,
+  spaceMembers,
+  users,
+  type UserNotificationPreferences,
+} from '@deft/db/schema';
+import { db } from './db.js';
+
+type NotificationChannel = keyof UserNotificationPreferences['channels'];
+type NotificationInsert = typeof notifications.$inferInsert;
+
+export type NotificationPolicyOptions = {
+  channel?: NotificationChannel | null;
+  spaceId?: string | null;
+  isMention?: boolean;
+  respectDnd?: boolean;
+  bypassUserPreferences?: boolean;
+};
+
+export type NotificationPolicyDecision = {
+  allowed: boolean;
+  reason:
+    | 'allowed'
+    | 'recipient_not_found'
+    | 'do_not_disturb'
+    | 'channel_disabled'
+    | 'not_space_member'
+    | 'space_muted'
+    | 'space_mentions_only';
+  channel: NotificationChannel | null;
+};
+
+function normalizePreferences(value: unknown): UserNotificationPreferences {
+  const candidate = value as Partial<UserNotificationPreferences> | null | undefined;
+  return {
+    keywords: Array.isArray(candidate?.keywords)
+      ? candidate.keywords.filter((keyword): keyword is string => typeof keyword === 'string')
+      : [],
+    channels: {
+      chat: candidate?.channels?.chat ?? DEFAULT_NOTIFICATION_PREFERENCES.channels.chat,
+      tasks: candidate?.channels?.tasks ?? DEFAULT_NOTIFICATION_PREFERENCES.channels.tasks,
+      approvals:
+        candidate?.channels?.approvals ??
+        DEFAULT_NOTIFICATION_PREFERENCES.channels.approvals,
+      calendar:
+        candidate?.channels?.calendar ??
+        DEFAULT_NOTIFICATION_PREFERENCES.channels.calendar,
+      agents: candidate?.channels?.agents ?? DEFAULT_NOTIFICATION_PREFERENCES.channels.agents,
+    },
+  };
+}
+
+export function notificationChannelForType(
+  type: string,
+): NotificationChannel | null {
+  switch (type) {
+    case 'mention':
+    case 'message':
+    case 'huddle_started':
+      return 'chat';
+    case 'task':
+    case 'task_assigned':
+    case 'task_updated':
+    case 'blocked':
+    case 'workload_imbalance':
+      return 'tasks';
+    case 'reminder':
+      return 'calendar';
+    case 'agent_suggestion':
+    case 'skill_update_available':
+      return 'agents';
+    default:
+      return null;
+  }
+}
+
+function spaceLevelAllowsNotification(
+  level: string | null | undefined,
+  isMention: boolean,
+): boolean {
+  if (level === 'nothing') return false;
+  if (level === 'mentions') return isMention;
+  return true;
+}
+
+export async function explainNotificationPolicy(
+  values: Pick<NotificationInsert, 'user_id' | 'type'>,
+  options: NotificationPolicyOptions = {},
+): Promise<NotificationPolicyDecision> {
+  const inferredChannel =
+    options.channel === undefined
+      ? notificationChannelForType(String(values.type))
+      : options.channel;
+
+  const [recipient] = await db
+    .select({
+      notification_preferences: users.notification_preferences,
+      status_text: users.status_text,
+    })
+    .from(users)
+    .where(eq(users.id, values.user_id))
+    .limit(1);
+
+  if (!recipient) {
+    return { allowed: false, reason: 'recipient_not_found', channel: inferredChannel ?? null };
+  }
+
+  if (options.respectDnd && recipient.status_text === 'Do Not Disturb') {
+    return { allowed: false, reason: 'do_not_disturb', channel: inferredChannel ?? null };
+  }
+
+  if (inferredChannel && !options.bypassUserPreferences) {
+    const preferences = normalizePreferences(recipient.notification_preferences);
+    if (preferences.channels[inferredChannel] === false) {
+      return { allowed: false, reason: 'channel_disabled', channel: inferredChannel };
+    }
+  }
+
+  if (options.spaceId) {
+    const [membership] = await db
+      .select({
+        is_muted: spaceMembers.is_muted,
+        notification_level: spaceMembers.notification_level,
+      })
+      .from(spaceMembers)
+      .where(
+        and(
+          eq(spaceMembers.space_id, options.spaceId),
+          eq(spaceMembers.user_id, values.user_id),
+        ),
+      )
+      .limit(1);
+
+    if (!membership) {
+      return { allowed: false, reason: 'not_space_member', channel: inferredChannel ?? null };
+    }
+    if (membership.is_muted) {
+      return { allowed: false, reason: 'space_muted', channel: inferredChannel ?? null };
+    }
+    if (!spaceLevelAllowsNotification(membership.notification_level, !!options.isMention)) {
+      return { allowed: false, reason: 'space_mentions_only', channel: inferredChannel ?? null };
+    }
+  }
+
+  return { allowed: true, reason: 'allowed', channel: inferredChannel ?? null };
+}
+
+export async function shouldCreateNotification(
+  values: Pick<NotificationInsert, 'user_id' | 'type'>,
+  options: NotificationPolicyOptions = {},
+): Promise<boolean> {
+  const decision = await explainNotificationPolicy(values, options);
+  return decision.allowed;
+}
+
+export async function createNotificationIfAllowed(
+  values: NotificationInsert,
+  options: NotificationPolicyOptions = {},
+): Promise<typeof notifications.$inferSelect | null> {
+  const decision = await explainNotificationPolicy(values, options);
+  if (!decision.allowed) return null;
+
+  const existingMetadata =
+    values.metadata && typeof values.metadata === 'object' && !Array.isArray(values.metadata)
+      ? values.metadata as Record<string, unknown>
+      : {};
+  const [notification] = await db.insert(notifications).values({
+    ...values,
+    metadata: {
+      ...existingMetadata,
+      delivery_policy: {
+        status: 'delivered',
+        reason: decision.reason,
+        channel: decision.channel,
+        evaluated_at: new Date().toISOString(),
+      },
+    },
+  }).returning();
+  return notification ?? null;
+}

--- a/apps/api/src/lib/queues.ts
+++ b/apps/api/src/lib/queues.ts
@@ -1,4 +1,4 @@
-// Postgres-based job queue for Deft background jobs — replaces BullMQ/Redis
+// Postgres-based job queue for Deft background jobs - replaces BullMQ/Redis
 import { db } from './db.js';
 import { jobQueue } from '@deft/db/schema';
 import { eq, and, sql } from 'drizzle-orm';
@@ -10,6 +10,14 @@ export const QUEUE_NAMES = {
 } as const;
 
 export type QueueName = (typeof QUEUE_NAMES)[keyof typeof QUEUE_NAMES];
+
+export function jobPriorityRank(queueName: QueueName | string, jobName: string): number {
+  if (queueName !== QUEUE_NAMES.AGENT_JOBS) return 3;
+  if (['agent-reply', 'agent-employee-message', 'agent-employee-task'].includes(jobName)) return 0;
+  if (['employee-trigger', 'agent-employee-trigger', 'plan-executor'].includes(jobName)) return 1;
+  if (jobName === OBSERVE_CHAT_MESSAGE_JOB) return 5;
+  return 3;
+}
 
 /**
  * Enqueue a job onto a named queue.
@@ -56,7 +64,14 @@ export async function dequeueJob(
       WHERE status = 'pending'
         AND queue = ${queueName}
         AND run_at <= now()
-      ORDER BY created_at ASC
+      ORDER BY
+        CASE
+          WHEN queue = ${QUEUE_NAMES.AGENT_JOBS} AND name IN ('agent-reply', 'agent-employee-message', 'agent-employee-task') THEN 0
+          WHEN queue = ${QUEUE_NAMES.AGENT_JOBS} AND name IN ('employee-trigger', 'agent-employee-trigger', 'plan-executor') THEN 1
+          WHEN queue = ${QUEUE_NAMES.AGENT_JOBS} AND name = ${OBSERVE_CHAT_MESSAGE_JOB} THEN 5
+          ELSE 3
+        END,
+        created_at ASC
       LIMIT 1
       FOR UPDATE SKIP LOCKED
     )

--- a/apps/api/src/routes/messages.ts
+++ b/apps/api/src/routes/messages.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono';
 import { z } from 'zod';
 import { eq, and, desc, lt, lte, gt, sql, isNull, inArray } from 'drizzle-orm';
 import { db } from '../lib/db.js';
-import { messages, users, reactions, notifications, spaces, spaceMembers, orgs, threadReads, messageVersions, agentEmployees } from '@deft/db/schema';
+import { messages, users, reactions, spaces, spaceMembers, orgs, threadReads, messageVersions, agentEmployees, userGroups, userGroupMembers, orgMembers } from '@deft/db/schema';
 import { getIO, emitToUser } from '../socket.js';
 import { parseMentions } from '../lib/mentions.js';
 import { fetchLinkPreview, extractUrls, type LinkPreview } from '../lib/link-preview.js';
@@ -11,6 +11,7 @@ import { resolveReasonProvider } from '../lib/org-ai-config.js';
 import { requireSpaceMembership } from '../lib/space-membership.js';
 import { DEFTY_EMAIL, ensureDeftyMembership } from '../lib/ensure-defty-membership.js';
 import { enqueueChatObservation } from '../lib/chat-observation.js';
+import { createNotificationIfAllowed } from '../lib/notification-policy.js';
 
 export const messageRoutes = new Hono();
 
@@ -80,6 +81,33 @@ async function getVisibleMessage(messageId: string, orgId: string, userId: strin
     .limit(1);
 
   return msg ?? null;
+}
+
+async function resolveGroupMentionUserIds(content: string, orgId: string): Promise<string[]> {
+  const handles = Array.from(
+    new Set(
+      Array.from(content.matchAll(/(^|[\s(>])@([a-z0-9][a-z0-9-]*[a-z0-9]|[a-z0-9])\b/g))
+        .map((match) => match[2]?.toLowerCase())
+        .filter((handle): handle is string => !!handle),
+    ),
+  );
+  if (handles.length === 0) return [];
+
+  const rows = await db
+    .select({ user_id: userGroupMembers.user_id })
+    .from(userGroups)
+    .innerJoin(userGroupMembers, eq(userGroupMembers.group_id, userGroups.id))
+    .innerJoin(orgMembers, and(
+      eq(orgMembers.user_id, userGroupMembers.user_id),
+      eq(orgMembers.org_id, userGroups.org_id),
+      eq(orgMembers.is_active, true),
+    ))
+    .where(and(
+      eq(userGroups.org_id, orgId),
+      inArray(userGroups.handle, handles),
+    ));
+
+  return Array.from(new Set(rows.map((row) => row.user_id)));
 }
 
 // Helper: get reply counts and latest_reply_at for a set of message IDs
@@ -424,7 +452,12 @@ messageRoutes.post('/:spaceId', async (c) => {
     }
 
     // Parse mentions and create notifications
-    const { userIds: mentionedUserIds } = parseMentions(parsed.data.content);
+    const { userIds: directMentionedUserIds } = parseMentions(parsed.data.content);
+    const groupMentionedUserIds = await resolveGroupMentionUserIds(parsed.data.content, user.org_id);
+    const mentionedUserIds = Array.from(new Set([
+      ...directMentionedUserIds,
+      ...groupMentionedUserIds,
+    ]));
 
     for (const mentionedUserId of mentionedUserIds) {
       // Don't notify the sender
@@ -437,16 +470,18 @@ messageRoutes.post('/:spaceId', async (c) => {
           .limit(1);
         if (!mentionedUser) continue;
 
-        const [notification] = await db.insert(notifications).values({
+        const notification = await createNotificationIfAllowed({
           org_id: user.org_id,
           user_id: mentionedUserId,
           type: 'mention',
           title: `${userData?.name ?? 'Someone'} mentioned you`,
           body: parsed.data.content.slice(0, 200),
           link: `/spaces/${spaceId}?message=${message!.id}`,
-        }).returning();
+        }, { channel: 'chat', spaceId, isMention: true });
 
-        emitToUser(mentionedUserId, 'notification:new', notification);
+        if (notification) {
+          emitToUser(mentionedUserId, 'notification:new', notification);
+        }
       } catch (err) {
         console.error(`Failed to create mention notification for ${mentionedUserId}:`, err);
       }
@@ -463,16 +498,18 @@ messageRoutes.post('/:spaceId', async (c) => {
           .limit(1);
 
         if (parentMessage && parentMessage.user_id !== user.id && !mentionedUserIds.includes(parentMessage.user_id)) {
-          const [notification] = await db.insert(notifications).values({
+          const notification = await createNotificationIfAllowed({
             org_id: user.org_id,
             user_id: parentMessage.user_id,
             type: 'mention',
             title: `${userData?.name ?? 'Someone'} replied to your message`,
             body: parsed.data.content.slice(0, 200),
             link: `/spaces/${spaceId}?message=${parsed.data.parent_id}`,
-          }).returning();
+          }, { channel: 'chat', spaceId, isMention: true });
 
-          emitToUser(parentMessage.user_id, 'notification:new', notification);
+          if (notification) {
+            emitToUser(parentMessage.user_id, 'notification:new', notification);
+          }
         }
 
         // Get updated reply stats for the parent
@@ -502,11 +539,8 @@ messageRoutes.post('/:spaceId', async (c) => {
         // Get all space members except sender (with mute + DND status)
         const members = await db.select({
           user_id: spaceMembers.user_id,
-          is_muted: spaceMembers.is_muted,
-          status_text: users.status_text,
         })
           .from(spaceMembers)
-          .innerJoin(users, eq(spaceMembers.user_id, users.id))
           .where(and(
             eq(spaceMembers.space_id, spaceId),
             sql`${spaceMembers.user_id} != ${user.id}`,
@@ -517,10 +551,6 @@ messageRoutes.post('/:spaceId', async (c) => {
         for (const member of members) {
           // Don't duplicate if already notified via mention
           if (mentionedUserIds.includes(member.user_id)) continue;
-          // Skip muted spaces
-          if (member.is_muted) continue;
-          // Skip DND users
-          if (member.status_text === 'Do Not Disturb') continue;
 
           const isDm = space.type === 'dm' || space.type === 'group_dm';
           const title = isDm
@@ -528,16 +558,18 @@ messageRoutes.post('/:spaceId', async (c) => {
             : `${userData?.name ?? 'Someone'} in #${space.name}`;
           const link = isDm ? `/chat` : `/chat?space=${spaceId}`;
 
-          const [notification] = await db.insert(notifications).values({
+          const notification = await createNotificationIfAllowed({
             org_id: user.org_id,
             user_id: member.user_id,
             type: 'message',
             title,
             body: plainContent,
             link,
-          }).returning();
+          }, { channel: 'chat', spaceId, isMention: false, respectDnd: true });
 
-          emitToUser(member.user_id, 'notification:new', notification);
+          if (notification) {
+            emitToUser(member.user_id, 'notification:new', notification);
+          }
         }
       }
     } catch (err) {

--- a/apps/api/src/routes/projects.ts
+++ b/apps/api/src/routes/projects.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono';
 import { z } from 'zod';
 import { eq, and, desc, gt, sql, inArray, isNull } from 'drizzle-orm';
 import { db } from '../lib/db.js';
-import { projects, tasks, taskLabels, labels, users, taskActivity, notifications } from '@deft/db/schema';
+import { projects, tasks, taskLabels, labels, users, taskActivity } from '@deft/db/schema';
 import { getIO, emitToUser } from '../socket.js';
 import { enqueue, QUEUE_NAMES } from '../lib/queues.js';
 import { visibleTaskCondition } from '../lib/task-visibility.js';
@@ -11,6 +11,7 @@ import {
 } from '../lib/project-resolved-config.js';
 import { reserveNextTaskNumber } from '../lib/task-numbering.js';
 import { resolveAssignableAssigneeId } from '../lib/resolve-assignee.js';
+import { createNotificationIfAllowed } from '../lib/notification-policy.js';
 
 export const projectRoutes = new Hono();
 
@@ -653,15 +654,17 @@ projectRoutes.post('/:id/tasks', async (c) => {
       try {
         const [creatorUser] = await db.select({ name: users.name }).from(users).where(eq(users.id, user.id)).limit(1);
         const taskId_str = `${project!.prefix}-${taskNumber}`;
-        await db.insert(notifications).values({
+        const notification = await createNotificationIfAllowed({
           org_id: user.org_id,
           user_id: task!.assignee_id,
           type: 'task_assigned',
           title: `${creatorUser?.name || 'Someone'} assigned you ${taskId_str}`,
           body: task!.title,
           link: `/tasks?task=${taskId_str}`,
-        });
-        emitToUser(task!.assignee_id, 'notification:new', { type: 'task_assigned', title: `New task: ${taskId_str}` });
+        }, { channel: 'tasks' });
+        if (notification) {
+          emitToUser(task!.assignee_id, 'notification:new', notification);
+        }
       } catch {}
     }
 

--- a/apps/api/src/routes/tasks.ts
+++ b/apps/api/src/routes/tasks.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono';
 import { z } from 'zod';
 import { eq, and, desc, asc, sql, inArray, ilike, or, isNull } from 'drizzle-orm';
 import { db } from '../lib/db.js';
-import { projects, tasks, taskComments, taskActivity, taskLabels, labels, users, projectSpaces, messages, notifications, taskRelationships, files, savedViews, taskWatchers, taskAssignees, taskReactions, wikiPages, wikiCitations, orgMembers, workflowRules, agentEmployees, agentActions, spaces, spaceMembers } from '@deft/db/schema';
+import { projects, tasks, taskComments, taskActivity, taskLabels, labels, users, projectSpaces, messages, taskRelationships, files, savedViews, taskWatchers, taskAssignees, taskReactions, wikiPages, wikiCitations, orgMembers, workflowRules, agentEmployees, agentActions, spaces, spaceMembers } from '@deft/db/schema';
 import { getIO, emitToUser } from '../socket.js';
 import { enqueue, QUEUE_NAMES } from '../lib/queues.js';
 import { canDeleteTask } from '../lib/task-permissions.js';
@@ -15,6 +15,7 @@ import { dispatchAgentEmployeeTask } from '../lib/dispatch-agent-task.js';
 import { publishAgentChannelEvent, type AgentChannelEventKind } from '../lib/agent-channel.js';
 import { reserveNextTaskNumber } from '../lib/task-numbering.js';
 import { resolveAssignableAssigneeId } from '../lib/resolve-assignee.js';
+import { createNotificationIfAllowed } from '../lib/notification-policy.js';
 
 export const taskRoutes = new Hono();
 
@@ -305,7 +306,7 @@ async function dispatchMentionNotifications(params: {
 
   for (const userId of mentionedIds) {
     try {
-      await db.insert(notifications).values({
+      const notification = await createNotificationIfAllowed({
         org_id: orgId,
         user_id: userId,
         type: 'mention',
@@ -313,8 +314,10 @@ async function dispatchMentionNotifications(params: {
         body: snippet,
         link,
         metadata: { task_id: taskId, surface },
-      });
-      emitToUser(userId, 'notification:new', { type: 'mention', title: `Mention on ${taskRef}` });
+      }, { channel: 'tasks', isMention: true });
+      if (notification) {
+        emitToUser(userId, 'notification:new', notification);
+      }
     } catch (err) {
       console.error('Failed to create mention notification:', err);
     }
@@ -593,7 +596,7 @@ taskRoutes.patch('/bulk', async (c) => {
     // deep-link to the filtered list.
     if (nextAssigneeId && nextAssigneeId !== user.id && task_ids.length >= 3) {
       try {
-        await db.insert(notifications).values({
+        const notification = await createNotificationIfAllowed({
           org_id: user.org_id,
           user_id: nextAssigneeId,
           type: 'task_assigned',
@@ -601,11 +604,10 @@ taskRoutes.patch('/bulk', async (c) => {
           body: null,
           link: `/tasks?mine=1`,
           metadata: { task_ids, grouped: true, kind: 'bulk_assign' },
-        });
-        emitToUser(nextAssigneeId, 'notification:new', {
-          type: 'task_assigned',
-          title: `You were assigned ${task_ids.length} tasks`,
-        });
+        }, { channel: 'tasks' });
+        if (notification) {
+          emitToUser(nextAssigneeId, 'notification:new', notification);
+        }
       } catch (err) {
         console.error('Failed to write grouped bulk-assign notification:', err);
       }
@@ -1216,15 +1218,17 @@ taskRoutes.post('/:id/comments', async (c) => {
       const taskId_str = `${prefix}-${number}`;
 
       if (commentedTask?.assignee_id && commentedTask.assignee_id !== user.id) {
-        await db.insert(notifications).values({
+        const notification = await createNotificationIfAllowed({
           org_id: user.org_id,
           user_id: commentedTask.assignee_id,
           type: 'task_updated',
           title: `${userData?.name || 'Someone'} commented on ${taskId_str}`,
           body: parsed.data.content.slice(0, 200),
           link: `/tasks?task=${taskId_str}`,
-        });
-        emitToUser(commentedTask.assignee_id, 'notification:new', { type: 'task_updated', title: `Comment on ${taskId_str}` });
+        }, { channel: 'tasks' });
+        if (notification) {
+          emitToUser(commentedTask.assignee_id, 'notification:new', notification);
+        }
       }
 
       // Task 6.4 — mention notifications for this comment.
@@ -1611,15 +1615,17 @@ async function createTaskForProject(
     try {
       const [creatorUser] = await db.select({ name: users.name }).from(users).where(eq(users.id, userId)).limit(1);
       const taskId_str = `${project.prefix}-${taskNumber}`;
-      await db.insert(notifications).values({
+      const notification = await createNotificationIfAllowed({
         org_id: orgId,
         user_id: task!.assignee_id,
         type: 'task_assigned',
         title: `${creatorUser?.name || 'Someone'} assigned you ${taskId_str}`,
         body: task!.title,
         link: `/tasks?task=${taskId_str}`,
-      });
-      emitToUser(task!.assignee_id, 'notification:new', { type: 'task_assigned', title: `New task: ${taskId_str}` });
+      }, { channel: 'tasks' });
+      if (notification) {
+        emitToUser(task!.assignee_id, 'notification:new', notification);
+      }
     } catch {}
   }
 
@@ -1990,15 +1996,17 @@ taskRoutes.patch('/:id', async (c) => {
         try {
           const [assignerUser] = await db.select({ name: users.name }).from(users).where(eq(users.id, user.id)).limit(1);
           const taskId_str = `${project?.prefix || ''}-${updatedTask!.number}`;
-          await db.insert(notifications).values({
+          const notification = await createNotificationIfAllowed({
             org_id: user.org_id,
             user_id: newAssignee,
             type: 'task_assigned',
             title: `${assignerUser?.name || 'Someone'} assigned you ${taskId_str}`,
             body: updatedTask!.title,
             link: `/tasks?task=${taskId_str}`,
-          });
-          emitToUser(newAssignee, 'notification:new', { type: 'task_assigned', title: `Assigned ${taskId_str}` });
+          }, { channel: 'tasks' });
+          if (notification) {
+            emitToUser(newAssignee, 'notification:new', notification);
+          }
         } catch {}
       }
 
@@ -2021,15 +2029,17 @@ taskRoutes.patch('/:id', async (c) => {
           const [changerUser] = await db.select({ name: users.name }).from(users).where(eq(users.id, user.id)).limit(1);
           const taskId_str = `${project?.prefix || ''}-${updatedTask!.number}`;
           const statusLabel = { backlog:'Backlog', todo:'To Do', in_progress:'In Progress', in_review:'In Review', done:'Done', cancelled:'Cancelled' }[parsed.data.status] || parsed.data.status;
-          await db.insert(notifications).values({
+          const notification = await createNotificationIfAllowed({
             org_id: user.org_id,
             user_id: assignee,
             type: 'task_updated',
             title: `${changerUser?.name || 'Someone'} moved ${taskId_str} to ${statusLabel}`,
             body: updatedTask!.title,
             link: `/tasks?task=${taskId_str}`,
-          });
-          emitToUser(assignee, 'notification:new', { type: 'task_updated', title: `${taskId_str} → ${statusLabel}` });
+          }, { channel: 'tasks' });
+          if (notification) {
+            emitToUser(assignee, 'notification:new', notification);
+          }
         } catch {}
       }
 

--- a/apps/api/src/socket.ts
+++ b/apps/api/src/socket.ts
@@ -3,10 +3,11 @@ import type { Server as HTTPServer } from 'node:http';
 import jwt from 'jsonwebtoken';
 import { env } from './lib/env.js';
 import { db } from './lib/db.js';
-import { users, spaceMembers, spaces, notifications } from '@deft/db/schema';
+import { users, spaceMembers, spaces } from '@deft/db/schema';
 import { eq, and, ne } from 'drizzle-orm';
 import * as huddle from './huddle-rooms.js';
 import { requireActiveOrgMembership } from './lib/org-membership.js';
+import { createNotificationIfAllowed } from './lib/notification-policy.js';
 
 function updateLastSeen(userId: string) {
   db.update(users).set({ last_seen_at: new Date() }).where(eq(users.id, userId)).catch(() => {});
@@ -202,21 +203,14 @@ export function setupSocket(server: HTTPServer) {
           // Get all space members except creator
           const members = await db.select({
             user_id: spaceMembers.user_id,
-            is_muted: spaceMembers.is_muted,
-            status_text: users.status_text,
           }).from(spaceMembers)
-            .innerJoin(users, eq(spaceMembers.user_id, users.id))
             .where(and(
               eq(spaceMembers.space_id, data.space_id),
               ne(spaceMembers.user_id, user.id),
             ));
 
           for (const member of members) {
-            if (member.is_muted) continue;
-            if (member.status_text === 'Do Not Disturb') continue;
-
-            // Create notification record
-            await db.insert(notifications).values({
+            const notification = await createNotificationIfAllowed({
               org_id: user.org_id,
               user_id: member.user_id,
               type: 'huddle_started',
@@ -224,7 +218,13 @@ export function setupSocket(server: HTTPServer) {
               body: `#${spaceName}`,
               link: `/chat?space=${data.space_id}`,
               metadata: { huddle_id: id, space_id: data.space_id },
-            }).catch(() => {});
+            }, {
+              channel: 'chat',
+              spaceId: data.space_id,
+              isMention: false,
+              respectDnd: true,
+            }).catch(() => null);
+            if (!notification) continue;
 
             // Emit ring event
             emitToUser(member.user_id, 'huddle:ring', {
@@ -237,11 +237,7 @@ export function setupSocket(server: HTTPServer) {
             });
 
             // Also emit notification:new for badge count
-            emitToUser(member.user_id, 'notification:new', {
-              type: 'huddle_started',
-              title: `${creatorName} started a huddle`,
-              body: `#${spaceName}`,
-            });
+            emitToUser(member.user_id, 'notification:new', notification);
           }
         } catch (err) {
           console.error('Failed to send huddle rings:', err);

--- a/apps/api/src/workers/handlers/agent-reply.ts
+++ b/apps/api/src/workers/handlers/agent-reply.ts
@@ -120,9 +120,22 @@ function buildDiscussionTaskFallbackAction(params: {
   };
 }
 
-function isDiscussionTaskCommand(content: string): boolean {
-  return /\b(?:create|make|draft|turn|convert|summari[sz]e)\b.{0,80}\b(?:tasks?|todos?|tickets?)\b/i.test(content) &&
-    /\b(?:discussion|thread|chat|conversation|above|this)\b/i.test(content);
+export function isDiscussionTaskCommand(content: string): boolean {
+  const plain = toPlainText(content);
+  const positiveMatch =
+    /\b(?:create|make|draft|turn|convert)\b.{0,80}\b(?:tasks?|todos?|tickets?)\b/i.exec(plain) ??
+    /\bsummari[sz]e\b.{0,80}\b(?:into|as)\b.{0,30}\b(?:tasks?|todos?|tickets?)\b/i.exec(plain);
+  if (!positiveMatch) return false;
+
+  // A lot of real user prompts ask Defty to summarize a discussion while
+  // explicitly saying "do not create tasks yet". The old detector saw the
+  // words "create tasks" and queued a fallback action anyway. Only suppress
+  // the command when the negation owns the first task-creation phrase; still
+  // allow prompts like "create one task, but don't create duplicates".
+  const negatedCreationMatch = /\b(?:do\s+not|don't|dont|never|without|avoid|no\s+need\s+to)\s+(?:\S+\s+){0,6}?(?:create|creating|make|making|add|adding|open|opening|turn|turning|convert|converting|draft|drafting)\s+(?:\S+\s+){0,6}?(?:tasks?|todos?|tickets?)\b/i.exec(plain);
+  if (negatedCreationMatch && negatedCreationMatch.index <= positiveMatch.index) return false;
+
+  return /\b(?:discussion|thread|chat|conversation|above|this)\b/i.test(plain);
 }
 
 function isDiscussionBoundaryMessage(content: string): boolean {

--- a/apps/api/src/workers/handlers/blocked-alert.ts
+++ b/apps/api/src/workers/handlers/blocked-alert.ts
@@ -6,13 +6,13 @@ import {
   projects,
   users,
   spaces,
-  notifications,
   agentNudges,
   taskRelationships,
 } from '@deft/db/schema';
 import { eq, and, gte } from 'drizzle-orm';
 import { emitToUser } from '../../socket.js';
 import { toPlainText, truncatePlainText } from '../../lib/plain-text.js';
+import { createNotificationIfAllowed } from '../../lib/notification-policy.js';
 
 export async function handleBlockedAlert(job: JobData): Promise<void> {
   const { messageId, spaceId, content, orgId, userId } = job.data;
@@ -123,22 +123,19 @@ export async function handleBlockedAlert(job: JobData): Promise<void> {
       const message = `${userName} may be blocked — '${contentSnippet}' (in #${spaceName})`;
 
       // Create notification
-      const [notification] = await db
-        .insert(notifications)
-        .values({
-          org_id: orgId,
-          user_id: targetUserId,
-          type: 'agent_suggestion',
-          title: 'Blocked Team Member',
-          body: message,
-          link: `/spaces/${spaceId}?message=${messageId}`,
-          metadata: {
-            task_id: task.id,
-            nudge_type: 'blocked',
-            blocking_deps: blockingDeps.map((d) => d.source_task_id),
-          },
-        })
-        .returning();
+      const notification = await createNotificationIfAllowed({
+        org_id: orgId,
+        user_id: targetUserId,
+        type: 'agent_suggestion',
+        title: 'Blocked Team Member',
+        body: message,
+        link: `/spaces/${spaceId}?message=${messageId}`,
+        metadata: {
+          task_id: task.id,
+          nudge_type: 'blocked',
+          blocking_deps: blockingDeps.map((d) => d.source_task_id),
+        },
+      }, { channel: 'agents', spaceId, isMention: false });
 
       // Insert nudge record for deduplication
       await db.insert(agentNudges).values({

--- a/apps/api/src/workers/handlers/duplicate-detect.ts
+++ b/apps/api/src/workers/handlers/duplicate-detect.ts
@@ -4,11 +4,11 @@ import { db } from '../../lib/db.js';
 import {
   tasks,
   projects,
-  notifications,
   duplicateFlags,
 } from '@deft/db/schema';
 import { eq, and, sql } from 'drizzle-orm';
 import { emitToUser } from '../../socket.js';
+import { createNotificationIfAllowed } from '../../lib/notification-policy.js';
 
 /** Split a title into normalized words for comparison */
 function tokenize(title: string): Set<string> {
@@ -126,23 +126,20 @@ export async function handleDuplicateDetect(job: JobData): Promise<void> {
         const message = `Possible duplicate: ${newIdentifier} '${title}' may overlap with ${existingIdentifier} '${existing.title}'`;
 
         // Notify the creator of the new task
-        const [notification] = await db
-          .insert(notifications)
-          .values({
-            org_id: orgId,
-            user_id: newTask.created_by,
-            type: 'agent_suggestion',
-            title: 'Possible Duplicate Task',
-            body: message,
-            link: `/tasks?task=${newIdentifier}`,
-            metadata: {
-              nudge_type: 'duplicate_detected',
-              new_task_id: taskId,
-              existing_task_id: existing.id,
-              similarity: Math.round(similarity * 100),
-            },
-          })
-          .returning();
+        const notification = await createNotificationIfAllowed({
+          org_id: orgId,
+          user_id: newTask.created_by,
+          type: 'agent_suggestion',
+          title: 'Possible Duplicate Task',
+          body: message,
+          link: `/tasks?task=${newIdentifier}`,
+          metadata: {
+            nudge_type: 'duplicate_detected',
+            new_task_id: taskId,
+            existing_task_id: existing.id,
+            similarity: Math.round(similarity * 100),
+          },
+        }, { channel: 'tasks' });
 
         if (notification) {
           emitToUser(newTask.created_by, 'notification:new', notification);

--- a/apps/api/src/workers/handlers/meeting-prep-check.ts
+++ b/apps/api/src/workers/handlers/meeting-prep-check.ts
@@ -6,7 +6,6 @@ import {
   agentEmployees,
   events,
   meetingBriefs,
-  notifications,
   tasks,
   messages,
   spaces,
@@ -17,6 +16,7 @@ import { eq, and, gte, lt, sql, desc, inArray } from 'drizzle-orm';
 import { emitToUser } from '../../socket.js';
 import { enqueue, QUEUE_NAMES } from '../../lib/queues.js';
 import type { TriggerInvocation } from './employee-trigger.js';
+import { createNotificationIfAllowed } from '../../lib/notification-policy.js';
 
 const MEETING_PREP_TRIGGER_KIND = 'cron:meeting-prep';
 
@@ -292,18 +292,15 @@ export async function handleMeetingPrepCheck(_job: JobData): Promise<void> {
       });
 
       // 2g. Create notification
-      const [notification] = await db
-        .insert(notifications)
-        .values({
-          org_id: meeting.org_id,
-          user_id: meeting.user_id,
-          type: 'system',
-          title: `Meeting prep: ${meeting.title}`,
-          body: briefText,
-          link: `/dashboard`,
-          metadata: { event_id: meeting.id },
-        })
-        .returning();
+      const notification = await createNotificationIfAllowed({
+        org_id: meeting.org_id,
+        user_id: meeting.user_id,
+        type: 'system',
+        title: `Meeting prep: ${meeting.title}`,
+        body: briefText,
+        link: `/dashboard`,
+        metadata: { event_id: meeting.id },
+      }, { channel: 'calendar' });
 
       // 2h. Emit via socket
       if (notification) {

--- a/apps/api/src/workers/handlers/nudge-check.ts
+++ b/apps/api/src/workers/handlers/nudge-check.ts
@@ -16,6 +16,7 @@ import { emitToUser } from '../../socket.js';
 import { enqueue, QUEUE_NAMES } from '../../lib/queues.js';
 import type { TriggerInvocation } from './employee-trigger.js';
 import { getOrgTimezone, isOverdue, isDueWithinDays } from '../../lib/task-dates.js';
+import { createNotificationIfAllowed } from '../../lib/notification-policy.js';
 
 // Phase 6 — per-kind trigger routing. Stalled tasks and overdue tasks are
 // separate kinds so an employee can subscribe to just one. If the org has
@@ -363,18 +364,15 @@ async function processNudge(params: NudgeParams): Promise<void> {
     }
 
     // Create notification
-    const [notification] = await db
-      .insert(notifications)
-      .values({
-        org_id: orgId,
-        user_id: targetUserId,
-        type: 'agent_suggestion',
-        title: nudgeType === 'stalled' ? 'Stalled Task' : nudgeType === 'overdue' ? 'Overdue Task' : nudgeType === 'upcoming_due' ? 'Due Soon' : 'Overdue Task',
-        body: message,
-        link: `/tasks?task=${taskIdentifier}`,
-        metadata: { task_id: taskId, nudge_type: nudgeType },
-      })
-      .returning();
+    const notification = await createNotificationIfAllowed({
+      org_id: orgId,
+      user_id: targetUserId,
+      type: 'agent_suggestion',
+      title: nudgeType === 'stalled' ? 'Stalled Task' : nudgeType === 'overdue' ? 'Overdue Task' : nudgeType === 'upcoming_due' ? 'Due Soon' : 'Overdue Task',
+      body: message,
+      link: `/tasks?task=${taskIdentifier}`,
+      metadata: { task_id: taskId, nudge_type: nudgeType },
+    }, { channel: 'tasks' });
 
     // Insert nudge record
     await db.insert(agentNudges).values({
@@ -521,24 +519,21 @@ export async function checkWorkloadImbalance(): Promise<void> {
           const message = `Workload imbalance: ${person.assignee_name} has ${person.count} open tasks while the team average is ${Math.round(avg)}. Consider redistributing.`;
 
           // Create notification — one per (admin, overloaded user) pair.
-          const [notification] = await db
-            .insert(notifications)
-            .values({
-              org_id: orgId,
-              user_id: admin.user_id,
-              type: 'agent_suggestion',
-              title: 'Workload Imbalance',
-              body: message,
-              link: '/tasks',
-              metadata: {
-                nudge_type: 'workload_imbalance',
-                overloaded_user_id: person.assignee_id,
-                admin_user_id: admin.user_id,
-                task_count: person.count,
-                team_average: Math.round(avg),
-              },
-            })
-            .returning();
+          const notification = await createNotificationIfAllowed({
+            org_id: orgId,
+            user_id: admin.user_id,
+            type: 'agent_suggestion',
+            title: 'Workload Imbalance',
+            body: message,
+            link: '/tasks',
+            metadata: {
+              nudge_type: 'workload_imbalance',
+              overloaded_user_id: person.assignee_id,
+              admin_user_id: admin.user_id,
+              task_count: person.count,
+              team_average: Math.round(avg),
+            },
+          }, { channel: 'tasks' });
 
           if (notification) {
             emitToUser(admin.user_id, 'notification:new', notification);

--- a/apps/api/src/workers/handlers/reminder-fire.ts
+++ b/apps/api/src/workers/handlers/reminder-fire.ts
@@ -11,10 +11,11 @@
  */
 import { and, eq, isNull, or, gt, sql } from 'drizzle-orm';
 import { db } from '../../lib/db.js';
-import { reminders, notifications } from '@deft/db/schema';
+import { reminders } from '@deft/db/schema';
 import { emitToUser } from '../../socket.js';
 import { enqueue, QUEUE_NAMES } from '../../lib/queues.js';
 import type { JobData } from '../types.js';
+import { createNotificationIfAllowed } from '../../lib/notification-policy.js';
 
 export type ReminderFirePayload = { reminderId: string };
 
@@ -37,19 +38,16 @@ export async function reminderFireHandler(job: JobData): Promise<void> {
   }
 
   // Insert the notification.
-  const [notif] = await db
-    .insert(notifications)
-    .values({
-      org_id: reminder.org_id,
-      user_id: reminder.user_id,
-      type: 'reminder',
-      title: reminder.message.slice(0, 200),
-      link: reminder.source_message_id
-        ? `/chat?message=${reminder.source_message_id}`
-        : undefined,
-      metadata: { reminder_id: reminder.id },
-    })
-    .returning();
+  const notif = await createNotificationIfAllowed({
+    org_id: reminder.org_id,
+    user_id: reminder.user_id,
+    type: 'reminder',
+    title: reminder.message.slice(0, 200),
+    link: reminder.source_message_id
+      ? `/chat?message=${reminder.source_message_id}`
+      : undefined,
+    metadata: { reminder_id: reminder.id },
+  }, { channel: 'calendar' });
 
   // Mark the reminder fired.
   await db

--- a/apps/api/src/workers/handlers/workflow-execute.ts
+++ b/apps/api/src/workers/handlers/workflow-execute.ts
@@ -11,11 +11,12 @@ import type { JobData } from '../types.js';
 import { db } from '../../lib/db.js';
 import {
   workflowRules, workflowRuns,
-  tasks, taskComments, taskLabels, labels, notifications,
+  tasks, taskComments, taskLabels, labels,
   taskRelationships,
 } from '@deft/db/schema';
 import { eq, and } from 'drizzle-orm';
 import { emitToUser } from '../../socket.js';
+import { createNotificationIfAllowed } from '../../lib/notification-policy.js';
 
 interface WorkflowExecuteJobData {
   workflow_id: string;
@@ -96,7 +97,7 @@ export async function handleWorkflowExecute(job: JobData): Promise<void> {
         case 'notify': {
           if (!action.user_id) { results.push({ kind: 'notify', ok: false, error: 'missing user_id' }); break; }
           const title = action.title || `Workflow: ${rule.name}`;
-          const [notif] = await db.insert(notifications).values({
+          const notif = await createNotificationIfAllowed({
             org_id: rule.org_id,
             user_id: action.user_id,
             type: 'system',
@@ -104,7 +105,7 @@ export async function handleWorkflowExecute(job: JobData): Promise<void> {
             body: task.title,
             link: `/tasks`,
             metadata: { workflow_id, task_id: task.id },
-          }).returning();
+          }, { channel: 'tasks' });
           if (notif) emitToUser(action.user_id, 'notification:new', notif);
           results.push({ kind: 'notify', ok: true });
           break;
@@ -139,7 +140,7 @@ export async function handleWorkflowExecute(job: JobData): Promise<void> {
               .limit(1);
             if (!dep || !dep.assignee_id) continue;
             if (dep.status === 'done' || dep.status === 'cancelled') continue;
-            const [notif] = await db.insert(notifications).values({
+            const notif = await createNotificationIfAllowed({
               org_id: rule.org_id,
               user_id: dep.assignee_id,
               type: 'system',
@@ -152,7 +153,7 @@ export async function handleWorkflowExecute(job: JobData): Promise<void> {
                 unblocker_task_id: task.id,
                 subtype: 'unblocked',
               },
-            }).returning();
+            }, { channel: 'tasks' });
             if (notif) {
               emitToUser(dep.assignee_id, 'notification:new', notif);
               notified++;

--- a/apps/api/test/agent-reply-discussion-command.test.ts
+++ b/apps/api/test/agent-reply-discussion-command.test.ts
@@ -1,0 +1,39 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { isDiscussionTaskCommand } from '../src/workers/handlers/agent-reply.js';
+
+test('discussion task command accepts explicit discussion-to-task prompts', () => {
+  assert.equal(
+    isDiscussionTaskCommand('Defty, read this thread and create a task for the resolved buyer-label blocker.'),
+    true,
+  );
+  assert.equal(
+    isDiscussionTaskCommand('Can you summarize the conversation above into tasks for the launch team?'),
+    true,
+  );
+  assert.equal(
+    isDiscussionTaskCommand('Turn this chat into one ticket with the final resolution and owner.'),
+    true,
+  );
+});
+
+test('discussion task command rejects negated task creation prompts', () => {
+  assert.equal(
+    isDiscussionTaskCommand('Please summarize this discussion, but do not create tasks yet.'),
+    false,
+  );
+  assert.equal(
+    isDiscussionTaskCommand("Don't make todos from this conversation; I only need a recap."),
+    false,
+  );
+  assert.equal(
+    isDiscussionTaskCommand('Avoid opening tickets from the thread until Maya confirms scope.'),
+    false,
+  );
+});
+
+test('discussion task command does not treat ordinary task chatter as a command', () => {
+  assert.equal(isDiscussionTaskCommand('I created the task from the greenhouse conversation.'), false);
+  assert.equal(isDiscussionTaskCommand('Please create a task called "Check crates" in the packing project.'), false);
+  assert.equal(isDiscussionTaskCommand('This discussion was useful.'), false);
+});

--- a/apps/api/test/blocked-task-suggest.test.ts
+++ b/apps/api/test/blocked-task-suggest.test.ts
@@ -17,6 +17,7 @@ import {
   orgs,
   projects,
   projectSpaces,
+  spaceMembers,
   spaces,
   tasks,
   users,
@@ -94,6 +95,10 @@ before(async () => {
     type: 'public',
     created_by: leadUserId,
   });
+  await db.insert(spaceMembers).values([
+    { id: crypto.randomUUID(), space_id: spaceId, user_id: blockedUserId },
+    { id: crypto.randomUUID(), space_id: spaceId, user_id: leadUserId },
+  ]);
 
   projectId = crypto.randomUUID();
   await db.insert(projects).values({
@@ -168,6 +173,7 @@ after(async () => {
   if (taskId) await db.delete(tasks).where(eq(tasks.id, taskId));
   if (projectId) await db.delete(projectSpaces).where(eq(projectSpaces.project_id, projectId));
   if (projectId) await db.delete(projects).where(eq(projects.id, projectId));
+  if (spaceId) await db.delete(spaceMembers).where(eq(spaceMembers.space_id, spaceId));
   if (spaceId) await db.delete(spaces).where(eq(spaces.id, spaceId));
   if (testOrgId) await db.delete(orgMembers).where(eq(orgMembers.org_id, testOrgId));
   if (testOrgId) await db.delete(orgs).where(eq(orgs.id, testOrgId));

--- a/apps/api/test/job-queue-priority.test.ts
+++ b/apps/api/test/job-queue-priority.test.ts
@@ -1,0 +1,18 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { OBSERVE_CHAT_MESSAGE_JOB } from '../src/lib/chat-observation.js';
+import { jobPriorityRank, QUEUE_NAMES } from '../src/lib/queues.js';
+
+test('agent reply and employee action jobs outrank bulk observation jobs', () => {
+  assert.equal(jobPriorityRank(QUEUE_NAMES.AGENT_JOBS, 'agent-reply'), 0);
+  assert.equal(jobPriorityRank(QUEUE_NAMES.AGENT_JOBS, 'agent-employee-message'), 0);
+  assert.equal(jobPriorityRank(QUEUE_NAMES.AGENT_JOBS, 'employee-trigger'), 1);
+  assert.equal(jobPriorityRank(QUEUE_NAMES.AGENT_JOBS, 'plan-executor'), 1);
+  assert.equal(jobPriorityRank(QUEUE_NAMES.AGENT_JOBS, 'some-background-job'), 3);
+  assert.equal(jobPriorityRank(QUEUE_NAMES.AGENT_JOBS, OBSERVE_CHAT_MESSAGE_JOB), 5);
+});
+
+test('non-agent queues keep neutral priority', () => {
+  assert.equal(jobPriorityRank(QUEUE_NAMES.SCHEDULED_JOBS, 'agent-reply'), 3);
+  assert.equal(jobPriorityRank('custom-queue', OBSERVE_CHAT_MESSAGE_JOB), 3);
+});

--- a/apps/api/test/notification-policy.test.ts
+++ b/apps/api/test/notification-policy.test.ts
@@ -1,0 +1,26 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { notificationChannelForType } from '../src/lib/notification-policy.js';
+
+test('notification policy maps common events to user-facing preference channels', () => {
+  assert.equal(notificationChannelForType('mention'), 'chat');
+  assert.equal(notificationChannelForType('message'), 'chat');
+  assert.equal(notificationChannelForType('huddle_started'), 'chat');
+
+  assert.equal(notificationChannelForType('task'), 'tasks');
+  assert.equal(notificationChannelForType('task_assigned'), 'tasks');
+  assert.equal(notificationChannelForType('task_updated'), 'tasks');
+  assert.equal(notificationChannelForType('blocked'), 'tasks');
+  assert.equal(notificationChannelForType('workload_imbalance'), 'tasks');
+
+  assert.equal(notificationChannelForType('reminder'), 'calendar');
+
+  assert.equal(notificationChannelForType('agent_suggestion'), 'agents');
+  assert.equal(notificationChannelForType('skill_update_available'), 'agents');
+});
+
+test('notification policy leaves legacy or uncategorized events to explicit callers', () => {
+  assert.equal(notificationChannelForType('system'), null);
+  assert.equal(notificationChannelForType('wiki_update'), null);
+  assert.equal(notificationChannelForType('unknown_future_type'), null);
+});


### PR DESCRIPTION
﻿## What changed

- Adds a central notification policy helper that respects user notification channels, DND, space mute state, and space notification level before writing notification rows.
- Routes chat, task, project, socket, and worker notification creation through the shared policy.
- Adds group-handle mention expansion for chat notifications.
- Prioritizes interactive agent reply/employee action jobs above bulk observation jobs in the Postgres queue.
- Tightens discussion-command detection for agent replies so ordinary task chatter does not become an action command.

## Why

The UI polish made notification volume and agent responsiveness more visible. This backend pass makes notification delivery quieter and more user-respectful, while preventing lower-priority observation work from delaying interactive agent work.

## Validation

- `pnpm --filter @deft/api typecheck`
- `pnpm --filter @deft/api exec tsx src/scripts/seed-test-fixtures.ts`
- `pnpm --filter @deft/api exec tsx --test --test-concurrency=1 --test-force-exit test/notification-policy.test.ts test/job-queue-priority.test.ts test/agent-reply-discussion-command.test.ts`
- `pnpm --filter @deft/api exec tsx --test --test-concurrency=1 --test-force-exit test/tasks-bulk-grouped-notify.test.ts` with `DATABASE_URL` explicitly loaded from `.env`

Focused result: new tests 7/7 passed; bulk notification regression 3/3 passed.

## Notes

The first attempt to include the older bulk notification test failed because that test opens a raw pg connection before loading `.env`, causing it to fall back to the wrong local database. Re-running with `DATABASE_URL` explicitly loaded passed.
