### PR TITLE
Wire Defty through the governed action runtime

### DIFF
--- a/apps/api/src/lib/agent-runner.ts
+++ b/apps/api/src/lib/agent-runner.ts
@@ -5,7 +5,7 @@
 
 import Anthropic from '@anthropic-ai/sdk';
 import { db } from './db.js';
-import { orgs, agentMemory, wikiPages } from '@deft/db/schema';
+import { orgs, agentMemory, users, wikiPages } from '@deft/db/schema';
 import { eq, and, or, desc, sql } from 'drizzle-orm';
 import { resolveReasonProvider, getOrgAIConfig } from './org-ai-config.js';
 import { createAgentMessage } from './agent-llm.js';
@@ -25,7 +25,7 @@ Rules:
 - Cite your sources (the tools return source IDs)
 - Be concise and direct
 - Before proposing a write action that names a person (assignee, mentioned user) or project, verify they exist using the appropriate search tool. If the named entity doesn't exist in this workspace, ASK the user to clarify rather than confidently proposing a write against a fabricated name. Never invent a project name to attach a task to — if the user hasn't named a project, OR explicitly says "no project", set project_name to "" (empty string). NEVER default to "General", "Inbox", "Default", or any other invented project name; there is no implicit default project. Same rule for assignee_name when unassigned.
-- For write actions (create_task, update_task_status, post_message), clearly explain what you'll do. When invoked from a chat mention, write actions are not executed immediately — they're queued for the user's approval, which appears as an Approve/Reject card on your reply and in the user's Inbox under the Approvals tab. Do NOT refer to an "Agent panel" or "Agent dashboard" — neither exists.
+- For registered write actions (including tasks, messages, wiki, notes, reminders, canvas, and decision links), clearly explain what you'll do. When invoked from a chat mention, writes are not executed immediately — they're queued for the user's approval, which appears as an Approve/Reject card on your reply and in the user's Inbox under the Approvals tab. Do NOT refer to an "Agent panel" or "Agent dashboard" — neither exists.
 - You are responding in a chat thread. Keep your reply as a single cohesive message.
 - Use markdown formatting (bold, lists, headers) for structure but keep it compact.
 - Do NOT narrate your tool usage. Do NOT say "I'll search for..." or "Let me look up..." — just use the tools silently and present your findings directly.
