### PR TITLE
Narrow Defty compiler by resolved action family

### DIFF
--- a/apps/api/src/lib/agent-action-proposals.ts
+++ b/apps/api/src/lib/agent-action-proposals.ts
@@ -137,6 +137,7 @@ type CompileDeftyActionDraftParams = {
   priorTaskReferences?: string[];
   spaceName?: string | null;
   callerName?: string | null;
+  allowedActionNames?: string[];
 };
 
 const CLARIFICATION_TOOL = {
@@ -160,8 +161,11 @@ export function getActionCompilerTools() {
   ];
 }
 
-function getActionCompilerToolsForPrompt(promptContent: string) {
-  const tools = getActionCompilerTools();
+export function getActionCompilerToolsForPrompt(promptContent: string, allowedActionNames?: string[]) {
+  const allowlist = allowedActionNames?.length ? new Set(allowedActionNames) : null;
+  const tools = allowlist
+    ? getActionCompilerTools().filter((tool) => allowlist.has(tool.name) || tool.name === CLARIFICATION_TOOL.name)
+    : getActionCompilerTools();
   if (/\b(?:remind\s+me|create\s+(?:a\s+)?reminder|set\s+(?:a\s+)?reminder)\b/i.test(promptContent)) {
     return tools.filter((tool) => tool.name === 'create_reminder');
   }
@@ -271,7 +275,7 @@ export async function compileDeftyActionDraft(params: CompileDeftyActionDraftPar
       'For ambiguous channel names, ask a clarification instead of guessing.',
       'Return no actions for read-only questions.',
     ].join('\n'),
-    tools: getActionCompilerToolsForPrompt(params.promptContent),
+    tools: getActionCompilerToolsForPrompt(params.promptContent, params.allowedActionNames),
     messages: [{
       role: 'user',
       content: JSON.stringify({

--- a/apps/api/src/workers/handlers/agent-reply.ts
+++ b/apps/api/src/workers/handlers/agent-reply.ts
@@ -1643,6 +1643,7 @@ export async function handleAgentReply(job: JobData): Promise<void> {
           priorTaskReferences,
           spaceName: space?.name ?? null,
           callerName: callerUser?.name ?? null,
+          allowedActionNames: runtimeResolvedWikiUpdate ? ['wiki_write'] : undefined,
         });
       } catch (err) {
         console.warn('[agent-reply] Action draft compiler failed; falling back to deterministic extractors', {

--- a/apps/api/test/agent-action-proposals.test.ts
+++ b/apps/api/test/agent-action-proposals.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 
 import { ACTION_TOOLS } from '../src/lib/agent-tools.js';
 import {
+  getActionCompilerToolsForPrompt,
   getActionCompilerTools,
   normalizeCompiledToolCalls,
   validateCompiledIntentAlignment,
@@ -26,6 +27,13 @@ test('action compiler derives its write vocabulary from the registered action to
     assert.ok(names.has(action), `compiler is missing registered action tool ${action}`);
   }
   assert.ok(names.has('request_action_clarification'));
+});
+
+test('semantic resolution can narrow the compiler to one governed action family', () => {
+  assert.deepEqual(
+    getActionCompilerToolsForPrompt('Update Buyer Trial Certification 2026.', ['wiki_write']).map((tool) => tool.name),
+    ['wiki_write', 'request_action_clarification'],
+  );
 });
 
 test('wiki requests remain wiki actions and cannot be normalized into task cards', () => {


### PR DESCRIPTION
## What changed
- let semantic target resolution narrow the approval compiler to an allowed action family
- restrict runtime-resolved wiki follow-ups to `wiki_write` plus clarification
- add a deterministic tool-selection regression test

## Why
Live dogfood proved that even after Defty resolved the wiki page, the unrestricted approval compiler could guess `create_task`. Once the object family is known, asking another model to rediscover it adds avoidable failure modes.

## Validation
- proposal + discussion-command focused tests: 32 passing
- API TypeScript check
- live update card, approval, and applied-content proof follows deployment
