### PR TITLE
Create structured task bundles across native and MCP writes

### DIFF
--- a/apps/api/src/lib/agent-actions.ts
+++ b/apps/api/src/lib/agent-actions.ts
@@ -31,7 +31,8 @@ import { detectBlocksCycle } from './task-dependency.js';
 import { dispatchAgentEmployeeTask } from './dispatch-agent-task.js';
 import { checkReplyStorm, STORM_THRESHOLD } from './storm-detector.js';
 import { DEFTY_NAME } from './ensure-defty-membership.js';
-import { reserveNextTaskNumber } from './task-numbering.js';
+import { resolveSpaceTarget } from './resolve-space-target.js';
+import { createTaskBundle } from './task-bundle.js';
 
 /**
  * Resolve a task identifier (either "PREFIX-N" shorthand or a raw uuid) to
@@ -119,11 +120,18 @@ export async function executeAction(
 
     switch (action) {
       case 'create_task': {
-        const [project] = await db
-          .select()
-          .from(projects)
-          .where(and(eq(projects.org_id, orgId), ilike(projects.name, `%${params.project_name}%`)))
-          .limit(1);
+        const projectQuery = typeof params.resolved_project_id === 'string' && params.resolved_project_id.trim()
+          ? db
+            .select()
+            .from(projects)
+            .where(and(eq(projects.org_id, orgId), eq(projects.id, params.resolved_project_id)))
+            .limit(1)
+          : db
+            .select()
+            .from(projects)
+            .where(and(eq(projects.org_id, orgId), ilike(projects.name, `%${params.project_name}%`)))
+            .limit(1);
+        const [project] = await projectQuery;
         if (!project) return { success: false, result: null, error: 'Project not found' };
 
         let assigneeId: string | null = null;
@@ -156,52 +164,45 @@ export async function executeAction(
           }
         }
 
-        const taskNumber = await reserveNextTaskNumber({
-          projectId: project.id,
+        const bundle = await createTaskBundle({
           orgId,
+          projectId: project.id,
+          projectPrefix: project.prefix,
+          projectName: project.name,
+          createdBy: userId,
+          title: params.title,
+          description: params.description,
+          priority,
+          assigneeId,
+          dueDate: params.due_date ?? null,
+          startDate: params.start_date ?? null,
+          estimation: params.estimation ?? null,
+          sourceMessageId: params.source_message_id || null,
+          actionId,
+          actingAgentEmployeeId: agentEmployeeId,
+          subtasks: Array.isArray(params.subtasks) ? params.subtasks : null,
         });
-
-        const [task] = await db
-          .insert(tasks)
-          .values({
-            org_id: orgId,
-            project_id: project.id,
-            number: taskNumber,
-            title: params.title,
-            description: params.description || null,
-            status: 'backlog',
-            priority,
-            assignee_id: assigneeId,
-            created_by: userId,
-            due_date: params.due_date ? new Date(params.due_date) : null,
-            // Task 3.2 — if the agent was invoked by a message, link the
-            // created task back to it so the UI can show "from chat".
-            source_message_id: params.source_message_id || null,
-          })
-          .returning();
-
-        await db.insert(taskActivity).values({
-          org_id: orgId,
-          task_id: task!.id,
-          user_id: userId,
-          action: 'created',
-          agent_action_id: actionId,
-          acting_agent_employee_id: agentEmployeeId,
-        });
+        const task = bundle.parent;
 
         await db
           .update(agentActions)
           .set({
-            result: { task_id: task!.id, number: task!.number, prefix: project.prefix },
+            result: {
+              task_id: task.id,
+              number: task.number,
+              prefix: project.prefix,
+              subtasks: bundle.subtasks,
+            },
             before_state: null,
             after_state: {
-              id: task!.id,
-              title: task!.title,
-              status: task!.status,
-              priority: task!.priority,
-              assignee_id: task!.assignee_id,
-              project_id: task!.project_id,
-              number: task!.number,
+              id: task.id,
+              title: task.title,
+              status: task.status,
+              priority: task.priority,
+              assignee_id: task.assignee_id,
+              project_id: task.project_id,
+              number: task.number,
+              subtasks: bundle.subtasks,
             },
             executed_at: new Date(),
           })
@@ -209,10 +210,14 @@ export async function executeAction(
 
         const io = getIO();
         if (io) {
-          io.to(`org:${orgId}`).emit('task:created', {
-            ...task,
-            project_prefix: project.prefix,
-          });
+          for (const createdTask of bundle.allTasks) {
+            io.to(`org:${orgId}`).emit('task:created', {
+              ...createdTask,
+              project_id: project.id,
+              project_prefix: project.prefix,
+              project_name: project.name,
+            });
+          }
         }
 
         await logAuditEvent({
@@ -221,24 +226,25 @@ export async function executeAction(
           actorId: userId,
           action: 'create_task',
           entityType: 'task',
-          entityId: task!.id,
+          entityId: task.id,
           beforeState: null,
           afterState: {
-            id: task!.id,
-            title: task!.title,
-            status: task!.status,
-            priority: task!.priority,
-            assignee_id: task!.assignee_id,
+            id: task.id,
+            title: task.title,
+            status: task.status,
+            priority: task.priority,
+            assignee_id: task.assignee_id,
+            subtasks: bundle.subtasks,
           },
-          metadata: { action_id: actionId, project: project.prefix },
+          metadata: { action_id: actionId, project: project.prefix, subtask_count: bundle.subtasks.length },
         });
 
-        // If assignee is an agent employee, wake them up to work the task.
-        if (assigneeId) {
+        // If an assignee is an agent employee, wake them up to work the task.
+        for (const createdTask of bundle.allTasks.filter((row) => row.assignee_id)) {
           await dispatchAgentEmployeeTask({
-            taskId: task!.id,
+            taskId: createdTask.id,
             orgId,
-            assigneeUserId: assigneeId,
+            assigneeUserId: createdTask.assignee_id!,
             assignedBy: userId,
           });
         }
@@ -246,16 +252,21 @@ export async function executeAction(
         return {
           success: true,
           result: {
-            task_id: task!.id,
-            identifier: `${project.prefix}-${task!.number}`,
+            task_id: task.id,
+            identifier: task.identifier,
             title: params.title,
+            subtasks: bundle.subtasks,
           },
         };
       }
 
       case 'update_task_status': {
-        let taskId = params.task_identifier as string;
-        const m = taskId.match(/^([A-Z]+)-(\d+)$/);
+        let taskId = typeof params.resolved_task_id === 'string' && params.resolved_task_id.trim()
+          ? params.resolved_task_id
+          : params.task_identifier as string;
+        const m = typeof params.resolved_task_id === 'string' && params.resolved_task_id.trim()
+          ? null
+          : taskId.match(/^([A-Z]+)-(\d+)$/);
         if (m) {
           const [proj] = await db
             .select({ id: projects.id })
@@ -478,12 +489,14 @@ export async function executeAction(
       }
 
       case 'post_message': {
-        const [space] = await db
-          .select()
-          .from(spaces)
-          .where(and(eq(spaces.org_id, orgId), ilike(spaces.name, params.space_name)))
-          .limit(1);
-        if (!space) return { success: false, result: null, error: 'Space not found' };
+        const resolvedSpace = await resolveSpaceTarget(orgId, {
+          spaceId: params.space_id ?? params.resolved_space_id,
+          spaceName: params.space_name,
+        });
+        if (resolvedSpace.status !== 'resolved') {
+          return { success: false, result: null, error: resolvedSpace.message };
+        }
+        const space = resolvedSpace.space;
 
         const [msg] = await db
           .insert(messages)

--- a/apps/api/src/lib/agent-tools.ts
+++ b/apps/api/src/lib/agent-tools.ts
@@ -81,6 +81,31 @@ export const AGENT_TOOLS: Anthropic.Tool[] = [
         assignee_name: { type: 'string', description: 'Assignee name' },
         due_date: { type: 'string', description: 'Due date in YYYY-MM-DD format' },
         description: { type: 'string', description: 'Task description' },
+        subtasks: {
+          type: 'array',
+          description:
+            'Optional real subtasks to create under this task. Use this when the user asks for subtasks, checklist items, child tasks, or a multi-step task breakdown. Do not put requested subtasks only in the description.',
+          items: {
+            type: 'object',
+            properties: {
+              title: { type: 'string', description: 'Subtask title' },
+              description: { type: 'string', description: 'Optional subtask description' },
+              assignee_name: { type: 'string', description: 'Optional subtask assignee name' },
+              due_date: { type: 'string', description: 'Optional due date in YYYY-MM-DD format' },
+              priority: {
+                type: 'string',
+                enum: ['p0', 'p1', 'p2', 'p3'],
+                description: 'Optional subtask priority',
+              },
+              depends_on: {
+                type: 'array',
+                items: { type: 'number' },
+                description: 'Optional 1-based numbers of earlier subtasks that must finish before this subtask.',
+              },
+            },
+            required: ['title'],
+          },
+        },
         source_message_id: {
           type: 'string',
           description:
@@ -710,6 +735,7 @@ export const ACTION_TOOLS = new Set([
   'update_task_status',
   'assign_task',
   'post_message',
+  'create_reminder',
   'add_knowledge',
   'wiki_write',
   // Task 3.4 — new task-mutation tools

--- a/apps/api/src/lib/mcp-tools/human.ts
+++ b/apps/api/src/lib/mcp-tools/human.ts
@@ -24,9 +24,9 @@ import { retrieveContext, type ContextResult } from '../retrieve-context.js';
 import { visibleTaskCondition } from '../task-visibility.js';
 import { visibleWikiPageCondition } from '../wiki-visibility.js';
 import { errorResult, textResult, type ToolResult } from './types.js';
-import { reserveNextTaskNumber } from '../task-numbering.js';
 import { enrichOAuthAuditActions } from '../oauth-audit-receipts.js';
 import { getTeamContext, getTeamProfile, listTeamSummaries } from './team-context.js';
+import { createTaskBundle, type TaskBundleSubtaskInput } from '../task-bundle.js';
 
 export type HumanToolContext = {
   org_id: string;
@@ -1756,6 +1756,7 @@ type HumanTaskCreateArgs = {
   start_date?: string;
   estimation?: string;
   source_message_id?: string;
+  subtasks?: TaskBundleSubtaskInput[];
   idempotency_key?: string;
 };
 
@@ -1789,35 +1790,36 @@ export async function humanTaskCreate(args: HumanTaskCreateArgs, ctx: HumanToolC
       if (messageError) return messageError;
     }
 
-    let taskNumber: number;
+    let bundle;
     try {
-      taskNumber = await reserveNextTaskNumber({ projectId: project.id, orgId: ctx.org_id });
-    } catch {
-      return errorResult('task_create: project not found');
+      bundle = await createTaskBundle({
+        orgId: ctx.org_id,
+        projectId: project.id,
+        projectPrefix: project.prefix ?? 'TASK',
+        projectName: project.name,
+        createdBy: ctx.user_id,
+        title,
+        description: args.description,
+        priority: ['p0', 'p1', 'p2', 'p3'].includes(args.priority ?? '') ? args.priority : 'p2',
+        assigneeId: assigneeResult.user?.id ?? null,
+        dueDate: dueDate as Date | null,
+        startDate: startDate as Date | null,
+        estimation: typeof args.estimation === 'string' && args.estimation.trim() ? args.estimation.trim() : null,
+        sourceMessageId,
+        subtasks: Array.isArray(args.subtasks) ? args.subtasks : null,
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return errorResult(msg);
     }
-    const [task] = await db.insert(tasks).values({
-      org_id: ctx.org_id,
-      project_id: project.id,
-      number: taskNumber,
-      title,
-      description: args.description ?? null,
-      priority: ['p0', 'p1', 'p2', 'p3'].includes(args.priority ?? '') ? args.priority as any : 'p2',
-      assignee_id: assigneeResult.user?.id ?? null,
-      created_by: ctx.user_id,
-      due_date: dueDate as Date | null,
-      start_date: startDate as Date | null,
-      estimation: typeof args.estimation === 'string' && args.estimation.trim() ? args.estimation.trim() : null,
-      source_message_id: sourceMessageId,
-    }).returning();
-    if (task) {
-      await db.insert(taskActivity).values({ org_id: ctx.org_id, task_id: task.id, user_id: ctx.user_id, action: 'created' });
-    }
+    const task = bundle.parent;
     return textResult({
       ...task,
-      task_key: taskReference(project.prefix, task?.number ?? null),
+      task_key: taskReference(project.prefix, task.number ?? null),
       project_name: project.name,
       assignee_name: assigneeResult.user?.name ?? null,
       assignee_email: assigneeResult.user?.email ?? null,
+      subtasks: bundle.subtasks,
     });
   });
 }

--- a/apps/api/src/lib/mcp-tools/index.ts
+++ b/apps/api/src/lib/mcp-tools/index.ts
@@ -378,7 +378,43 @@ export const toolSchemas: ToolSchema[] = [
           description: 'Optional source chat message id to link the created task back to the conversation.',
         },
         priority: { type: 'string', enum: ['p0', 'p1', 'p2', 'p3'] },
+        due_date: {
+          type: 'string',
+          description: 'Optional ISO date/timestamp for the parent task due date.',
+        },
+        start_date: {
+          type: 'string',
+          description: 'Optional ISO date/timestamp for the parent task start date.',
+        },
+        estimation: {
+          type: 'string',
+          description: 'Optional parent task estimate such as 30m, 2h, or 1d.',
+        },
         size: { type: 'string' },
+        subtasks: {
+          type: 'array',
+          description:
+            'Optional real subtasks to create under the parent task. Use this for child tasks/checklists; do not bury requested subtasks only in description text.',
+          items: {
+            type: 'object',
+            properties: {
+              title: { type: 'string' },
+              description: { type: 'string' },
+              assignee_id: { type: 'string' },
+              assignee_name: { type: 'string' },
+              priority: { type: 'string', enum: ['p0', 'p1', 'p2', 'p3'] },
+              due_date: { type: 'string' },
+              start_date: { type: 'string' },
+              estimation: { type: 'string' },
+              depends_on: {
+                type: 'array',
+                items: { type: 'number' },
+                description: 'Optional 1-based numbers of earlier subtasks that block this subtask.',
+              },
+            },
+            required: ['title'],
+          },
+        },
       },
       required: ['caller_employee_slug', 'title'],
     },

--- a/apps/api/src/lib/mcp-tools/writes.ts
+++ b/apps/api/src/lib/mcp-tools/writes.ts
@@ -44,9 +44,9 @@ import { generateReceipt } from '../receipts.js';
 import { checkReplyStorm, STORM_THRESHOLD } from '../storm-detector.js';
 import { getProjectResolvedConfig } from '../project-resolved-config.js';
 import { isValidTransition } from '../task-status-machine.js';
-import { reserveNextTaskNumber } from '../task-numbering.js';
 import { enqueue, QUEUE_NAMES } from '../queues.js';
 import { resolveAssigneeWithMatches } from '../resolve-assignee.js';
+import { createTaskBundle, type TaskBundleSubtaskInput } from '../task-bundle.js';
 
 /**
  * Phase 7 — Insert an "auto-executed" agent_actions row up front so that
@@ -236,7 +236,11 @@ export type TaskCreateArgs = {
   assignee_name?: string;
   priority?: string;
   size?: string;
+  due_date?: string;
+  start_date?: string;
+  estimation?: string;
   source_message_id?: string;
+  subtasks?: TaskBundleSubtaskInput[];
 };
 
 /**
@@ -336,49 +340,44 @@ export async function executeTaskCreate(
       assigneeId = resolved.value.id;
     }
 
-    const taskNumber = await reserveNextTaskNumber({
-      projectId,
+    const [project] = await db
+      .select({ prefix: projects.prefix, name: projects.name })
+      .from(projects)
+      .where(and(eq(projects.id, projectId), eq(projects.org_id, ctx.org_id)))
+      .limit(1);
+    if (!project) return errorResult('task_create: project not found');
+
+    const bundle = await createTaskBundle({
       orgId: ctx.org_id,
+      projectId,
+      projectPrefix: project.prefix,
+      projectName: project.name,
+      createdBy: shadowUserId,
+      title: args.title.trim(),
+      description: args.description,
+      priority,
+      assigneeId,
+      dueDate: args.due_date ?? null,
+      startDate: args.start_date ?? null,
+      estimation: args.estimation ?? args.size ?? null,
+      sourceMessageId: args.source_message_id ?? null,
+      actionId: opts?.actionId ?? null,
+      actingAgentEmployeeId: ctx.employee_id,
+      subtasks: Array.isArray(args.subtasks) ? args.subtasks : null,
     });
-
-    const [task] = await db
-      .insert(tasks)
-      .values({
-        org_id: ctx.org_id,
-        project_id: projectId,
-        number: taskNumber,
-        title: args.title.trim(),
-        description: args.description ?? null,
-        priority,
-        assignee_id: assigneeId,
-        created_by: shadowUserId,
-        source_message_id: args.source_message_id ?? null,
-      })
-      .returning();
-
-    await db.insert(taskActivity).values({
-      org_id: ctx.org_id,
-      task_id: task!.id,
-      user_id: shadowUserId,
-      action: 'created',
-      agent_action_id: opts?.actionId ?? null,
-      acting_agent_employee_id: ctx.employee_id,
-    });
+    const task = bundle.parent;
 
     try {
-      const [project] = await db
-        .select({ prefix: projects.prefix, name: projects.name })
-        .from(projects)
-        .where(eq(projects.id, projectId))
-        .limit(1);
       const { getIO } = await import('../../socket.js');
       const io = getIO();
       if (io) {
-        io.to(`org:${ctx.org_id}`).emit('task:created', {
-          ...task,
-          project_prefix: project?.prefix,
-          project_name: project?.name,
-        });
+        for (const createdTask of bundle.allTasks) {
+          io.to(`org:${ctx.org_id}`).emit('task:created', {
+            ...createdTask,
+            project_prefix: project.prefix,
+            project_name: project.name,
+          });
+        }
       }
     } catch {
       // Socket broadcast is best-effort in tests and headless workers.
@@ -386,8 +385,8 @@ export async function executeTaskCreate(
 
     try {
       await enqueue(QUEUE_NAMES.AGENT_JOBS, 'duplicate-detect', {
-        taskId: task!.id,
-        title: task!.title,
+        taskId: task.id,
+        title: task.title,
         projectId,
         orgId: ctx.org_id,
       });
@@ -398,15 +397,18 @@ export async function executeTaskCreate(
     invalidatePlatformContextCacheFor(ctx.employee_id);
 
     const resultPayload = {
-      id: task!.id,
-      project_id: task!.project_id,
-      number: task!.number,
-      title: task!.title,
-      status: task!.status,
-      priority: task!.priority,
-      assignee_id: task!.assignee_id,
-      source_message_id: task!.source_message_id,
-      created_at: task!.created_at,
+      id: task.id,
+      task_id: task.id,
+      project_id: task.project_id,
+      number: task.number,
+      identifier: task.identifier,
+      title: task.title,
+      status: task.status,
+      priority: task.priority,
+      assignee_id: task.assignee_id,
+      source_message_id: task.source_message_id,
+      created_at: task.created_at,
+      subtasks: bundle.subtasks,
     };
 
     if (!opts?.skipReceipt) {

--- a/apps/api/src/lib/resolve-space-target.ts
+++ b/apps/api/src/lib/resolve-space-target.ts
@@ -1,0 +1,113 @@
+import { and, eq } from 'drizzle-orm';
+import { spaces } from '@deft/db/schema';
+import { db } from './db.js';
+
+export type SpaceTargetRow = Pick<typeof spaces.$inferSelect, 'id' | 'name' | 'type' | 'is_archived'>;
+
+export type SpaceTargetResolution =
+  | { status: 'resolved'; space: SpaceTargetRow; requestedName?: string | null }
+  | { status: 'missing'; message: string; requestedName?: string | null }
+  | { status: 'ambiguous'; message: string; requestedName?: string | null; matches: SpaceTargetRow[] };
+
+export function normalizeSpaceTargetName(value: unknown): string {
+  if (typeof value !== 'string') return '';
+  return value
+    .trim()
+    .replace(/^#/, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+function formatSpaceName(space: Pick<SpaceTargetRow, 'name'>) {
+  return `#${space.name}`;
+}
+
+function hasTokenMatch(spaceKey: string, requestedKey: string) {
+  const tokens = spaceKey.split('-').filter(Boolean);
+  return tokens.includes(requestedKey) || spaceKey.includes(requestedKey);
+}
+
+export function resolveSpaceTargetFromRows(
+  rows: SpaceTargetRow[],
+  args: { spaceId?: unknown; spaceName?: unknown },
+): SpaceTargetResolution {
+  const requestedId = typeof args.spaceId === 'string' && args.spaceId.trim()
+    ? args.spaceId.trim()
+    : '';
+  const requestedName = typeof args.spaceName === 'string' && args.spaceName.trim()
+    ? args.spaceName.trim().replace(/^#/, '')
+    : null;
+  const activeRows = rows.filter((space) => !space.is_archived);
+
+  if (requestedId) {
+    const exactId = activeRows.find((space) => space.id === requestedId);
+    if (exactId) return { status: 'resolved', space: exactId, requestedName };
+    return {
+      status: 'missing',
+      requestedName,
+      message: `Space ${requestedId} was not found or is archived.`,
+    };
+  }
+
+  const requestedKey = normalizeSpaceTargetName(requestedName);
+  if (!requestedKey) {
+    return {
+      status: 'missing',
+      requestedName,
+      message: 'Choose a destination space before approving this post.',
+    };
+  }
+
+  const exactMatches = activeRows.filter((space) => normalizeSpaceTargetName(space.name) === requestedKey);
+  if (exactMatches.length === 1) {
+    return { status: 'resolved', space: exactMatches[0]!, requestedName };
+  }
+  if (exactMatches.length > 1) {
+    return {
+      status: 'ambiguous',
+      requestedName,
+      matches: exactMatches,
+      message: `Multiple spaces are named like "${requestedName}": ${exactMatches.map(formatSpaceName).join(', ')}. Choose one before approving.`,
+    };
+  }
+
+  const fuzzyMatches = activeRows
+    .filter((space) => space.type !== 'dm')
+    .filter((space) => hasTokenMatch(normalizeSpaceTargetName(space.name), requestedKey));
+
+  if (fuzzyMatches.length === 1) {
+    return { status: 'resolved', space: fuzzyMatches[0]!, requestedName };
+  }
+  if (fuzzyMatches.length > 1) {
+    return {
+      status: 'ambiguous',
+      requestedName,
+      matches: fuzzyMatches,
+      message: `Multiple spaces match "${requestedName}": ${fuzzyMatches.map(formatSpaceName).join(', ')}. Choose one before approving.`,
+    };
+  }
+
+  return {
+    status: 'missing',
+    requestedName,
+    message: `Space "${requestedName}" was not found. Choose an existing channel before approving.`,
+  };
+}
+
+export async function resolveSpaceTarget(
+  orgId: string,
+  args: { spaceId?: unknown; spaceName?: unknown },
+): Promise<SpaceTargetResolution> {
+  const rows = await db
+    .select({
+      id: spaces.id,
+      name: spaces.name,
+      type: spaces.type,
+      is_archived: spaces.is_archived,
+    })
+    .from(spaces)
+    .where(and(eq(spaces.org_id, orgId), eq(spaces.is_archived, false)));
+
+  return resolveSpaceTargetFromRows(rows, args);
+}

--- a/apps/api/src/lib/task-bundle.ts
+++ b/apps/api/src/lib/task-bundle.ts
@@ -1,0 +1,400 @@
+import { and, eq } from 'drizzle-orm';
+import { db } from './db.js';
+import { tasks, taskActivity, projects, taskRelationships } from '@deft/db/schema';
+import { reserveTaskNumberRange } from './task-numbering.js';
+import { resolveAssigneeWithMatches } from './resolve-assignee.js';
+
+const VALID_PRIORITY = new Set(['p0', 'p1', 'p2', 'p3']);
+const MAX_SUBTASKS_PER_DRAFT = 20;
+type TaskPriority = 'p0' | 'p1' | 'p2' | 'p3';
+
+export type TaskBundleSubtaskInput = {
+  title?: string;
+  description?: string;
+  assignee_id?: string;
+  assignee_name?: string;
+  priority?: string;
+  due_date?: string;
+  start_date?: string;
+  estimation?: string;
+  depends_on?: number[];
+};
+
+export type CreatedTaskSummary = {
+  id: string;
+  task_id: string;
+  project_id: string;
+  number: number;
+  identifier: string;
+  title: string;
+  description: string | null;
+  status: string;
+  priority: string;
+  assignee_id: string | null;
+  due_date: Date | null;
+  start_date: Date | null;
+  estimation: string | null;
+  source_message_id: string | null;
+  created_at: Date;
+  parent_task_id: string | null;
+};
+
+export type TaskBundleCreateParams = {
+  orgId: string;
+  projectId: string;
+  projectPrefix: string;
+  projectName?: string | null;
+  createdBy: string;
+  title: string;
+  description?: string | null;
+  priority?: TaskPriority | string | null;
+  assigneeId?: string | null;
+  dueDate?: Date | string | null;
+  startDate?: Date | string | null;
+  estimation?: string | null;
+  sourceMessageId?: string | null;
+  actionId?: string | null;
+  actingAgentEmployeeId?: string | null;
+  subtasks?: TaskBundleSubtaskInput[] | null;
+};
+
+export type TaskBundleCreateResult = {
+  parent: CreatedTaskSummary;
+  subtasks: CreatedTaskSummary[];
+  allTasks: CreatedTaskSummary[];
+};
+
+type NormalizedSubtask = {
+  title: string;
+  description: string | null;
+  assigneeId: string | null;
+  priority: TaskPriority;
+  dueDate: Date | null;
+  startDate: Date | null;
+  estimation: string | null;
+  dependsOn: number[];
+};
+
+export function normalizeTaskDescriptionForStorage(description: unknown): string | null {
+  if (typeof description !== 'string') return null;
+  const trimmed = description.trim();
+  if (!trimmed) return null;
+  if (/<(p|ul|ol|li|h[1-6]|blockquote|pre|div|br)\b/i.test(trimmed)) {
+    return trimmed;
+  }
+
+  const blocks: string[] = [];
+  let listItems: string[] = [];
+  let orderedItems: string[] = [];
+  let paragraphLines: string[] = [];
+
+  const flushParagraph = () => {
+    if (paragraphLines.length === 0) return;
+    blocks.push(`<p>${escapeHtml(paragraphLines.join(' ').replace(/\s+/g, ' ').trim())}</p>`);
+    paragraphLines = [];
+  };
+  const flushList = () => {
+    if (listItems.length > 0) {
+      blocks.push(`<ul>${listItems.map((item) => `<li>${escapeHtml(item)}</li>`).join('')}</ul>`);
+      listItems = [];
+    }
+    if (orderedItems.length > 0) {
+      blocks.push(`<ol>${orderedItems.map((item) => `<li>${escapeHtml(item)}</li>`).join('')}</ol>`);
+      orderedItems = [];
+    }
+  };
+
+  for (const rawLine of trimmed.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line) {
+      flushParagraph();
+      flushList();
+      continue;
+    }
+
+    const bullet = line.match(/^[-*]\s+(.+)$/);
+    if (bullet) {
+      flushParagraph();
+      if (orderedItems.length > 0) flushList();
+      listItems.push(bullet[1]!.trim());
+      continue;
+    }
+
+    const ordered = line.match(/^\d+[.)]\s+(.+)$/);
+    if (ordered) {
+      flushParagraph();
+      if (listItems.length > 0) flushList();
+      orderedItems.push(ordered[1]!.trim());
+      continue;
+    }
+
+    const heading = line.match(/^#{1,4}\s+(.+)$/) ?? line.match(/^([A-Za-z][A-Za-z0-9 /&-]{2,48}):$/);
+    if (heading) {
+      flushParagraph();
+      flushList();
+      blocks.push(`<h3>${escapeHtml((heading[1] ?? line).replace(/:$/, '').trim())}</h3>`);
+      continue;
+    }
+
+    flushList();
+    paragraphLines.push(line);
+  }
+
+  flushParagraph();
+  flushList();
+
+  return blocks.join('');
+}
+
+export function summarizeTaskBundleParams(params: {
+  title?: string;
+  description?: string;
+  subtasks?: TaskBundleSubtaskInput[] | null;
+}) {
+  const normalizedSubtasks = normalizeSubtaskInputs(params.subtasks);
+  return {
+    title: typeof params.title === 'string' ? params.title.trim() : '',
+    description: normalizeTaskDescriptionForStorage(params.description),
+    subtask_count: normalizedSubtasks.length,
+    subtasks: normalizedSubtasks.map((subtask) => ({
+      title: subtask.title,
+      priority: subtask.priority,
+      assignee_name: subtask.assignee_name ?? null,
+      due_date: subtask.due_date ?? null,
+    })),
+  };
+}
+
+export async function createTaskBundle(params: TaskBundleCreateParams): Promise<TaskBundleCreateResult> {
+  const title = params.title.trim();
+  if (!title) throw new Error('task_create requires title');
+
+  const [project] = await db
+    .select({ id: projects.id, prefix: projects.prefix, name: projects.name })
+    .from(projects)
+    .where(and(eq(projects.id, params.projectId), eq(projects.org_id, params.orgId)))
+    .limit(1);
+  if (!project) throw new Error('task_create: project not found');
+
+  validateTaskBundleSubtasks(params.subtasks);
+  const subtasks = await normalizeSubtasksForOrg(params.subtasks, params.orgId, params.priority);
+  const count = 1 + subtasks.length;
+  const created = await db.transaction(async (tx) => {
+    const range = await reserveTaskNumberRange({
+      projectId: params.projectId,
+      orgId: params.orgId,
+      count,
+      executor: tx as any,
+    });
+
+    const [parent] = await tx
+      .insert(tasks)
+      .values({
+        org_id: params.orgId,
+        project_id: params.projectId,
+        number: range.firstNumber,
+        title,
+        description: normalizeTaskDescriptionForStorage(params.description),
+        status: 'backlog',
+        priority: normalizePriority(params.priority, 'p2'),
+        assignee_id: params.assigneeId ?? null,
+        created_by: params.createdBy,
+        due_date: normalizeDate(params.dueDate),
+        start_date: normalizeDate(params.startDate),
+        estimation: normalizeOptionalString(params.estimation),
+        source_message_id: params.sourceMessageId ?? null,
+      })
+      .returning();
+
+    if (!parent) throw new Error('task_create: failed to create parent task');
+
+    const childRows: Array<typeof tasks.$inferSelect> = [];
+    for (let index = 0; index < subtasks.length; index += 1) {
+      const subtask = subtasks[index]!;
+      const [child] = await tx
+        .insert(tasks)
+        .values({
+          org_id: params.orgId,
+          project_id: params.projectId,
+          parent_task_id: parent.id,
+          number: range.firstNumber + index + 1,
+          title: subtask.title,
+          description: subtask.description,
+          status: 'backlog',
+          priority: subtask.priority,
+          assignee_id: subtask.assigneeId,
+          created_by: params.createdBy,
+          due_date: subtask.dueDate,
+          start_date: subtask.startDate,
+          estimation: subtask.estimation,
+          source_message_id: params.sourceMessageId ?? null,
+        })
+        .returning();
+      if (child) childRows.push(child);
+    }
+
+    const relationshipRows = subtasks.flatMap((subtask, index) =>
+      subtask.dependsOn.map((dependencyIndex) => ({
+        source_task_id: childRows[dependencyIndex - 1]!.id,
+        target_task_id: childRows[index]!.id,
+        type: 'blocks' as const,
+      })),
+    );
+    if (relationshipRows.length > 0) {
+      await tx.insert(taskRelationships).values(relationshipRows);
+    }
+
+    const activityRows = [parent, ...childRows].map((task) => ({
+      org_id: params.orgId,
+      task_id: task.id,
+      user_id: params.createdBy,
+      action: 'created',
+      agent_action_id: params.actionId ?? null,
+      acting_agent_employee_id: params.actingAgentEmployeeId ?? null,
+    }));
+    await tx.insert(taskActivity).values(activityRows);
+
+    return { parent, children: childRows };
+  });
+
+  const parentSummary = toCreatedTaskSummary(created.parent, project.prefix);
+  const subtaskSummaries = created.children.map((task) => toCreatedTaskSummary(task, project.prefix));
+  return {
+    parent: parentSummary,
+    subtasks: subtaskSummaries,
+    allTasks: [parentSummary, ...subtaskSummaries],
+  };
+}
+
+function normalizeSubtaskInputs(subtasks: TaskBundleSubtaskInput[] | null | undefined) {
+  if (!Array.isArray(subtasks)) return [];
+  return subtasks
+    .slice(0, MAX_SUBTASKS_PER_DRAFT)
+    .map((subtask) => {
+      const record = (subtask && typeof subtask === 'object' ? subtask : {}) as Partial<TaskBundleSubtaskInput>;
+      return {
+        ...record,
+        title: typeof record.title === 'string' ? record.title.trim() : '',
+        assignee_name: normalizeOptionalString(record.assignee_name) ?? undefined,
+        due_date: normalizeOptionalString(record.due_date) ?? undefined,
+      };
+    })
+    .filter((subtask) => subtask.title.length > 0);
+}
+
+export function validateTaskBundleSubtasks(subtasks: unknown): void {
+  if (subtasks === undefined || subtasks === null) return;
+  if (!Array.isArray(subtasks)) throw new Error('task_create: subtasks must be a list');
+  if (subtasks.length > MAX_SUBTASKS_PER_DRAFT) {
+    throw new Error(`task_create: no more than ${MAX_SUBTASKS_PER_DRAFT} subtasks are allowed`);
+  }
+  for (let index = 0; index < subtasks.length; index += 1) {
+    const subtask = subtasks[index];
+    if (!subtask || typeof subtask !== 'object' || Array.isArray(subtask)) {
+      throw new Error(`task_create: subtask ${index + 1} must be an object`);
+    }
+    const record = subtask as Record<string, unknown>;
+    if (typeof record.title !== 'string' || !record.title.trim()) {
+      throw new Error(`task_create: subtask ${index + 1} requires a title`);
+    }
+    if (record.subtasks !== undefined) {
+      throw new Error('task_create: nested subtasks are not supported');
+    }
+    if (record.depends_on !== undefined) {
+      if (!Array.isArray(record.depends_on) || record.depends_on.some((value) => !Number.isInteger(value))) {
+        throw new Error(`task_create: subtask ${index + 1} depends_on must contain subtask numbers`);
+      }
+      if (record.depends_on.some((value) => Number(value) < 1 || Number(value) > index)) {
+        throw new Error(`task_create: subtask ${index + 1} may depend only on an earlier subtask`);
+      }
+    }
+  }
+}
+
+async function normalizeSubtasksForOrg(
+  subtasks: TaskBundleSubtaskInput[] | null | undefined,
+  orgId: string,
+  inheritedPriority?: string | null,
+): Promise<NormalizedSubtask[]> {
+  const normalized = normalizeSubtaskInputs(subtasks);
+  const result: NormalizedSubtask[] = [];
+  for (const subtask of normalized) {
+    let assigneeId: string | null = null;
+    const assigneeLookup = normalizeOptionalString(subtask.assignee_id) ?? normalizeOptionalString(subtask.assignee_name);
+    if (assigneeLookup) {
+      const resolved = await resolveAssigneeWithMatches(assigneeLookup, orgId);
+      if (!resolved.ok) {
+        if (resolved.ambiguous) {
+          throw new Error(
+            `task_create: ambiguous subtask assignee "${assigneeLookup}". Matches: ${resolved.matches
+              .map((match) => match.name)
+              .join(', ')}`,
+          );
+        }
+        throw new Error(`task_create: subtask assignee "${assigneeLookup}" not found`);
+      }
+      assigneeId = resolved.value.id;
+    }
+    result.push({
+      title: subtask.title,
+      description: normalizeTaskDescriptionForStorage(subtask.description),
+      assigneeId,
+      priority: normalizePriority(subtask.priority, normalizePriority(inheritedPriority, 'p2')),
+      dueDate: normalizeDate(subtask.due_date),
+      startDate: normalizeDate(subtask.start_date),
+      estimation: normalizeOptionalString(subtask.estimation),
+      dependsOn: Array.isArray(subtask.depends_on) ? [...new Set(subtask.depends_on)] : [],
+    });
+  }
+  return result;
+}
+
+export function normalizePriority(value: unknown, fallback: TaskPriority = 'p2'): TaskPriority {
+  return typeof value === 'string' && VALID_PRIORITY.has(value) ? (value as TaskPriority) : fallback;
+}
+
+export function normalizeDate(value: unknown): Date | null {
+  if (!value) return null;
+  if (value instanceof Date) return Number.isFinite(value.getTime()) ? value : null;
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const parsed = new Date(trimmed);
+  return Number.isFinite(parsed.getTime()) ? parsed : null;
+}
+
+function normalizeOptionalString(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+function toCreatedTaskSummary(task: typeof tasks.$inferSelect, prefix: string): CreatedTaskSummary {
+  return {
+    id: task.id,
+    task_id: task.id,
+    project_id: task.project_id,
+    number: task.number,
+    identifier: `${prefix}-${task.number}`,
+    title: task.title,
+    description: task.description,
+    status: task.status,
+    priority: task.priority,
+    assignee_id: task.assignee_id,
+    due_date: task.due_date,
+    start_date: task.start_date,
+    estimation: task.estimation,
+    source_message_id: task.source_message_id,
+    created_at: task.created_at,
+    parent_task_id: task.parent_task_id,
+  };
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}

--- a/apps/api/test/resolve-space-target.test.ts
+++ b/apps/api/test/resolve-space-target.test.ts
@@ -1,0 +1,65 @@
+import { strict as assert } from 'node:assert';
+import test from 'node:test';
+import { resolveSpaceTargetFromRows, type SpaceTargetRow } from '../src/lib/resolve-space-target.js';
+
+function space(id: string, name: string, type = 'public'): SpaceTargetRow {
+  return { id, name, type, is_archived: false };
+}
+
+test('space target resolution uses exact space names before fuzzy aliases', () => {
+  const result = resolveSpaceTargetFromRows(
+    [
+      space('sales', 'sales'),
+      space('internal', 'sales-internal'),
+      space('leadership', 'sales-leadership'),
+    ],
+    { spaceName: 'sales' },
+  );
+
+  assert.equal(result.status, 'resolved');
+  if (result.status === 'resolved') {
+    assert.equal(result.space.id, 'sales');
+  }
+});
+
+test('space target resolution allows a single unambiguous channel alias', () => {
+  const result = resolveSpaceTargetFromRows(
+    [
+      space('buyers', 'sales-and-buyers'),
+      space('marketing', 'marketing'),
+    ],
+    { spaceName: '#sales' },
+  );
+
+  assert.equal(result.status, 'resolved');
+  if (result.status === 'resolved') {
+    assert.equal(result.space.id, 'buyers');
+  }
+});
+
+test('space target resolution refuses ambiguous channel aliases', () => {
+  const result = resolveSpaceTargetFromRows(
+    [
+      space('internal', 'sales-internal'),
+      space('leadership', 'sales-leadership'),
+      space('buyers', 'sales-and-buyers'),
+    ],
+    { spaceName: 'sales' },
+  );
+
+  assert.equal(result.status, 'ambiguous');
+  if (result.status === 'ambiguous') {
+    assert.equal(result.matches.length, 3);
+    assert.match(result.message, /Multiple spaces match "sales"/);
+  }
+});
+
+test('space target resolution reports missing spaces', () => {
+  const result = resolveSpaceTargetFromRows(
+    [space('marketing', 'marketing')],
+    { spaceName: 'sales' },
+  );
+
+  assert.equal(result.status, 'missing');
+  assert.match(result.message, /not found/);
+});

--- a/apps/api/test/task-bundle.test.ts
+++ b/apps/api/test/task-bundle.test.ts
@@ -1,0 +1,72 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { AGENT_TOOLS } from '../src/lib/agent-tools.js';
+import { toolSchemas } from '../src/lib/mcp-tools/index.js';
+import {
+  normalizeTaskDescriptionForStorage,
+  summarizeTaskBundleParams,
+  validateTaskBundleSubtasks,
+} from '../src/lib/task-bundle.js';
+
+test('task bundle description formatter turns plain bullet text into readable HTML', () => {
+  const html = normalizeTaskDescriptionForStorage(`Context:
+- First step
+- Second step
+
+Owner notes here.`);
+
+  assert.equal(
+    html,
+    '<h3>Context</h3><ul><li>First step</li><li>Second step</li></ul><p>Owner notes here.</p>',
+  );
+});
+
+test('task bundle summarizer keeps real subtasks out of description-only drafts', () => {
+  const summary = summarizeTaskBundleParams({
+    title: 'Launch buyer outreach',
+    description: 'Coordinate buyer launch follow-up.',
+    subtasks: [
+      { title: 'Draft buyer email', assignee_name: 'Lina', priority: 'p1' },
+      { title: 'Review pricing sheet', due_date: '2026-07-16' },
+      { title: '  ' },
+    ],
+  });
+
+  assert.equal(summary.title, 'Launch buyer outreach');
+  assert.equal(summary.subtask_count, 2);
+  assert.deepEqual(summary.subtasks, [
+    { title: 'Draft buyer email', priority: 'p1', assignee_name: 'Lina', due_date: null },
+    { title: 'Review pricing sheet', priority: undefined, assignee_name: null, due_date: '2026-07-16' },
+  ]);
+});
+
+test('Defty create_task tool advertises structured subtasks', () => {
+  const createTask = AGENT_TOOLS.find((tool) => tool.name === 'create_task');
+  assert.ok(createTask);
+  const properties = createTask.input_schema.properties as Record<string, unknown>;
+  assert.ok(properties.subtasks);
+});
+
+test('MCP task_create tool advertises structured subtasks', () => {
+  const taskCreate = toolSchemas.find((tool) => tool.name === 'task_create');
+  assert.ok(taskCreate);
+  const inputSchema = taskCreate.inputSchema as { properties?: Record<string, unknown> };
+  assert.ok(inputSchema.properties?.subtasks);
+});
+
+test('task bundles accept 1, 3, and 10 well-formed subtasks', () => {
+  for (const count of [1, 3, 10]) {
+    assert.doesNotThrow(() => validateTaskBundleSubtasks(Array.from({ length: count }, (_, index) => ({
+      title: `Step ${index + 1}`,
+      ...(index > 0 ? { depends_on: [index] } : {}),
+    }))));
+  }
+});
+
+test('task bundles reject malformed, nested, oversized, and forward dependencies', () => {
+  assert.throws(() => validateTaskBundleSubtasks([{ title: '' }]), /requires a title/);
+  assert.throws(() => validateTaskBundleSubtasks([{ title: 'Parent', subtasks: [{ title: 'Nested' }] }]), /nested subtasks/);
+  assert.throws(() => validateTaskBundleSubtasks(Array.from({ length: 21 }, (_, i) => ({ title: `Step ${i}` }))), /no more than 20/);
+  assert.throws(() => validateTaskBundleSubtasks([{ title: 'First', depends_on: [1] }]), /earlier subtask/);
+});


### PR DESCRIPTION
## Summary
- add one transactional task-bundle primitive for parent tasks, real subtasks, and dependency edges
- share bundle behavior across native Defty execution and both MCP task-create paths
- preserve formatted descriptions, task numbering, dates, estimates, receipts, audit rows, and socket events
- resolve message targets exactly and reject ambiguous channel aliases

## Validation
- focused task-bundle and target-resolution tests: 10/10
- API typecheck
- full API suite: 670/670

## Risk
Medium-high. This changes task creation internals, but keeps the public action/tool contracts compatible and adds focused regression coverage.