### PR TITLE
Preserve Defty wiki append semantics

### DIFF
--- a/apps/api/src/lib/agent-action-proposals.ts
+++ b/apps/api/src/lib/agent-action-proposals.ts
@@ -375,17 +375,29 @@ function normalizeRegisteredToolCall(
   const requestedWikiWriteMode = action === 'wiki_write'
     ? inferRequestedWikiWriteMode(params.promptContent)
     : undefined;
+  const requestedWikiUpdateOperation = requestedWikiWriteMode === 'update'
+    ? inferRequestedWikiUpdateOperation(params.promptContent)
+    : undefined;
+  const requestedWikiTypeChange = requestedWikiWriteMode === 'update'
+    ? /\b(?:change|set|make)\b.{0,50}\btype\b/i.test(params.promptContent)
+    : false;
   return [{
     action,
     params: {
       ...call.input,
       ...(requestedWikiWriteMode ? { requested_wiki_write_mode: requestedWikiWriteMode } : {}),
+      ...(requestedWikiUpdateOperation ? { requested_wiki_update_operation: requestedWikiUpdateOperation } : {}),
+      ...(requestedWikiTypeChange ? { requested_wiki_type_change: true } : {}),
       source_message_id: params.sourceMessageId,
     },
     approval_tier: getApprovalTier(action),
     tool_use_id: null,
     source: 'action_compiler',
   }];
+}
+
+function inferRequestedWikiUpdateOperation(promptContent: string): 'append' | 'replace' {
+  return /\b(?:add|append|include|insert)\b/i.test(promptContent) ? 'append' : 'replace';
 }
 
 function inferRequestedWikiWriteMode(promptContent: string): 'create' | 'update' | undefined {

--- a/apps/api/src/workers/handlers/agent-reply.ts
+++ b/apps/api/src/workers/handlers/agent-reply.ts
@@ -57,6 +57,18 @@ export function shouldCompileRuntimeWikiSuggestion(
   return asksForEdit && executedActions.some((action) => action.action === 'wiki_suggest_update');
 }
 
+export function mergeWikiUpdateContent(
+  existingContent: string,
+  requestedContent: string,
+  operation: unknown,
+): string {
+  const existing = existingContent.trim();
+  const requested = requestedContent.trim();
+  if (operation !== 'append' || !existing || !requested) return requested || existing;
+  if (existing.toLowerCase().includes(requested.toLowerCase())) return existing;
+  return `${existing}\n\n${requested}`;
+}
+
 function titleCaseTaskFragment(value: string): string {
   const cleaned = value
     .replace(/\b(?:a|an|the)\s+/i, '')
@@ -307,7 +319,15 @@ async function resolvePendingActionTargets(
         : '';
       const [existingPage] = requestedSlug || requestedTitle
         ? await db
-          .select({ id: wikiPages.id, slug: wikiPages.slug, title: wikiPages.title, scope: wikiPages.scope, space_id: wikiPages.space_id })
+          .select({
+            id: wikiPages.id,
+            slug: wikiPages.slug,
+            title: wikiPages.title,
+            content: wikiPages.content,
+            type: wikiPages.type,
+            scope: wikiPages.scope,
+            space_id: wikiPages.space_id,
+          })
           .from(wikiPages)
           .where(and(
             eq(wikiPages.org_id, orgId),
@@ -340,6 +360,12 @@ async function resolvePendingActionTargets(
           ...params,
           slug: existingPage.slug,
           title: existingPage.title,
+          content: mergeWikiUpdateContent(
+            existingPage.content,
+            typeof params.content === 'string' ? params.content : '',
+            params.requested_wiki_update_operation,
+          ),
+          type: params.requested_wiki_type_change === true ? params.type : existingPage.type,
           wiki_write_mode: 'update',
           resolved_wiki_page_id: existingPage.id,
         }

--- a/apps/api/test/agent-action-proposals.test.ts
+++ b/apps/api/test/agent-action-proposals.test.ts
@@ -164,6 +164,7 @@ test('wiki compiler preserves explicit create versus update intent', () => {
 
   assert.equal(create.actions[0]?.params.requested_wiki_write_mode, 'create');
   assert.equal(update.actions[0]?.params.requested_wiki_write_mode, 'update');
+  assert.equal(update.actions[0]?.params.requested_wiki_update_operation, 'append');
 });
 
 test('clarification calls and malformed registered actions never create approval actions', () => {

--- a/apps/api/test/agent-reply-discussion-command.test.ts
+++ b/apps/api/test/agent-reply-discussion-command.test.ts
@@ -12,6 +12,7 @@ import {
   isThreadTaskContinuationCommand,
   normalizeApprovalSurfaceCopy,
   preferSubtaskReferences,
+  mergeWikiUpdateContent,
   shouldCompileRuntimeWikiSuggestion,
 } from '../src/workers/handlers/agent-reply.js';
 
@@ -51,6 +52,21 @@ test('resolved wiki suggestion triggers governed compilation for a natural updat
       [{ action: 'read_task' }],
     ),
     false,
+  );
+});
+
+test('wiki append updates preserve existing durable content and dedupe repeats', () => {
+  assert.equal(
+    mergeWikiUpdateContent('Original durable fact.', 'New reviewed rule.', 'append'),
+    'Original durable fact.\n\nNew reviewed rule.',
+  );
+  assert.equal(
+    mergeWikiUpdateContent('Original durable fact.\n\nNew reviewed rule.', 'New reviewed rule.', 'append'),
+    'Original durable fact.\n\nNew reviewed rule.',
+  );
+  assert.equal(
+    mergeWikiUpdateContent('Old content.', 'Replacement content.', 'replace'),
+    'Replacement content.',
   );
 });
 


### PR DESCRIPTION
## What changed
- preserve explicit wiki append vs replace intent
- merge appended content with the existing page deterministically
- dedupe repeated append content
- preserve the existing wiki page type unless the user explicitly requests a type change
- add compiler and merge regression tests

## Why
Live card review caught a draft that would have replaced the entire page with one sentence and changed its type from `fact` to `resource`. Approval must not turn model formatting choices into silent data loss.

## Validation
- proposal + discussion-command focused tests: 33 passing
- API TypeScript check
- final live approval and persisted-page proof follows deployment
