### PR TITLE
Govern Defty wiki update followups

### DIFF
--- a/apps/api/src/workers/handlers/agent-reply.ts
+++ b/apps/api/src/workers/handlers/agent-reply.ts
@@ -49,6 +49,14 @@ export function hasExplicitRegisteredWriteIntent(content: string): boolean {
   return !/\b(?:do\s+not|don't|dont|never|without|avoid|no\s+need\s+to)\s+(?:\S+\s+){0,6}?(?:create|add|make|write|save|record|capture|post|send|update|edit|change|set|mark|move|close|reopen|assign|link|remove)\b/i.test(plain);
 }
 
+export function shouldCompileRuntimeWikiSuggestion(
+  content: string,
+  executedActions: Array<{ action?: unknown }>,
+): boolean {
+  const asksForEdit = /\b(?:update|edit|revise|correct|append|add)\b/i.test(stripMentionSyntax(content));
+  return asksForEdit && executedActions.some((action) => action.action === 'wiki_suggest_update');
+}
+
 function titleCaseTaskFragment(value: string): string {
   const cleaned = value
     .replace(/\b(?:a|an|the)\s+/i, '')
@@ -1609,9 +1617,11 @@ export async function handleAgentReply(job: JobData): Promise<void> {
     const referentialStatusRequest = result.pendingActions.length === 0 && !wantsDiscussionTask
       ? extractReferentialStatusUpdateRequest(promptContent)
       : null;
+    const runtimeResolvedWikiUpdate = shouldCompileRuntimeWikiSuggestion(promptContent, result.executedActions);
     const shouldCompileActionDraft = !wantsDiscussionTask && (
       hasWriteIntent ||
       Boolean(referentialStatusRequest) ||
+      runtimeResolvedWikiUpdate ||
       hasApprovalQueuedClaim(result.text)
     );
     if (shouldCompileActionDraft && !compiledActionDraft) {

--- a/apps/api/test/agent-reply-discussion-command.test.ts
+++ b/apps/api/test/agent-reply-discussion-command.test.ts
@@ -12,6 +12,7 @@ import {
   isThreadTaskContinuationCommand,
   normalizeApprovalSurfaceCopy,
   preferSubtaskReferences,
+  shouldCompileRuntimeWikiSuggestion,
 } from '../src/workers/handlers/agent-reply.js';
 
 test('compiler recovery gate recognizes the registered write families without choosing one', () => {
@@ -27,6 +28,30 @@ test('compiler recovery gate recognizes the registered write families without ch
   }
   assert.equal(hasExplicitRegisteredWriteIntent('What does the wiki say about watering?'), false);
   assert.equal(hasExplicitRegisteredWriteIntent('Do not create a wiki page for this lunch chat.'), false);
+});
+
+test('resolved wiki suggestion triggers governed compilation for a natural update follow-up', () => {
+  assert.equal(
+    shouldCompileRuntimeWikiSuggestion(
+      'Update Buyer Trial Certification 2026 to add the reviewed summary rule.',
+      [{ action: 'wiki_suggest_update' }],
+    ),
+    true,
+  );
+  assert.equal(
+    shouldCompileRuntimeWikiSuggestion(
+      'What does Buyer Trial Certification 2026 say?',
+      [{ action: 'wiki_suggest_update' }],
+    ),
+    false,
+  );
+  assert.equal(
+    shouldCompileRuntimeWikiSuggestion(
+      'Update MKT-25 to done.',
+      [{ action: 'read_task' }],
+    ),
+    false,
+  );
 });
 
 test('discussion task command accepts explicit discussion-to-task prompts', () => {


### PR DESCRIPTION
## What changed
- treat a successful runtime `wiki_suggest_update` resolution as semantic evidence for the approval compiler
- compile natural wiki follow-ups into governed `wiki_write` cards even when the user does not repeat the word `wiki`
- keep read-only questions and unrelated updates out of this recovery path

## Why
Live dogfood showed `Update Buyer Trial Certification 2026...` being logged as an inert suggestion with no review/apply surface. The initial agent had correctly resolved the page, but the approval compiler did not activate because the follow-up omitted an object-family keyword.

## Validation
- `agent-reply-discussion-command.test.ts`: 19 passing
- API TypeScript check
- post-merge live update approval and content verification will run after deployment
