### PR TITLE
Harden Defty subtask follow-ups

### DIFF
--- a/apps/api/src/lib/agent-action-proposals.ts
+++ b/apps/api/src/lib/agent-action-proposals.ts
@@ -265,6 +265,7 @@ export async function compileDeftyActionDraft(params: CompileDeftyActionDraftPar
       'Missing priority should default to p2. Missing due date is allowed and means no due date.',
       'For create_task descriptions, write concise markdown: short summary plus bullets when useful. Do not create an unformatted text wall.',
       'If subtasks are requested, put them in subtasks and keep the parent task description brief.',
+      'Preserve subtask ordering as dependencies: when a later subtask says "after that", "after the previous step", or "after the draft", set depends_on to the matching earlier subtask using 1-based indexes.',
       'If the user says "me" or "myself", use caller_name as assignee_name when caller_name is provided.',
       'If the request refers to "all three", "both", or "those tasks", use the supplied prior task references.',
       'For ambiguous channel names, ask a clarification instead of guessing.',
@@ -563,7 +564,36 @@ function normalizeCompiledSubtasks(value: unknown, params: CompileDeftyActionDra
       });
     })
     .filter((subtask): subtask is NonNullable<typeof subtask> => Boolean(subtask));
-  return subtasks.length > 0 ? subtasks : undefined;
+  if (subtasks.length === 0) return undefined;
+
+  return subtasks.map((subtask, index) => {
+    if (subtask.depends_on?.length || index === 0) return subtask;
+    const inferred = inferSubtaskDependencies(subtask.title, subtasks, index);
+    if (inferred.length === 0) return subtask;
+    return { ...subtask, depends_on: inferred };
+  });
+}
+
+function inferSubtaskDependencies(
+  title: string,
+  subtasks: Array<{ title: string; depends_on?: number[] }>,
+  index: number,
+): number[] {
+  const normalized = title.toLowerCase();
+  if (/\bafter\s+(?:that|this|the previous (?:step|task)|the prior (?:step|task))\b/.test(normalized)) {
+    return [index];
+  }
+
+  const namedDependency = normalized.match(/\bafter\s+(?:the\s+)?([a-z][a-z0-9-]*)\b/)?.[1];
+  if (!namedDependency) return [];
+  const candidates = subtasks
+    .slice(0, index)
+    .map((candidate, candidateIndex) => ({
+      index: candidateIndex + 1,
+      matches: candidate.title.toLowerCase().includes(namedDependency),
+    }))
+    .filter((candidate) => candidate.matches);
+  return candidates.length === 1 ? [candidates[0]!.index] : [];
 }
 
 function normalizeCompiledAssignee(value: unknown, params: CompileDeftyActionDraftParams) {

--- a/apps/api/src/workers/handlers/agent-reply.ts
+++ b/apps/api/src/workers/handlers/agent-reply.ts
@@ -745,6 +745,7 @@ async function collectRecentAgentTaskReferences(options: {
   agentUserId: string;
   messageId: string;
   parentId?: string | null;
+  promptContent: string;
 }) {
   const [trigger] = await db
     .select({ created_at: messages.created_at })
@@ -777,9 +778,59 @@ async function collectRecentAgentTaskReferences(options: {
     .orderBy(desc(messages.created_at))
     .limit(5);
 
-  return uniqueTaskReferences(
+  const references = uniqueTaskReferences(
     priorAgentReplies.flatMap((reply) => extractTaskReferencesFromAgentReply(reply.content, reply.metadata)),
-  ).slice(0, MAX_INLINE_APPROVAL_ACTIONS);
+  );
+  if (!/\bsubtasks?\b/i.test(stripMentionSyntax(options.promptContent)) || references.length === 0) {
+    return references.slice(0, MAX_INLINE_APPROVAL_ACTIONS);
+  }
+
+  const referencedTasks = await db
+    .select({
+      id: tasks.id,
+      parent_task_id: tasks.parent_task_id,
+      identifier: sql<string>`${projects.prefix} || '-' || ${tasks.number}`,
+    })
+    .from(tasks)
+    .innerJoin(projects, eq(tasks.project_id, projects.id))
+    .where(and(
+      eq(tasks.org_id, options.orgId),
+      eq(tasks.is_deleted, false),
+      inArray(sql<string>`${projects.prefix} || '-' || ${tasks.number}`, references),
+    ));
+  const parentIds = referencedTasks.filter((task) => !task.parent_task_id).map((task) => task.id);
+  if (parentIds.length === 0) return references.slice(0, MAX_INLINE_APPROVAL_ACTIONS);
+
+  const childTasks = await db
+    .select({
+      identifier: sql<string>`${projects.prefix} || '-' || ${tasks.number}`,
+      number: tasks.number,
+    })
+    .from(tasks)
+    .innerJoin(projects, eq(tasks.project_id, projects.id))
+    .where(and(
+      eq(tasks.org_id, options.orgId),
+      eq(tasks.is_deleted, false),
+      inArray(tasks.parent_task_id, parentIds),
+    ))
+    .orderBy(tasks.number);
+  if (childTasks.length === 0) return references.slice(0, MAX_INLINE_APPROVAL_ACTIONS);
+
+  return preferSubtaskReferences(references, referencedTasks, childTasks);
+}
+
+export function preferSubtaskReferences(
+  references: string[],
+  referencedTasks: Array<{ identifier: string; parent_task_id: string | null }>,
+  childTasks: Array<{ identifier: string; number: number }>,
+) {
+  const parentReferences = new Set(
+    referencedTasks.filter((task) => !task.parent_task_id).map((task) => task.identifier.toUpperCase()),
+  );
+  return uniqueTaskReferences([
+    ...references.filter((reference) => !parentReferences.has(reference.toUpperCase())),
+    ...childTasks.sort((left, right) => left.number - right.number).map((task) => task.identifier),
+  ]).slice(0, MAX_INLINE_APPROVAL_ACTIONS);
 }
 
 function hasExplicitPostMessageIntent(content: string): boolean {
@@ -1419,6 +1470,7 @@ export async function handleAgentReply(job: JobData): Promise<void> {
           agentUserId,
           messageId,
           parentId: threadParentId,
+          promptContent,
         });
         compiledActionDraft = await compileDeftyActionDraft({
           orgId,
@@ -1566,6 +1618,7 @@ export async function handleAgentReply(job: JobData): Promise<void> {
           agentUserId,
           messageId,
           parentId: threadParentId,
+          promptContent,
         });
         compiledActionDraft = await compileDeftyActionDraft({
           orgId,

--- a/apps/api/test/agent-action-proposals.test.ts
+++ b/apps/api/test/agent-action-proposals.test.ts
@@ -84,6 +84,27 @@ test('real subtasks are not duplicated as bullets in the parent description', ()
   assert.deepEqual(result.actions[0]?.params.subtasks[1]?.depends_on, [1]);
 });
 
+test('natural subtask sequencing becomes real task dependencies', () => {
+  const result = normalizeCompiledToolCalls([{
+    name: 'create_task',
+    input: {
+      title: 'Buyer trial follow-up',
+      project_name: 'Pilot Marketing Launch',
+      subtasks: [
+        { title: 'Confirm trial rows' },
+        { title: 'Draft the buyer summary after that' },
+        { title: 'Post the approved summary after the draft' },
+      ],
+    },
+  }], compileContext);
+
+  assert.deepEqual(result.actions[0]?.params.subtasks, [
+    { title: 'Confirm trial rows' },
+    { title: 'Draft the buyer summary after that', depends_on: [1] },
+    { title: 'Post the approved summary after the draft', depends_on: [2] },
+  ]);
+});
+
 test('compound compiler normalization preserves every requested action family', () => {
   const result = normalizeCompiledToolCalls([
     { name: 'wiki_write', input: { title: 'Trial', type: 'fact', content: 'Water deeply.' } },

--- a/apps/api/test/agent-reply-discussion-command.test.ts
+++ b/apps/api/test/agent-reply-discussion-command.test.ts
@@ -11,6 +11,7 @@ import {
   isDiscussionTaskCommand,
   isThreadTaskContinuationCommand,
   normalizeApprovalSurfaceCopy,
+  preferSubtaskReferences,
 } from '../src/workers/handlers/agent-reply.js';
 
 test('compiler recovery gate recognizes the registered write families without choosing one', () => {
@@ -234,6 +235,26 @@ test('task references prefer the prior reply list before noisy source/citation t
   );
 
   assert.deepEqual(references, ['BUY-1', 'OPS-2', 'MKT-9']);
+});
+
+test('subtask follow-ups replace a parent reference with every child before applying the three-card cap', () => {
+  assert.deepEqual(
+    preferSubtaskReferences(
+      ['MKT-17', 'MKT-18', 'MKT-19', 'MKT-20'],
+      [
+        { identifier: 'MKT-17', parent_task_id: null },
+        { identifier: 'MKT-18', parent_task_id: 'parent-17' },
+        { identifier: 'MKT-19', parent_task_id: 'parent-17' },
+        { identifier: 'MKT-20', parent_task_id: 'parent-17' },
+      ],
+      [
+        { identifier: 'MKT-20', number: 20 },
+        { identifier: 'MKT-18', number: 18 },
+        { identifier: 'MKT-19', number: 19 },
+      ],
+    ),
+    ['MKT-18', 'MKT-19', 'MKT-20'],
+  );
 });
 
 test('post message fallback creates channel approval action but refuses DM wording', () => {

--- a/apps/web/src/components/agent-action-card.tsx
+++ b/apps/web/src/components/agent-action-card.tsx
@@ -439,6 +439,26 @@ function getDraftDetailText(actionName: string, params: Record<string, any>) {
     const subtasks = getSubtaskDraftText(params);
     return [description, subtasks].filter(Boolean).join('\n\n');
   }
+  const taskMutationActions = new Set([
+    'update_task', 'update_task_status', 'assign_task', 'comment_on_task', 'set_due_date',
+    'set_priority', 'add_label', 'close_task', 'reopen_task', 'add_dependency',
+    'remove_dependency', 'task_transition',
+  ]);
+  if (taskMutationActions.has(actionName)) {
+    const task = getStringParam(params, ['task_identifier', 'task_id', 'id']);
+    const status = getStringParam(params, ['new_status', 'status']) ||
+      (actionName === 'close_task' ? 'done' : actionName === 'reopen_task' ? 'reopened' : '');
+    const assignee = getStringParam(params, ['assignee_name', 'assignee']);
+    const due = getStringParam(params, ['due_date', 'dueDate']);
+    const priority = getStringParam(params, ['priority']);
+    return [
+      task ? `Task: ${task}` : '',
+      status ? `Status: ${status.replaceAll('_', ' ')}` : '',
+      assignee ? `Assignee: ${assignee}` : '',
+      due ? `Due: ${due}` : '',
+      priority ? `Priority: ${priority.toUpperCase()}` : '',
+    ].filter(Boolean).join('\n');
+  }
   if (actionName.includes('wiki') || actionName.includes('memory') || actionName === 'create_note') {
     return getStringParam(params, ['content', 'description', 'summary']);
   }

--- a/apps/web/src/lib/agent-action-presentation.ts
+++ b/apps/web/src/lib/agent-action-presentation.ts
@@ -184,7 +184,7 @@ function getTaskIdentity(params: Record<string, any>) {
   ]);
 }
 
-function getTaskPatchSummary(params: Record<string, any>) {
+function getTaskPatchSummary(params: Record<string, any>, actionName = '') {
   const task = getTaskIdentity(params) || 'task';
   const status = getNestedStringParam(params, ['new_status', 'status', 'patch.status']);
   const assignee = getNestedStringParam(params, ['assignee_name', 'assignee', 'patch.assignee_name']);
@@ -193,6 +193,8 @@ function getTaskPatchSummary(params: Record<string, any>) {
   const label = getNestedStringParam(params, ['label_name', 'patch.label_name']);
   const comment = getNestedStringParam(params, ['comment', 'content', 'patch.comment']);
 
+  if (actionName === 'close_task') return `Mark ${task} done`;
+  if (actionName === 'reopen_task') return `Reopen ${task}`;
   if (status) return `Move ${task} to ${status.replaceAll('_', ' ')}`;
   if (assignee) return `Assign ${task} to ${assignee}`;
   if (priority) return `Set ${task} to ${priority.toUpperCase()}`;
@@ -318,7 +320,7 @@ export function getAgentActionPresentation(action: AgentActionForPresentation): 
       icon: 'task',
       eyebrow: 'Task update',
       headline: 'Defty drafted a task update',
-      title: getTaskPatchSummary(params),
+      title: getTaskPatchSummary(params, action.action),
       summary: content ? truncateApprovalText(content, 140) : 'Review the proposed task change before it is applied.',
       approveLabel: 'Approve update',
       doneLabel: 'Task updated',


### PR DESCRIPTION
## What changed
- resolve natural follow-ups such as �all three subtasks� to the children of the latest parent task before the three-card safety cap
- preserve explicit natural subtask sequencing as real dependency edges
- show concrete task mutation details and clearer close/reopen titles on approval cards

## Why
Live post-merge dogfood on `demo.deft.ing` found that a parent plus three children were flattened and capped to the parent plus the first two children. The third child was omitted. The same run showed that task-update card details repeated generic approval copy instead of the proposed mutation, and natural �after that� ordering did not become dependencies.

## Validation
- `pnpm --filter @deft/api test` (701 passed)
- `pnpm --filter @deft/api typecheck`
- `pnpm --filter @deft/web typecheck`
- `pnpm --filter @deft/web lint`
- `pnpm --filter @deft/web build`
- focused regression battery for action compiler and discussion follow-ups (28 passed)
