### PR TITLE
Harden API test isolation and build

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "tsx watch src/server.ts",
-    "build": "tsx src/server.ts",
+    "build": "tsc -p tsconfig.json",
     "typecheck": "tsc --noEmit",
     "test": "tsx src/scripts/run-api-tests.ts",
     "start": "node dist/server.js"

--- a/apps/api/src/scripts/run-api-tests.ts
+++ b/apps/api/src/scripts/run-api-tests.ts
@@ -11,6 +11,25 @@ if (!process.env.DATABASE_URL) {
   process.exit(1);
 }
 
+const configuredDatabaseUrl = process.env.DATABASE_URL;
+const explicitTestDatabaseUrl = process.env.DEFT_TEST_DATABASE_URL;
+const runningInCi = process.env.CI === 'true';
+
+if (explicitTestDatabaseUrl) {
+  process.env.DATABASE_URL = explicitTestDatabaseUrl;
+} else if (!runningInCi) {
+  console.error(
+    '[run-api-tests] Refusing to run database-writing tests against DATABASE_URL. ' +
+    'Set DEFT_TEST_DATABASE_URL to a disposable test database.',
+  );
+  process.exit(1);
+}
+
+if (!runningInCi && process.env.DATABASE_URL === configuredDatabaseUrl) {
+  console.error('[run-api-tests] DEFT_TEST_DATABASE_URL must not point at the active application database');
+  process.exit(1);
+}
+
 const pnpmCli = process.env.npm_execpath;
 if (!pnpmCli) {
   console.error('[run-api-tests] Run this script through pnpm so npm_execpath is available');
@@ -19,6 +38,7 @@ if (!pnpmCli) {
 const requestedTests = process.argv.slice(2);
 const commands = [
   ['exec', 'tsx', 'src/scripts/seed-test-fixtures.ts'],
+  ['exec', 'tsx', 'src/scripts/seed-platform-bundles.ts'],
   [
     'exec',
     'tsx',
@@ -30,11 +50,16 @@ const commands = [
 ];
 
 for (const args of commands) {
+  console.log(`[run-api-tests] ${args.join(' ')}`);
   const result = spawnSync(process.execPath, [pnpmCli, ...args], {
     cwd: resolve(here, '..', '..'),
     env: process.env,
     stdio: 'inherit',
+    timeout: Number(process.env.DEFT_TEST_TIMEOUT_MS ?? 15 * 60 * 1000),
   });
-  if (result.error) throw result.error;
+  if (result.error) {
+    console.error(`[run-api-tests] command failed: ${result.error.message}`);
+    throw result.error;
+  }
   if (result.status !== 0) process.exit(result.status ?? 1);
 }

--- a/apps/api/test/apply-template-from-table.test.ts
+++ b/apps/api/test/apply-template-from-table.test.ts
@@ -10,10 +10,12 @@ import { app } from '../src/index.js';
 async function authHeaders() {
   const res = await app.request('/api/auth/login', {
     method: 'POST',
-    body: JSON.stringify({ email: 'diego@testers-tomatoes.com', password: 'tomato123' }),
+    body: JSON.stringify({ email: 'maneek@test.com', password: 'test1234' }),
     headers: { 'content-type': 'application/json' },
   });
+  assert.equal(res.status, 200, 'canonical test fixture login should succeed');
   const body = (await res.json()) as { accessToken: string };
+  assert.ok(body.accessToken, 'login should return an access token');
   return {
     authorization: `Bearer ${body.accessToken}`,
     'content-type': 'application/json',
@@ -51,6 +53,7 @@ test('POST /api/projects/:id/apply-template with missing template returns 404', 
     headers,
     body: JSON.stringify({ name: 'test-apply-template-2-' + ts, prefix: 'AG' + ts.toString().slice(-4) }),
   });
+  assert.equal(createRes.status, 201);
   const project2 = (await createRes.json()) as { id: string };
 
   const res = await app.request(`/api/projects/${project2.id}/apply-template`, {

--- a/apps/api/test/task-templates-list.test.ts
+++ b/apps/api/test/task-templates-list.test.ts
@@ -9,10 +9,12 @@ import { app } from '../src/index.js';
 async function authHeaders(): Promise<Record<string, string>> {
   const res = await app.request('/api/auth/login', {
     method: 'POST',
-    body: JSON.stringify({ email: 'diego@testers-tomatoes.com', password: 'tomato123' }),
+    body: JSON.stringify({ email: 'maneek@test.com', password: 'test1234' }),
     headers: { 'content-type': 'application/json' },
   });
+  assert.equal(res.status, 200, 'canonical test fixture login should succeed');
   const body = (await res.json()) as { accessToken: string };
+  assert.ok(body.accessToken, 'login should return an access token');
   return { authorization: `Bearer ${body.accessToken}` };
 }
 


### PR DESCRIPTION
## What changed
- make the API `build` script compile TypeScript instead of starting the server
- refuse to run the API suite against the active development database unless an explicit isolated test database is supplied
- seed canonical fixtures and platform bundles for self-contained fresh-database runs
- update stale template tests to assert login success before continuing

## Why
The full suite could accidentally inherit local pilot state, and the API build command did not behave like a release build. This makes failures reproducible and prevents test runs from mutating a developer or pilot database.

## Validation
- `pnpm --filter @deft/api build`
- full disposable-database API suite completed earlier in this landing loop: 710/710 passing
- active-database guard was verified to refuse an unsafe run