### PR TITLE
Preserve Defty subtask dependency meaning

### DIFF
--- a/apps/api/src/lib/agent-action-proposals.ts
+++ b/apps/api/src/lib/agent-action-proposals.ts
@@ -568,18 +568,22 @@ function normalizeCompiledSubtasks(value: unknown, params: CompileDeftyActionDra
 
   return subtasks.map((subtask, index) => {
     if (subtask.depends_on?.length || index === 0) return subtask;
-    const inferred = inferSubtaskDependencies(subtask.title, subtasks, index);
+    const inferred = inferSubtaskDependencies(
+      [subtask.title, subtask.description].filter(Boolean).join(' '),
+      subtasks,
+      index,
+    );
     if (inferred.length === 0) return subtask;
     return { ...subtask, depends_on: inferred };
   });
 }
 
 function inferSubtaskDependencies(
-  title: string,
-  subtasks: Array<{ title: string; depends_on?: number[] }>,
+  meaning: string,
+  subtasks: Array<{ title: string; description?: string; depends_on?: number[] }>,
   index: number,
 ): number[] {
-  const normalized = title.toLowerCase();
+  const normalized = meaning.toLowerCase();
   if (/\bafter\s+(?:that|this|the previous (?:step|task)|the prior (?:step|task))\b/.test(normalized)) {
     return [index];
   }
@@ -590,7 +594,11 @@ function inferSubtaskDependencies(
     .slice(0, index)
     .map((candidate, candidateIndex) => ({
       index: candidateIndex + 1,
-      matches: candidate.title.toLowerCase().includes(namedDependency),
+      matches: [candidate.title, candidate.description]
+        .filter(Boolean)
+        .join(' ')
+        .toLowerCase()
+        .includes(namedDependency),
     }))
     .filter((candidate) => candidate.matches);
   return candidates.length === 1 ? [candidates[0]!.index] : [];

--- a/apps/api/test/agent-action-proposals.test.ts
+++ b/apps/api/test/agent-action-proposals.test.ts
@@ -105,6 +105,27 @@ test('natural subtask sequencing becomes real task dependencies', () => {
   ]);
 });
 
+test('subtask sequencing in descriptions becomes real task dependencies', () => {
+  const result = normalizeCompiledToolCalls([{
+    name: 'create_task',
+    input: {
+      title: 'Buyer trial dependency proof',
+      project_name: 'Pilot Marketing Launch',
+      subtasks: [
+        { title: 'verify trial inventory' },
+        { title: 'draft the buyer brief', description: 'after that' },
+        { title: 'send the approved brief', description: 'after the draft' },
+      ],
+    },
+  }], compileContext);
+
+  assert.deepEqual(result.actions[0]?.params.subtasks, [
+    { title: 'verify trial inventory' },
+    { title: 'draft the buyer brief', description: 'after that', depends_on: [1] },
+    { title: 'send the approved brief', description: 'after the draft', depends_on: [2] },
+  ]);
+});
+
 test('compound compiler normalization preserves every requested action family', () => {
   const result = normalizeCompiledToolCalls([
     { name: 'wiki_write', input: { title: 'Trial', type: 'fact', content: 'Water deeply.' } },


### PR DESCRIPTION
## What changed
- infer subtask dependencies from the full compiled subtask meaning, including descriptions
- match named dependency references against earlier subtask titles and descriptions
- add the exact live Defty payload as a regression test

## Why
Live post-merge dogfood showed that the model sometimes places phrases such as `after that` and `after the draft` in a subtask description rather than its title. The existing normalizer only inspected titles, so valid ordering intent was silently dropped and no task relationship rows were created.

## Validation
- `pnpm --filter @deft/api exec tsx --test test/agent-action-proposals.test.ts` (11 passing)
- `pnpm --filter @deft/api typecheck`
- full local API runner reached the existing long-running `mcp-server.test.ts` boundary and did not complete inside the local command window; GitHub Test API is the release gate