@@ -134,6 +134,8 @@ export async function runAgentQuery(params: {
     name: string;
     otherMemberName?: string;
   };
+  /** Bound ordinary interactive work without changing background-agent depth. */
+  maxIterations?: number;
 }): Promise<{
   text: string;
   citations: any[];
@@ -146,7 +148,14 @@ export async function runAgentQuery(params: {
   tokensIn: number;
   tokensOut: number;
   assistantBlocks: Anthropic.ContentBlock[] | null;
+  metrics: {
+    total_ms: number;
+    retrieval_ms: number;
+    reasoning_ms: number;
+    iterations: number;
+  };
 }> {
+  const runStartedAt = Date.now();
   const { content, orgId, userId, orgName, conversationHistory, mode = 'chat_mention', systemPromptOverride, agentEmployeeId } = params;
 
   // BYOK — resolve the org's chosen reasoning provider (anthropic | openai |
@@ -187,9 +196,17 @@ export async function runAgentQuery(params: {
     trustLevel = (params.trustLevelOverride || org?.trust_level || 'conservative') as TrustLevel;
   }
 
+  const [[orgClock], [userClock]] = await Promise.all([
+    db.select({ timezone: orgs.timezone }).from(orgs).where(eq(orgs.id, orgId)).limit(1),
+    db.select({ timezone: users.timezone }).from(users).where(eq(users.id, userId)).limit(1),
+  ]);
+  const workspaceTimezone = userClock?.timezone || orgClock?.timezone || 'UTC';
+  const nowIso = new Date().toISOString();
+
   let systemPrompt = SYSTEM_PROMPT
     .replace('{{DATE}}', new Date().toISOString().split('T')[0]!)
     .replace('{{ORG}}', orgName || 'Unknown') + connectionInfo;
+  systemPrompt += `\nCurrent time: ${nowIso}. User/workspace timezone: ${workspaceTimezone}. Resolve relative dates and times in this timezone unless the user explicitly supplies another one.`;
 
   // Surface context — let the agent adapt to DM vs channel.
   if (params.spaceContext) {
@@ -204,6 +221,7 @@ export async function runAgentQuery(params: {
   }
 
   // Auto-load relevant wiki context through the shared retrieval gateway.
+  const retrievalStartedAt = Date.now();
   try {
     const searchQuery = content.replace(/[^a-zA-Z0-9\s]/g, '').trim();
     if (searchQuery.length > 2) {
@@ -240,7 +258,7 @@ export async function runAgentQuery(params: {
               })),
             ))
             .orderBy(desc(wikiPages.updated_at))
-            .limit(3)
+            .limit(2)
         : [];
       const allRelevantPages = await retrieveContext({
         query: searchQuery,
@@ -248,25 +266,30 @@ export async function runAgentQuery(params: {
         user_id: userId,
         agent_employee_id: agentEmployeeId,
         types: ['wiki'],
-        limit: 5,
+        limit: 3,
       });
 
       if (exactWikiRows.length > 0) {
         const exactWikiContext = exactWikiRows.map((p) => {
           const summary = p.summary?.trim()
-            || p.content.replace(/\s+/g, ' ').slice(0, 900);
+            || p.content.replace(/\s+/g, ' ').slice(0, 500);
           return `- **${p.title}** (${p.type ?? 'wiki'}, slug: ${p.slug}, fresh exact match): ${summary}`;
         }).join('\n');
         systemPrompt += `\n\nFresh exact matches from the team wiki:\n${exactWikiContext}`;
       }
 
-      if (allRelevantPages.length > 0) {
-        const wikiContext = allRelevantPages.map((p) => {
+      const exactSlugs = new Set(exactWikiRows.map((page) => page.slug));
+      const uniqueRelevantPages = allRelevantPages.filter((page) => {
+        const slug = typeof page.metadata?.slug === 'string' ? page.metadata.slug : page.source_id;
+        return !exactSlugs.has(slug);
+      });
+      if (uniqueRelevantPages.length > 0) {
+        const wikiContext = uniqueRelevantPages.map((p) => {
           const type = typeof p.metadata?.type === 'string' ? p.metadata.type : 'wiki';
           const slug = typeof p.metadata?.slug === 'string' ? p.metadata.slug : p.source_id;
           const summary = typeof p.metadata?.summary === 'string' && p.metadata.summary.trim().length > 0
             ? p.metadata.summary.trim()
-            : p.content.replace(/\s+/g, ' ').slice(0, 600);
+            : p.content.replace(/\s+/g, ' ').slice(0, 350);
           return `- **${p.title}** (${type}, slug: ${slug}, confidence: ${p.confidence ?? 'unknown'}): ${summary}`;
         }).join('\n');
         systemPrompt += `\n\nRelevant knowledge from the team wiki:\n${wikiContext}\nUse wiki_search and wiki_read tools for more details.`;
@@ -276,12 +299,14 @@ export async function runAgentQuery(params: {
     // Non-critical: don't fail the agent reply if wiki auto-load errors
     console.warn('[agent-runner] Wiki auto-load failed:', (err as Error).message);
   }
+  const retrievalMs = Date.now() - retrievalStartedAt;
 
   // Apply system prompt override if provided (for agent employees)
   if (systemPromptOverride) {
     systemPrompt = systemPromptOverride
       .replace('{{DATE}}', new Date().toISOString().split('T')[0]!)
-      .replace('{{ORG}}', orgName || 'Unknown') + connectionInfo;
+      .replace('{{ORG}}', orgName || 'Unknown') + connectionInfo
+      + `\nCurrent time: ${nowIso}. User/workspace timezone: ${workspaceTimezone}. Resolve relative dates and times in this timezone unless the user explicitly supplies another one.`;
   }
 
   const reasonModel = reasonProvider.model;
@@ -317,7 +342,8 @@ export async function runAgentQuery(params: {
   let totalTokensOut = 0;
 
   let iterations = 0;
-  const maxIterations = params.mode === 'background' ? 25 : 8;
+  const maxIterations = params.maxIterations ?? (params.mode === 'background' ? 25 : 8);
+  const reasoningStartedAt = Date.now();
 
   // Task 3.10 — emit live step progress to the org room so the task-detail
   // UI can render a strip while the agent works. We don't know the true
@@ -537,5 +563,11 @@ export async function runAgentQuery(params: {
     tokensIn: totalTokensIn,
     tokensOut: totalTokensOut,
     assistantBlocks: lastResponseContent,
+    metrics: {
+      total_ms: Date.now() - runStartedAt,
+      retrieval_ms: retrievalMs,
+      reasoning_ms: Date.now() - reasoningStartedAt,
+      iterations,
+    },
   };
 }

--- a/apps/api/src/routes/agent.ts
+++ b/apps/api/src/routes/agent.ts
@@ -42,8 +42,97 @@ import {
   markWorkIntentFailedForAction,
   markWorkIntentsExpiredForActions,
 } from '../lib/work-intents.js';
+import { getIO } from '../socket.js';
+import { formatApprovalConfirmation } from '../lib/agent-action-confirmation.js';
 
 export const agentRoutes = new Hono();
+
+async function maybePostApprovalConfirmation(params: {
+  orgId: string;
+  actionMessageId: string | null;
+  actorUserId: string;
+}) {
+  if (!params.actionMessageId) return;
+
+  const [approvalMessage] = await db
+    .select({
+      id: messages.id,
+      space_id: messages.space_id,
+      parent_id: messages.parent_id,
+      user_id: messages.user_id,
+    })
+    .from(messages)
+    .where(and(
+      eq(messages.id, params.actionMessageId),
+      eq(messages.org_id, params.orgId),
+      eq(messages.is_deleted, false),
+    ))
+    .limit(1);
+  if (!approvalMessage) return;
+
+  const [existingConfirmation] = await db
+    .select({ id: messages.id })
+    .from(messages)
+    .where(and(
+      eq(messages.org_id, params.orgId),
+      eq(messages.space_id, approvalMessage.space_id),
+      sql`${messages.metadata}->>'approval_confirmation_for_message_id' = ${params.actionMessageId}`,
+    ))
+    .limit(1);
+  if (existingConfirmation) return;
+
+  const siblingActions = await db
+    .select()
+    .from(agentActions)
+    .where(and(
+      eq(agentActions.org_id, params.orgId),
+      eq(agentActions.message_id, params.actionMessageId),
+    ))
+    .orderBy(asc(agentActions.created_at));
+  if (siblingActions.length === 0) return;
+
+  const pendingCount = siblingActions.filter((row) => row.approval_status === 'pending').length;
+  if (pendingCount > 0) return;
+
+  const approvedActions = siblingActions.filter((row) => row.approval_status === 'approved');
+  if (approvedActions.length === 0) return;
+
+  const content = formatApprovalConfirmation(approvedActions);
+
+  const confirmationAuthorId = approvalMessage.user_id || params.actorUserId;
+  const [actor] = await db
+    .select({ name: users.name, avatar_url: users.avatar_url })
+    .from(users)
+    .where(eq(users.id, confirmationAuthorId))
+    .limit(1);
+
+  const [confirmation] = await db
+    .insert(messages)
+    .values({
+      org_id: params.orgId,
+      space_id: approvalMessage.space_id,
+      user_id: confirmationAuthorId,
+      content,
+      parent_id: approvalMessage.parent_id ?? null,
+      metadata: {
+        is_agent_reply: true,
+        subtype: 'approval_confirmation',
+        approval_confirmation_for_message_id: params.actionMessageId,
+        confirmed_action_ids: approvedActions.map((row) => row.id),
+        requested_by_user_id: params.actorUserId,
+      } as any,
+    })
+    .returning();
+
+  const io = getIO();
+  if (io && confirmation) {
+    io.to(`space:${approvalMessage.space_id}`).emit('message:new', {
+      ...confirmation,
+      user_name: actor?.name ?? 'Defty',
+      user_avatar: actor?.avatar_url ?? null,
+    });
+  }
+}
 
 function visibleCaptureActionSql(user: { id: string; org_id: string }) {
   return sql`(
@@ -1167,6 +1256,18 @@ agentRoutes.post('/actions/:id/approve', async (c) => {
         statusCode,
       );
     }
+    try {
+      await maybePostApprovalConfirmation({
+        orgId: user.org_id,
+        actionMessageId: action.message_id,
+        actorUserId: action.user_id,
+      });
+    } catch (err) {
+      console.warn('[agent-routes] Failed to post approval confirmation', {
+        actionId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
     return c.json({
       status: result.status,
       message: 'message' in result ? result.message : undefined,
@@ -1175,6 +1276,9 @@ agentRoutes.post('/actions/:id/approve', async (c) => {
   }
 
   if (action.approval_status === 'approved') {
+    if ((action.result as any)?.lifecycle_state === 'executing') {
+      return c.json({ status: 'executing', message: 'execution is already in progress' }, 202);
+    }
     return c.json({ status: 'approved', message: 'already approved', result: action.result ?? undefined });
   }
   if (action.approval_status === 'rejected') {
@@ -1189,7 +1293,12 @@ agentRoutes.post('/actions/:id/approve', async (c) => {
 
   const [claimedAction] = await db
     .update(agentActions)
-    .set({ approval_status: 'approved', approved_at: new Date() })
+    .set({
+      approval_status: 'approved',
+      approved_at: new Date(),
+      result: { lifecycle_state: 'executing', started_at: new Date().toISOString() } as any,
+      error: null,
+    })
     .where(and(
       eq(agentActions.id, actionId),
       eq(agentActions.org_id, user.org_id),
@@ -1214,6 +1323,9 @@ agentRoutes.post('/actions/:id/approve', async (c) => {
       ))
       .limit(1);
     if (winner?.approval_status === 'approved') {
+      if ((winner.result as any)?.lifecycle_state === 'executing') {
+        return c.json({ status: 'executing', message: 'execution is already in progress' }, 202);
+      }
       return c.json({ status: 'approved', message: 'already approved', result: winner.result ?? undefined });
     }
     if (winner?.approval_status === 'rejected') {
@@ -1250,7 +1362,12 @@ agentRoutes.post('/actions/:id/approve', async (c) => {
   if (execResult.success) {
     await db
       .update(agentActions)
-      .set({ approval_status: 'approved', approved_at: new Date() })
+      .set({
+        approval_status: 'approved',
+        approved_at: new Date(),
+        result: execResult.result as any,
+        error: null,
+      })
       .where(eq(agentActions.id, actionId));
     if (action.source === 'defty_capture') {
       await generateReceipt({
@@ -1273,12 +1390,29 @@ agentRoutes.post('/actions/:id/approve', async (c) => {
         convertedBy: user.id,
       });
     }
+    try {
+      await maybePostApprovalConfirmation({
+        orgId: user.org_id,
+        actionMessageId: action.message_id,
+        actorUserId: action.user_id,
+      });
+    } catch (err) {
+      console.warn('[agent-routes] Failed to post approval confirmation', {
+        actionId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
   } else {
     await db
       .update(agentActions)
       .set({
         approval_status: 'pending',
         approved_at: null,
+        result: {
+          lifecycle_state: 'failed',
+          failed_at: new Date().toISOString(),
+          retryable: true,
+        } as any,
         error: execResult.error ?? 'Action failed',
       })
       .where(eq(agentActions.id, actionId));

--- a/apps/api/src/routes/messages.ts
+++ b/apps/api/src/routes/messages.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import { z } from 'zod';
-import { eq, and, desc, lt, lte, gt, sql, isNull, inArray } from 'drizzle-orm';
+import { eq, and, desc, lt, lte, gt, sql, isNull, inArray, ne } from 'drizzle-orm';
 import { db } from '../lib/db.js';
 import { messages, users, reactions, spaces, spaceMembers, orgs, threadReads, messageVersions, agentEmployees, userGroups, userGroupMembers, orgMembers } from '@deft/db/schema';
 import { getIO, emitToUser } from '../socket.js';
@@ -706,6 +706,7 @@ messageRoutes.post('/:spaceId', async (c) => {
           .where(and(
             eq(agentEmployees.org_id, user.org_id),
             eq(agentEmployees.is_active, true),
+            ne(agentEmployees.runtime_kind, 'defty_system'),
             inArray(agentEmployees.user_id, Array.from(targetUserIds)),
           ));
 

--- a/apps/api/src/workers/handlers/agent-reply.ts
+++ b/apps/api/src/workers/handlers/agent-reply.ts
@@ -1,26 +1,468 @@
 // Handler: process @agent/@deft mentions in chat and generate AI replies in-thread
 import type { JobData } from '../types.js';
 import { db } from '../../lib/db.js';
-import { messages, users, spaces, spaceMembers, agentActions } from '@deft/db/schema';
+import { messages, users, spaces, spaceMembers, projects, projectSpaces, tasks, wikiPages, notes } from '@deft/db/schema';
 import { getApprovalTier } from '../../lib/agent-approval.js';
-import { eq, and, desc, sql, ne, lt } from 'drizzle-orm';
+import { eq, and, desc, sql, ne, lt, ilike, inArray } from 'drizzle-orm';
 import { getIO } from '../../socket.js';
 import { runAgentQuery } from '../../lib/agent-runner.js';
 import { ensureDeftyMembership, DEFTY_NAME } from '../../lib/ensure-defty-membership.js';
 import { toPlainText, truncatePlainText } from '../../lib/plain-text.js';
+import { resolveSpaceTarget } from '../../lib/resolve-space-target.js';
+import { resolveAssigneeWithMatches } from '../../lib/resolve-assignee.js';
+import {
+  compileDeftyActionDraft,
+  persistAgentReplyWithActions,
+  validateRegisteredProposalAction,
+} from '../../lib/agent-action-proposals.js';
 
-function extractExplicitCreateTaskAction(content: string, sourceMessageId: string) {
-  const title = content.match(/\b(?:task|todo|ticket)\s+(?:titled|called|named)\s+"([^"]+)"/i)?.[1]
-    ?? content.match(/\b(?:task|todo|ticket)\s+(?:titled|called|named)\s+'([^']+)'/i)?.[1];
-  const projectName = content.match(/\bproject\s+"([^"]+)"/i)?.[1]
-    ?? content.match(/\bproject\s+'([^']+)'/i)?.[1];
+function stripMentionSyntax(content: string): string {
+  return toPlainText(content)
+    .replace(/<@[a-zA-Z0-9_-]+(?:\|[^>]+)?>/g, '')
+    .replace(/@(agent|defty|deft)\b/gi, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
 
-  if (!title || !projectName || !/\b(create|add|make|open|track)\b/i.test(content)) {
+function hasExplicitCreateTaskIntent(content: string): boolean {
+  const plain = stripMentionSyntax(content);
+  const positive =
+    /\b(?:create|add|make|open|track)\b.{0,80}\b(?:task|todo|ticket)\b/i.test(plain) ||
+    /\b(?:task|todo|ticket)\b.{0,40}\b(?:needs? to|should|for)\b/i.test(plain);
+  if (!positive) return false;
+
+  return !/\b(?:do\s+not|don't|dont|never|without|avoid|no\s+need\s+to)\s+(?:\S+\s+){0,6}?(?:create|creating|make|making|add|adding|open|opening|track|tracking)\s+(?:\S+\s+){0,6}?(?:task|todo|ticket)s?\b/i.test(plain);
+}
+
+export function hasExplicitRegisteredWriteIntent(content: string): boolean {
+  const plain = stripMentionSyntax(content);
+  const asksForChange = /\b(?:create|add|make|open|track|write|save|record|capture|post|send|put|share|update|edit|change|set|mark|move|close|reopen|assign|comment|label|link|unlink|remove|promote|convert)\b/i.test(plain);
+  const namesWorkspaceObject =
+    /\b(?:tasks?|todos?|tickets?|subtasks?|messages?|announcements?|channels?|spaces?|wiki|pages?|knowledge|facts?|decisions?|resources?|notes?|canvas|reminders?|status|assignees?|priorities|due dates?|labels?|dependencies|thread replies)\b/i.test(plain) ||
+    /\b(?:post|send|put|share)\b.{0,80}(?:#|\bchannel\s+|\bspace\s+)[a-z0-9]/i.test(plain);
+  if (!asksForChange || !namesWorkspaceObject) return false;
+
+  if (/\b(?:do\s+not|don't|dont|never)\s+(?:create|queue|post|send|write|save|record|update|edit|change|mark|move|close|assign)(?:\s+or\s+(?:create|queue|post|send|write|update))?\s+(?:any\s+)?(?:tasks?|actions?|changes?|messages?|posts?|pages?|notes?|reminders?)\b/i.test(plain)) {
+    return false;
+  }
+
+  return !/\b(?:do\s+not|don't|dont|never|without|avoid|no\s+need\s+to)\s+(?:\S+\s+){0,6}?(?:create|add|make|write|save|record|capture|post|send|update|edit|change|set|mark|move|close|reopen|assign|link|remove)\b/i.test(plain);
+}
+
+function titleCaseTaskFragment(value: string): string {
+  const cleaned = value
+    .replace(/\b(?:a|an|the)\s+/i, '')
+    .replace(/\b(?:needs?|should|has)\s+to\s+(?:go\s+out\s+to\s+)?/i, '')
+    .replace(/\b(?:please|pls)\b/gi, '')
+    .replace(/\s+[-:]\s*$/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (!cleaned) return '';
+  return cleaned
+    .split(/\s+/)
+    .map((word) => {
+      if (/^[A-Z0-9-]{2,}$/.test(word)) return word;
+      return word.charAt(0).toUpperCase() + word.slice(1);
+    })
+    .join(' ');
+}
+
+function inferTaskTitle(content: string): string | null {
+  const plain = stripMentionSyntax(content);
+  const quoted = plain.match(/\b(?:task|todo|ticket)\s+(?:titled|called|named)\s+"([^"]+)"/i)?.[1]
+    ?? plain.match(/\b(?:task|todo|ticket)\s+(?:titled|called|named)\s+'([^']+)'/i)?.[1]
+    ?? plain.match(/\bname\s+(?:it|this|the\s+(?:task|todo|ticket))\s+"([^"]+)"/i)?.[1]
+    ?? plain.match(/\bname\s+(?:it|this|the\s+(?:task|todo|ticket))\s+'([^']+)'/i)?.[1];
+  if (quoted?.trim()) return truncatePlainText(quoted.trim(), 80);
+
+  const subject =
+    plain.match(/\bname\s+(?:it|this|the\s+(?:task|todo|ticket))\s+(.+?)(?:\s+(?:and|assign|assigned|due|with|by|for)\b|[.;\n]|$)/i)?.[1] ??
+    plain.match(/\b(?:task|todo|ticket)\s+(?:for|about|to)\s+(.+?)(?:\s+(?:assigned?|assign|due|with|by|for)\b|[.;\n]|$)/i)?.[1] ??
+    plain.match(/\b(?:create|add|make|open|track)\b.{0,30}\b(?:task|todo|ticket)(?:\s+draft)?\s+(?:from|for|about|to)\s+(.+?)(?:\s+(?:assigned?|assign|due|with|by|for)\b|[.;\n]|$)/i)?.[1] ??
+    plain.match(/\b(?:create|add|make|open|track)\b.{0,30}\b(?:task|todo|ticket)\b(?:\s+with\s+[^.]+)?[.;]\s*(.+?)(?:\s+(?:assigned?|assign|due|with|by|for)\b|[.;\n]|$)/i)?.[1] ??
+    plain.match(/\b(?:a|an|the)\s+(.+?)\s+(?:needs?|should|has)\s+to\s+(?:go\s+out\s+to\s+)?(.+?)(?:\s+(?:assigned?|assign|due|with|by)\b|[.;\n]|$)/i)?.slice(1).filter(Boolean).join(' to ');
+
+  const title = titleCaseTaskFragment(subject ?? '');
+  return title ? truncatePlainText(title, 80) : null;
+}
+
+function inferAssigneeName(content: string): string | undefined {
+  const plain = stripMentionSyntax(content);
+  const match =
+    plain.match(/\bassign(?:\s+it)?\s+to\s+([^.;\n]+?)(?:\s+(?:and|with|for|by|due)\b|[.;\n]|$)/i)?.[1] ??
+    plain.match(/\bassign\s+((?!(?:and|with|for|by|due)\b)[\p{L}][\p{L}.'-]*(?:\s+(?!(?:and|with|for|by|due)\b)[\p{L}][\p{L}.'-]*)?)(?=\s+(?:and|with|for|by|due)\b|[.;\n]|$)/iu)?.[1] ??
+    plain.match(/\bassigned\s+to\s+([^.;\n]+?)(?:\s+(?:and|with|for|by|due)\b|[.;\n]|$)/i)?.[1] ??
+    plain.match(/\b(?:next\s+(?:monday|tuesday|wednesday|thursday|friday|saturday|sunday)|tomorrow|today|\d{4}-\d{2}-\d{2})\s+to\s+([^.;\n]+?)(?:\s+(?:and|with|for|by|due)\b|[.;\n]|$)/i)?.[1] ??
+    plain.match(/\bfor\s+([A-Z][a-z]+(?:\s+[A-Z][a-z]+)?)(?:\s+(?:by|due|to|with)\b|[.;\n]|$)/)?.[1];
+  return match?.trim();
+}
+
+function nextWeekdayIso(now: Date, weekday: number): string {
+  const date = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+  const current = date.getUTCDay();
+  let delta = (weekday - current + 7) % 7;
+  if (delta === 0) delta = 7;
+  date.setUTCDate(date.getUTCDate() + delta);
+  return date.toISOString().slice(0, 10);
+}
+
+function addDaysIso(now: Date, days: number): string {
+  const date = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+  date.setUTCDate(date.getUTCDate() + days);
+  return date.toISOString().slice(0, 10);
+}
+
+function inferDueDate(content: string, now = new Date()): string | undefined {
+  const plain = stripMentionSyntax(content);
+  const iso = plain.match(/\b(\d{4}-\d{2}-\d{2})\b/)?.[1];
+  if (iso) return iso;
+  if (/\btoday\b/i.test(plain)) return addDaysIso(now, 0);
+  if (/\btomorrow\b/i.test(plain)) return addDaysIso(now, 1);
+  if (/\bnext\s+monday\b/i.test(plain)) return nextWeekdayIso(now, 1);
+  if (/\bnext\s+tuesday\b/i.test(plain)) return nextWeekdayIso(now, 2);
+  if (/\bnext\s+wednesday\b/i.test(plain)) return nextWeekdayIso(now, 3);
+  if (/\bnext\s+thursday\b/i.test(plain)) return nextWeekdayIso(now, 4);
+  if (/\bnext\s+friday\b/i.test(plain)) return nextWeekdayIso(now, 5);
+  if (/\bnext\s+saturday\b/i.test(plain)) return nextWeekdayIso(now, 6);
+  if (/\bnext\s+sunday\b/i.test(plain)) return nextWeekdayIso(now, 0);
+  return undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, any> {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value));
+}
+
+async function resolvePendingActionTargets(
+  orgId: string,
+  userId: string,
+  sourceSpaceId: string,
+  actions: any[],
+): Promise<{ actions: any[]; warnings: string[] }> {
+  const resolvedActions: any[] = [];
+  const warnings: string[] = [];
+
+  for (const action of actions) {
+    if (!isRecord(action?.params)) {
+      resolvedActions.push(action);
+      continue;
+    }
+
+    if (action.action === 'create_task') {
+      const params = action.params;
+      let projectName = typeof params.project_name === 'string' ? params.project_name.trim() : '';
+      if (!projectName) {
+        projectName = await resolveProjectNameForMentionFallback(
+          orgId,
+          typeof params.source_space_id === 'string' ? params.source_space_id : sourceSpaceId,
+          [params.title, params.description].filter(Boolean).join('\n'),
+        ) ?? '';
+      }
+
+      if (!projectName) {
+        warnings.push('I need the target project before I can create the task approval card.');
+        continue;
+      }
+
+      const [project] = await db
+        .select({ id: projects.id, name: projects.name })
+        .from(projects)
+        .where(and(
+          eq(projects.org_id, orgId),
+          ilike(projects.name, projectName),
+          eq(projects.is_archived, false),
+          eq(projects.is_deleted, false),
+        ))
+        .limit(1);
+      if (!project) {
+        warnings.push(`I could not find an active project named "${projectName}".`);
+        continue;
+      }
+
+      if (typeof params.assignee_name === 'string' && params.assignee_name.trim()) {
+        const resolvedAssignee = await resolveAssigneeWithMatches(params.assignee_name.trim(), orgId);
+        if (!resolvedAssignee.ok) {
+          if (resolvedAssignee.ambiguous) {
+            warnings.push(`I need the exact assignee. "${params.assignee_name}" matches: ${resolvedAssignee.matches.map((m) => m.name).join(', ')}.`);
+          } else {
+            warnings.push(`I could not find a workspace member named "${params.assignee_name}".`);
+          }
+          continue;
+        }
+      }
+
+      resolvedActions.push({
+        ...action,
+        params: {
+          ...params,
+          project_name: project.name,
+          resolved_project_id: project.id,
+        },
+      });
+      continue;
+    }
+
+    if (action.action === 'update_task_status') {
+      const taskIdentifier = typeof action.params.task_identifier === 'string'
+        ? action.params.task_identifier.trim()
+        : '';
+      const newStatus = typeof action.params.new_status === 'string'
+        ? action.params.new_status.trim()
+        : '';
+      if (!taskIdentifier) {
+        warnings.push('I need the exact task id before I can create the status-update approval card.');
+        continue;
+      }
+      if (!['backlog', 'todo', 'in_progress', 'in_review', 'done', 'cancelled'].includes(newStatus)) {
+        warnings.push(`I need a valid target status for ${taskIdentifier}: backlog, todo, in_progress, in_review, done, or cancelled.`);
+        continue;
+      }
+
+      let resolvedTaskId = '';
+      const shorthand = taskIdentifier.match(/^([A-Z]+)-(\d+)$/i);
+      if (shorthand) {
+        const [project] = await db
+          .select({ id: projects.id })
+          .from(projects)
+          .where(and(eq(projects.org_id, orgId), eq(projects.prefix, shorthand[1]!.toUpperCase())))
+          .limit(1);
+        if (project) {
+          const [foundTask] = await db
+            .select({ id: tasks.id })
+            .from(tasks)
+            .where(and(
+              eq(tasks.org_id, orgId),
+              eq(tasks.project_id, project.id),
+              eq(tasks.number, Number.parseInt(shorthand[2]!, 10)),
+            ))
+            .limit(1);
+          resolvedTaskId = foundTask?.id ?? '';
+        }
+      } else {
+        const [foundTask] = await db
+          .select({ id: tasks.id })
+          .from(tasks)
+          .where(and(eq(tasks.org_id, orgId), eq(tasks.id, taskIdentifier)))
+          .limit(1);
+        resolvedTaskId = foundTask?.id ?? '';
+      }
+
+      if (!resolvedTaskId) {
+        warnings.push(`I could not find task "${taskIdentifier}" in this workspace.`);
+        continue;
+      }
+
+      resolvedActions.push({
+        ...action,
+        params: {
+          ...action.params,
+          task_identifier: shorthand ? taskIdentifier.toUpperCase() : taskIdentifier,
+          resolved_task_id: resolvedTaskId,
+        },
+      });
+      continue;
+    }
+
+    if (action.action === 'post_message') {
+      const resolution = await resolveSpaceTarget(orgId, {
+        spaceId: action.params.space_id ?? action.params.resolved_space_id,
+        spaceName: action.params.space_name,
+      });
+
+      if (resolution.status !== 'resolved') {
+        warnings.push(resolution.message);
+        continue;
+      }
+
+      const requestedName = typeof action.params.space_name === 'string'
+        ? action.params.space_name.trim().replace(/^#/, '')
+        : null;
+      resolvedActions.push({
+        ...action,
+        params: {
+          ...action.params,
+          space_id: resolution.space.id,
+          space_name: resolution.space.name,
+          requested_space_name: requestedName && requestedName !== resolution.space.name
+            ? requestedName
+            : action.params.requested_space_name,
+        },
+      });
+      continue;
+    }
+
+    if (action.action === 'wiki_write') {
+      const params = action.params;
+      const requestedSlug = typeof params.slug === 'string' ? params.slug.trim() : '';
+      const requestedTitle = typeof params.title === 'string' ? params.title.trim() : '';
+      const candidateSlug = requestedTitle
+        ? requestedTitle.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '')
+        : '';
+      const [existingPage] = requestedSlug || requestedTitle
+        ? await db
+          .select({ id: wikiPages.id, slug: wikiPages.slug, title: wikiPages.title, scope: wikiPages.scope, space_id: wikiPages.space_id })
+          .from(wikiPages)
+          .where(and(
+            eq(wikiPages.org_id, orgId),
+            eq(wikiPages.is_deleted, false),
+            requestedSlug
+              ? eq(wikiPages.slug, requestedSlug)
+              : sql`(lower(${wikiPages.title}) = lower(${requestedTitle}) OR ${wikiPages.slug} = ${candidateSlug})`,
+          ))
+          .limit(1)
+        : [];
+      if (requestedSlug && !existingPage) {
+        warnings.push(`I could not find wiki page "${requestedSlug}".`);
+        continue;
+      }
+      if (existingPage?.scope === 'space' && existingPage.space_id) {
+        const [membership] = await db.select({ user_id: spaceMembers.user_id }).from(spaceMembers).where(and(
+          eq(spaceMembers.space_id, existingPage.space_id),
+          eq(spaceMembers.user_id, userId),
+        )).limit(1);
+        if (!membership) {
+          warnings.push(`You do not have access to update wiki page "${existingPage.title}".`);
+          continue;
+        }
+      }
+      resolvedActions.push({
+        ...action,
+        params: {
+          ...params,
+          ...(existingPage ? {
+            slug: existingPage.slug,
+            title: existingPage.title,
+            wiki_write_mode: 'update',
+            resolved_wiki_page_id: existingPage.id,
+          } : { wiki_write_mode: 'create' }),
+        },
+      });
+      continue;
+    }
+
+    if (action.action === 'create_note' && action.params.visibility === 'space') {
+      const spaceId = typeof action.params.visibility_space_id === 'string' ? action.params.visibility_space_id : '';
+      const [targetSpace] = spaceId ? await db.select({ id: spaces.id, name: spaces.name }).from(spaces).innerJoin(
+        spaceMembers,
+        and(eq(spaceMembers.space_id, spaces.id), eq(spaceMembers.user_id, userId)),
+      ).where(and(
+        eq(spaces.id, spaceId),
+        eq(spaces.org_id, orgId),
+        eq(spaces.is_archived, false),
+      )).limit(1) : [];
+      if (!targetSpace) {
+        warnings.push('I could not verify access to the target space for this note.');
+        continue;
+      }
+      resolvedActions.push(action);
+      continue;
+    }
+
+    if (action.action === 'note_to_wiki') {
+      const noteId = typeof action.params.note_id === 'string' ? action.params.note_id : '';
+      const [visibleNote] = noteId ? await db.select({ id: notes.id, title: notes.title }).from(notes).where(and(
+        eq(notes.id, noteId),
+        eq(notes.org_id, orgId),
+        eq(notes.is_deleted, false),
+        sql`(
+          ${notes.user_id} = ${userId}
+          OR ${notes.visibility} = 'org'
+          OR (${notes.visibility} = 'space' AND EXISTS (
+            SELECT 1 FROM space_members sm
+            WHERE sm.space_id = ${notes.visibility_space_id} AND sm.user_id = ${userId}
+          ))
+        )`,
+      )).limit(1) : [];
+      if (!visibleNote) {
+        warnings.push('I could not find that note or you do not have access to it.');
+        continue;
+      }
+      resolvedActions.push({ ...action, params: { ...action.params, resolved_note_title: visibleNote.title } });
+      continue;
+    }
+
+    if (action.action === 'link_decision_to_tasks' || action.action === 'mark_decision_implemented') {
+      const decisionId = typeof action.params.decision_id === 'string' ? action.params.decision_id : '';
+      const [decision] = decisionId ? await db.select({ id: wikiPages.id, title: wikiPages.title }).from(wikiPages).where(and(
+        eq(wikiPages.id, decisionId),
+        eq(wikiPages.org_id, orgId),
+        eq(wikiPages.type, 'decision'),
+        eq(wikiPages.is_deleted, false),
+      )).limit(1) : [];
+      if (!decision) {
+        warnings.push('I could not find that active decision in this workspace.');
+        continue;
+      }
+      if (action.action === 'link_decision_to_tasks') {
+        const taskIds = Array.isArray(action.params.task_ids)
+          ? action.params.task_ids.filter((id: unknown): id is string => typeof id === 'string')
+          : [];
+        const foundTasks = taskIds.length ? await db.select({ id: tasks.id }).from(tasks).where(and(
+          eq(tasks.org_id, orgId),
+          inArray(tasks.id, taskIds),
+        )) : [];
+        if (foundTasks.length !== taskIds.length) {
+          warnings.push('One or more selected tasks no longer exist in this workspace.');
+          continue;
+        }
+      }
+      resolvedActions.push({ ...action, params: { ...action.params, resolved_decision_title: decision.title } });
+      continue;
+    }
+
+    resolvedActions.push(action);
+  }
+
+  return { actions: resolvedActions, warnings };
+}
+
+function buildTargetClarificationMessage(warnings: string[]) {
+  const uniqueWarnings = [...new Set(warnings)].filter(Boolean);
+  if (uniqueWarnings.length === 0) return '';
+  return [
+    'I need one clarification before I can create the approval card.',
+    ...uniqueWarnings.map((warning) => `- ${warning}`),
+    'Reply with the missing detail or a narrower request and I will draft it again.',
+  ].join('\n');
+}
+
+const MAX_INLINE_APPROVAL_ACTIONS = 3;
+const INLINE_STATUS_UPDATE_APPROVAL_TIER = 'quick' as const;
+
+function normalizePendingApprovalTier(action: any) {
+  const approvalTier = action?.approval_tier ?? getApprovalTier(action?.action);
+  return {
+    ...action,
+    approval_tier: approvalTier === 'auto' ? 'quick' : approvalTier,
+  };
+}
+
+export function extractExplicitCreateTaskAction(
+  content: string,
+  sourceMessageId: string,
+  options: { projectName?: string | null; now?: Date; callerName?: string | null } = {},
+) {
+  if (!hasExplicitCreateTaskIntent(content)) {
     return null;
   }
 
-  const assigneeName = content.match(/\bassigned to\s+([^.;\n]+?)(?:\s+(?:and|with|for|due)\b|[.;\n]|$)/i)?.[1]?.trim();
-  const description = content.replace(/<[^>]+>/g, '').replace(/\s+/g, ' ').trim();
+  const title = inferTaskTitle(content);
+  if (!title) return null;
+
+  const explicitProjectName = content.match(/\bproject\s+"([^"]+)"/i)?.[1]
+    ?? content.match(/\bproject\s+'([^']+)'/i)?.[1]
+    ?? content.match(/\bin\s+(?:the\s+)?([A-Za-z][A-Za-z0-9 &+_-]{2,80})\s+project\b/i)?.[1];
+  const projectName = explicitProjectName && /^[A-Z]/.test(explicitProjectName.trim())
+    ? explicitProjectName.trim()
+    : options.projectName ?? explicitProjectName?.trim() ?? undefined;
+  if (!projectName) return null;
+
+  const inferredAssigneeName = inferAssigneeName(content);
+  const normalizedAssigneeToken = inferredAssigneeName?.replace(/[?!.,;:]+$/g, '').trim();
+  const assigneeName = normalizedAssigneeToken && /^(?:me|myself)$/i.test(normalizedAssigneeToken)
+    ? options.callerName ?? undefined
+    : inferredAssigneeName;
+  const dueDate = inferDueDate(content, options.now);
+  const description = stripMentionSyntax(content);
 
   return {
     action: 'create_task',
@@ -28,6 +470,7 @@ function extractExplicitCreateTaskAction(content: string, sourceMessageId: strin
       title,
       project_name: projectName,
       ...(assigneeName ? { assignee_name: assigneeName } : {}),
+      ...(dueDate ? { due_date: dueDate } : {}),
       description,
       source_message_id: sourceMessageId,
     },
@@ -35,6 +478,455 @@ function extractExplicitCreateTaskAction(content: string, sourceMessageId: strin
     tool_use_id: null,
     source: 'deterministic_create_task_fallback',
   };
+}
+
+function normalizeTaskStatusToken(value: string | undefined): string | null {
+  if (!value) return null;
+  const normalized = value.toLowerCase().replace(/[_\s-]+/g, ' ').trim();
+  if (/^(?:done|complete|completed|closed|finish|finished)$/.test(normalized)) return 'done';
+  if (/^(?:todo|to do|open|reopened|reopen)$/.test(normalized)) return 'todo';
+  if (/^(?:in progress|doing|started)$/.test(normalized)) return 'in_progress';
+  if (/^(?:in review|review|reviewing|ready for review)$/.test(normalized)) return 'in_review';
+  if (/^(?:backlog|later)$/.test(normalized)) return 'backlog';
+  if (/^(?:cancelled|canceled|cancel)$/.test(normalized)) return 'cancelled';
+  return null;
+}
+
+function inferStatusUpdateTargetStatus(content: string): string | null {
+  const plain = stripMentionSyntax(content);
+  const statusPhrase =
+    plain.match(/\b(?:to|as|status\s+to)\s+(done|complete|completed|in progress|in review|todo|to do|backlog|cancelled|canceled)\b/i)?.[1] ??
+    plain.match(/\b(done|complete|completed|in progress|in review|todo|to do|backlog|cancelled|canceled)\b/i)?.[1];
+  const explicitStatus = normalizeTaskStatusToken(statusPhrase);
+  if (explicitStatus) return explicitStatus;
+  if (/\b(?:close|closed)\b/i.test(plain)) return 'done';
+  if (/\b(?:reopen|reopened)\b/i.test(plain)) return 'todo';
+  return null;
+}
+
+function hasExplicitStatusUpdateIntent(content: string): boolean {
+  const plain = stripMentionSyntax(content);
+  const positive =
+    /\b(?:mark|move|set|change|update|transition|close|reopen)\b.{0,80}\b(?:[A-Z]{2,12}-\d+|[0-9a-f]{8}-[0-9a-f-]{27})\b/i.test(plain) ||
+    /\b(?:[A-Z]{2,12}-\d+|[0-9a-f]{8}-[0-9a-f-]{27})\b.{0,80}\b(?:done|complete|completed|in progress|in review|todo|to do|backlog|cancelled|canceled)\b/i.test(plain);
+  if (!positive) return false;
+
+  return !/\b(?:do\s+not|don't|dont|never|without|avoid|no\s+need\s+to)\s+(?:\S+\s+){0,6}?(?:mark|move|set|change|update|transition|close|reopen)\b/i.test(plain);
+}
+
+export function extractStatusUpdateAction(content: string, sourceMessageId: string) {
+  if (!hasExplicitStatusUpdateIntent(content)) return null;
+  const plain = stripMentionSyntax(content);
+  const taskIdentifier = plain.match(/\b([A-Z]{2,12}-\d+|[0-9a-f]{8}-[0-9a-f-]{27})\b/i)?.[1];
+  if (!taskIdentifier) return null;
+
+  const newStatus = inferStatusUpdateTargetStatus(plain);
+  if (!newStatus) return null;
+
+  return {
+    action: 'update_task_status',
+    params: {
+      task_identifier: taskIdentifier.toUpperCase(),
+      new_status: newStatus,
+      source_message_id: sourceMessageId,
+    },
+    approval_tier: INLINE_STATUS_UPDATE_APPROVAL_TIER,
+    tool_use_id: null,
+    source: 'deterministic_status_update_fallback',
+  };
+}
+
+type ReferentialStatusSelector = {
+  mode: 'all' | 'first' | 'last';
+  count?: number;
+};
+
+const SMALL_COUNTS: Record<string, number> = {
+  one: 1,
+  two: 2,
+  three: 3,
+  four: 4,
+  five: 5,
+};
+
+function parseSmallCount(value: string | undefined | null): number | undefined {
+  const token = value?.trim().toLowerCase();
+  if (!token) return undefined;
+  if (/^\d+$/.test(token)) return Number.parseInt(token, 10);
+  return SMALL_COUNTS[token];
+}
+
+function hasNegatedStatusUpdateIntent(content: string): boolean {
+  const plain = stripMentionSyntax(content);
+  return /\b(?:do\s+not|don't|dont|never|without|avoid|no\s+need\s+to)\s+(?:\S+\s+){0,6}?(?:mark|move|set|change|update|transition|close|reopen)\b/i.test(plain);
+}
+
+export function extractReferentialStatusUpdateRequest(content: string): {
+  new_status: string;
+  selector: ReferentialStatusSelector;
+} | null {
+  if (hasNegatedStatusUpdateIntent(content)) return null;
+  const plain = stripMentionSyntax(content);
+  if (!/\b(?:mark|move|set|change|update|transition|close|reopen)\b/i.test(plain)) return null;
+
+  const newStatus = inferStatusUpdateTargetStatus(plain);
+  if (!newStatus) return null;
+
+  const firstLastMatch = plain.match(/\b(?:the\s+)?(first|last)\s+(one|two|three|four|five|\d+)\b/i);
+  if (firstLastMatch) {
+    const count = parseSmallCount(firstLastMatch[2]);
+    if (!count) return null;
+    return {
+      new_status: newStatus,
+      selector: {
+        mode: firstLastMatch[1]!.toLowerCase() === 'last' ? 'last' : 'first',
+        count,
+      },
+    };
+  }
+
+  const allCountMatch = plain.match(/\ball\s+(one|two|three|four|five|\d+)\b/i);
+  if (allCountMatch) {
+    const count = parseSmallCount(allCountMatch[1]);
+    if (!count) return null;
+    return { new_status: newStatus, selector: { mode: 'all', count } };
+  }
+
+  if (/\bboth\b/i.test(plain)) {
+    return { new_status: newStatus, selector: { mode: 'all', count: 2 } };
+  }
+
+  if (/\b(?:all\s+of\s+)?(?:these|those|them|the above|the listed tasks|the tasks)\b/i.test(plain)) {
+    return { new_status: newStatus, selector: { mode: 'all' } };
+  }
+
+  return null;
+}
+
+function normalizeTaskReference(value: string): string {
+  const trimmed = value.trim();
+  return /^[A-Z]{2,12}-\d+$/i.test(trimmed) ? trimmed.toUpperCase() : trimmed;
+}
+
+function uniqueTaskReferences(values: string[]): string[] {
+  const seen = new Set<string>();
+  const unique: string[] = [];
+  for (const value of values) {
+    const normalized = normalizeTaskReference(value);
+    const key = normalized.toLowerCase();
+    if (!normalized || seen.has(key)) continue;
+    seen.add(key);
+    unique.push(normalized);
+  }
+  return unique;
+}
+
+function extractTaskReferencesFromText(text: string): string[] {
+  return uniqueTaskReferences(
+    [...toPlainText(text).matchAll(/\b([A-Z]{2,12}-\d+)\b/g)].map((match) => match[1]!),
+  );
+}
+
+export function extractTaskReferencesFromAgentReply(content: string, metadata: unknown): string[] {
+  const primaryReplyText = toPlainText(content).split(/\bSources?:/i)[0] ?? content;
+  const textReferences = extractTaskReferencesFromText(primaryReplyText);
+  if (textReferences.length > 0) return textReferences;
+
+  const citations = isRecord(metadata) && Array.isArray(metadata.citations)
+    ? metadata.citations
+    : [];
+  const citationReferences: string[] = [];
+  for (const citation of citations) {
+    if (!isRecord(citation) || citation.type !== 'task') continue;
+    const title = typeof citation.title === 'string' ? citation.title : '';
+    const code = title.match(/\b([A-Z]{2,12}-\d+)\b/)?.[1];
+    if (code) {
+      citationReferences.push(code);
+      continue;
+    }
+    if (typeof citation.id === 'string' && citation.id.trim()) {
+      citationReferences.push(citation.id.trim());
+    }
+  }
+  return uniqueTaskReferences(citationReferences);
+}
+
+function selectReferencedTasks(
+  references: string[],
+  selector: ReferentialStatusSelector,
+): string[] {
+  const unique = uniqueTaskReferences(references);
+  const count = selector.count ?? unique.length;
+  if (count <= 0) return [];
+  if (selector.count && unique.length < selector.count) return [];
+  if (!selector.count && count > MAX_INLINE_APPROVAL_ACTIONS) return [];
+  if (count > MAX_INLINE_APPROVAL_ACTIONS) return [];
+  if (selector.mode === 'first') return unique.slice(0, count);
+  if (selector.mode === 'last') return unique.slice(-count);
+  return unique.slice(0, count);
+}
+
+export function buildReferentialStatusUpdateActions(
+  content: string,
+  sourceMessageId: string,
+  references: string[],
+) {
+  const request = extractReferentialStatusUpdateRequest(content);
+  if (!request) return null;
+  const selectedReferences = selectReferencedTasks(references, request.selector);
+  if (selectedReferences.length === 0) return null;
+
+  return selectedReferences.map((taskIdentifier) => ({
+    action: 'update_task_status',
+    params: {
+      task_identifier: taskIdentifier,
+      new_status: request.new_status,
+      source_message_id: sourceMessageId,
+    },
+    approval_tier: INLINE_STATUS_UPDATE_APPROVAL_TIER,
+    tool_use_id: null,
+    source: 'deterministic_referential_status_update_fallback',
+  }));
+}
+
+async function buildReferentialStatusUpdateFallback(options: {
+  orgId: string;
+  spaceId: string;
+  agentUserId: string;
+  messageId: string;
+  parentId?: string | null;
+  content: string;
+}) {
+  if (!extractReferentialStatusUpdateRequest(options.content)) return null;
+
+  const [trigger] = await db
+    .select({ created_at: messages.created_at })
+    .from(messages)
+    .where(and(
+      eq(messages.id, options.messageId),
+      eq(messages.org_id, options.orgId),
+    ))
+    .limit(1);
+  if (!trigger) return null;
+
+  const parentScope = options.parentId
+    ? eq(messages.parent_id, options.parentId)
+    : sql`${messages.parent_id} IS NULL`;
+
+  const priorAgentReplies = await db
+    .select({
+      content: messages.content,
+      metadata: messages.metadata,
+    })
+    .from(messages)
+    .where(and(
+      eq(messages.org_id, options.orgId),
+      eq(messages.space_id, options.spaceId),
+      eq(messages.user_id, options.agentUserId),
+      eq(messages.is_deleted, false),
+      parentScope,
+      lt(messages.created_at, trigger.created_at),
+    ))
+    .orderBy(desc(messages.created_at))
+    .limit(5);
+
+  for (const reply of priorAgentReplies) {
+    const references = extractTaskReferencesFromAgentReply(reply.content, reply.metadata);
+    const actions = buildReferentialStatusUpdateActions(options.content, options.messageId, references);
+    if (actions && actions.length > 0) return actions;
+  }
+
+  return null;
+}
+
+async function collectRecentAgentTaskReferences(options: {
+  orgId: string;
+  spaceId: string;
+  agentUserId: string;
+  messageId: string;
+  parentId?: string | null;
+}) {
+  const [trigger] = await db
+    .select({ created_at: messages.created_at })
+    .from(messages)
+    .where(and(
+      eq(messages.id, options.messageId),
+      eq(messages.org_id, options.orgId),
+    ))
+    .limit(1);
+  if (!trigger) return [];
+
+  const parentScope = options.parentId
+    ? eq(messages.parent_id, options.parentId)
+    : sql`${messages.parent_id} IS NULL`;
+
+  const priorAgentReplies = await db
+    .select({
+      content: messages.content,
+      metadata: messages.metadata,
+    })
+    .from(messages)
+    .where(and(
+      eq(messages.org_id, options.orgId),
+      eq(messages.space_id, options.spaceId),
+      eq(messages.user_id, options.agentUserId),
+      eq(messages.is_deleted, false),
+      parentScope,
+      lt(messages.created_at, trigger.created_at),
+    ))
+    .orderBy(desc(messages.created_at))
+    .limit(5);
+
+  return uniqueTaskReferences(
+    priorAgentReplies.flatMap((reply) => extractTaskReferencesFromAgentReply(reply.content, reply.metadata)),
+  ).slice(0, MAX_INLINE_APPROVAL_ACTIONS);
+}
+
+function hasExplicitPostMessageIntent(content: string): boolean {
+  const plain = stripMentionSyntax(content);
+  const positive =
+    /\b(?:post|send|put|share)\b.{0,50}\b(?:message|update|note|announcement)\b/i.test(plain) ||
+    /\b(?:post|send|put|share)\b.{0,50}\b(?:in|to)\s+#?[A-Za-z0-9][A-Za-z0-9 &+_-]{1,80}\b/i.test(plain);
+  if (!positive) return false;
+  return !/\b(?:do\s+not|don't|dont|never|without|avoid|no\s+need\s+to)\s+(?:\S+\s+){0,6}?(?:post|send|put|share)\b/i.test(plain);
+}
+
+function hasLiteralPostMessagePayload(content: string): boolean {
+  const plain = stripMentionSyntax(content);
+  return /["'][\s\S]{8,}["']/.test(plain) || /\b(?:in|to)\s+#?[A-Za-z0-9][A-Za-z0-9 &+_-]{1,80}?(?:\s+(?:channel|space))?[.:;]\s+\S+/i.test(plain);
+}
+
+export function extractPostMessageAction(content: string, sourceMessageId: string) {
+  if (!hasExplicitPostMessageIntent(content)) return null;
+  const plain = stripMentionSyntax(content);
+  if (/\b(?:dm|direct message|private message)\b/i.test(plain)) return null;
+
+  const quotedContent =
+    plain.match(/\b(?:saying|that says|with text)\s+"([^"]+)"/i)?.[1] ??
+    plain.match(/\b(?:saying|that says|with text)\s+'([^']+)'/i)?.[1];
+  const channelMatch =
+    plain.match(/\b(?:in|to)\s+#([A-Za-z0-9][A-Za-z0-9_-]{1,80})\b/i)?.[1] ??
+    plain.match(/\b(?:in|to)\s+(?:the\s+)?([A-Za-z0-9][A-Za-z0-9 &+_-]{1,80}?)(?:\s+(?:channel|space)\b|[.:;]\s+|\s+saying\b|\s+that\b)/i)?.[1];
+
+  let messageContent = quotedContent?.trim();
+  if (!messageContent) {
+    messageContent =
+      plain.match(/\b(?:in|to)\s+#?[A-Za-z0-9][A-Za-z0-9 &+_-]{1,80}?(?:\s+(?:channel|space))?[.:;]\s+(.+)$/i)?.[1]?.trim() ??
+      plain.match(/\b(?:in|to)\s+#?[A-Za-z0-9][A-Za-z0-9 &+_-]{1,80}?\s+(?:saying|that)\s+(.+)$/i)?.[1]?.trim();
+  }
+
+  messageContent = messageContent?.replace(/^["']|["']$/g, '').trim();
+
+  if (!channelMatch?.trim() || !messageContent) return null;
+
+  return {
+    action: 'post_message',
+    params: {
+      space_name: channelMatch.trim().replace(/^#/, ''),
+      content: truncatePlainText(messageContent, 4000),
+      source_message_id: sourceMessageId,
+    },
+    approval_tier: getApprovalTier('post_message'),
+    tool_use_id: null,
+    source: 'deterministic_post_message_fallback',
+  };
+}
+
+function hasApprovalQueuedClaim(text: string): boolean {
+  return /\b(?:queued|ready|prepared|drafted|set up).{0,80}\b(?:approval|approve|card)\b/i.test(toPlainText(text));
+}
+
+function buildWriteIntentClarification(content: string, replyText: string): string {
+  const claimedQueued = hasApprovalQueuedClaim(replyText);
+  if (hasExplicitStatusUpdateIntent(content)) {
+    return [
+      'I need one detail before I can create the approval card.',
+      'Please include the exact task id and target status, for example: "mark MKT-18 done."',
+    ].join('\n');
+  }
+  if (hasExplicitPostMessageIntent(content)) {
+    if (/\b(?:dm|direct message|private message)\b/i.test(stripMentionSyntax(content))) {
+      return [
+        'I need one clarification before I can draft that message.',
+        'This approval flow can safely post to a named channel right now. Tell me the exact channel, or use MCP send_message for direct DMs.',
+      ].join('\n');
+    }
+    return [
+      'I need one detail before I can create the approval card.',
+      'Please include the exact destination channel and the full message text.',
+    ].join('\n');
+  }
+  if (hasExplicitCreateTaskIntent(content)) {
+    return [
+      'I need one detail before I can create the approval card.',
+      'Please include the target project and a clear task title or outcome.',
+    ].join('\n');
+  }
+  if (claimedQueued) {
+    return 'I could not create a valid approval card for that draft. Please restate the action with the exact target and I will try again.';
+  }
+  return '';
+}
+
+export function normalizeApprovalSurfaceCopy(text: string): string {
+  const inlineApprovalCopy =
+    'Use the approval card below this message to approve or dismiss it. It is also mirrored in Inbox > Approvals.';
+  let normalized = text
+    .replace(
+      /(?:Please\s+)?(?:check|open|go to)\s+(?:your\s+)?Inbox\s+(?:under|in)\s+the\s+["']?Approvals["']?\s+tab\s+to\s+approve\s+or\s+reject[^.\n]*(?:\.|$)/gi,
+      inlineApprovalCopy,
+    )
+    .replace(
+      /You can also manage this in your Inbox under the Approvals tab\.?/gi,
+      'It is also mirrored in Inbox > Approvals.',
+    );
+
+  const mentionsInlineCard = /\b(?:approval card|approve\/reject button|approve or dismiss|below this message|here to finalize)\b/i.test(normalized);
+  if (!mentionsInlineCard) {
+    normalized = `${normalized.trim()}\n\n${inlineApprovalCopy}`;
+  }
+  return normalized;
+}
+
+async function resolveProjectNameForMentionFallback(
+  orgId: string,
+  spaceId: string,
+  content: string,
+): Promise<string | null> {
+  const explicitProjectName = content.match(/\bproject\s+"([^"]+)"/i)?.[1]
+    ?? content.match(/\bproject\s+'([^']+)'/i)?.[1]
+    ?? content.match(/\bin\s+(?:the\s+)?([A-Z][A-Za-z0-9 &+_-]{2,80})\s+project\b/i)?.[1];
+
+  if (explicitProjectName?.trim()) {
+    const [project] = await db
+      .select({ name: projects.name })
+      .from(projects)
+      .where(and(
+        eq(projects.org_id, orgId),
+        ilike(projects.name, explicitProjectName.trim()),
+        eq(projects.is_archived, false),
+        eq(projects.is_deleted, false),
+      ))
+      .limit(1);
+    if (project) return project.name;
+  }
+
+  const [linked] = await db
+    .select({ name: projects.name })
+    .from(projectSpaces)
+    .innerJoin(projects, and(
+      eq(projectSpaces.project_id, projects.id),
+      eq(projects.org_id, orgId),
+    ))
+    .where(and(
+      eq(projectSpaces.space_id, spaceId),
+      eq(projects.is_archived, false),
+      eq(projects.is_deleted, false),
+    ))
+    .limit(1);
+  if (linked) return linked.name;
+
+  return null;
 }
 
 function extractDiscussionTaskActionFromReply(replyText: string, sourceMessageId: string) {
@@ -138,6 +1030,24 @@ export function isDiscussionTaskCommand(content: string): boolean {
   return /\b(?:discussion|thread|chat|conversation|above|this)\b/i.test(plain);
 }
 
+export function isThreadTaskContinuationCommand(
+  content: string,
+  sourceMessages: DiscussionSourceMessage[],
+): boolean {
+  if (sourceMessages.length === 0) return false;
+  const plain = stripMentionSyntax(content).toLowerCase();
+  const isContinuation =
+    /^(?:do\s+(?:it|that|the\s+above)|go\s+ahead|yes|yep|yeah|please\s+do|make\s+it\s+happen|proceed)(?:[.!?\s]|$)/i.test(plain) ||
+    /\b(?:do\s+(?:it|that|the\s+above)|go\s+ahead|please\s+do|make\s+it\s+happen|proceed)\b/i.test(plain);
+  if (!isContinuation) return false;
+
+  return sourceMessages.some((message) => {
+    const messageText = toPlainText(message.content);
+    return hasExplicitCreateTaskIntent(messageText) ||
+      /\b(?:task creation request|proposed task creation|create the task|queued for your approval|approve this task creation)\b/i.test(messageText);
+  });
+}
+
 function isDiscussionBoundaryMessage(content: string): boolean {
   const plain = toPlainText(content);
   return /(?:^|\s)@(agent|defty|deft)\b/i.test(plain) || isDiscussionTaskCommand(plain);
@@ -238,10 +1148,12 @@ function withMentionProvenance(params: {
   const isWriteAction = [
     'create_task',
     'task_create',
+    'update_task_status',
     'task_update',
     'update_task',
     'task_transition',
     'comment_on_task',
+    'post_message',
   ].includes(String(action.action ?? ''));
   if (!isWriteAction) return action;
 
@@ -311,7 +1223,13 @@ export async function handleAgentReply(job: JobData): Promise<void> {
     // - Channel or explicit thread: last 10 messages in the thread + the
     //   thread root for context.
     const agentUserId = await ensureDeftyMembership(orgId);
+    const [callerUser] = await db
+      .select({ name: users.name })
+      .from(users)
+      .where(eq(users.id, userId))
+      .limit(1);
     const conversationHistory: { role: string; content: string }[] = [];
+    const threadContextMessages: DiscussionSourceMessage[] = [];
 
     if (isDmLike && !parentId) {
       const recent = await db.select({
@@ -366,6 +1284,11 @@ export async function handleAgentReply(job: JobData): Promise<void> {
         .limit(1);
 
       if (parentMsg && parentMsg.id !== messageId) {
+        threadContextMessages.push({
+          id: parentMsg.id,
+          userName: parentMsg.user_name,
+          content: parentMsg.content,
+        });
         conversationHistory.push({
           role: parentMsg.user_id === agentUserId ? 'assistant' : 'user',
           content: parentMsg.user_id === agentUserId ? parentMsg.content : `[${parentMsg.user_name}]: ${parentMsg.content}`,
@@ -374,6 +1297,11 @@ export async function handleAgentReply(job: JobData): Promise<void> {
 
       for (const msg of [...threadMessages].reverse()) {
         if (msg.id === messageId) continue;
+        threadContextMessages.push({
+          id: msg.id,
+          userName: msg.user_name,
+          content: msg.content,
+        });
         conversationHistory.push({
           role: msg.user_id === agentUserId ? 'assistant' : 'user',
           content: msg.user_id === agentUserId ? msg.content : `[${msg.user_name}]: ${msg.content}`,
@@ -397,8 +1325,14 @@ export async function handleAgentReply(job: JobData): Promise<void> {
 
     // Strip the @agent/@deft mention from the content for a cleaner prompt
     const cleanContent = content.replace(/<@[^|]*\|Defty?>/gi, '').replace(/@(agent|defty|deft)\b/gi, '').trim();
-    const wantsDiscussionTask = isDiscussionTaskCommand(cleanContent);
+    const wantsDiscussionTask = isDiscussionTaskCommand(cleanContent) ||
+      Boolean(parentId && isThreadTaskContinuationCommand(cleanContent, threadContextMessages));
     const discussionSourceMessages: DiscussionSourceMessage[] = [];
+    if (wantsDiscussionTask && parentId && threadContextMessages.length > 0) {
+      discussionSourceMessages.push(
+        ...threadContextMessages.filter((message) => !isSocialOnlyDiscussionMessage(message.content)),
+      );
+    }
 
     if (wantsDiscussionTask && !isDmLike && !parentId) {
       const [trigger] = await db
@@ -468,6 +1402,40 @@ export async function handleAgentReply(job: JobData): Promise<void> {
     const promptContent = wantsDiscussionTask
       ? discussionTaskPrompt(cleanContent || 'Create tasks from this discussion.')
       : cleanContent || 'Hey, what can you help me with?';
+    const hasWriteIntent = !wantsDiscussionTask && hasExplicitRegisteredWriteIntent(promptContent);
+
+    // Explicit writes go through the typed action compiler first. The general
+    // reasoning loop remains the fallback for reads, discussion synthesis, and
+    // requests the compiler cannot safely resolve. This avoids paying for two
+    // independent reasoning passes for a straightforward governed write.
+    let fallbackProjectName: string | null = null;
+    let compiledActionDraft: Awaited<ReturnType<typeof compileDeftyActionDraft>> | null = null;
+    if (hasWriteIntent) {
+      try {
+        fallbackProjectName = await resolveProjectNameForMentionFallback(orgId, spaceId, promptContent);
+        const priorTaskReferences = await collectRecentAgentTaskReferences({
+          orgId,
+          spaceId,
+          agentUserId,
+          messageId,
+          parentId: threadParentId,
+        });
+        compiledActionDraft = await compileDeftyActionDraft({
+          orgId,
+          promptContent,
+          sourceMessageId: messageId,
+          projectNameHint: fallbackProjectName,
+          priorTaskReferences,
+          spaceName: space?.name ?? null,
+          callerName: callerUser?.name ?? null,
+        });
+      } catch (err) {
+        console.warn('[agent-reply] Fast action compiler failed; using the general reasoning path', {
+          messageId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
 
     // Call the agent reasoning engine with a 60s hard timeout so a stuck
     // MCP tool / Anthropic call can never wedge the worker.
@@ -476,7 +1444,27 @@ export async function handleAgentReply(job: JobData): Promise<void> {
     const timeout = setTimeout(() => abort.abort(), AGENT_TIMEOUT_MS);
     let result: Awaited<ReturnType<typeof runAgentQuery>>;
     try {
-      result = await Promise.race([
+      if (compiledActionDraft && (compiledActionDraft.actions.length > 0 || compiledActionDraft.clarification)) {
+        result = {
+          text: compiledActionDraft.summary
+            ?? compiledActionDraft.clarification
+            ?? 'I drafted the requested update for review.',
+          pendingActions: [],
+          executedActions: [],
+          assistantBlocks: [],
+          model: compiledActionDraft.metrics.model,
+          tokensIn: compiledActionDraft.metrics.tokens_in,
+          tokensOut: compiledActionDraft.metrics.tokens_out,
+          citations: [],
+          metrics: {
+            total_ms: compiledActionDraft.metrics.duration_ms,
+            retrieval_ms: 0,
+            reasoning_ms: compiledActionDraft.metrics.duration_ms,
+            iterations: 1,
+          },
+        } as Awaited<ReturnType<typeof runAgentQuery>>;
+      } else {
+        result = await Promise.race([
       runAgentQuery({
         content: promptContent,
         orgId,
@@ -493,11 +1481,13 @@ export async function handleAgentReply(job: JobData): Promise<void> {
           otherMemberName,
         } : undefined,
         abortSignal: abort.signal,
+        maxIterations: hasWriteIntent ? 4 : undefined,
       }),
       new Promise<never>((_, reject) =>
         setTimeout(() => reject(new Error('agent-reply: runAgentQuery timeout after 60s')), AGENT_TIMEOUT_MS),
       ),
-      ]);
+        ]);
+      }
     } catch (err) {
       if (!wantsDiscussionTask || discussionSourceMessages.length === 0) throw err;
       const fallbackAction = buildDiscussionTaskFallbackAction({
@@ -518,6 +1508,7 @@ export async function handleAgentReply(job: JobData): Promise<void> {
         tokensIn: 0,
         tokensOut: 0,
         citations: [],
+        metrics: { total_ms: 0, retrieval_ms: 0, reasoning_ms: 0, iterations: 0 },
       } as Awaited<ReturnType<typeof runAgentQuery>>;
     } finally {
       clearTimeout(timeout);
@@ -542,12 +1533,82 @@ export async function handleAgentReply(job: JobData): Promise<void> {
         tokensIn: 0,
         tokensOut: 0,
         citations: [],
+        metrics: { total_ms: 0, retrieval_ms: 0, reasoning_ms: 0, iterations: 0 },
       } as Awaited<ReturnType<typeof runAgentQuery>>;
     }
 
-    const fallbackCreateTask = result.pendingActions.length === 0
+    const discussionFallbackContent = discussionSourceMessages.map((message) => message.content).join('\n');
+    const discussionFallbackProjectName = result.pendingActions.length === 0 && wantsDiscussionTask && discussionFallbackContent
+      ? await resolveProjectNameForMentionFallback(orgId, spaceId, `${discussionFallbackContent}\n${cleanContent}`)
+      : null;
+    const explicitDiscussionFallback = result.pendingActions.length === 0 && wantsDiscussionTask && discussionFallbackContent
+      ? extractExplicitCreateTaskAction(discussionFallbackContent, messageId, {
+        projectName: discussionFallbackProjectName,
+        callerName: callerUser?.name ?? null,
+      })
+      : null;
+    if (fallbackProjectName === null && result.pendingActions.length === 0 && !wantsDiscussionTask) {
+      fallbackProjectName = await resolveProjectNameForMentionFallback(orgId, spaceId, promptContent);
+    }
+    const referentialStatusRequest = result.pendingActions.length === 0 && !wantsDiscussionTask
+      ? extractReferentialStatusUpdateRequest(promptContent)
+      : null;
+    const shouldCompileActionDraft = !wantsDiscussionTask && (
+      hasWriteIntent ||
+      Boolean(referentialStatusRequest) ||
+      hasApprovalQueuedClaim(result.text)
+    );
+    if (shouldCompileActionDraft && !compiledActionDraft) {
+      try {
+        const priorTaskReferences = await collectRecentAgentTaskReferences({
+          orgId,
+          spaceId,
+          agentUserId,
+          messageId,
+          parentId: threadParentId,
+        });
+        compiledActionDraft = await compileDeftyActionDraft({
+          orgId,
+          promptContent,
+          agentReplyText: result.text,
+          sourceMessageId: messageId,
+          projectNameHint: fallbackProjectName,
+          priorTaskReferences,
+          spaceName: space?.name ?? null,
+          callerName: callerUser?.name ?? null,
+        });
+      } catch (err) {
+        console.warn('[agent-reply] Action draft compiler failed; falling back to deterministic extractors', {
+          messageId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+    const fallbackStatusUpdate = result.pendingActions.length === 0 && !wantsDiscussionTask
+      ? extractStatusUpdateAction(promptContent, messageId)
+      : null;
+    const fallbackReferentialStatusUpdates = result.pendingActions.length === 0 && !wantsDiscussionTask && !fallbackStatusUpdate
+      ? await buildReferentialStatusUpdateFallback({
+        orgId,
+        spaceId,
+        agentUserId,
+        messageId,
+        parentId: threadParentId,
+        content: promptContent,
+      })
+      : null;
+    const explicitPostMessageAction = !wantsDiscussionTask
+      ? extractPostMessageAction(promptContent, messageId)
+      : null;
+    const literalPostMessageOverride = explicitPostMessageAction && hasLiteralPostMessagePayload(promptContent)
+      ? explicitPostMessageAction
+      : null;
+    const fallbackPostMessage = result.pendingActions.length === 0 && !wantsDiscussionTask && !fallbackStatusUpdate && !fallbackReferentialStatusUpdates
+      ? explicitPostMessageAction
+      : null;
+    const fallbackCreateTask = result.pendingActions.length === 0 && !fallbackStatusUpdate && !fallbackReferentialStatusUpdates && !fallbackPostMessage
       ? wantsDiscussionTask
-        ? extractDiscussionTaskActionFromReply(result.text, messageId) ?? (
+        ? explicitDiscussionFallback ?? extractDiscussionTaskActionFromReply(result.text, messageId) ?? (
           discussionSourceMessages.length > 0
             ? buildDiscussionTaskFallbackAction({
               command: cleanContent,
@@ -556,13 +1617,21 @@ export async function handleAgentReply(job: JobData): Promise<void> {
             })
             : null
         )
-        : extractExplicitCreateTaskAction(promptContent, messageId)
+        : extractExplicitCreateTaskAction(promptContent, messageId, {
+          projectName: fallbackProjectName,
+          callerName: callerUser?.name ?? null,
+        })
       : null;
-    const rawPendingActions = fallbackCreateTask ? [fallbackCreateTask] : result.pendingActions;
+    const fallbackWriteAction = fallbackStatusUpdate ?? fallbackPostMessage ?? fallbackCreateTask;
+    const compiledActions = compiledActionDraft?.actions?.length ? compiledActionDraft.actions : null;
+    const rawPendingActions = fallbackReferentialStatusUpdates
+      ?? (literalPostMessageOverride ? [literalPostMessageOverride] : null)
+      ?? (compiledActionDraft ? compiledActionDraft.actions : null)
+      ?? (fallbackWriteAction ? [fallbackWriteAction] : result.pendingActions);
     const enrichedPendingActions = wantsDiscussionTask
       ? enrichDiscussionTaskActions(rawPendingActions, discussionSourceMessages)
       : rawPendingActions;
-    const pendingActions = enrichedPendingActions.map((action: any) =>
+    const pendingActionsWithProvenance = enrichedPendingActions.map((action: any) =>
       withMentionProvenance({
         action,
         commandMessageId: messageId,
@@ -570,60 +1639,132 @@ export async function handleAgentReply(job: JobData): Promise<void> {
         discussionSourceMessages,
       }),
     );
+    const validatedPendingActions: any[] = [];
+    const proposalValidationWarnings: string[] = [];
+    for (const action of pendingActionsWithProvenance) {
+      const validation = validateRegisteredProposalAction(action);
+      if (validation.ok) validatedPendingActions.push(action);
+      else proposalValidationWarnings.push(validation.message);
+    }
+    const resolvedPendingActions = await resolvePendingActionTargets(orgId, userId, spaceId, validatedPendingActions);
+    let pendingActions = resolvedPendingActions.actions.map(normalizePendingApprovalTier);
+    const pendingActionTargetWarnings = [...proposalValidationWarnings, ...resolvedPendingActions.warnings];
+    if (pendingActions.length > MAX_INLINE_APPROVAL_ACTIONS) {
+      pendingActionTargetWarnings.push(
+        `That request produced ${pendingActions.length} separate write actions. Ask me for the top ${MAX_INLINE_APPROVAL_ACTIONS}, or ask for a plan first so we can review it safely.`,
+      );
+      pendingActions = [];
+    }
     if (fallbackCreateTask) {
       console.warn('[agent-reply] Added deterministic create_task fallback for explicit task-create prompt', {
         messageId,
         title: fallbackCreateTask.params.title,
       });
     }
+    if (fallbackStatusUpdate) {
+      console.warn('[agent-reply] Added deterministic update_task_status fallback for explicit status prompt', {
+        messageId,
+        task_identifier: fallbackStatusUpdate.params.task_identifier,
+        new_status: fallbackStatusUpdate.params.new_status,
+      });
+    }
+    if (fallbackReferentialStatusUpdates) {
+      console.warn('[agent-reply] Added deterministic referential update_task_status fallback for prior task list', {
+        messageId,
+        task_identifiers: fallbackReferentialStatusUpdates.map((action: any) => action.params.task_identifier),
+        new_status: fallbackReferentialStatusUpdates[0]?.params?.new_status,
+      });
+    }
+    if (fallbackPostMessage) {
+      console.warn('[agent-reply] Added deterministic post_message fallback for explicit message prompt', {
+        messageId,
+        space_name: fallbackPostMessage.params.space_name,
+      });
+    }
+    const targetClarificationMessage = buildTargetClarificationMessage(pendingActionTargetWarnings);
+    const writeIntentClarificationMessage = pendingActions.length === 0 && !wantsDiscussionTask
+      ? (compiledActionDraft?.clarification || buildWriteIntentClarification(promptContent, result.text))
+      : '';
+    const referentialApprovalReplyText = fallbackReferentialStatusUpdates?.length
+      ? normalizeApprovalSurfaceCopy([
+        `I drafted ${fallbackReferentialStatusUpdates.length} task status update${fallbackReferentialStatusUpdates.length === 1 ? '' : 's'} for approval:`,
+        ...fallbackReferentialStatusUpdates.map((action: any) => `- ${action.params.task_identifier} → ${action.params.new_status}`),
+      ].join('\n'))
+      : null;
+    const literalPostApprovalReplyText = literalPostMessageOverride
+      ? normalizeApprovalSurfaceCopy(`I drafted a message for #${literalPostMessageOverride.params.space_name}.`)
+      : null;
+    const approvalReplyText = referentialApprovalReplyText ?? literalPostApprovalReplyText ?? (compiledActions && compiledActionDraft?.summary
+      ? normalizeApprovalSurfaceCopy(compiledActionDraft.summary)
+      : normalizeApprovalSurfaceCopy(result.text));
+    const agentReplyContent = targetClarificationMessage && pendingActions.length === 0
+      ? targetClarificationMessage
+      : pendingActions.length > 0
+        ? [
+          approvalReplyText,
+          targetClarificationMessage || null,
+        ].filter(Boolean).join('\n\n')
+        : writeIntentClarificationMessage || result.text;
 
     // Insert the agent's reply as a message in the space.
     // Phase 2 — populate agent_blocks / model / tokens so <AgentMessageBlocks/>
     // can render tool chips, citations footer, and the model+tokens detail
     // (parity with the agent-stream-loop path).
-    const [agentMessage] = await db.insert(messages).values({
-      org_id: orgId,
-      space_id: spaceId,
-      user_id: agentUserId,
-      content: result.text,
-      parent_id: threadParentId,
-      metadata: {
-        is_agent_reply: true,
-        agent_blocks: result.assistantBlocks ?? undefined,
-        model: result.model,
-        tokens_in: result.tokensIn,
-        tokens_out: result.tokensOut,
-        citations: result.citations.length > 0 ? result.citations : undefined,
-        pending_actions: pendingActions.length > 0 ? pendingActions : undefined,
-      } as never,
-    }).returning();
+    const replyMetadata = {
+      is_agent_reply: true,
+      agent_blocks: result.assistantBlocks ?? undefined,
+      model: result.model,
+      tokens_in: result.tokensIn,
+      tokens_out: result.tokensOut,
+      citations: result.citations.length > 0 ? result.citations : undefined,
+      pending_actions: pendingActions.length > 0 ? pendingActions : undefined,
+      action_compiler_metrics: compiledActionDraft?.metrics,
+      action_graph: compiledActionDraft?.graph,
+      agent_run_metrics: result.metrics,
+    };
+
+    let agentMessage: typeof messages.$inferSelect;
+    try {
+      const persisted = await persistAgentReplyWithActions({
+        orgId,
+        spaceId,
+        userId,
+        agentUserId,
+        content: agentReplyContent,
+        parentId: threadParentId,
+        metadata: replyMetadata,
+        pendingActions,
+      });
+      agentMessage = persisted.message;
+    } catch (err) {
+      if (pendingActions.length === 0) throw err;
+      const pendingActionPersistError = err instanceof Error ? err.message : String(err);
+      console.error('[agent-reply] Failed to persist agent reply with pending actions:', err);
+      const failedApprovalContent = [
+        'I drafted the action, but I could not create the approval card.',
+        'Please try again or create it manually.',
+      ].join(' ');
+      const [fallbackMessage] = await db.insert(messages).values({
+        org_id: orgId,
+        space_id: spaceId,
+        user_id: agentUserId,
+        content: failedApprovalContent,
+        parent_id: threadParentId,
+        metadata: {
+          ...replyMetadata,
+          pending_actions: undefined,
+          pending_actions_error: pendingActionPersistError,
+        } as never,
+      }).returning();
+      if (!fallbackMessage) throw err;
+      agentMessage = fallbackMessage;
+    }
 
     // Persist pending write actions as agent_actions rows so the inline
     // <AgentActionCard/> on the reply and the /inbox?tab=approvals queue
     // can render them. Without this, write-intent chat mentions were
     // ghost-queued — stored in metadata.pending_actions but invisible to
     // the approval UI (parity with agent-stream-loop.ts:208).
-    if (pendingActions.length > 0) {
-      try {
-        await db.insert(agentActions).values(
-          pendingActions.map((p: any) => ({
-            org_id: orgId,
-            user_id: userId,
-            conversation_id: spaceId,
-            message_id: agentMessage!.id,
-            action: p.action,
-            params: p.params,
-            approval_tier: (p.approval_tier ?? getApprovalTier(p.action)) as 'auto' | 'quick' | 'full',
-            approval_status: 'pending' as const,
-            source: p.source ?? 'mention',
-            tool_use_id: p.tool_use_id ?? null,
-          })),
-        );
-      } catch (err) {
-        console.error('[agent-reply] Failed to persist pending agent_actions:', err);
-      }
-    }
-
     // Get the agent user info for the broadcast
     const [agentUserData] = await db.select({
       name: users.name,
@@ -659,12 +1800,12 @@ export async function handleAgentReply(job: JobData): Promise<void> {
         io.to(`space:${spaceId}`).emit('thread:updated', {
           parent_id: threadParentId,
           reply_count: replyStats?.count ?? 1,
-          latest_reply_at: replyStats?.latest ?? agentMessage!.created_at,
+          latest_reply_at: replyStats?.latest ?? agentMessage.created_at,
         });
       }
     }
 
-    console.log(`[agent-reply] Posted agent reply ${agentMessage!.id} in space ${spaceId}${threadParentId ? ` thread ${threadParentId}` : ' (flat)'}`);
+    console.log(`[agent-reply] Posted agent reply ${agentMessage.id} in space ${spaceId}${threadParentId ? ` thread ${threadParentId}` : ' (flat)'}`);
   } catch (err) {
     console.error('[agent-reply] Failed to generate agent reply:', err);
     throw err; // Re-throw so BullMQ can retry

--- a/apps/api/test/agent-actions-routes.test.ts
+++ b/apps/api/test/agent-actions-routes.test.ts
@@ -126,9 +126,9 @@ async function teardownFixtures() {
     // them first so the subsequent cascade doesn't bounce off the FK.
     await c.query(
       `DELETE FROM action_receipts
-       WHERE action_id IN (SELECT id FROM agent_actions WHERE user_id = $1)
+       WHERE action_id IN (SELECT id FROM agent_actions WHERE user_id IN ($1, $3))
           OR employee_id = $2`,
-      [SHADOW_USER_ID, EMP_ID],
+      [SHADOW_USER_ID, EMP_ID, APPROVER_USER_ID],
     );
     await c.query(
       `DELETE FROM work_intents
@@ -138,8 +138,8 @@ async function teardownFixtures() {
       [ORG_ID, EMP_ID, SHADOW_USER_ID, APPROVER_USER_ID],
     );
     await c.query(
-      `DELETE FROM agent_actions WHERE user_id = $1`,
-      [SHADOW_USER_ID],
+      `DELETE FROM agent_actions WHERE user_id IN ($1, $2)`,
+      [SHADOW_USER_ID, APPROVER_USER_ID],
     );
     await c.query(
       `DELETE FROM messages WHERE space_id IN ($1, $2)`,
@@ -156,12 +156,12 @@ async function teardownFixtures() {
     if (TEST_PROJECT_ID) {
       await c.query(
         `DELETE FROM task_activity
-         WHERE task_id IN (SELECT id FROM tasks WHERE project_id = $1 AND created_by = $2)`,
-        [TEST_PROJECT_ID, SHADOW_USER_ID],
+         WHERE task_id IN (SELECT id FROM tasks WHERE project_id = $1 AND created_by IN ($2, $3))`,
+        [TEST_PROJECT_ID, SHADOW_USER_ID, APPROVER_USER_ID],
       );
       await c.query(
-        `DELETE FROM tasks WHERE project_id = $1 AND created_by = $2`,
-        [TEST_PROJECT_ID, SHADOW_USER_ID],
+        `DELETE FROM tasks WHERE project_id = $1 AND created_by IN ($2, $3)`,
+        [TEST_PROJECT_ID, SHADOW_USER_ID, APPROVER_USER_ID],
       );
     }
     await c.query(
@@ -1070,6 +1070,49 @@ test('POST /api/agent/actions/:id/approve executes the write', async () => {
 
     const t = await c.query(`SELECT title FROM tasks WHERE title = $1`, [title]);
     assert.equal(t.rows.length, 1);
+  });
+});
+
+test('approval confirmation is authored by the proposing agent, not the human requester', async () => {
+  const title = `routes-confirmation-author-${Date.now()}`;
+  const { actionId, approvalMessageId } = await withClient(async (c) => {
+    const message = await c.query(
+      `INSERT INTO messages (id, org_id, space_id, user_id, content, metadata)
+       VALUES (gen_random_uuid()::text, $1, $2, $3, 'Review the task draft below.', '{"is_agent_reply":true}'::jsonb)
+       RETURNING id`,
+      [ORG_ID, VISIBLE_SPACE_ID, SHADOW_USER_ID],
+    );
+    const action = await c.query(
+      `INSERT INTO agent_actions
+        (id, org_id, user_id, agent_employee_id, conversation_id, message_id, source, action, params,
+         approval_tier, approval_status)
+       VALUES (gen_random_uuid()::text, $1, $2, $3, $4, $5, 'mention', 'task_create', $6::jsonb, 'quick', 'pending')
+       RETURNING id`,
+      [
+        ORG_ID,
+        APPROVER_USER_ID,
+        EMP_ID,
+        VISIBLE_SPACE_ID,
+        message.rows[0].id,
+        JSON.stringify({ title, project_id: TEST_PROJECT_ID, priority: 'p2' }),
+      ],
+    );
+    return { actionId: action.rows[0].id as string, approvalMessageId: message.rows[0].id as string };
+  });
+
+  const res = await app().request(`/api/agent/actions/${actionId}/approve`, { method: 'POST' });
+  assert.equal(res.status, 200);
+
+  await withClient(async (c) => {
+    const confirmation = await c.query(
+      `SELECT user_id, metadata->>'requested_by_user_id' AS requested_by_user_id
+       FROM messages
+       WHERE metadata->>'approval_confirmation_for_message_id' = $1`,
+      [approvalMessageId],
+    );
+    assert.equal(confirmation.rows.length, 1);
+    assert.equal(confirmation.rows[0].user_id, SHADOW_USER_ID);
+    assert.equal(confirmation.rows[0].requested_by_user_id, APPROVER_USER_ID);
   });
 });
 

--- a/apps/api/test/agent-mention-detection.test.ts
+++ b/apps/api/test/agent-mention-detection.test.ts
@@ -19,14 +19,16 @@ import { test, before, after } from 'node:test';
 import assert from 'node:assert/strict';
 import { Hono } from 'hono';
 import { db } from '../src/lib/db.js';
-import { users, orgs, orgMembers, spaces, spaceMembers, jobQueue, messages, notifications } from '@deft/db/schema';
+import { users, orgs, orgMembers, spaces, spaceMembers, jobQueue, messages, notifications, agentEmployees, agentActions } from '@deft/db/schema';
 import { eq, and, inArray, sql } from 'drizzle-orm';
-import { ensureDeftyMembership, DEFTY_EMAIL } from '../src/lib/ensure-defty-membership.js';
+import { ensureDeftyEmployee, ensureDeftyMembership, DEFTY_EMAIL } from '../src/lib/ensure-defty-membership.js';
 
 let testOrgId: string;
 let humanUserId: string;
 let deftyUserId: string;
+let deftyEmployeeId: string;
 let byoaAgentUserId: string;
+let byoaAgentEmployeeId: string;
 let spaceId: string;
 let app: Hono;
 // Whether Defty already existed before this test run — used in cleanup.
@@ -62,6 +64,7 @@ before(async () => {
   // Defty — the real system agent. ensureDeftyMembership creates-or-reuses
   // the canonical Defty user and adds it as a member of testOrgId.
   deftyUserId = await ensureDeftyMembership(testOrgId);
+  deftyEmployeeId = (await ensureDeftyEmployee(testOrgId)).employeeId;
 
   // BYOA agent — kind='agent' but NOT Defty. Simulates an arbitrary BYOA
   // employee. agent-reply must NOT fire for mentions of this user.
@@ -78,6 +81,28 @@ before(async () => {
     { org_id: testOrgId, user_id: byoaAgentUserId, role: 'member' },
     // Defty's org_members row is handled by ensureDeftyMembership above.
   ]);
+
+  const [byoaEmployee] = await db.insert(agentEmployees).values({
+    org_id: testOrgId,
+    user_id: byoaAgentUserId,
+    name: 'AMD BYOA Agent',
+    slug: `amd-byoa-agent-${ts}`,
+    role: 'custom',
+    system_prompt: 'Test BYOA agent.',
+    expertise_description: 'Test employee for mention routing.',
+    starter_prompts: [],
+    disabled_tools: [],
+    space_ids: [],
+    project_ids: [],
+    trust_level: 'conservative',
+    is_active: true,
+    is_byoa: true,
+    runtime_kind: 'custom_mcp',
+    wake_mode: 'manual',
+    certification_status: 'token_issued',
+    created_by: humanUserId,
+  }).returning({ id: agentEmployees.id });
+  byoaAgentEmployeeId = byoaEmployee!.id;
 
   const [space] = await db.insert(spaces).values({
     org_id: testOrgId,
@@ -124,8 +149,11 @@ after(async () => {
     // The message route creates mention + space notifications, so clean these before users.
     const userIdsToClean = [humanUserId, byoaAgentUserId, deftyUserId];
     await db.delete(notifications).where(inArray(notifications.user_id, userIdsToClean));
+    await db.delete(agentActions).where(eq(agentActions.org_id, testOrgId));
+    await db.delete(messages).where(eq(messages.space_id, spaceId));
     await db.delete(spaceMembers).where(eq(spaceMembers.space_id, spaceId));
     await db.delete(spaces).where(eq(spaces.id, spaceId));
+    await db.delete(agentEmployees).where(inArray(agentEmployees.id, [byoaAgentEmployeeId, deftyEmployeeId]));
     // Remove only the org_members rows we created for testOrgId.
     await db.delete(orgMembers).where(eq(orgMembers.org_id, testOrgId));
     await db.delete(users).where(inArray(users.id, [humanUserId, byoaAgentUserId]));
@@ -162,6 +190,24 @@ async function findAgentReplyJob(messageId: string): Promise<boolean> {
   return false;
 }
 
+async function findAgentEmployeeMessageJob(messageId: string): Promise<boolean> {
+  for (let i = 0; i < 6; i++) {
+    const rows = await db
+      .select({ id: jobQueue.id })
+      .from(jobQueue)
+      .where(
+        and(
+          eq(jobQueue.name, 'agent-employee-message'),
+          sql`${jobQueue.data}->>'messageId' = ${messageId}`,
+        ),
+      )
+      .limit(1);
+    if (rows.length > 0) return true;
+    if (i < 5) await new Promise((r) => setTimeout(r, 50));
+  }
+  return false;
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 
 test('structured mention of Defty user triggers agent-reply dispatch', async () => {
@@ -181,6 +227,12 @@ test('structured mention of Defty user triggers agent-reply dispatch', async () 
 
   const dispatched = await findAgentReplyJob(body.id!);
   assert.ok(dispatched, 'agent-reply job should be enqueued for Defty mention');
+  const employeeQueued = await findAgentEmployeeMessageJob(body.id!);
+  assert.equal(
+    employeeQueued,
+    false,
+    'Defty mention should not also enqueue the external agent-employee message path',
+  );
 });
 
 test('structured mention of BYOA agent (kind=agent, not Defty) does NOT trigger agent-reply dispatch', async () => {
@@ -203,6 +255,8 @@ test('structured mention of BYOA agent (kind=agent, not Defty) does NOT trigger 
   await new Promise((r) => setTimeout(r, 100));
   const dispatched = await findAgentReplyJob(body.id!);
   assert.ok(!dispatched, 'agent-reply job should NOT be enqueued for BYOA agent mention');
+  const employeeQueued = await findAgentEmployeeMessageJob(body.id!);
+  assert.ok(employeeQueued, 'BYOA agent mention should enqueue agent-employee-message');
 });
 
 test('structured mention of kind=human user does NOT trigger agent-reply dispatch', async () => {

--- a/apps/api/test/agent-reply-discussion-command.test.ts
+++ b/apps/api/test/agent-reply-discussion-command.test.ts
@@ -1,6 +1,32 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { isDiscussionTaskCommand } from '../src/workers/handlers/agent-reply.js';
+import {
+  buildReferentialStatusUpdateActions,
+  extractExplicitCreateTaskAction,
+  extractPostMessageAction,
+  extractReferentialStatusUpdateRequest,
+  extractStatusUpdateAction,
+  extractTaskReferencesFromAgentReply,
+  hasExplicitRegisteredWriteIntent,
+  isDiscussionTaskCommand,
+  isThreadTaskContinuationCommand,
+  normalizeApprovalSurfaceCopy,
+} from '../src/workers/handlers/agent-reply.js';
+
+test('compiler recovery gate recognizes the registered write families without choosing one', () => {
+  for (const prompt of [
+    'Create a wiki fact page about Cherokee Purple watering.',
+    'Save this as an org note.',
+    'Update the shared canvas with the launch outline.',
+    'Link this decision to MKT-18.',
+    'Post an update to #marketing.',
+    'Mark all three tasks done.',
+  ]) {
+    assert.equal(hasExplicitRegisteredWriteIntent(prompt), true, prompt);
+  }
+  assert.equal(hasExplicitRegisteredWriteIntent('What does the wiki say about watering?'), false);
+  assert.equal(hasExplicitRegisteredWriteIntent('Do not create a wiki page for this lunch chat.'), false);
+});
 
 test('discussion task command accepts explicit discussion-to-task prompts', () => {
   assert.equal(
@@ -36,4 +62,239 @@ test('discussion task command does not treat ordinary task chatter as a command'
   assert.equal(isDiscussionTaskCommand('I created the task from the greenhouse conversation.'), false);
   assert.equal(isDiscussionTaskCommand('Please create a task called "Check crates" in the packing project.'), false);
   assert.equal(isDiscussionTaskCommand('This discussion was useful.'), false);
+});
+
+test('explicit create-task fallback handles natural chat commands without quoted title', () => {
+  const action = extractExplicitCreateTaskAction(
+    '@Defty create a task with a deadline for next monday. a social media post needs to go out to praise our lord emperor zorgon, the lord of all tomatoes. assign it to lina.',
+    'msg_123',
+    {
+      projectName: 'Pilot Marketing Launch',
+      now: new Date('2026-07-08T00:00:00.000Z'),
+    },
+  );
+
+  assert.ok(action);
+  assert.equal(action.action, 'create_task');
+  assert.equal(action.params.project_name, 'Pilot Marketing Launch');
+  assert.equal(action.params.assignee_name, 'lina');
+  assert.equal(action.params.due_date, '2026-07-13');
+  assert.match(action.params.title, /Social Media Post/i);
+  assert.equal(action.params.source_message_id, 'msg_123');
+});
+
+test('explicit create-task fallback handles quoted title from prior thread context', () => {
+  const action = extractExplicitCreateTaskAction(
+    '@defty assign a task named "peepee poopoo" for next thursday to marigold. place it in the marketing pilot project',
+    'thread_reply_123',
+    {
+      projectName: 'Pilot Marketing Launch',
+      now: new Date('2026-07-09T00:00:00.000Z'),
+    },
+  );
+
+  assert.ok(action);
+  assert.equal(action.action, 'create_task');
+  assert.equal(action.params.title, 'peepee poopoo');
+  assert.equal(action.params.project_name, 'Pilot Marketing Launch');
+  assert.equal(action.params.assignee_name, 'marigold');
+  assert.equal(action.params.due_date, '2026-07-16');
+  assert.equal(action.params.source_message_id, 'thread_reply_123');
+});
+
+test('explicit create-task fallback handles name-it title phrasing', () => {
+  const action = extractExplicitCreateTaskAction(
+    '@Defty can you create a task in pilot project, name it "33 Gun Salute" and assign it to me?',
+    'msg_name_it_123',
+    {
+      projectName: 'Pilot Marketing Launch',
+      callerName: 'Diego Vargas',
+      now: new Date('2026-07-09T00:00:00.000Z'),
+    },
+  );
+
+  assert.ok(action);
+  assert.equal(action.action, 'create_task');
+  assert.equal(action.params.title, '33 Gun Salute');
+  assert.equal(action.params.project_name, 'Pilot Marketing Launch');
+  assert.equal(action.params.assignee_name, 'Diego Vargas');
+  assert.equal(action.params.source_message_id, 'msg_name_it_123');
+});
+
+test('explicit create-task fallback handles assign-name and tomorrow phrasing', () => {
+  const action = extractExplicitCreateTaskAction(
+    '@Defty create one task draft from the recent blocker. Assign Tomas and make it due tomorrow.',
+    'msg_tomorrow_123',
+    {
+      projectName: 'Route + Packing Reliability',
+      now: new Date('2026-07-09T00:00:00.000Z'),
+    },
+  );
+
+  assert.ok(action);
+  assert.equal(action.action, 'create_task');
+  assert.equal(action.params.project_name, 'Route + Packing Reliability');
+  assert.equal(action.params.assignee_name, 'Tomas');
+  assert.equal(action.params.due_date, '2026-07-10');
+  assert.match(action.params.title, /Recent Blocker/i);
+});
+
+test('status update fallback creates update_task_status approval action', () => {
+  const action = extractStatusUpdateAction('@Defty mark MKT-18 done once the final buyer copy ships.', 'msg_status_123');
+
+  assert.ok(action);
+  assert.equal(action.action, 'update_task_status');
+  assert.equal(action.params.task_identifier, 'MKT-18');
+  assert.equal(action.params.new_status, 'done');
+  assert.equal(action.params.source_message_id, 'msg_status_123');
+  assert.equal(action.approval_tier, 'quick');
+});
+
+test('referential status fallback maps all 3 to prior Defty task references', () => {
+  const actions = buildReferentialStatusUpdateActions(
+    '@Defty mark all 3 as complete.',
+    'msg_referential_123',
+    ['BUY-1', 'OPS-2', 'MKT-9'],
+  );
+
+  assert.ok(actions);
+  assert.equal(actions.length, 3);
+  assert.deepEqual(
+    actions.map((action) => action.params.task_identifier),
+    ['BUY-1', 'OPS-2', 'MKT-9'],
+  );
+  assert.deepEqual(
+    actions.map((action) => action.params.new_status),
+    ['done', 'done', 'done'],
+  );
+  assert.equal(actions[0].source, 'deterministic_referential_status_update_fallback');
+  assert.deepEqual(
+    actions.map((action) => action.approval_tier),
+    ['quick', 'quick', 'quick'],
+  );
+});
+
+test('referential status fallback supports first two and both without inventing extra tasks', () => {
+  const firstTwo = buildReferentialStatusUpdateActions(
+    '@Defty mark the first two done.',
+    'msg_first_two_123',
+    ['BUY-1', 'OPS-2', 'MKT-9'],
+  );
+
+  assert.ok(firstTwo);
+  assert.deepEqual(
+    firstTwo.map((action) => action.params.task_identifier),
+    ['BUY-1', 'OPS-2'],
+  );
+
+  const both = buildReferentialStatusUpdateActions(
+    '@Defty close both.',
+    'msg_both_123',
+    ['BUY-1', 'OPS-2'],
+  );
+
+  assert.ok(both);
+  assert.deepEqual(
+    both.map((action) => action.params.task_identifier),
+    ['BUY-1', 'OPS-2'],
+  );
+  assert.equal(both[0].params.new_status, 'done');
+});
+
+test('referential status fallback rejects negation and overlarge ambiguous sets', () => {
+  assert.equal(
+    extractReferentialStatusUpdateRequest('@Defty do not mark all 3 complete.'),
+    null,
+  );
+
+  assert.equal(
+    buildReferentialStatusUpdateActions(
+      '@Defty mark those complete.',
+      'msg_too_many_123',
+      ['BUY-1', 'OPS-2', 'MKT-9', 'OPS-7'],
+    ),
+    null,
+  );
+});
+
+test('task references prefer the prior reply list before noisy source/citation tails', () => {
+  const references = extractTaskReferencesFromAgentReply(
+    [
+      'I found 3 open Chef Amara/sample-box tasks:',
+      '- BUY-1 — Confirm Chef Amara sample-box size',
+      '- OPS-2 — Stage sample-box crates beside cold-room door',
+      '- MKT-9 — Call Chef Amara about first Sun Gold sample box',
+      'Sources: BUY-7, OPS-7',
+    ].join('\n'),
+    {
+      citations: [
+        { type: 'task', id: 'task-buy-7', title: 'BUY-7: Prepare Saturday booth buyer handout' },
+      ],
+    },
+  );
+
+  assert.deepEqual(references, ['BUY-1', 'OPS-2', 'MKT-9']);
+});
+
+test('post message fallback creates channel approval action but refuses DM wording', () => {
+  const action = extractPostMessageAction(
+    '@Defty put a message in sales-and-buyers: We need to close at least two major clients before harvest.',
+    'msg_post_123',
+  );
+
+  assert.ok(action);
+  assert.equal(action.action, 'post_message');
+  assert.equal(action.params.space_name, 'sales-and-buyers');
+  assert.match(action.params.content, /close at least two major clients/i);
+  assert.equal(action.params.source_message_id, 'msg_post_123');
+
+  assert.equal(
+    extractPostMessageAction('@Defty send Marigold a DM saying the deck is ready.', 'msg_dm_123'),
+    null,
+  );
+});
+
+test('thread continuation commands only activate when the thread already contains task intent', () => {
+  assert.equal(
+    isThreadTaskContinuationCommand('@Defty do the above', [
+      {
+        id: 'root_1',
+        userName: 'Diego',
+        content: '@defty assign a task named "peepee poopoo" for next thursday to marigold.',
+      },
+    ]),
+    true,
+  );
+
+  assert.equal(
+    isThreadTaskContinuationCommand('@Defty do the above', [
+      {
+        id: 'root_2',
+        userName: 'Diego',
+        content: 'I think the pizza order should be half thin crust and half deep dish.',
+      },
+    ]),
+    false,
+  );
+});
+
+test('explicit create-task fallback rejects negated task commands', () => {
+  assert.equal(
+    extractExplicitCreateTaskAction(
+      "Defty, do not create a task for this yet. I'm only thinking out loud.",
+      'msg_456',
+      { projectName: 'Pilot Marketing Launch' },
+    ),
+    null,
+  );
+});
+
+test('approval copy points to the inline card before inbox fallback', () => {
+  const normalized = normalizeApprovalSurfaceCopy(
+    'The task is ready. Please check your Inbox under the Approvals tab to approve or reject this task creation.',
+  );
+
+  assert.match(normalized, /approval card below this message/i);
+  assert.match(normalized, /Inbox > Approvals/i);
+  assert.doesNotMatch(normalized, /check your Inbox under the Approvals tab/i);
 });


### PR DESCRIPTION
## Summary
- route live Defty writes through the shared compiler and transactional reply/action persistence
- resolve project, task, assignee, and channel targets before approval
- support deterministic task creation, task status follow-ups, discussion-to-task requests, and message-post fallbacks
- preserve referential follow-ups such as all three, both, and first two without inventing targets
- author completion confirmations as Defty rather than the approving human
- add timing/iteration metrics and bounded interactive reasoning
- prevent the Defty system employee from being dispatched as a BYOA runtime

## Validation
- focused runtime/route/mention battery: 44/44
- API typecheck
- full API suite: 699/699

## Risk
High. This adopts the governed compiler in the live Defty reply and approval lifecycle. The compiler primitives and task-bundle foundation were merged separately first, and the UI integration remains in a later PR.