### PR TITLE
Fix avatar rendering in people popups

### DIFF
--- a/apps/web/src/app/(app)/tasks/page.tsx
+++ b/apps/web/src/app/(app)/tasks/page.tsx
@@ -38,6 +38,7 @@ import { AppMenu } from '@/components/overlay-primitives';
 const TaskTimeline = lazy(() => import('./timeline'));
 import { EmptyState } from '@/components/empty-state';
 import { CreateProjectModal } from '@/components/create-project-modal';
+import { PersonAvatar } from '@/components/person-avatar';
 
 type Task = {
   id: string;
@@ -1406,12 +1407,7 @@ export default function TasksPage() {
                       onMouseEnter={(e) => (e.currentTarget.style.background = 'var(--hover-tint)')}
                       onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
                     >
-                      <div
-                        className="w-4 h-4 rounded-full flex items-center justify-center text-[9px] font-medium text-white flex-shrink-0"
-                        style={{ background: 'var(--accent)' }}
-                      >
-                        {member.name.charAt(0).toUpperCase()}
-                      </div>
+                      <PersonAvatar name={member.name} avatarUrl={member.avatar_url} size={16} fontSize={9} />
                       <span className="truncate">{member.name}</span>
                     </button>
                   ))}

--- a/apps/web/src/components/calendar/create-event-modal.tsx
+++ b/apps/web/src/components/calendar/create-event-modal.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useRef } from 'react';
 import { api } from '@/lib/api';
 import { X, Users } from 'lucide-react';
+import { PersonAvatar } from '../person-avatar';
 
 type OrgMember = { id: string; name: string; email: string; avatar_url: string | null };
 
