### PR TITLE
Show governed approvals inline in chat and threads

### DIFF
--- a/apps/api/src/routes/messages.ts
+++ b/apps/api/src/routes/messages.ts
@@ -64,15 +64,22 @@ async function getVisibleMessage(messageId: string, orgId: string, userId: strin
     org_id: messages.org_id,
     space_id: messages.space_id,
     user_id: messages.user_id,
+    parent_id: messages.parent_id,
     content: messages.content,
+    is_deleted: messages.is_deleted,
+    metadata: messages.metadata,
     created_at: messages.created_at,
     edited_at: messages.edited_at,
+    user_name: users.name,
+    user_avatar: users.avatar_url,
+    user_timezone: users.timezone,
   })
     .from(messages)
     .innerJoin(spaceMembers, and(
       eq(messages.space_id, spaceMembers.space_id),
       eq(spaceMembers.user_id, userId),
     ))
+    .innerJoin(users, eq(messages.user_id, users.id))
     .where(and(
       eq(messages.id, messageId),
       eq(messages.org_id, orgId),
@@ -957,16 +964,21 @@ messageRoutes.get('/:id/thread', async (c) => {
       )
       .orderBy(messages.created_at);
 
-    // Fetch reactions for replies
+    // Fetch reactions for parent + replies so deep-linked thread drawers can
+    // hydrate from this endpoint without needing the parent message list first.
     const replyIds = replies.map((r) => r.id);
-    const reactionsMap = await getReactionsForMessages(replyIds);
+    const reactionsMap = await getReactionsForMessages([parentMsg.id, ...replyIds]);
+    const parentWithReactions = {
+      ...parentMsg,
+      reactions: reactionsMap.get(parentMsg.id) ?? [],
+    };
 
     const repliesWithReactions = replies.map((reply) => ({
       ...reply,
       reactions: reactionsMap.get(reply.id) ?? [],
     }));
 
-    return c.json({ replies: repliesWithReactions });
+    return c.json({ parent: parentWithReactions, replies: repliesWithReactions });
   } catch (err) {
     console.error('Failed to fetch thread:', err);
     return c.json({ error: 'Failed to fetch thread', code: 'INTERNAL_ERROR' }, 500);

--- a/apps/api/src/workers/handlers/agent-employee-message.ts
+++ b/apps/api/src/workers/handlers/agent-employee-message.ts
@@ -114,18 +114,17 @@ export async function handleAgentEmployeeMessage(job: JobData): Promise<void> {
   try {
     const io = getIO();
     const deftyUserId = await ensureDeftyMembership(orgId);
-    const cadence = employee.heartbeat_interval_min ?? 30;
     const lastSeen = employee.last_mcp_call_at ?? employee.last_heartbeat_at ?? null;
-    const statusText = lastSeen
-      ? `Last MCP contact: ${new Date(lastSeen).toLocaleString('en-US', { timeZone: 'UTC' })} UTC.`
-      : 'No MCP contact has been recorded yet; connect or certify the runtime from the Developer tab.';
+    const humanStatus = lastSeen
+      ? `${employee.name} will reply here when they pick it up.`
+      : `${employee.name} has not checked in yet, but this is waiting for them.`;
     const [sysMsg] = await db
       .insert(messages)
       .values({
         org_id: orgId,
         space_id: spaceId,
         user_id: deftyUserId,
-        content: `Queued for ${employee.name}. Live channel delivery will wake the runtime when it is connected; fetch_unread remains available as a fallback${employee.wake_mode === 'polling' ? ` (polling about every ${cadence}m)` : ''}. ${statusText}`,
+        content: `Sent to ${employee.name}. ${humanStatus}`,
         parent_id: triggerMsg.parent_id ?? null,
         metadata: {
           kind: 'system_note',

--- a/apps/web/src/app/(app)/chat/page.tsx
+++ b/apps/web/src/app/(app)/chat/page.tsx
@@ -4,6 +4,7 @@ import { useEffect } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { SpaceChat } from '@/components/space-chat';
 import { ThreadPanel } from '@/components/thread-panel';
+import { api } from '@/lib/api';
 import { useChatContext } from '@/lib/chat-context';
 
 export default function ChatPage() {
@@ -12,6 +13,7 @@ export default function ChatPage() {
 
   const urlSpaceId = searchParams.get('space');
   const urlMessageId = searchParams.get('message');
+  const urlThreadId = searchParams.get('thread');
 
   // Sync layout's activeSpaceId state from the URL (back/forward, deep links).
   // MUST use the state-only setter — calling the navigating setActiveSpaceId
@@ -24,7 +26,28 @@ export default function ChatPage() {
     }
   }, [urlSpaceId, activeSpaceId, spaces, syncActiveSpaceIdFromUrl]);
 
-  const effectiveSpaceId = urlSpaceId || activeSpaceId;
+  useEffect(() => {
+    if (!urlThreadId || threadMessage?.id === urlThreadId) return;
+
+    let cancelled = false;
+    async function loadThreadParent() {
+      const res = await api.get(`/api/messages/${urlThreadId}/thread`);
+      if (!res.ok) return;
+      const data = await res.json();
+      const parent = data.parent;
+      if (!parent || cancelled) return;
+      if (parent.space_id && parent.space_id !== activeSpaceId && spaces.some(s => s.id === parent.space_id)) {
+        syncActiveSpaceIdFromUrl(parent.space_id);
+      }
+      setThreadMessage(parent);
+    }
+    loadThreadParent();
+    return () => {
+      cancelled = true;
+    };
+  }, [urlThreadId, threadMessage?.id, activeSpaceId, spaces, syncActiveSpaceIdFromUrl, setThreadMessage]);
+
+  const effectiveSpaceId = urlSpaceId || threadMessage?.space_id || activeSpaceId;
   const activeSpace = spaces.find((s) => s.id === effectiveSpaceId);
 
   return (

--- a/apps/web/src/components/agent-action-card.tsx
+++ b/apps/web/src/components/agent-action-card.tsx
@@ -3,17 +3,35 @@
 import { useState } from 'react';
 import {
   AlertTriangle,
+  BookOpen,
+  CalendarClock,
   CheckCircle2,
+  CheckSquare,
+  ChevronDown,
+  ChevronUp,
   Clock3,
   ExternalLink,
+  FolderKanban,
   Info,
+  MessageSquare,
   ReceiptText,
   RotateCcw,
+  ScrollText,
+  ShieldAlert,
+  Sparkles,
+  StickyNote,
+  Tag,
+  UserRound,
   XCircle,
 } from 'lucide-react';
 import { ReceiptViewer } from './receipt-viewer';
 import { humanizeToolName } from '@/lib/tool-display';
 import { stripHtml } from '@/lib/strip-html';
+import {
+  getAgentActionPresentation,
+  type ApprovalChipIconName,
+  type ApprovalIconName,
+} from '@/lib/agent-action-presentation';
 
 export type AgentAction = {
   id: string;
@@ -33,6 +51,7 @@ export type AgentAction = {
 };
 
 type LocalStatus = 'approving' | 'rejecting' | 'approved' | 'rejected' | null;
+type AgentActionCardVariant = 'review' | 'compact';
 export type AgentActionMutationResult = {
   status?: string;
   approval_status?: string;
@@ -264,6 +283,100 @@ function getProposedOutcome(actionName: string, params: Record<string, any>, fal
   };
 }
 
+function getDueLabel(params: Record<string, any>) {
+  const value = getStringParam(params, ['due_date', 'dueDate', 'deadline', 'due_at', 'scheduled_for']);
+  if (!value) return '';
+  const parsed = new Date(value);
+  if (Number.isFinite(parsed.getTime()) && /^\d{4}-\d{2}-\d{2}/.test(value)) {
+    return parsed.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  }
+  return truncate(value, 30);
+}
+
+function getCompactEyebrow(actionName: string, captureKind: unknown) {
+  if (actionName === 'wiki_create') {
+    if (captureKind === 'decision_candidate') return 'Decision draft';
+    if (captureKind === 'resource_candidate') return 'Resource draft';
+    return 'Knowledge draft';
+  }
+  if (actionName === 'task_create' || actionName === 'create_task') return 'Task draft';
+  if (actionName === 'task_update') return 'Task update draft';
+  if (actionName === 'post_message') return 'Message draft';
+  return 'Action draft';
+}
+
+function getCompactTitle(actionName: string, params: Record<string, any>, fallbackLabel: string) {
+  const title = getStringParam(params, ['title', 'name', 'summary']);
+  const space = getStringParam(params, ['space_name']);
+  if (actionName === 'post_message') {
+    return space ? `Post in #${space}` : 'Post a message';
+  }
+  if (title) return truncate(title, 96);
+  if (actionName === 'wiki_create') return 'Save a knowledge entry';
+  if (actionName === 'task_create' || actionName === 'create_task') return 'Create a task';
+  return fallbackLabel;
+}
+
+function getCompactSummary(actionName: string, params: Record<string, any>) {
+  const content = getStringParam(params, ['description', 'content', 'summary']);
+  if (!content) return '';
+  const max = actionName === 'post_message' ? 120 : 140;
+  return truncate(content, max);
+}
+
+function getCompactChips(actionName: string, params: Record<string, any>) {
+  const chips: Array<{ label: string; icon?: 'user' | 'calendar' | 'project' | 'book' | 'task' }> = [];
+  const assignee = getStringParam(params, ['assignee_name', 'assignee']);
+  const due = getDueLabel(params);
+  const project = getStringParam(params, ['project_name']);
+  const priority = getStringParam(params, ['priority']);
+  const scope = getScopeLabel(params);
+  const type = getStringParam(params, ['type']);
+  const subtaskText = getSubtaskDraftText(params);
+  const subtaskCount = subtaskText ? subtaskText.split('\n').filter((line) => /^\d+\./.test(line)).length : 0;
+
+  if (actionName === 'task_create' || actionName === 'create_task' || actionName === 'task_update') {
+    if (assignee) chips.push({ label: assignee, icon: 'user' });
+    if (due) chips.push({ label: due, icon: 'calendar' });
+    if (project) chips.push({ label: project, icon: 'project' });
+    if (subtaskCount > 0) chips.push({ label: `${subtaskCount} subtasks`, icon: 'task' });
+    if (priority) chips.push({ label: priority.toUpperCase(), icon: 'task' });
+  } else if (actionName === 'wiki_create') {
+    if (type) chips.push({ label: type.replaceAll('_', ' '), icon: 'book' });
+    if (scope) chips.push({ label: scope, icon: 'book' });
+  } else if (actionName === 'post_message') {
+    const space = getStringParam(params, ['space_name']);
+    if (space) chips.push({ label: `#${space}`, icon: 'project' });
+  }
+
+  return chips.slice(0, 4);
+}
+
+function CompactChipIcon({ icon }: { icon?: ApprovalChipIconName }) {
+  if (icon === 'user') return <UserRound size={12} strokeWidth={1.8} />;
+  if (icon === 'calendar') return <CalendarClock size={12} strokeWidth={1.8} />;
+  if (icon === 'project') return <FolderKanban size={12} strokeWidth={1.8} />;
+  if (icon === 'book') return <BookOpen size={12} strokeWidth={1.8} />;
+  if (icon === 'task') return <CheckSquare size={12} strokeWidth={1.8} />;
+  if (icon === 'message') return <MessageSquare size={12} strokeWidth={1.8} />;
+  if (icon === 'shield') return <ShieldAlert size={12} strokeWidth={1.8} />;
+  if (icon === 'clock') return <Clock3 size={12} strokeWidth={1.8} />;
+  if (icon === 'tag') return <Tag size={12} strokeWidth={1.8} />;
+  return null;
+}
+
+function CompactActionIcon({ icon }: { icon: ApprovalIconName }) {
+  if (icon === 'knowledge') return <BookOpen size={14} strokeWidth={1.9} />;
+  if (icon === 'message') return <MessageSquare size={14} strokeWidth={1.9} />;
+  if (icon === 'note') return <StickyNote size={14} strokeWidth={1.9} />;
+  if (icon === 'calendar') return <CalendarClock size={14} strokeWidth={1.9} />;
+  if (icon === 'canvas') return <ScrollText size={14} strokeWidth={1.9} />;
+  if (icon === 'plan') return <Sparkles size={14} strokeWidth={1.9} />;
+  if (icon === 'admin') return <ShieldAlert size={14} strokeWidth={1.9} />;
+  if (icon === 'generic') return <Info size={14} strokeWidth={1.9} />;
+  return <CheckSquare size={14} strokeWidth={1.9} />;
+}
+
 function getSourceQuote(params: Record<string, any>) {
   return getStringParam(params, [
     'source_message_content',
@@ -271,6 +384,65 @@ function getSourceQuote(params: Record<string, any>) {
     'source_content',
     'origin_message_content',
   ]);
+}
+
+function getDisplaySourceQuote(params: Record<string, any>) {
+  const quote = getSourceQuote(params)
+    .replace(/\*\*/g, '')
+    .replace(/^\s*[-*]\s+/gm, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  if (!quote) return '';
+  const lower = quote.toLowerCase();
+  if (
+    lower.includes('queued for your approval') ||
+    lower.includes('review the approval card') ||
+    lower.includes('where you can approve') ||
+    lower.includes('you can approve it')
+  ) {
+    return '';
+  }
+
+  return quote;
+}
+
+function getSubtaskDraftText(params: Record<string, any>) {
+  const subtasks = params.subtasks;
+  if (!Array.isArray(subtasks)) return '';
+  const lines = subtasks
+    .map((subtask, index) => {
+      if (!subtask || typeof subtask !== 'object') return '';
+      const record = subtask as Record<string, any>;
+      const title = getStringParam(record, ['title']);
+      if (!title) return '';
+      const assignee = getStringParam(record, ['assignee_name', 'assignee']);
+      const due = getStringParam(record, ['due_date', 'dueDate']);
+      const priority = getStringParam(record, ['priority']);
+      const meta = [assignee ? `assignee: ${assignee}` : '', due ? `due: ${due}` : '', priority ? priority.toUpperCase() : '']
+        .filter(Boolean)
+        .join(', ');
+      return `${index + 1}. ${title}${meta ? ` (${meta})` : ''}`;
+    })
+    .filter(Boolean);
+  if (lines.length === 0) return '';
+  return `Subtasks:\n${lines.join('\n')}`;
+}
+
+function getDraftDetailText(actionName: string, params: Record<string, any>) {
+  const messageActions = new Set(['post_message', 'message_post', 'send_message', 'post_thread_reply']);
+  if (messageActions.has(actionName)) {
+    return getStringParam(params, ['content', 'message', 'body', 'text']);
+  }
+  if (actionName === 'create_task' || actionName === 'task_create' || actionName === 'task_update') {
+    const description = getStringParam(params, ['description', 'content', 'summary', 'comment']);
+    const subtasks = getSubtaskDraftText(params);
+    return [description, subtasks].filter(Boolean).join('\n\n');
+  }
+  if (actionName.includes('wiki') || actionName.includes('memory') || actionName === 'create_note') {
+    return getStringParam(params, ['content', 'description', 'summary']);
+  }
+  return '';
 }
 
 function getTierLabel(tier?: string | null) {
@@ -285,18 +457,22 @@ export function AgentActionCard({
   onApprove,
   onReject,
   onUndo,
+  variant = 'review',
 }: {
   action: AgentAction;
   onApprove: () => AgentActionMutationResult | Promise<AgentActionMutationResult>;
   onReject: () => AgentActionMutationResult | Promise<AgentActionMutationResult>;
   onUndo?: () => void;
+  variant?: AgentActionCardVariant;
 }) {
   const [localStatus, setLocalStatus] = useState<LocalStatus>(null);
   const [localError, setLocalError] = useState<string | null>(null);
   const [localResult, setLocalResult] = useState<unknown>(null);
   const [showReceipt, setShowReceipt] = useState(false);
+  const [showDetails, setShowDetails] = useState(false);
 
   const humanized = humanizeToolName(action.action);
+  const presentation = getAgentActionPresentation(action);
   const displayLabel = ACTION_LABELS[action.action] ?? humanized.full;
   const captureLabel = typeof action.params.capture_kind === 'string'
     ? CAPTURE_LABELS[action.params.capture_kind] ?? null
@@ -304,9 +480,9 @@ export function AgentActionCard({
   const isCapture = Boolean(captureLabel || action.params.proposed_by === 'defty' || action.params.source_message_id || action.source === 'defty_capture');
   const captureHeadline = isCapture
     ? getCaptureHeadline(action.action, action.params.capture_kind, displayLabel)
-    : displayLabel;
-  const approveLabel = getApproveLabel(action.action, action.params.capture_kind, displayLabel);
-  const doneLabel = getStateLabel(action.action, action.params.capture_kind, displayLabel);
+    : presentation.headline || displayLabel;
+  const approveLabel = presentation.approveLabel || getApproveLabel(action.action, action.params.capture_kind, displayLabel);
+  const doneLabel = presentation.doneLabel || getStateLabel(action.action, action.params.capture_kind, displayLabel);
   const captureReason = getStringParam(action.params, ['capture_reason', 'policy_reason']);
   const workIntentStatus = typeof action.params.work_intent_status === 'string'
     ? INTENT_STATUS_LABELS[action.params.work_intent_status] ?? null
@@ -321,7 +497,8 @@ export function AgentActionCard({
   const resolvedStatus = localStatus ?? serverStatus;
   const isBusy = resolvedStatus === 'approving' || resolvedStatus === 'rejecting' || resolvedStatus === 'executing';
   const hasReceipt = Boolean(action.has_receipt || resolvedStatus === 'approved' || resolvedStatus === 'rejected');
-  const sourceQuote = getSourceQuote(action.params);
+  const sourceQuote = getDisplaySourceQuote(action.params);
+  const draftDetailText = getDraftDetailText(action.action, action.params);
   const outcome = getProposedOutcome(action.action, action.params, displayLabel);
   const confidence = formatConfidence(getNumberParam(action.params, ['confidence', 'capture_confidence', 'classification_confidence']));
   const age = formatAge(action.created_at);
@@ -348,6 +525,7 @@ export function AgentActionCard({
       : null;
   const createdAtMs = action.created_at ? new Date(action.created_at).getTime() : null;
   const isPossiblyStale = resolvedStatus === 'pending' && createdAtMs != null && Date.now() - createdAtMs > 60 * 60 * 1000;
+  const isCompact = variant === 'compact';
 
   async function handleApprove() {
     if (isBusy) return;
@@ -512,26 +690,281 @@ export function AgentActionCard({
     );
   }
 
+  if (isCompact) {
+    const compactTitle = presentation.title || getCompactTitle(action.action, action.params, displayLabel);
+    const compactSummary = presentation.summary || getCompactSummary(action.action, action.params);
+    const compactEyebrow = presentation.eyebrow || getCompactEyebrow(action.action, action.params.capture_kind);
+    const compactChips = presentation.chips.length > 0 ? presentation.chips : getCompactChips(action.action, action.params);
+    const compactBadge = presentation.badge ?? getStringParam(action.params, ['priority']);
+    const compactApproveLabel = presentation.approveLabel || approveLabel;
+    const compactBadgeStyle = presentation.badgeTone === 'danger'
+      ? {
+        color: 'var(--status-red)',
+        background: 'rgba(239,68,68,0.12)',
+        border: '1px solid rgba(239,68,68,0.18)',
+      }
+      : presentation.badgeTone === 'caution'
+        ? {
+          color: 'var(--status-amber)',
+          background: 'rgba(245,158,11,0.12)',
+          border: '1px solid rgba(245,158,11,0.18)',
+        }
+        : {
+          color: 'var(--muted)',
+          background: 'var(--surface-container-highest)',
+          border: '1px solid var(--border)',
+        };
+
+    return (
+      <div
+        className="mt-2.5 w-full max-w-[500px]"
+        style={{
+          color: 'var(--foreground)',
+        }}
+      >
+        <div
+          className="rounded-[18px] px-3.5 py-3"
+          style={{
+            background: 'linear-gradient(180deg, color-mix(in srgb, var(--bg-elevated) 96%, var(--primary) 4%), var(--bg-elevated))',
+            border: '1px solid color-mix(in srgb, var(--border) 72%, var(--primary) 28%)',
+            boxShadow: '0 12px 30px rgba(0,0,0,0.14)',
+          }}
+        >
+          <div className="flex items-start gap-2.5">
+            <div
+              className="mt-0.5 flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-xl"
+              style={{
+                background: 'color-mix(in srgb, var(--primary) 16%, transparent)',
+                color: 'var(--primary)',
+              }}
+              aria-hidden="true"
+            >
+              <CompactActionIcon icon={presentation.icon} />
+            </div>
+            <div className="min-w-0 flex-1">
+              <div className="flex min-w-0 items-start justify-between gap-2">
+                <p className="min-w-0 text-[11px] font-semibold uppercase tracking-[0.035em]" style={{ color: 'var(--primary)' }}>
+                  {compactEyebrow}
+                </p>
+                {compactBadge && (
+                  <span
+                    className="inline-flex flex-shrink-0 items-center rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase"
+                    style={compactBadgeStyle}
+                  >
+                    {compactBadge}
+                  </span>
+                )}
+              </div>
+              <p
+                className="mt-1 text-[14px] font-semibold leading-snug break-words [overflow-wrap:anywhere]"
+                style={{ color: 'var(--text-primary)' }}
+              >
+                {compactTitle}
+              </p>
+              {compactSummary && (
+                <p
+                  className="mt-1.5 line-clamp-2 text-[12px] leading-relaxed break-words [overflow-wrap:anywhere]"
+                  style={{ color: 'var(--foreground-secondary)' }}
+                >
+                  {compactSummary}
+                </p>
+              )}
+            </div>
+          </div>
+
+          {compactChips.length > 0 && (
+            <div
+              className="mt-3 flex flex-wrap gap-1.5 border-t pt-2.5"
+              style={{ borderColor: 'color-mix(in srgb, var(--border) 72%, transparent)' }}
+            >
+              {compactChips
+                .filter((chip) => chip.label.toLowerCase() !== String(compactBadge ?? '').toLowerCase())
+                .map((chip) => (
+                  <span
+                    key={`${chip.icon}-${chip.label}`}
+                    className="inline-flex max-w-full items-center gap-1.5 rounded-full px-2.5 py-1 text-[11px] font-medium"
+                    style={{
+                      color: 'var(--foreground-secondary)',
+                      background: 'color-mix(in srgb, var(--surface-container-highest) 82%, transparent)',
+                      border: '1px solid color-mix(in srgb, var(--border) 85%, transparent)',
+                    }}
+                  >
+                    <CompactChipIcon icon={chip.icon} />
+                    <span className="truncate">{chip.label}</span>
+                  </span>
+                ))}
+            </div>
+          )}
+
+          <div
+            className="mt-2.5 flex flex-wrap items-center gap-x-2 gap-y-1 text-[11px]"
+            style={{ color: 'var(--muted)' }}
+          >
+            <span>{presentation.sourceLabel}</span>
+          </div>
+
+          {showDetails && (
+            <div
+              className="mt-3 rounded-xl px-3 py-2.5 text-[12px]"
+              style={{
+                background: 'color-mix(in srgb, var(--surface) 86%, transparent)',
+                border: '1px solid var(--border)',
+              }}
+            >
+              <div className="flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-[0.04em]" style={{ color: 'var(--muted)' }}>
+                <Info size={12} strokeWidth={1.8} />
+                {presentation.detailsLabel}
+              </div>
+              {draftDetailText ? (
+                <p
+                  className="mt-1.5 max-h-72 overflow-y-auto whitespace-pre-wrap break-words [overflow-wrap:anywhere]"
+                  style={{ color: 'var(--foreground-secondary)' }}
+                >
+                  {draftDetailText}
+                </p>
+              ) : sourceQuote ? (
+                <p className="mt-1.5 max-h-20 overflow-y-auto break-words [overflow-wrap:anywhere]" style={{ color: 'var(--foreground-secondary)' }}>
+                  "{truncate(sourceQuote, 180)}"
+                </p>
+              ) : (
+                <p className="mt-1.5" style={{ color: 'var(--foreground-secondary)' }}>
+                  {presentation.emptyDetails}
+                </p>
+              )}
+              {isPossiblyStale && (
+                <p className="mt-1.5 text-[11px]" style={{ color: 'var(--muted)' }}>
+                  This draft is older than an hour. Re-read the thread if the work has moved on.
+                </p>
+              )}
+              {sourceMessageId && sourceSpaceId && (
+                <a
+                  href={`/chat?space=${sourceSpaceId}&message=${sourceMessageId}`}
+                  className="mt-2 inline-flex items-center gap-1 text-[11px] font-medium underline underline-offset-2"
+                  style={{ color: 'var(--primary)' }}
+                >
+                  Open source message
+                  <ExternalLink size={12} strokeWidth={1.7} />
+                </a>
+              )}
+            </div>
+          )}
+
+          {localError && (
+            <div
+              className="mt-3 flex items-start gap-2 rounded-xl px-3 py-2 text-[12px]"
+              style={{ background: 'rgba(239,68,68,0.08)', border: '1px solid rgba(239,68,68,0.18)', color: 'var(--status-red)' }}
+            >
+              <AlertTriangle size={13} strokeWidth={1.8} className="mt-0.5 flex-shrink-0" />
+              <p className="min-w-0 break-words [overflow-wrap:anywhere]">
+                {truncate(localError, 180)}
+              </p>
+            </div>
+          )}
+        </div>
+
+        <div className="mt-2.5 flex flex-wrap items-center gap-2">
+          <button
+            type="button"
+            onClick={handleApprove}
+            disabled={isBusy}
+            className="inline-flex min-h-[34px] items-center justify-center gap-1.5 rounded-xl px-4 py-1.5 text-[12px] font-semibold text-white shadow-sm disabled:opacity-60"
+            style={{ background: 'var(--primary-container)' }}
+          >
+            <CheckCircle2 size={13} strokeWidth={1.9} />
+            {compactApproveLabel}
+          </button>
+          <button
+            type="button"
+            onClick={handleReject}
+            disabled={isBusy}
+            className="inline-flex min-h-[34px] items-center justify-center gap-1.5 rounded-xl px-4 py-1.5 text-[12px] font-medium disabled:opacity-60"
+            style={{ background: 'var(--surface-container-highest)', color: 'var(--text-secondary)', border: '1px solid var(--border)' }}
+          >
+            Dismiss
+          </button>
+          <button
+            type="button"
+            onClick={() => setShowDetails((value) => !value)}
+            className="inline-flex min-h-[34px] items-center justify-center gap-1 rounded-xl px-2.5 py-1.5 text-[12px] font-medium"
+            style={{ color: 'var(--muted)' }}
+          >
+            {showDetails ? <ChevronUp size={14} strokeWidth={1.8} /> : <ChevronDown size={14} strokeWidth={1.8} />}
+            Details
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  const reviewTitle = presentation.title || captureHeadline;
+  const reviewSummary = presentation.summary || outcome.detail;
+  const reviewEyebrow = presentation.eyebrow || proposerLabel;
+  const reviewChips = presentation.chips.length > 0
+    ? presentation.chips
+    : getCompactChips(action.action, action.params);
+  const reviewBadge = presentation.badge ?? null;
+
   return (
     <div
       className="p-3 sm:p-3.5 mt-2 max-w-[460px] w-full min-w-0"
-      style={{ background: 'var(--bg-elevated)', border: '1px solid var(--border-strong)', borderRadius: '8px' }}
+      style={{
+        background: 'linear-gradient(180deg, color-mix(in srgb, var(--bg-elevated) 97%, var(--primary) 3%), var(--bg-elevated))',
+        border: '1px solid color-mix(in srgb, var(--border-strong) 78%, var(--primary) 22%)',
+        borderRadius: '18px',
+      }}
     >
       <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
-        <div className="min-w-0">
-          <p className="text-[10px] font-semibold uppercase tracking-[0.04em]" style={{ color: 'var(--muted)' }}>
-            {proposerLabel}
-          </p>
-          <p className="text-[13px] font-semibold break-words [overflow-wrap:anywhere]" style={{ color: 'var(--text-primary)' }}>
-            {captureHeadline}
-          </p>
-          {isCapture && (
-            <p className="text-[11px] mt-0.5" style={{ color: 'var(--muted)' }}>
-              Nothing changes until you approve.
+        <div className="flex min-w-0 items-start gap-2.5">
+          <div
+            className="mt-0.5 flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-xl"
+            style={{
+              background: 'color-mix(in srgb, var(--primary) 16%, transparent)',
+              color: 'var(--primary)',
+            }}
+            aria-hidden="true"
+          >
+            <CompactActionIcon icon={presentation.icon} />
+          </div>
+          <div className="min-w-0">
+            <p className="text-[10px] font-semibold uppercase tracking-[0.045em]" style={{ color: 'var(--primary)' }}>
+              {reviewEyebrow}
             </p>
-          )}
+            <p className="mt-0.5 text-[14px] font-semibold leading-snug break-words [overflow-wrap:anywhere]" style={{ color: 'var(--text-primary)' }}>
+              {reviewTitle}
+            </p>
+            {reviewSummary && (
+              <p className="mt-1 text-[12px] leading-relaxed line-clamp-2 break-words [overflow-wrap:anywhere]" style={{ color: 'var(--foreground-secondary)' }}>
+                {reviewSummary}
+              </p>
+            )}
+            {isCapture && (
+              <p className="text-[11px] mt-1" style={{ color: 'var(--muted)' }}>
+                Nothing changes until you approve.
+              </p>
+            )}
+          </div>
         </div>
         <div className="flex flex-wrap gap-1.5 sm:justify-end">
+          {reviewBadge && (
+            <span
+              className="text-[10px] px-2 py-0.5 rounded-full whitespace-nowrap font-semibold uppercase"
+              style={{
+                color: presentation.badgeTone === 'danger'
+                  ? 'var(--status-red)'
+                  : presentation.badgeTone === 'caution'
+                    ? 'var(--status-amber)'
+                    : 'var(--muted)',
+                background: presentation.badgeTone === 'danger'
+                  ? 'rgba(239,68,68,0.12)'
+                  : presentation.badgeTone === 'caution'
+                    ? 'rgba(245,158,11,0.12)'
+                    : 'var(--surface-container-highest)',
+                border: '1px solid var(--border)',
+              }}
+            >
+              {reviewBadge}
+            </span>
+          )}
           {isPossiblyStale && (
             <span
               className="text-[10px] px-2 py-0.5 rounded-full whitespace-nowrap"
@@ -549,17 +982,48 @@ export function AgentActionCard({
         </div>
       </div>
 
+      {reviewChips.length > 0 && (
+        <div
+          className="mt-3 flex flex-wrap gap-1.5 border-t pt-2.5"
+          style={{ borderColor: 'color-mix(in srgb, var(--border) 72%, transparent)' }}
+        >
+          {reviewChips
+            .filter((chip) => chip.label.toLowerCase() !== String(reviewBadge ?? '').toLowerCase())
+            .map((chip) => (
+              <span
+                key={`${chip.icon}-${chip.label}`}
+                className="inline-flex max-w-full items-center gap-1.5 rounded-full px-2.5 py-1 text-[11px] font-medium"
+                style={{
+                  color: 'var(--foreground-secondary)',
+                  background: 'color-mix(in srgb, var(--surface-container-highest) 82%, transparent)',
+                  border: '1px solid color-mix(in srgb, var(--border) 85%, transparent)',
+                }}
+              >
+                <CompactChipIcon icon={chip.icon} />
+                <span className="truncate">{chip.label}</span>
+              </span>
+            ))}
+        </div>
+      )}
+
       <div
         className="mt-3 rounded-md px-3 py-2 min-w-0"
         style={{ background: 'var(--surface)', border: '1px solid var(--border)' }}
       >
         <p className="text-[10px] font-semibold uppercase tracking-[0.04em]" style={{ color: 'var(--muted)' }}>
-          Proposed outcome
+          {presentation.detailsLabel}
         </p>
         <p className="text-[12px] font-medium mt-0.5 break-words [overflow-wrap:anywhere]" style={{ color: 'var(--foreground)' }}>
           {outcome.label}
         </p>
-        {outcome.detail && (
+        {draftDetailText ? (
+          <p
+            className="text-[11px] mt-1 max-h-72 overflow-y-auto whitespace-pre-wrap break-words [overflow-wrap:anywhere]"
+            style={{ color: 'var(--foreground-secondary)' }}
+          >
+            {draftDetailText}
+          </p>
+        ) : outcome.detail && (
           <p className="text-[11px] mt-0.5 break-words [overflow-wrap:anywhere]" style={{ color: 'var(--foreground-secondary)' }}>
             {outcome.detail}
           </p>

--- a/apps/web/src/components/notification-panel.tsx
+++ b/apps/web/src/components/notification-panel.tsx
@@ -13,6 +13,13 @@ type Props = {
   onClose: () => void;
 };
 
+async function apiErrorMessage(res: Response, fallback: string) {
+  const body = await res.json().catch(() => null);
+  if (body && typeof body.error === 'string' && body.error.trim()) return body.error;
+  if (body && typeof body.message === 'string' && body.message.trim()) return body.message;
+  return fallback;
+}
+
 export function NotificationPanel({ onClose }: Props) {
   const router = useRouter();
   const { items, isLoading, markRead, markAllRead, refresh } = useInbox();
@@ -45,7 +52,7 @@ export function NotificationPanel({ onClose }: Props) {
   const handleApprove = async (item: InboxItem) => {
     if (!item.approval) return;
     const res = await api.post(`/api/agent/actions/${item.approval.action_id}/approve`, {});
-    if (!res.ok) throw new Error(`Approve failed (${res.status})`);
+    if (!res.ok) throw new Error(await apiErrorMessage(res, `Approve failed (${res.status})`));
     const body = await res.json().catch(() => ({ status: 'approved' }));
     await markRead([item.id]);
     void refresh();
@@ -55,7 +62,7 @@ export function NotificationPanel({ onClose }: Props) {
   const handleReject = async (item: InboxItem) => {
     if (!item.approval) return;
     const res = await api.post(`/api/agent/actions/${item.approval.action_id}/reject`, {});
-    if (!res.ok) throw new Error(`Reject failed (${res.status})`);
+    if (!res.ok) throw new Error(await apiErrorMessage(res, `Reject failed (${res.status})`));
     const body = await res.json().catch(() => ({ status: 'rejected' }));
     await markRead([item.id]);
     void refresh();

--- a/apps/web/src/components/space-chat.tsx
+++ b/apps/web/src/components/space-chat.tsx
@@ -58,6 +58,7 @@ import { ClipRecorder } from './clip-recorder';
 import { UserProfileCard } from './user-profile-card';
 import { parseReminderTime } from './slash-command-autocomplete';
 import ConfirmDialog from './confirm-dialog';
+import { normalizeInlineApprovalCopy } from '@/lib/agent-approval-copy';
 import { useEditor, EditorContent } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
 import Link from '@tiptap/extension-link';
@@ -84,6 +85,13 @@ type LinkPreview = {
   favicon: string | null;
   siteName: string | null;
 };
+
+async function apiErrorMessage(res: Response, fallback: string) {
+  const body = await res.json().catch(() => null);
+  if (body && typeof body.error === 'string' && body.error.trim()) return body.error;
+  if (body && typeof body.message === 'string' && body.message.trim()) return body.message;
+  return fallback;
+}
 
 type Message = {
   id: string;
@@ -669,6 +677,12 @@ export function SpaceChat({
     },
     { refreshInterval: 5000, fallbackData: {} },
   );
+
+  const displayContentForMessage = useCallback((msg: Message) => {
+    const hasInlineApproval = Boolean(pendingByMessage?.[msg.id]?.length);
+    const hasApprovalContext = hasInlineApproval || Object.keys(pendingByMessage ?? {}).length > 0;
+    return normalizeInlineApprovalCopy(msg.content, hasApprovalContext);
+  }, [pendingByMessage]);
 
   const workIntentBySpaceKey = spaceId
     ? `/api/work-intents?space_id=${spaceId}&limit=100`
@@ -1437,14 +1451,14 @@ export function SpaceChat({
                         background: 'var(--surface)',
                       }}
                     >
-                      {renderContent(msg.content)}
+                      {renderContent(displayContentForMessage(msg))}
                     </span>
                   </div>
                 )}
 
                 {/* Message row */}
                 {!isSystemMessage && <div
-                  className={`relative px-3 -mx-3 rounded-lg ${highlightedId === msg.id ? 'message-highlight' : ''}`}
+                  className={`relative px-3 -mx-2 md:-mx-3 rounded-lg ${highlightedId === msg.id ? 'message-highlight' : ''}`}
                   style={{
                     background: highlightedId === msg.id ? 'var(--accent-subtle)' : 'transparent',
                     marginTop: grouped ? '2px' : (i === 0 || showDaySeparator) ? '0px' : '16px',
@@ -1810,7 +1824,7 @@ export function SpaceChat({
                               return (
                                 <>
                                   <div className="text-[13px] whitespace-pre-wrap break-words" style={{ color: 'var(--foreground)', lineHeight: '20px' }}>
-                                    {renderContent(msg.content)}
+                                    {renderContent(displayContentForMessage(msg))}
                                     <WorkIntentReceiptChips intents={messageWorkIntents} inline className="ml-1 align-middle" />
                                     {msg.edited_at && <EditedIndicator messageId={msg.id} />}
                                   </div>
@@ -1843,9 +1857,10 @@ export function SpaceChat({
                               <AgentActionCard
                                 key={action.id}
                                 action={action}
+                                variant="compact"
                                 onApprove={async () => {
                                   const res = await api.post(`/api/agent/actions/${action.id}/approve`, {});
-                                  if (!res.ok) throw new Error(`Approve failed (${res.status})`);
+                                  if (!res.ok) throw new Error(await apiErrorMessage(res, `Approve failed (${res.status})`));
                                   const body = await res.json().catch(() => ({ status: 'approved' }));
                                   if (pendingBySpaceKey) swrMutate(pendingBySpaceKey);
                                   if (workIntentBySpaceKey) swrMutate(workIntentBySpaceKey);
@@ -1853,7 +1868,7 @@ export function SpaceChat({
                                 }}
                                 onReject={async () => {
                                   const res = await api.post(`/api/agent/actions/${action.id}/reject`, {});
-                                  if (!res.ok) throw new Error(`Reject failed (${res.status})`);
+                                  if (!res.ok) throw new Error(await apiErrorMessage(res, `Reject failed (${res.status})`));
                                   const body = await res.json().catch(() => ({ status: 'rejected' }));
                                   if (pendingBySpaceKey) swrMutate(pendingBySpaceKey);
                                   if (workIntentBySpaceKey) swrMutate(workIntentBySpaceKey);
@@ -1967,7 +1982,7 @@ export function SpaceChat({
                               return (
                                 <>
                                   <div className="text-[13px] whitespace-pre-wrap break-words mt-0.5" style={{ color: 'var(--foreground)', lineHeight: '20px' }}>
-                                    {renderContent(msg.content)}
+                                    {renderContent(displayContentForMessage(msg))}
                                     {msg.edited_at && <EditedIndicator messageId={msg.id} />}
                                   </div>
                                   <MessageFiles files={[...(msg.files || []), ...getEmbeddedFiles(msg.content)]} onImageClick={setLightboxSrc} />
@@ -1999,9 +2014,10 @@ export function SpaceChat({
                               <AgentActionCard
                                 key={action.id}
                                 action={action}
+                                variant="compact"
                                 onApprove={async () => {
                                   const res = await api.post(`/api/agent/actions/${action.id}/approve`, {});
-                                  if (!res.ok) throw new Error(`Approve failed (${res.status})`);
+                                  if (!res.ok) throw new Error(await apiErrorMessage(res, `Approve failed (${res.status})`));
                                   const body = await res.json().catch(() => ({ status: 'approved' }));
                                   if (pendingBySpaceKey) swrMutate(pendingBySpaceKey);
                                   if (workIntentBySpaceKey) swrMutate(workIntentBySpaceKey);
@@ -2009,7 +2025,7 @@ export function SpaceChat({
                                 }}
                                 onReject={async () => {
                                   const res = await api.post(`/api/agent/actions/${action.id}/reject`, {});
-                                  if (!res.ok) throw new Error(`Reject failed (${res.status})`);
+                                  if (!res.ok) throw new Error(await apiErrorMessage(res, `Reject failed (${res.status})`));
                                   const body = await res.json().catch(() => ({ status: 'rejected' }));
                                   if (pendingBySpaceKey) swrMutate(pendingBySpaceKey);
                                   if (workIntentBySpaceKey) swrMutate(workIntentBySpaceKey);

--- a/apps/web/src/components/thread-panel.tsx
+++ b/apps/web/src/components/thread-panel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useRef, useState, useCallback } from 'react';
-import { useRouter, useSearchParams } from 'next/navigation';
+import { useRouter } from 'next/navigation';
 import { api } from '@/lib/api';
 import { sanitizeHtml } from '@/lib/sanitize';
 import { getSocket } from '@/lib/socket';
@@ -11,6 +11,9 @@ import { formatMessageTime } from '@/lib/time';
 import { EmojiPicker } from './emoji-picker';
 import { RichComposer } from './rich-composer';
 import { useFileUpload } from './file-upload';
+import { AgentActionCard, type AgentAction } from './agent-action-card';
+import useSWR, { mutate as swrMutate } from 'swr';
+import { normalizeInlineApprovalCopy } from '@/lib/agent-approval-copy';
 
 type Reaction = {
   emoji: string;
@@ -21,6 +24,7 @@ type Reaction = {
 type Message = {
   id: string;
   content: string;
+  space_id?: string;
   user_id: string;
   user_name: string;
   user_avatar: string | null;
@@ -30,6 +34,13 @@ type Message = {
   reactions?: Reaction[];
   file_ids?: string[];
 };
+
+async function apiErrorMessage(res: Response, fallback: string) {
+  const body = await res.json().catch(() => null);
+  if (body && typeof body.error === 'string' && body.error.trim()) return body.error;
+  if (body && typeof body.message === 'string' && body.message.trim()) return body.message;
+  return fallback;
+}
 
 // formatTime imported as formatMessageTime from @/lib/time
 
@@ -152,7 +163,6 @@ export function ThreadPanel({ parentMessage, spaceId, onClose }: Props) {
   const messageId = parentMessage.id;
   const { user } = useAuth();
   const router = useRouter();
-  const searchParams = useSearchParams();
   const [replies, setReplies] = useState<Message[]>([]);
   const [loading, setLoading] = useState(true);
   const [emojiPickerMsgId, setEmojiPickerMsgId] = useState<string | null>(null);
@@ -162,6 +172,26 @@ export function ThreadPanel({ parentMessage, spaceId, onClose }: Props) {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const { uploadFile, uploading, progress: uploadProgress } = useFileUpload();
 
+  const pendingBySpaceKey = spaceId
+    ? `/api/agent/actions/pending-by-space?space_id=${spaceId}`
+    : null;
+
+  const { data: pendingByMessage } = useSWR(
+    pendingBySpaceKey,
+    async (url: string) => {
+      const res = await api.get(url);
+      if (!res.ok) return {} as Record<string, AgentAction[]>;
+      const list: Array<AgentAction & { message_id: string }> = await res.json();
+      const map: Record<string, AgentAction[]> = {};
+      for (const action of list) {
+        if (!action.message_id) continue;
+        (map[action.message_id] ??= []).push(action);
+      }
+      return map;
+    },
+    { refreshInterval: 5000, fallbackData: {} },
+  );
+
   useEffect(() => {
     const check = () => setIsMobile(window.innerWidth < 768);
     check();
@@ -169,23 +199,19 @@ export function ThreadPanel({ parentMessage, spaceId, onClose }: Props) {
     return () => window.removeEventListener('resize', check);
   }, []);
 
-  // Sync ?thread= URL param on open/close
+  const closeThread = useCallback(() => {
+    router.replace(spaceId ? `/chat?space=${spaceId}` : '/chat');
+    onClose();
+  }, [onClose, router, spaceId]);
+
+  // Sync ?thread= URL param on open. Closing owns URL cleanup explicitly via
+  // closeThread; doing this in effect cleanup races with React dev remounts and
+  // can strip a valid deep link before the thread has hydrated.
   useEffect(() => {
-    const currentSpace = searchParams.get('space');
-    const base = currentSpace ? `/chat?space=${currentSpace}&thread=${messageId}` : `/chat?thread=${messageId}`;
-    router.replace(base);
-    return () => {
-      // Strip ?thread= only if the user is still on /chat. If they navigated
-      // away (e.g. clicked Tasks/Notes in the sidebar), Next.js has already
-      // started pushing the new route — running router.replace here would
-      // race with and override that navigation, sending them back to /chat.
-      if (typeof window === 'undefined' || window.location.pathname !== '/chat') return;
-      const currentSpaceNow = new URLSearchParams(window.location.search).get('space');
-      const sp = currentSpaceNow ? `/chat?space=${currentSpaceNow}` : '/chat';
-      router.replace(sp);
-    };
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [messageId]);
+    const nextUrl = `/chat?space=${spaceId}&thread=${messageId}`;
+    if (typeof window !== 'undefined' && `${window.location.pathname}${window.location.search}` === nextUrl) return;
+    router.replace(nextUrl);
+  }, [messageId, router, spaceId]);
 
   const scrollToBottom = useCallback(() => {
     repliesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
@@ -225,6 +251,7 @@ export function ThreadPanel({ parentMessage, spaceId, onClose }: Props) {
     const onNewMessage = (msg: Message & { parent_id?: string }) => {
       if (msg.parent_id === messageId) {
         setReplies((prev) => [...prev, msg]);
+        if (pendingBySpaceKey) swrMutate(pendingBySpaceKey);
         setTimeout(scrollToBottom, 50);
       }
     };
@@ -277,16 +304,16 @@ export function ThreadPanel({ parentMessage, spaceId, onClose }: Props) {
       socket.off('reaction:added', onReactionAdded);
       socket.off('reaction:removed', onReactionRemoved);
     };
-  }, [messageId, scrollToBottom]);
+  }, [messageId, pendingBySpaceKey, scrollToBottom]);
 
   // Escape to close
   useEffect(() => {
     function handleKey(e: KeyboardEvent) {
-      if (e.key === 'Escape') onClose();
+      if (e.key === 'Escape') closeThread();
     }
     document.addEventListener('keydown', handleKey);
     return () => document.removeEventListener('keydown', handleKey);
-  }, [onClose]);
+  }, [closeThread]);
 
   const handleRichSend = async (html: string, _text: string) => {
     let content = html;
@@ -338,8 +365,41 @@ export function ThreadPanel({ parentMessage, spaceId, onClose }: Props) {
     }
   };
 
+  const renderPendingActions = (msgId: string) => {
+    const actions = pendingByMessage?.[msgId] ?? [];
+    if (actions.length === 0) return null;
+    return (
+      <div className="mt-3 space-y-2">
+        {actions.map((action) => (
+          <AgentActionCard
+            key={action.id}
+            action={action}
+            variant="compact"
+            onApprove={async () => {
+              const res = await api.post(`/api/agent/actions/${action.id}/approve`, {});
+              if (!res.ok) throw new Error(await apiErrorMessage(res, `Approve failed (${res.status})`));
+              const body = await res.json().catch(() => ({ status: 'approved' }));
+              if (pendingBySpaceKey) swrMutate(pendingBySpaceKey);
+              return body;
+            }}
+            onReject={async () => {
+              const res = await api.post(`/api/agent/actions/${action.id}/reject`, {});
+              if (!res.ok) throw new Error(await apiErrorMessage(res, `Reject failed (${res.status})`));
+              const body = await res.json().catch(() => ({ status: 'rejected' }));
+              if (pendingBySpaceKey) swrMutate(pendingBySpaceKey);
+              return body;
+            }}
+          />
+        ))}
+      </div>
+    );
+  };
+
   const renderMessage = (msg: Message, isParent = false) => {
     const color = avatarColor(msg.user_name || '');
+    const inlineActions = pendingByMessage?.[msg.id] ?? [];
+    const hasApprovalContext = inlineActions.length > 0 || Object.keys(pendingByMessage ?? {}).length > 0;
+    const displayContent = normalizeInlineApprovalCopy(msg.content, hasApprovalContext);
     return (
       <div className={`flex gap-3 ${isParent ? 'py-3' : 'py-2'}`}>
         <div className="flex-shrink-0">
@@ -376,13 +436,15 @@ export function ThreadPanel({ parentMessage, spaceId, onClose }: Props) {
                 className="text-[13px] break-words mt-0.5"
                 style={{ color: 'var(--text-primary)', lineHeight: '20px' }}
               >
-                {renderContent(msg.content)}
+                {renderContent(displayContent)}
                 {msg.edited_at && (
                   <span className="text-[10px] ml-1.5" style={{ color: 'var(--muted)' }}>
                     (edited)
                   </span>
                 )}
               </div>
+
+              {renderPendingActions(msg.id)}
 
               {/* Reactions */}
               {msg.reactions && msg.reactions.length > 0 && (
@@ -447,7 +509,7 @@ export function ThreadPanel({ parentMessage, spaceId, onClose }: Props) {
         <div className="flex items-center gap-2">
           {isMobile && (
             <button
-              onClick={onClose}
+              onClick={closeThread}
               className="flex items-center justify-center min-h-[44px] min-w-[44px] rounded-md mr-1"
               style={{ color: 'var(--muted)' }}
             >
@@ -463,7 +525,7 @@ export function ThreadPanel({ parentMessage, spaceId, onClose }: Props) {
         </div>
         {!isMobile && (
           <button
-            onClick={onClose}
+            onClick={closeThread}
             className="flex items-center justify-center min-h-[44px] min-w-[44px] md:min-h-0 md:min-w-0 md:p-1 rounded-md"
             style={{ color: 'var(--muted)' }}
           >

--- a/apps/web/src/lib/agent-action-presentation.ts
+++ b/apps/web/src/lib/agent-action-presentation.ts
@@ -1,0 +1,487 @@
+import { stripHtml } from '@/lib/strip-html';
+
+export type AgentActionForPresentation = {
+  action: string;
+  params: Record<string, any>;
+  approval_tier?: 'auto' | 'quick' | 'full' | string | null;
+  source?: string | null;
+  employee_name?: string | null;
+  proposer?: 'employee' | 'defty' | string | null;
+  created_at?: string;
+};
+
+export type ApprovalIconName =
+  | 'task'
+  | 'message'
+  | 'knowledge'
+  | 'note'
+  | 'calendar'
+  | 'canvas'
+  | 'plan'
+  | 'admin'
+  | 'generic';
+
+export type ApprovalChipIconName =
+  | 'user'
+  | 'calendar'
+  | 'project'
+  | 'book'
+  | 'task'
+  | 'message'
+  | 'shield'
+  | 'clock'
+  | 'tag';
+
+export type ApprovalCardPresentation = {
+  kind:
+    | 'task_create'
+    | 'task_update'
+    | 'message'
+    | 'knowledge'
+    | 'note'
+    | 'calendar'
+    | 'canvas'
+    | 'plan'
+    | 'admin'
+    | 'generic';
+  icon: ApprovalIconName;
+  eyebrow: string;
+  headline: string;
+  title: string;
+  summary: string;
+  approveLabel: string;
+  doneLabel: string;
+  sourceLabel: string;
+  detailsLabel: string;
+  emptyDetails: string;
+  badge?: string;
+  badgeTone?: 'neutral' | 'caution' | 'danger';
+  chips: Array<{ label: string; icon?: ApprovalChipIconName }>;
+};
+
+function cleanText(value: unknown): string {
+  if (typeof value !== 'string') return '';
+  return stripHtml(value).replace(/\s+/g, ' ').trim();
+}
+
+export function truncateApprovalText(value: string, max = 140) {
+  const cleaned = value.replace(/\s+/g, ' ').trim();
+  return cleaned.length > max ? `${cleaned.slice(0, max - 3)}...` : cleaned;
+}
+
+export function getStringParam(params: Record<string, any>, keys: string[]) {
+  for (const key of keys) {
+    const value = params[key];
+    if (typeof value === 'string' && value.trim()) return cleanText(value);
+  }
+  return '';
+}
+
+function getNestedStringParam(params: Record<string, any>, keys: string[]) {
+  for (const key of keys) {
+    const parts = key.split('.');
+    let value: unknown = params;
+    for (const part of parts) {
+      if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        value = undefined;
+        break;
+      }
+      value = (value as Record<string, unknown>)[part];
+    }
+    if (typeof value === 'string' && value.trim()) return cleanText(value);
+  }
+  return '';
+}
+
+function getSubtaskDrafts(params: Record<string, any>): Array<{ title: string }> {
+  const subtasks = params.subtasks;
+  if (!Array.isArray(subtasks)) return [];
+  return subtasks
+    .map((subtask) => {
+      if (!subtask || typeof subtask !== 'object') return { title: '' };
+      return { title: cleanText((subtask as Record<string, unknown>).title) };
+    })
+    .filter((subtask) => subtask.title.length > 0);
+}
+
+function getNumberParam(params: Record<string, any>, keys: string[]) {
+  for (const key of keys) {
+    const value = params[key];
+    if (typeof value === 'number' && Number.isFinite(value)) return value;
+    if (typeof value === 'string' && value.trim() && Number.isFinite(Number(value))) return Number(value);
+  }
+  return null;
+}
+
+function getDueLabel(params: Record<string, any>) {
+  const value = getNestedStringParam(params, [
+    'due_date',
+    'dueDate',
+    'deadline',
+    'due_at',
+    'scheduled_for',
+    'patch.due_date',
+    'remind_at',
+  ]);
+  if (!value) return '';
+  const parsed = new Date(value);
+  if (Number.isFinite(parsed.getTime()) && /^\d{4}-\d{2}-\d{2}/.test(value)) {
+    return parsed.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  }
+  return truncateApprovalText(value, 30);
+}
+
+function getScopeLabel(params: Record<string, any>) {
+  const scope = getStringParam(params, ['scope', 'visibility']);
+  if (scope === 'org') return 'Team-wide';
+  if (scope === 'space') return params.space_name ? `#${cleanText(params.space_name)}` : 'Space scoped';
+  if (scope === 'user') return 'Personal';
+  if (scope === 'private') return 'Private';
+  if (scope) return scope.replaceAll('_', ' ');
+  if (params.source_space_id || params.space_id) return 'Space source';
+  return '';
+}
+
+function formatConfidence(value: number | null) {
+  if (value === null) return '';
+  const normalized = value > 1 ? value / 100 : value;
+  const clamped = Math.max(0, Math.min(1, normalized));
+  if (clamped >= 0.8) return `${Math.round(clamped * 100)}% confidence`;
+  if (clamped >= 0.55) return `${Math.round(clamped * 100)}% confidence`;
+  return `${Math.round(clamped * 100)}% confidence`;
+}
+
+function formatAge(createdAt?: string) {
+  if (!createdAt) return '';
+  const ageMs = Date.now() - new Date(createdAt).getTime();
+  if (!Number.isFinite(ageMs) || ageMs < 0) return '';
+  const minutes = Math.floor(ageMs / 60000);
+  if (minutes < 1) return 'just now';
+  if (minutes < 60) return `${minutes}m old`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h old`;
+  const days = Math.floor(hours / 24);
+  return `${days}d old`;
+}
+
+function pushChip(
+  chips: ApprovalCardPresentation['chips'],
+  label: string,
+  icon?: ApprovalChipIconName,
+) {
+  if (!label) return;
+  if (chips.some((chip) => chip.label.toLowerCase() === label.toLowerCase())) return;
+  chips.push({ label: truncateApprovalText(label, 34), icon });
+}
+
+function getTaskIdentity(params: Record<string, any>) {
+  return getNestedStringParam(params, [
+    'task_identifier',
+    'task_id',
+    'task_number',
+    'id',
+    'patch.task_identifier',
+  ]);
+}
+
+function getTaskPatchSummary(params: Record<string, any>) {
+  const task = getTaskIdentity(params) || 'task';
+  const status = getNestedStringParam(params, ['new_status', 'status', 'patch.status']);
+  const assignee = getNestedStringParam(params, ['assignee_name', 'assignee', 'patch.assignee_name']);
+  const priority = getNestedStringParam(params, ['priority', 'patch.priority']);
+  const due = getDueLabel(params);
+  const label = getNestedStringParam(params, ['label_name', 'patch.label_name']);
+  const comment = getNestedStringParam(params, ['comment', 'content', 'patch.comment']);
+
+  if (status) return `Move ${task} to ${status.replaceAll('_', ' ')}`;
+  if (assignee) return `Assign ${task} to ${assignee}`;
+  if (priority) return `Set ${task} to ${priority.toUpperCase()}`;
+  if (due) return `Set ${task} due ${due}`;
+  if (label) return `Add ${label} to ${task}`;
+  if (comment) return `Comment on ${task}`;
+  return `Update ${task}`;
+}
+
+function actionKind(actionName: string): ApprovalCardPresentation['kind'] {
+  if (['create_task', 'task_create'].includes(actionName)) return 'task_create';
+  if (
+    [
+      'task_update',
+      'update_task',
+      'update_task_status',
+      'assign_task',
+      'comment_on_task',
+      'set_due_date',
+      'set_priority',
+      'add_label',
+      'close_task',
+      'reopen_task',
+      'add_dependency',
+      'remove_dependency',
+      'task_transition',
+    ].includes(actionName)
+  ) return 'task_update';
+  if (['post_message', 'message_post', 'send_message', 'post_thread_reply'].includes(actionName)) return 'message';
+  if (
+    [
+      'wiki_create',
+      'wiki_update',
+      'wiki_write',
+      'memory_update',
+      'add_knowledge',
+      'note_to_wiki',
+      'link_decision_to_tasks',
+      'mark_decision_implemented',
+    ].includes(actionName)
+  ) return 'knowledge';
+  if (['create_note'].includes(actionName)) return 'note';
+  if (['create_reminder', 'schedule_meeting', 'calendar_create', 'calendar_update'].includes(actionName)) return 'calendar';
+  if (['write_canvas'].includes(actionName)) return 'canvas';
+  if (['create_plan'].includes(actionName)) return 'plan';
+  if (
+    [
+      'manage_agent_employee',
+      'manage_mcp_connection',
+      'manage_triggers',
+      'remove_member',
+    ].includes(actionName) ||
+    actionName.startsWith('delete_')
+  ) return 'admin';
+  return 'generic';
+}
+
+function getMessageTarget(params: Record<string, any>) {
+  const space = getNestedStringParam(params, ['space_name', 'target.space_name']);
+  if (space) return `#${space}`;
+  const spaceId = getNestedStringParam(params, ['space_id', 'resolved_space_id', 'target.space_id']);
+  if (spaceId) return 'selected space';
+  const user = getNestedStringParam(params, ['target.user_name', 'user_name']);
+  if (user) return user;
+  const thread = getNestedStringParam(params, ['parent_message_id', 'thread_id', 'target.thread_id']);
+  if (thread) return 'thread';
+  return 'chat';
+}
+
+export function getAgentActionPresentation(action: AgentActionForPresentation): ApprovalCardPresentation {
+  const { params } = action;
+  const kind = actionKind(action.action);
+  const title = getStringParam(params, ['title', 'name', 'summary']);
+  const content = getNestedStringParam(params, ['description', 'content', 'summary', 'patch.description']);
+  const assignee = getNestedStringParam(params, ['assignee_name', 'assignee', 'patch.assignee_name']);
+  const due = getDueLabel(params);
+  const project = getNestedStringParam(params, ['project_name', 'project', 'project_title']);
+  const priority = getNestedStringParam(params, ['priority', 'patch.priority']);
+  const type = getStringParam(params, ['type']);
+  const scope = getScopeLabel(params);
+  const confidence = formatConfidence(getNumberParam(params, ['confidence', 'capture_confidence', 'classification_confidence']));
+  const age = formatAge(action.created_at);
+  const chips: ApprovalCardPresentation['chips'] = [];
+
+  if (kind === 'task_create') {
+    const subtasks = getSubtaskDrafts(params);
+    pushChip(chips, assignee, 'user');
+    pushChip(chips, due, 'calendar');
+    pushChip(chips, project, 'project');
+    if (subtasks.length > 0) pushChip(chips, `${subtasks.length} subtasks`, 'task');
+    pushChip(chips, priority.toUpperCase(), 'task');
+    return {
+      kind,
+      icon: 'task',
+      eyebrow: 'Task draft',
+      headline: 'Defty drafted a task',
+      title: title || 'Create a task',
+      summary: content
+        ? truncateApprovalText(content, 140)
+        : subtasks.length > 0
+          ? `Creates a parent task with ${subtasks.length} subtasks: ${truncateApprovalText(subtasks.map((subtask) => subtask.title).join(', '), 110)}`
+          : 'Review the proposed task before it is added to the workspace.',
+      approveLabel: 'Approve task',
+      doneLabel: 'Task created',
+      sourceLabel: age ? `Source: Defty - ${age}` : 'Source: Defty',
+      detailsLabel: 'Task details',
+      emptyDetails: 'Prepared from this thread. A receipt is saved after approval or dismissal.',
+      badge: priority ? priority.toUpperCase() : undefined,
+      badgeTone: 'caution',
+      chips,
+    };
+  }
+
+  if (kind === 'task_update') {
+    const task = getTaskIdentity(params);
+    pushChip(chips, task, 'task');
+    pushChip(chips, getNestedStringParam(params, ['new_status', 'status', 'patch.status']).replaceAll('_', ' '), 'tag');
+    pushChip(chips, assignee, 'user');
+    pushChip(chips, due, 'calendar');
+    pushChip(chips, priority.toUpperCase(), 'task');
+    return {
+      kind,
+      icon: 'task',
+      eyebrow: 'Task update',
+      headline: 'Defty drafted a task update',
+      title: getTaskPatchSummary(params),
+      summary: content ? truncateApprovalText(content, 140) : 'Review the proposed task change before it is applied.',
+      approveLabel: 'Approve update',
+      doneLabel: 'Task updated',
+      sourceLabel: age ? `Source: Defty - ${age}` : 'Source: Defty',
+      detailsLabel: 'Change details',
+      emptyDetails: 'The card shows the proposed task mutation. A receipt is saved after approval or dismissal.',
+      chips,
+    };
+  }
+
+  if (kind === 'message') {
+    const target = getMessageTarget(params);
+    pushChip(chips, target, 'message');
+    pushChip(chips, age, 'clock');
+    return {
+      kind,
+      icon: 'message',
+      eyebrow: 'Message draft',
+      headline: 'Defty drafted a message',
+      title: `Post to ${target}`,
+      summary: content ? truncateApprovalText(content, 150) : 'Review the exact message before it is posted.',
+      approveLabel: 'Approve post',
+      doneLabel: 'Message posted',
+      sourceLabel: age ? `Source: Defty - ${age}` : 'Source: Defty',
+      detailsLabel: 'Full message',
+      emptyDetails: 'Nothing is posted until you approve this draft.',
+      badge: 'Visible',
+      badgeTone: 'caution',
+      chips,
+    };
+  }
+
+  if (kind === 'knowledge') {
+    pushChip(chips, type.replaceAll('_', ' '), 'book');
+    pushChip(chips, scope, 'shield');
+    pushChip(chips, confidence, 'tag');
+    return {
+      kind,
+      icon: 'knowledge',
+      eyebrow: action.action.includes('update') || action.action === 'memory_update' ? 'Knowledge update' : 'Knowledge draft',
+      headline: 'Defty drafted a knowledge change',
+      title: title || getNestedStringParam(params, ['slug']) || 'Save knowledge',
+      summary: content ? truncateApprovalText(content, 150) : 'Review what will be saved into shared memory.',
+      approveLabel: action.action.includes('update') ? 'Approve update' : 'Approve save',
+      doneLabel: action.action.includes('update') ? 'Knowledge updated' : 'Knowledge saved',
+      sourceLabel: age ? `Source: Defty - ${age}` : 'Source: Defty',
+      detailsLabel: 'Knowledge preview',
+      emptyDetails: 'This changes the workspace memory. Review scope and source before approving.',
+      chips,
+    };
+  }
+
+  if (kind === 'note') {
+    pushChip(chips, scope || 'Private', 'book');
+    pushChip(chips, age, 'clock');
+    return {
+      kind,
+      icon: 'note',
+      eyebrow: 'Note draft',
+      headline: 'Defty drafted a note',
+      title: title || 'Create a note',
+      summary: content ? truncateApprovalText(content, 150) : 'Review the note before it is saved.',
+      approveLabel: 'Approve note',
+      doneLabel: 'Note saved',
+      sourceLabel: age ? `Source: Defty - ${age}` : 'Source: Defty',
+      detailsLabel: 'Note preview',
+      emptyDetails: 'This creates a note using the visibility shown above.',
+      chips,
+    };
+  }
+
+  if (kind === 'calendar') {
+    pushChip(chips, due, 'calendar');
+    pushChip(chips, getNestedStringParam(params, ['attendee_name', 'attendees']), 'user');
+    return {
+      kind,
+      icon: 'calendar',
+      eyebrow: action.action === 'create_reminder' ? 'Reminder draft' : 'Calendar draft',
+      headline: 'Defty drafted a calendar change',
+      title: title || content || 'Create reminder',
+      summary: content ? truncateApprovalText(content, 150) : 'Review the timing before this is scheduled.',
+      approveLabel: action.action === 'create_reminder' ? 'Approve reminder' : 'Approve calendar',
+      doneLabel: action.action === 'create_reminder' ? 'Reminder created' : 'Calendar updated',
+      sourceLabel: age ? `Source: Defty - ${age}` : 'Source: Defty',
+      detailsLabel: 'Timing details',
+      emptyDetails: 'This will create or change a scheduled item.',
+      chips,
+    };
+  }
+
+  if (kind === 'canvas') {
+    pushChip(chips, getNestedStringParam(params, ['space_name']), 'project');
+    return {
+      kind,
+      icon: 'canvas',
+      eyebrow: 'Canvas update',
+      headline: 'Defty drafted a canvas update',
+      title: title || 'Update shared canvas',
+      summary: content ? truncateApprovalText(content, 150) : 'Review the shared canvas change before applying it.',
+      approveLabel: 'Approve canvas',
+      doneLabel: 'Canvas updated',
+      sourceLabel: age ? `Source: Defty - ${age}` : 'Source: Defty',
+      detailsLabel: 'Canvas preview',
+      emptyDetails: 'This changes a shared surface visible to the space.',
+      chips,
+    };
+  }
+
+  if (kind === 'plan') {
+    const steps = Array.isArray(params.steps) ? params.steps.length : null;
+    pushChip(chips, steps ? `${steps} steps` : '', 'task');
+    return {
+      kind,
+      icon: 'plan',
+      eyebrow: 'Plan draft',
+      headline: 'Defty drafted a plan',
+      title: title || 'Review plan',
+      summary: content ? truncateApprovalText(content, 150) : 'Review the sequence before Defty starts executing.',
+      approveLabel: 'Approve plan',
+      doneLabel: 'Plan approved',
+      sourceLabel: age ? `Source: Defty - ${age}` : 'Source: Defty',
+      detailsLabel: 'Plan details',
+      emptyDetails: 'Plan steps are listed in the details payload.',
+      badge: 'Multi-step',
+      badgeTone: 'caution',
+      chips,
+    };
+  }
+
+  if (kind === 'admin') {
+    const target = getNestedStringParam(params, ['target', 'mode', 'name', 'slug']);
+    pushChip(chips, target, 'shield');
+    return {
+      kind,
+      icon: 'admin',
+      eyebrow: 'Admin review',
+      headline: 'Defty drafted an admin change',
+      title: title || action.action.replaceAll('_', ' '),
+      summary: content ? truncateApprovalText(content, 150) : 'Review this workspace-level change carefully.',
+      approveLabel: 'Approve change',
+      doneLabel: 'Admin change applied',
+      sourceLabel: age ? `Source: Defty - ${age}` : 'Source: Defty',
+      detailsLabel: 'Admin details',
+      emptyDetails: 'This may affect workspace access, agents, or connected apps.',
+      badge: 'Sensitive',
+      badgeTone: 'danger',
+      chips,
+    };
+  }
+
+  pushChip(chips, age, 'clock');
+  return {
+    kind,
+    icon: 'generic',
+    eyebrow: 'Action draft',
+    headline: `Defty drafted ${action.action.replaceAll('_', ' ')}`,
+    title: title || action.action.replaceAll('_', ' '),
+    summary: content ? truncateApprovalText(content, 150) : 'Review the proposed action before it runs.',
+    approveLabel: 'Approve',
+    doneLabel: 'Action completed',
+    sourceLabel: age ? `Source: Defty - ${age}` : 'Source: Defty',
+    detailsLabel: 'Action details',
+    emptyDetails: 'Review the parameters below before approving.',
+    chips,
+  };
+}

--- a/apps/web/src/lib/agent-approval-copy.ts
+++ b/apps/web/src/lib/agent-approval-copy.ts
@@ -1,0 +1,28 @@
+export function normalizeInlineApprovalCopy(content: string, hasInlineApproval: boolean) {
+  if (!hasInlineApproval) return content;
+
+  const normalized = content
+    .replace(
+      /\n?\s*Please check your Inbox under the ["']?Approvals["']? tab to approve or reject this task creation\.?/gi,
+      '\n\nReview the approval card below.',
+    )
+    .replace(
+      /\n?\s*You can approve the task creation by checking your Inbox under the ["']?Approvals["']? tab\.[\s\S]*?where you can approve or reject it\.?/gi,
+      '\n\nReview the approval card below.',
+    )
+    .replace(
+      /\n?\s*This task will be queued for your approval\. You can approve it for it to be created\.?/gi,
+      '\n\nReview the approval card below.',
+    )
+    .replace(
+      /\n?\s*You'll see an Approve\/Reject button here to finalize the task creation\. You can also manage this in your Inbox under the Approvals tab\.?/gi,
+      '\n\nReview the approval card below.',
+    );
+
+  if (/queued for your approval|approve or reject|approval card below|you can approve it/i.test(normalized)) {
+    if (/task/i.test(normalized)) return 'I drafted the task. Review the approval card below.';
+    return 'I drafted the update. Review the approval card below.';
+  }
+
+  return normalized.replace(/\n{3,}/g, '\n\n').trim();
+}

--- a/apps/web/src/lib/chat-context.tsx
+++ b/apps/web/src/lib/chat-context.tsx
@@ -17,6 +17,7 @@ type Space = {
 type ThreadMessage = {
   id: string;
   content: string;
+  space_id?: string;
   user_id: string;
   user_name: string;
   user_avatar: string | null;


### PR DESCRIPTION
## Summary
- render compact, action-aware approval cards beside the Defty reply that created them
- hydrate deep-linked thread drawers with their parent message and reactions
- mirror approvals in Inbox while keeping chat as the primary review surface
- show full detail payloads and actionable failure states without truncating the review path
- update pending cards through socket events and preserve mobile composer width
- replace BYOA runtime diagnostics with human queue copy

## Validation
- focused API route/mention tests: 27/27
- API typecheck
- web lint and typecheck
- full Next.js production build
- exact UI files were visually certified in the saved release-candidate checkpoint; a fresh browser pass is pending because the in-app browser could not attach a local tab during this run

## Risk
Medium-high. This changes approval presentation and thread hydration, while leaving execution semantics in the separately merged governed-runtime PR.