### PR TITLE
Record Defty helper tool execution

### DIFF
--- a/apps/api/src/lib/agent-runner.ts
+++ b/apps/api/src/lib/agent-runner.ts
@@ -505,6 +505,14 @@ export async function runAgentQuery(params: {
           agentEmployeeId,
         );
         allCitations.push(...citations);
+        executedActions.push({
+          actionId: null,
+          action: tool.name,
+          params: tool.input,
+          success: !(result && typeof result === 'object' && 'error' in result),
+          result,
+          readOnly: true,
+        });
 
         toolResults.push({
           type: 'tool_result' as const,


### PR DESCRIPTION
## What changed
- record completed helper/read tool calls in the agent runner execution trace
- include tool name, params, result, success, and read-only classification

## Why
The governed wiki-followup recovery path needs to know when the runtime successfully resolved a page through `wiki_suggest_update`. Previously only auto-executed write tools were recorded, so the handler could not use the runtime's semantic resolution to compile the actual wiki edit approval.

## Validation
- agent reply discussion-command tests: 19 passing
- API TypeScript check
- live wiki update card and applied-content proof follows deployment
