### PR TITLE
Preserve Defty wiki write intent

### DIFF
--- a/apps/api/src/lib/agent-action-proposals.ts
+++ b/apps/api/src/lib/agent-action-proposals.ts
@@ -368,16 +368,29 @@ function normalizeRegisteredToolCall(
 
   const validation = validateRegisteredProposalAction({ action, params: call.input });
   if (!validation.ok) return [];
+  const requestedWikiWriteMode = action === 'wiki_write'
+    ? inferRequestedWikiWriteMode(params.promptContent)
+    : undefined;
   return [{
     action,
     params: {
       ...call.input,
+      ...(requestedWikiWriteMode ? { requested_wiki_write_mode: requestedWikiWriteMode } : {}),
       source_message_id: params.sourceMessageId,
     },
     approval_tier: getApprovalTier(action),
     tool_use_id: null,
     source: 'action_compiler',
   }];
+}
+
+function inferRequestedWikiWriteMode(promptContent: string): 'create' | 'update' | undefined {
+  const plain = promptContent.replace(/\s+/g, ' ').trim();
+  if (/\b(?:update|edit|revise|correct|append|add\s+.+?\s+to)\b/i.test(plain)) return 'update';
+  if (/\b(?:create|make|start|write|save|record|capture)\b.{0,100}\b(?:wiki|knowledge)(?:\s+page)?\b/i.test(plain)) {
+    return 'create';
+  }
+  return undefined;
 }
 
 export function validateRegisteredProposalAction(action: {

--- a/apps/api/src/workers/handlers/agent-reply.ts
+++ b/apps/api/src/workers/handlers/agent-reply.ts
@@ -310,7 +310,10 @@ async function resolvePendingActionTargets(
           ))
           .limit(1)
         : [];
-      if (requestedSlug && !existingPage) {
+      const requestedMode = params.requested_wiki_write_mode === 'create' || params.requested_wiki_write_mode === 'update'
+        ? params.requested_wiki_write_mode
+        : undefined;
+      if (!existingPage && (requestedMode === 'update' || (requestedSlug && requestedMode !== 'create'))) {
         warnings.push(`I could not find wiki page "${requestedSlug}".`);
         continue;
       }
@@ -324,17 +327,18 @@ async function resolvePendingActionTargets(
           continue;
         }
       }
+      const resolvedParams = existingPage
+        ? {
+          ...params,
+          slug: existingPage.slug,
+          title: existingPage.title,
+          wiki_write_mode: 'update',
+          resolved_wiki_page_id: existingPage.id,
+        }
+        : { ...params, slug: undefined, wiki_write_mode: 'create' };
       resolvedActions.push({
         ...action,
-        params: {
-          ...params,
-          ...(existingPage ? {
-            slug: existingPage.slug,
-            title: existingPage.title,
-            wiki_write_mode: 'update',
-            resolved_wiki_page_id: existingPage.id,
-          } : { wiki_write_mode: 'create' }),
-        },
+        params: resolvedParams,
       });
       continue;
     }

--- a/apps/api/test/agent-action-proposals.test.ts
+++ b/apps/api/test/agent-action-proposals.test.ts
@@ -136,6 +136,28 @@ test('compound compiler normalization preserves every requested action family', 
   assert.deepEqual(result.actions.map((action) => action.action), ['wiki_write', 'create_task']);
 });
 
+test('wiki compiler preserves explicit create versus update intent', () => {
+  const create = normalizeCompiledToolCalls([{
+    name: 'wiki_write',
+    input: {
+      slug: 'buyer-trial-certification-2026',
+      title: 'Buyer Trial Certification 2026',
+      content: 'Trial inventory is verified first.',
+      type: 'fact',
+    },
+  }], { ...compileContext, promptContent: 'Create a wiki page called Buyer Trial Certification 2026.' });
+  const update = normalizeCompiledToolCalls([{
+    name: 'wiki_write',
+    input: {
+      slug: 'buyer-trial-certification-2026',
+      content: 'Add the reviewed summary rule.',
+    },
+  }], { ...compileContext, promptContent: 'Update Buyer Trial Certification 2026 to add the reviewed summary rule.' });
+
+  assert.equal(create.actions[0]?.params.requested_wiki_write_mode, 'create');
+  assert.equal(update.actions[0]?.params.requested_wiki_write_mode, 'update');
+});
+
 test('clarification calls and malformed registered actions never create approval actions', () => {
   const result = normalizeCompiledToolCalls([
     { name: 'request_action_clarification', input: { question: 'Which space?' } },


### PR DESCRIPTION
## What changed
- preserve explicit wiki create/update intent in compiled approval actions
- allow explicit creates even when the model supplies a generated slug
- strip generated slugs before executing new-page writes
- keep explicit updates fail-closed when the requested page does not exist
- add create/update intent regression coverage

## Why
Live sequential dogfood showed a clear `create a wiki page` request being rejected because the model supplied a slug and target resolution treated every slug as proof of update intent. This made wiki creation depend on model parameter style rather than the user's request.

## Validation
- focused action proposal tests: 12 passing
- API typecheck
- post-merge live create/update dogfood will run after GitHub checks and deployment