@@ -199,10 +200,7 @@ export function CreateEventModal({
                         style={{ color: 'var(--text-primary)' }}
                         onMouseEnter={e => (e.currentTarget.style.background = 'var(--hover-tint, rgba(255,255,255,0.05))')}
                         onMouseLeave={e => (e.currentTarget.style.background = 'transparent')}>
-                        <div className="w-5 h-5 rounded-full flex items-center justify-center text-[9px] font-medium text-white"
-                          style={{ background: 'var(--accent)' }}>
-                          {m.name.charAt(0).toUpperCase()}
-                        </div>
+                        <PersonAvatar name={m.name} avatarUrl={m.avatar_url} size={20} fontSize={9} />
                         <span>{m.name}</span>
                         <span className="ml-auto" style={{ color: 'var(--text-tertiary)' }}>{m.email}</span>
                       </button>

--- a/apps/web/src/components/create-dm-modal.tsx
+++ b/apps/web/src/components/create-dm-modal.tsx
@@ -2,15 +2,16 @@
 
 import { useState, useEffect, useRef } from 'react';
 import { api } from '@/lib/api';
-import { X, Search, Bot, Check } from 'lucide-react';
+import { X, Search, Check } from 'lucide-react';
 import { useChatContext } from '@/lib/chat-context';
 import { useAuth } from '@/lib/auth-context';
 import { AIBadge } from './ai-badge';
+import { PersonAvatar } from './person-avatar';
 
 type Member = {
   id: string;
   name: string;
-  avatar: string | null;
+  avatar_url: string | null;
   kind?: 'human' | 'agent' | 'system';
 };
 
@@ -20,11 +21,15 @@ type Props = {
   initialSelected?: Member[];
 };
 
-function avatarColor(name: string) {
-  const colors = ['#7C6B4F', '#5B7A6B', '#6B5D7A', '#7A5B5B', '#5B6B7A', '#7A6B5B'];
-  let hash = 0;
-  for (let i = 0; i < name.length; i++) hash = name.charCodeAt(i) + ((hash << 5) - hash);
-  return colors[Math.abs(hash) % colors.length];
+type ApiMember = Omit<Member, 'avatar_url'> & { avatar_url?: string | null; avatar?: string | null };
+
+function normalizeMember(member: ApiMember): Member {
+  return {
+    id: member.id,
+    name: member.name,
+    avatar_url: member.avatar_url ?? member.avatar ?? null,
+    kind: member.kind,
+  };
 }
 
 function MemberRow({
@@ -53,23 +58,7 @@ function MemberRow({
         if (!selected) (e.currentTarget as HTMLElement).style.background = 'transparent';
       }}
     >
-      {member.avatar ? (
-        <img src={member.avatar} className="w-8 h-8 rounded-full" alt={member.name} />
-      ) : isAgent ? (
-        <div
-          className="w-8 h-8 rounded-full flex items-center justify-center"
-          style={{ background: '#6366f1', color: '#fff' }}
-        >
-          <Bot size={15} strokeWidth={1.5} />
-        </div>
-      ) : (
-        <div
-          className="w-8 h-8 rounded-full flex items-center justify-center text-[12px] font-medium text-white"
-          style={{ background: avatarColor(member.name) }}
-        >
-          {member.name.charAt(0).toUpperCase()}
-        </div>
-      )}
+      <PersonAvatar name={member.name} avatarUrl={member.avatar_url} kind={member.kind} size={32} fontSize={12} />
       <span
         className="text-[13px] font-medium flex-1"
         style={{ color: 'var(--foreground)', fontFamily: 'var(--font-body)' }}
@@ -110,8 +99,8 @@ export function CreateDmModal({ onClose, initialSelected = [] }: Props) {
         const res = await api.get('/api/members');
         if (res.ok) {
           const data = await res.json();
-          const list: Member[] = data.members || data || [];
-          setMembers(list.filter((m) => m.id !== user?.id));
+          const list: ApiMember[] = data.members || data || [];
+          setMembers(list.map(normalizeMember).filter((m) => m.id !== user?.id));
         }
       } catch {
         // ignore

--- a/apps/web/src/components/huddle-overlay.tsx
+++ b/apps/web/src/components/huddle-overlay.tsx
@@ -3,6 +3,13 @@
 import { useState } from 'react';
 import { Mic, MicOff, PhoneOff, ChevronUp, ChevronDown, Monitor, UserPlus } from 'lucide-react';
 import { useChatContext } from '@/lib/chat-context';
+import { PersonAvatar } from './person-avatar';
+
+type HuddleMember = {
+  id: string;
+  name: string;
+  avatar_url?: string | null;
+};
 
 function formatDuration(seconds: number): string {
   const m = Math.floor(seconds / 60);
@@ -159,7 +166,7 @@ function CompactBarMobile({
 }: {
   spaceName: string;
   participants: { user_id: string; muted: boolean }[];
-  orgMembers: { id: string; name: string }[];
+  orgMembers: HuddleMember[];
   speakingMap: Map<string, boolean>;
   muted: boolean;
   duration: number;
@@ -203,7 +210,16 @@ function CompactBarMobile({
           {participants.slice(0, 3).map((p) => {
             const member = orgMembers.find(m => m.id === p.user_id);
             const speaking = speakingMap.get(p.user_id);
-            return <ParticipantDot key={p.user_id} name={member?.name} muted={p.muted} speaking={speaking} size={28} />;
+            return (
+              <ParticipantDot
+                key={p.user_id}
+                name={member?.name}
+                avatarUrl={member?.avatar_url}
+                muted={p.muted}
+                speaking={speaking}
+                size={28}
+              />
+            );
           })}
           {participants.length > 3 && (
             <div className="w-7 h-7 rounded-full flex items-center justify-center text-[10px] font-medium border-2"
@@ -247,7 +263,7 @@ function ExpandedSheetMobile({
 }: {
   spaceName: string;
   participants: { user_id: string; user_name: string; muted: boolean }[];
-  orgMembers: { id: string; name: string }[];
+  orgMembers: HuddleMember[];
   speakingMap: Map<string, boolean>;
   muted: boolean;
   duration: number;
@@ -299,7 +315,7 @@ function ExpandedSheetMobile({
           return (
             <div key={p.user_id} className="flex flex-col items-center gap-2">
               <div className="relative">
-                <ParticipantDot name={name} muted={p.muted} speaking={speaking} size={72} fontSize={24} />
+                <ParticipantDot name={name} avatarUrl={member?.avatar_url} muted={p.muted} speaking={speaking} size={72} fontSize={24} />
                 {p.muted && (
                   <div className="absolute bottom-0 right-0 w-6 h-6 rounded-full flex items-center justify-center border-2"
                     style={{ background: '#ef4444', borderColor: 'var(--surface-container-highest, #1e1e2e)' }}>
@@ -400,7 +416,7 @@ function CompactBarDesktop({
 }: {
   spaceName: string;
   participants: { user_id: string; muted: boolean }[];
-  orgMembers: { id: string; name: string }[];
+  orgMembers: HuddleMember[];
   speakingMap: Map<string, boolean>;
   muted: boolean;
   duration: number;
@@ -440,7 +456,16 @@ function CompactBarDesktop({
         {participants.slice(0, 4).map((p) => {
           const member = orgMembers.find(m => m.id === p.user_id);
           const speaking = speakingMap.get(p.user_id);
-          return <ParticipantDot key={p.user_id} name={member?.name} muted={p.muted} speaking={speaking} size={24} />;
+          return (
+            <ParticipantDot
+              key={p.user_id}
+              name={member?.name}
+              avatarUrl={member?.avatar_url}
+              muted={p.muted}
+              speaking={speaking}
+              size={24}
+            />
+          );
         })}
         {participants.length > 4 && (
           <div className="w-6 h-6 rounded-full flex items-center justify-center text-[8px] font-medium border-2"
@@ -475,7 +500,7 @@ function ExpandedPanelDesktop({
 }: {
   spaceName: string;
   participants: { user_id: string; user_name: string; muted: boolean }[];
-  orgMembers: { id: string; name: string }[];
+  orgMembers: HuddleMember[];
   speakingMap: Map<string, boolean>;
   muted: boolean;
   duration: number;
@@ -528,7 +553,7 @@ function ExpandedPanelDesktop({
           return (
             <div key={p.user_id} className="flex flex-col items-center gap-1.5">
               <div className="relative">
-                <ParticipantDot name={name} muted={p.muted} speaking={speaking} size={48} fontSize={16} />
+                <ParticipantDot name={name} avatarUrl={member?.avatar_url} muted={p.muted} speaking={speaking} size={48} fontSize={16} />
                 {p.muted && (
                   <div className="absolute -bottom-0.5 -right-0.5 w-4 h-4 rounded-full flex items-center justify-center"
                     style={{ background: '#ef4444' }}>
@@ -580,32 +605,29 @@ function ExpandedPanelDesktop({
 // ═══ Participant Avatar with Speaking Ring ═══
 
 function ParticipantDot({
-  name, muted, speaking, size = 24, fontSize = 10,
+  name, avatarUrl, muted, speaking, size = 24, fontSize = 10,
 }: {
   name?: string;
+  avatarUrl?: string | null;
   muted?: boolean;
   speaking?: boolean;
   size?: number;
   fontSize?: number;
 }) {
-  const initial = (name || '?')[0]?.toUpperCase();
   return (
-    <div
-      className="rounded-full flex items-center justify-center font-semibold border-2 transition-shadow"
+    <PersonAvatar
+      name={name}
+      avatarUrl={avatarUrl}
+      size={size}
+      fontSize={fontSize}
+      className="border-2 transition-shadow"
       style={{
-        width: size,
-        height: size,
-        fontSize,
-        background: 'var(--accent, #6366f1)',
-        color: 'white',
         borderColor: 'var(--surface-container-highest, #1e1e2e)',
         boxShadow: speaking ? '0 0 0 3px #22c55e' : 'none',
         opacity: muted ? 0.6 : 1,
         transitionDuration: '200ms',
       }}
       title={`${name || 'User'}${muted ? ' (muted)' : ''}${speaking ? ' (speaking)' : ''}`}
-    >
-      {initial}
-    </div>
+    />
   );
 }

--- a/apps/web/src/components/mention-autocomplete.tsx
+++ b/apps/web/src/components/mention-autocomplete.tsx
@@ -2,14 +2,17 @@
 
 import { useEffect, useState, useRef, useCallback } from 'react';
 import { api } from '@/lib/api';
-import { AtSign, Users, Bot } from 'lucide-react';
+import { AtSign, Users } from 'lucide-react';
+import { PersonAvatar } from './person-avatar';
 
 type Member = {
   id: string;
   name: string;
-  avatar: string | null;
+  avatar_url: string | null;
   kind?: 'human' | 'agent' | 'system';
 };
+
+type ApiMember = Omit<Member, 'avatar_url'> & { avatar_url?: string | null; avatar?: string | null };
 
 type Props = {
   query: string;
@@ -18,6 +21,15 @@ type Props = {
 };
 
 let cachedMembers: Member[] | null = null;
+
+function normalizeMembers(list: ApiMember[]): Member[] {
+  return list.map((member) => ({
+    id: member.id,
+    name: member.name,
+    avatar_url: member.avatar_url ?? member.avatar ?? null,
+    kind: member.kind,
+  }));
+}
 
 export function MentionAutocomplete({ query, onSelect, onClose }: Props) {
   const [members, setMembers] = useState<Member[]>(cachedMembers || []);
@@ -31,9 +43,10 @@ export function MentionAutocomplete({ query, onSelect, onClose }: Props) {
         const res = await api.get('/api/members');
         if (res.ok) {
           const data = await res.json();
-          const list = data.members || data || [];
-          cachedMembers = list;
-          setMembers(list);
+          const list: ApiMember[] = data.members || data || [];
+          const normalized = normalizeMembers(list);
+          cachedMembers = normalized;
+          setMembers(normalized);
         }
       } catch {
         // ignore
@@ -103,13 +116,6 @@ export function MentionAutocomplete({ query, onSelect, onClose }: Props) {
 
   if (allOptions.length === 0) return null;
 
-  function avatarColor(name: string) {
-    const colors = ['#7C6B4F', '#5B7A6B', '#6B5D7A', '#7A5B5B', '#5B6B7A', '#7A6B5B'];
-    let hash = 0;
-    for (let i = 0; i < name.length; i++) hash = name.charCodeAt(i) + ((hash << 5) - hash);
-    return colors[Math.abs(hash) % colors.length];
-  }
-
   return (
     <div
       ref={ref}
@@ -132,16 +138,7 @@ export function MentionAutocomplete({ query, onSelect, onClose }: Props) {
           }}
           onMouseEnter={() => setSelectedIndex(i)}
         >
-          {member.avatar ? (
-            <img src={member.avatar} className="w-6 h-6 rounded-full" alt={member.name} />
-          ) : (
-            <div
-              className="w-6 h-6 rounded-full flex items-center justify-center text-[10px] font-medium text-white"
-              style={{ background: avatarColor(member.name) }}
-            >
-              {member.name.charAt(0).toUpperCase()}
-            </div>
-          )}
+          <PersonAvatar name={member.name} avatarUrl={member.avatar_url} kind={member.kind} size={24} fontSize={10} />
           <span>{member.name}</span>
         </button>
       ))}
@@ -162,16 +159,7 @@ export function MentionAutocomplete({ query, onSelect, onClose }: Props) {
             }}
             onMouseEnter={() => setSelectedIndex(idx)}
           >
-            {agent.avatar ? (
-              <img src={agent.avatar} className="w-6 h-6 rounded-full" alt={agent.name} />
-            ) : (
-              <div
-                className="w-6 h-6 rounded-full flex items-center justify-center"
-                style={{ background: '#6366f1', color: '#fff' }}
-              >
-                <Bot size={13} strokeWidth={1.5} />
-              </div>
-            )}
+            <PersonAvatar name={agent.name} avatarUrl={agent.avatar_url} kind={agent.kind} size={24} fontSize={10} />
             <span>{agent.name}</span>
             <span
               className="text-[11px] ml-auto px-1.5 py-0.5 rounded-full"

--- a/apps/web/src/components/person-avatar.tsx
+++ b/apps/web/src/components/person-avatar.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import type { CSSProperties } from 'react';
+import { Bot } from 'lucide-react';
+
+type PersonAvatarProps = {
+  name?: string | null;
+  avatarUrl?: string | null;
+  kind?: string | null;
+  size?: number;
+  fontSize?: number;
+  className?: string;
+  style?: CSSProperties;
+  title?: string;
+};
+
+function avatarColor(name: string) {
+  const colors = ['#7C6B4F', '#5B7A6B', '#6B5D7A', '#7A5B5B', '#5B6B7A', '#7A6B5B'];
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) hash = name.charCodeAt(i) + ((hash << 5) - hash);
+  return colors[Math.abs(hash) % colors.length];
+}
+
+export function PersonAvatar({
+  name,
+  avatarUrl,
+  kind,
+  size = 32,
+  fontSize,
+  className = '',
+  style,
+  title,
+}: PersonAvatarProps) {
+  const label = name?.trim() || 'User';
+  const isAgent = kind === 'agent' || kind === 'system';
+  const mergedStyle: CSSProperties = {
+    width: size,
+    height: size,
+    fontSize: fontSize ?? Math.max(9, Math.round(size * 0.38)),
+    ...style,
+  };
+
+  if (avatarUrl) {
+    return (
+      <img
+        src={avatarUrl}
+        alt={label}
+        title={title ?? label}
+        className={`rounded-full object-cover flex-shrink-0 ${className}`}
+        style={mergedStyle}
+      />
+    );
+  }
+
+  return (
+    <div
+      title={title ?? label}
+      className={`rounded-full flex items-center justify-center font-medium text-white flex-shrink-0 ${className}`}
+      style={{
+        background: isAgent ? '#6366f1' : avatarColor(label),
+        ...mergedStyle,
+      }}
+    >
+      {isAgent ? <Bot size={Math.max(12, Math.round(size * 0.5))} strokeWidth={1.7} /> : label.charAt(0).toUpperCase()}
+    </div>
+  );
+}

--- a/apps/web/src/components/space-members-panel.tsx
+++ b/apps/web/src/components/space-members-panel.tsx
@@ -440,7 +440,7 @@ export function SpaceMembersPanel({ spaceId, spaceName, spaceType, onClose }: Pr
             .map((m) => ({
               id: m.id,
               name: m.name,
-              avatar: m.avatar_url,
+              avatar_url: m.avatar_url,
               kind: m.kind,
             }))}
         />

--- a/apps/web/src/components/task-detail.tsx
+++ b/apps/web/src/components/task-detail.tsx
@@ -12,6 +12,7 @@ import { createBaseExtensions } from '@/lib/editor/shared-config';
 import { registerBuiltInCommands } from '@/lib/editor/built-in-commands';
 import { registerAICommands } from '@/lib/editor/ai-commands';
 import { AILoadingListener } from '@/components/editor/ai-loading-listener';
+import { PersonAvatar } from './person-avatar';
 import { Callout } from '@/lib/editor/blocks/callout';
 import { Toggle, ToggleSummary, ToggleContent } from '@/lib/editor/blocks/toggle';
 import { CodeBlock } from '@/lib/editor/blocks/code-block';
@@ -179,6 +180,7 @@ type AgentEmployee = {
   id: string;
   user_id: string;
   name: string;
+  avatar_url?: string | null;
   role?: string;
   runtime_kind?: string | null;
   wake_mode?: string | null;
@@ -1424,12 +1426,7 @@ export function TaskDetail({ taskId, projectPrefix, onClose, onUpdated, onDuplic
               >
                 {task.assignee_name ? (
                   <>
-                    <div
-                      className="w-5 h-5 rounded-full flex items-center justify-center text-[10px] font-medium text-white"
-                      style={{ background: 'var(--accent)' }}
-                    >
-                      {task.assignee_name.charAt(0).toUpperCase()}
-                    </div>
+                    <PersonAvatar name={task.assignee_name} avatarUrl={task.assignee_avatar} size={20} fontSize={10} />
                     {task.assignee_name}
                   </>
                 ) : (
@@ -1479,12 +1476,7 @@ export function TaskDetail({ taskId, projectPrefix, onClose, onUpdated, onDuplic
                       onMouseEnter={(e) => (e.currentTarget.style.background = 'var(--hover-tint)')}
                       onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
                     >
-                      <div
-                        className="w-5 h-5 rounded-full flex items-center justify-center text-[10px] font-medium text-white"
-                        style={{ background: 'var(--accent)' }}
-                      >
-                        {m.name.charAt(0).toUpperCase()}
-                      </div>
+                      <PersonAvatar name={m.name} avatarUrl={m.avatar_url} size={20} fontSize={10} />
                       {m.name}
                     </button>
                   ))}
@@ -1506,12 +1498,7 @@ export function TaskDetail({ taskId, projectPrefix, onClose, onUpdated, onDuplic
                           onMouseEnter={(e) => (e.currentTarget.style.background = 'var(--hover-tint)')}
                           onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
                         >
-                          <div
-                            className="w-5 h-5 rounded-full flex items-center justify-center text-[10px] font-medium text-white"
-                            style={{ background: '#8B5CF6' }}
-                          >
-                            {emp.name.charAt(0).toUpperCase()}
-                          </div>
+                          <PersonAvatar name={emp.name} avatarUrl={emp.avatar_url} kind="agent" size={20} fontSize={10} />
                           {emp.name}
                           <span className="text-[10px] px-1 py-0.5 rounded" style={{ background: 'var(--hover-tint)', color: 'var(--muted)' }}>AI</span>
                         </button>
@@ -2111,13 +2098,13 @@ export function TaskDetail({ taskId, projectPrefix, onClose, onUpdated, onDuplic
 
                     {/* Assignee avatar */}
                     {subtask.assignee_name && (
-                      <div
-                        className="w-4 h-4 rounded-full flex items-center justify-center text-[8px] font-medium text-white flex-shrink-0"
-                        style={{ background: 'var(--accent)' }}
+                      <PersonAvatar
+                        name={subtask.assignee_name}
+                        avatarUrl={subtask.assignee_avatar}
+                        size={16}
+                        fontSize={8}
                         title={subtask.assignee_name}
-                      >
-                        {subtask.assignee_name.charAt(0).toUpperCase()}
-                      </div>
+                      />
                     )}
                   </div>
                 ))}
@@ -2515,10 +2502,13 @@ export function TaskDetail({ taskId, projectPrefix, onClose, onUpdated, onDuplic
                       className="flex items-start gap-2.5 px-3 py-2 rounded-lg cursor-pointer hover:bg-[var(--bg-hover)] transition-colors min-w-0"
                       style={{ background: 'var(--surface-container)' }}
                     >
-                      <div className="w-6 h-6 rounded-full flex items-center justify-center text-[9px] font-medium text-white flex-shrink-0 mt-0.5"
-                        style={{ background: 'var(--accent)' }}>
-                        {sourceMessage.author_name?.charAt(0).toUpperCase() || '?'}
-                      </div>
+                      <PersonAvatar
+                        name={sourceMessage.author_name}
+                        avatarUrl={sourceMessage.author_avatar}
+                        size={24}
+                        fontSize={9}
+                        className="mt-0.5"
+                      />
                       <div className="flex-1 min-w-0">
                         <div className="flex flex-wrap items-center gap-1.5 mb-0.5">
                           <span className="text-[12px] font-medium" style={{ color: 'var(--foreground)' }}>
@@ -2558,10 +2548,7 @@ export function TaskDetail({ taskId, projectPrefix, onClose, onUpdated, onDuplic
                       }}
                       className="flex items-start gap-2.5 px-3 py-2 rounded-lg cursor-pointer hover:bg-[var(--bg-hover)] transition-colors"
                       style={{ background: 'var(--surface-container)' }}>
-                      <div className="w-6 h-6 rounded-full flex items-center justify-center text-[9px] font-medium text-white flex-shrink-0 mt-0.5"
-                        style={{ background: 'var(--primary-container)' }}>
-                        {ref.author_name?.charAt(0).toUpperCase() || '?'}
-                      </div>
+                      <PersonAvatar name={ref.author_name} avatarUrl={ref.author_avatar} size={24} fontSize={9} className="mt-0.5" />
                       <div className="flex-1 min-w-0">
                         <div className="flex items-center gap-2 mb-0.5">
                           <span className="text-[12px] font-medium" style={{ color: 'var(--foreground)' }}>
@@ -2598,12 +2585,7 @@ export function TaskDetail({ taskId, projectPrefix, onClose, onUpdated, onDuplic
                   )}
                   {comments.map((c) => (
                     <div key={c.id} className="flex gap-2.5">
-                      <div
-                        className="w-6 h-6 rounded-full flex items-center justify-center text-[10px] font-medium text-white flex-shrink-0 mt-0.5"
-                        style={{ background: 'var(--accent)' }}
-                      >
-                        {c.user_name.charAt(0).toUpperCase()}
-                      </div>
+                      <PersonAvatar name={c.user_name} avatarUrl={c.user_avatar} size={24} fontSize={10} className="mt-0.5" />
                       <div className="flex-1 min-w-0">
                         <div className="flex items-center gap-2">
                           <span
@@ -2631,12 +2613,7 @@ export function TaskDetail({ taskId, projectPrefix, onClose, onUpdated, onDuplic
 
                   {/* Add comment */}
                   <div className="flex gap-2 mt-2">
-                    <div
-                      className="w-6 h-6 rounded-full flex items-center justify-center text-[10px] font-medium text-white flex-shrink-0 mt-1"
-                      style={{ background: 'var(--accent)' }}
-                    >
-                      {user?.name?.charAt(0).toUpperCase()}
-                    </div>
+                    <PersonAvatar name={user?.name} avatarUrl={user?.avatar_url} size={24} fontSize={10} className="mt-1" />
                     <div className="flex-1">
                       <div
                         className="rounded-lg overflow-hidden"

--- a/apps/web/src/components/task-quick-create.tsx
+++ b/apps/web/src/components/task-quick-create.tsx
@@ -6,6 +6,7 @@ import { X, ChevronDown } from 'lucide-react';
 import { statusLabel } from '@/lib/task-status-labels';
 import { useProjectResolvedConfig } from '@/hooks/use-project-resolved-config';
 import { TemplatePickerModal } from './template-picker-modal';
+import { PersonAvatar } from './person-avatar';
 
 type Props = {
   projectId: string;
@@ -40,7 +41,7 @@ export function TaskQuickCreate({ projectId, defaultStatus, initialTitle, initia
   const [dueDate, setDueDate] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [members, setMembers] = useState<{ id: string; name: string }[]>([]);
+  const [members, setMembers] = useState<{ id: string; name: string; avatar_url: string | null }[]>([]);
   const [openDropdown, setOpenDropdown] = useState<string | null>(null);
   const [templatePickerOpen, setTemplatePickerOpen] = useState(false);
   // Task 4.11 — resolved skill config drives custom fields + status vocab.
@@ -333,12 +334,7 @@ export function TaskQuickCreate({ projectId, defaultStatus, initialTitle, initia
                         onMouseEnter={(e) => (e.currentTarget.style.background = 'var(--hover-tint)')}
                         onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
                       >
-                        <div
-                          className="w-4 h-4 rounded-full flex items-center justify-center text-[9px] font-medium text-white"
-                          style={{ background: 'var(--accent)' }}
-                        >
-                          {m.name.charAt(0).toUpperCase()}
-                        </div>
+                        <PersonAvatar name={m.name} avatarUrl={m.avatar_url} size={16} fontSize={9} />
                         {m.name}
                       </button>
                     ))}


### PR DESCRIPTION
## Summary
- Add a shared `PersonAvatar` primitive for avatar URL + fallback rendering.
- Fix avatar rendering in chat mention autocomplete, new DM modal, and huddle compact/expanded overlays.
- Carry the same avatar behavior into adjacent task and calendar people pickers.

## Root cause
Some older popups still expected `avatar` or passed only `{ id, name }`, while the API and app context now provide `avatar_url`. Those surfaces silently fell back to initials even when profile images existed.

## Validation
- `pnpm --filter @deft/web typecheck`
- `pnpm --filter @deft/web build`
- `git diff --check`

## Note
`pnpm --filter @deft/web lint` is currently blocked by the existing ESLint 10 / `eslint-plugin-react` `react/display-name` loader crash, unrelated to this patch.
