### PR TITLE
Make Inbox attention scopes truthful

### DIFF
--- a/apps/api/src/lib/notification-digests.test.ts
+++ b/apps/api/src/lib/notification-digests.test.ts
@@ -1,0 +1,50 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { buildTaskNudgeDigest } from './notification-digests.js';
+
+test('keeps a single task nudge directly actionable', () => {
+  const digest = buildTaskNudgeDigest({
+    nudgeType: 'overdue',
+    taskId: 'task-1',
+    taskIdentifier: 'MKT-1',
+  });
+
+  assert.equal(digest.title, 'Overdue task');
+  assert.equal(digest.body, 'MKT-1 needs your attention.');
+  assert.equal(digest.link, '/tasks?task=MKT-1');
+  assert.deepEqual(digest.metadata.task_ids, ['task-1']);
+});
+
+test('bundles repeated task nudges into one compact digest', () => {
+  const digest = buildTaskNudgeDigest({
+    nudgeType: 'overdue',
+    taskId: 'task-3',
+    taskIdentifier: 'OPS-3',
+    existingMetadata: {
+      task_ids: ['task-1', 'task-2'],
+      task_identifiers: ['MKT-1', 'BUY-2'],
+    },
+  });
+
+  assert.equal(digest.title, '3 overdue tasks');
+  assert.equal(digest.body, 'MKT-1, BUY-2, OPS-3 need your attention.');
+  assert.equal(digest.link, '/tasks?view=list');
+  assert.equal(digest.metadata.bundled_count, 3);
+});
+
+test('deduplicates a repeated task in the same digest', () => {
+  const digest = buildTaskNudgeDigest({
+    nudgeType: 'stalled',
+    taskId: 'task-1',
+    taskIdentifier: 'MKT-1',
+    existingMetadata: {
+      task_id: 'task-1',
+      task_identifier: 'MKT-1',
+      task_ids: ['task-1'],
+      task_identifiers: ['MKT-1'],
+    },
+  });
+
+  assert.equal(digest.title, 'Stalled task');
+  assert.equal(digest.metadata.bundled_count, 1);
+});

--- a/apps/api/src/lib/notification-digests.ts
+++ b/apps/api/src/lib/notification-digests.ts
@@ -1,0 +1,63 @@
+export type TaskNudgeType = 'stalled' | 'overdue' | 'upcoming_due';
+
+type TaskNudgeMetadata = {
+  nudge_type?: unknown;
+  task_id?: unknown;
+  task_ids?: unknown;
+  task_identifier?: unknown;
+  task_identifiers?: unknown;
+  [key: string]: unknown;
+};
+
+const NUDGE_LABELS: Record<TaskNudgeType, { singular: string; plural: string }> = {
+  stalled: { singular: 'Stalled task', plural: 'stalled tasks' },
+  overdue: { singular: 'Overdue task', plural: 'overdue tasks' },
+  upcoming_due: { singular: 'Task due soon', plural: 'tasks due soon' },
+};
+
+function stringValues(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is string => typeof item === 'string' && item.length > 0);
+}
+
+export function buildTaskNudgeDigest(params: {
+  nudgeType: TaskNudgeType;
+  taskId: string;
+  taskIdentifier: string;
+  existingMetadata?: TaskNudgeMetadata | null;
+}) {
+  const { nudgeType, taskId, taskIdentifier, existingMetadata } = params;
+  const labels = NUDGE_LABELS[nudgeType];
+  const taskIds = Array.from(new Set([
+    ...stringValues(existingMetadata?.task_ids),
+    typeof existingMetadata?.task_id === 'string' ? existingMetadata.task_id : '',
+    taskId,
+  ].filter(Boolean)));
+  const taskIdentifiers = Array.from(new Set([
+    ...stringValues(existingMetadata?.task_identifiers),
+    typeof existingMetadata?.task_identifier === 'string' ? existingMetadata.task_identifier : '',
+    taskIdentifier,
+  ].filter(Boolean)));
+  const count = taskIds.length;
+  const visibleIdentifiers = taskIdentifiers.slice(0, 3);
+  const remaining = Math.max(0, count - visibleIdentifiers.length);
+  const subject = visibleIdentifiers.join(', ');
+  const body = count === 1
+    ? `${taskIdentifier} needs your attention.`
+    : `${subject}${remaining > 0 ? ` and ${remaining} more` : ''} need your attention.`;
+
+  return {
+    title: count === 1 ? labels.singular : `${count} ${labels.plural}`,
+    body,
+    link: count === 1 ? `/tasks?task=${taskIdentifier}` : '/tasks?view=list',
+    metadata: {
+      ...(existingMetadata ?? {}),
+      nudge_type: nudgeType,
+      task_id: taskIds[0],
+      task_identifier: taskIdentifiers[0],
+      task_ids: taskIds,
+      task_identifiers: taskIdentifiers,
+      bundled_count: count,
+    },
+  };
+}

--- a/apps/api/src/routes/inbox.ts
+++ b/apps/api/src/routes/inbox.ts
@@ -49,7 +49,9 @@ export type InboxItem = {
   dm?: { space_id: string; unread_count: number; last_message_preview: string | null };
 };
 
-const NOTIF_KIND_MAP: Record<string, InboxItemKind> = {
+type NotificationType = typeof notifications.$inferSelect.type;
+
+const NOTIF_KIND_MAP: Record<NotificationType, InboxItemKind> = {
   mention: 'mention',
   task_assigned: 'task_assigned',
   task_updated: 'task_updated',
@@ -65,6 +67,35 @@ const NOTIF_KIND_MAP: Record<string, InboxItemKind> = {
   agent_suggestion: 'system',
   skill_update_available: 'system',
 };
+
+const INBOX_KINDS = new Set<InboxItemKind>([
+  'mention',
+  'dm_unread',
+  'task_assigned',
+  'task_updated',
+  'blocked',
+  'cross_reference',
+  'wiki_update',
+  'system',
+  'work_capture',
+  'pending_approval',
+]);
+
+function parseKindFilter(value: string | undefined): Set<InboxItemKind> | null {
+  if (!value) return null;
+  const values = value.split(',').map((kind) => kind.trim()).filter(Boolean);
+  if (values.length === 0 || values.some((kind) => !INBOX_KINDS.has(kind as InboxItemKind))) {
+    return new Set();
+  }
+  return new Set(values as InboxItemKind[]);
+}
+
+function notificationTypesForKinds(kinds: Set<InboxItemKind> | null) {
+  if (!kinds) return Object.keys(NOTIF_KIND_MAP) as NotificationType[];
+  return (Object.entries(NOTIF_KIND_MAP) as Array<[NotificationType, InboxItemKind]>)
+    .filter(([, kind]) => kinds.has(kind))
+    .map(([type]) => type);
+}
 
 function visibleCaptureActionSql(user: { id: string; org_id: string }) {
   return sql`(
@@ -129,8 +160,15 @@ inboxRoutes.get('/', async (c) => {
     const user = c.get('user') as { id: string; org_id: string };
     const limit = Math.min(parseInt(c.req.query('limit') ?? '50', 10) || 50, 100);
     const cursor = c.req.query('cursor');
-    const kindFilter = c.req.query('kind') as InboxItemKind | undefined;
+    const requestedKinds = parseKindFilter(c.req.query('kind'));
     const countOnly = c.req.query('count_only') === '1';
+
+    if (requestedKinds && requestedKinds.size === 0) {
+      return c.json({ error: 'Invalid inbox kind', code: 'VALIDATION_ERROR' }, 400);
+    }
+
+    const wantsKind = (kind: InboxItemKind) => !requestedKinds || requestedKinds.has(kind);
+    const notificationTypes = notificationTypesForKinds(requestedKinds);
 
     const expiredActions = await db.update(agentActions)
       .set({ approval_status: 'expired' })
@@ -146,19 +184,37 @@ inboxRoutes.get('/', async (c) => {
       actions: expiredActions,
     });
 
-    const notifRows = await db.select()
-      .from(notifications)
-      .where(and(
-        eq(notifications.user_id, user.id),
-        eq(notifications.org_id, user.org_id),
-        cursor ? lt(notifications.created_at, new Date(cursor)) : sql`TRUE`,
-      ))
-      .orderBy(desc(notifications.created_at))
-      .limit(limit);
+    const notificationWhere = and(
+      eq(notifications.user_id, user.id),
+      eq(notifications.org_id, user.org_id),
+      notificationTypes.length > 0 ? inArray(notifications.type, notificationTypes) : sql`FALSE`,
+      cursor ? lt(notifications.created_at, new Date(cursor)) : sql`TRUE`,
+    );
+    const unreadNotificationWhere = and(
+      eq(notifications.user_id, user.id),
+      eq(notifications.org_id, user.org_id),
+      eq(notifications.is_read, false),
+      notificationTypes.length > 0 ? inArray(notifications.type, notificationTypes) : sql`FALSE`,
+    );
+
+    const notifRows = countOnly || notificationTypes.length === 0
+      ? []
+      : await db.select()
+        .from(notifications)
+        .where(notificationWhere)
+        .orderBy(desc(notifications.created_at))
+        .limit(limit);
+
+    const [notificationCountRow] = notificationTypes.length === 0
+      ? [{ count: 0 }]
+      : await db.select({ count: sql<number>`count(*)::int` })
+        .from(notifications)
+        .where(unreadNotificationWhere);
+    const unreadNotificationCount = Number(notificationCountRow?.count ?? 0);
 
     const notifItems: InboxItem[] = notifRows.map((n) => ({
       id: `notif:${n.id}`,
-      kind: NOTIF_KIND_MAP[n.type as string] ?? 'system',
+      kind: NOTIF_KIND_MAP[n.type] ?? 'system',
       title: n.title,
       body: n.body ?? null,
       link: n.link ?? null,
@@ -167,7 +223,7 @@ inboxRoutes.get('/', async (c) => {
       source: 'notification',
     }));
 
-    const dmSpaces = await db.select({
+    const dmSpaces = !wantsKind('dm_unread') ? [] : await db.select({
       space_id: spaceMembers.space_id,
       last_read_at: spaceMembers.last_read_at,
       space_name: spaces.name,
@@ -215,7 +271,8 @@ inboxRoutes.get('/', async (c) => {
       });
     }
 
-    const approvalRows = await db.select({
+    const wantsApprovals = wantsKind('pending_approval') || wantsKind('work_capture');
+    const approvalRows = !wantsApprovals ? [] : await db.select({
       id: agentActions.id,
       action: agentActions.action,
       params: agentActions.params,
@@ -241,8 +298,7 @@ inboxRoutes.get('/', async (c) => {
         inArray(agentActions.approval_tier, ['quick', 'full']),
         visibleCaptureActionSql(user),
       ))
-      .orderBy(desc(agentActions.created_at))
-      .limit(limit);
+      .orderBy(desc(agentActions.created_at));
 
     const approvalItems: InboxItem[] = approvalRows.map((r) => {
       const isCapture = r.action_source === 'defty_capture';
@@ -271,11 +327,11 @@ inboxRoutes.get('/', async (c) => {
       };
     });
 
-    const all = [...notifItems, ...dmItems, ...approvalItems]
-      .filter((it) => !kindFilter || it.kind === kindFilter)
+    const filteredApprovalItems = approvalItems.filter((item) => wantsKind(item.kind));
+    const all = [...notifItems, ...dmItems, ...filteredApprovalItems]
       .sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
 
-    const unreadCount = all.filter((it) => !it.read).length;
+    const unreadCount = unreadNotificationCount + dmItems.length + filteredApprovalItems.length;
 
     if (countOnly) {
       return c.json({ unread_count: unreadCount });
@@ -300,15 +356,23 @@ inboxRoutes.get('/', async (c) => {
 inboxRoutes.post('/read', async (c) => {
   try {
     const user = c.get('user') as { id: string; org_id: string };
-    const body = await c.req.json().catch(() => ({})) as { ids?: string[]; all?: boolean };
+    const body = await c.req.json().catch(() => ({})) as { ids?: string[]; all?: boolean; kinds?: unknown };
 
     if (body.all) {
+      const requestedKinds = Array.isArray(body.kinds)
+        ? new Set(body.kinds.filter((kind): kind is InboxItemKind => typeof kind === 'string' && INBOX_KINDS.has(kind as InboxItemKind)))
+        : null;
+      const notificationTypes = notificationTypesForKinds(requestedKinds);
+      if (notificationTypes.length === 0) {
+        return c.json({ success: true, updated: 0 });
+      }
       const updated = await db.update(notifications)
         .set({ is_read: true })
         .where(and(
           eq(notifications.user_id, user.id),
           eq(notifications.org_id, user.org_id),
           eq(notifications.is_read, false),
+          inArray(notifications.type, notificationTypes),
         ))
         .returning({ id: notifications.id });
       return c.json({ success: true, updated: updated.length });

--- a/apps/api/src/workers/handlers/nudge-check.ts
+++ b/apps/api/src/workers/handlers/nudge-check.ts
@@ -17,6 +17,7 @@ import { enqueue, QUEUE_NAMES } from '../../lib/queues.js';
 import type { TriggerInvocation } from './employee-trigger.js';
 import { getOrgTimezone, isOverdue, isDueWithinDays } from '../../lib/task-dates.js';
 import { createNotificationIfAllowed } from '../../lib/notification-policy.js';
+import { buildTaskNudgeDigest } from '../../lib/notification-digests.js';
 
 // Phase 6 — per-kind trigger routing. Stalled tasks and overdue tasks are
 // separate kinds so an employee can subscribe to just one. If the org has
@@ -336,7 +337,7 @@ interface NudgeParams {
   taskId: string;
   orgId: string;
   targetUserId: string;
-  nudgeType: 'stalled' | 'overdue' | 'workload_imbalance' | 'upcoming_due';
+  nudgeType: 'stalled' | 'overdue' | 'upcoming_due';
   taskIdentifier: string;
   message: string;
   since: Date;
@@ -363,16 +364,50 @@ async function processNudge(params: NudgeParams): Promise<void> {
       return; // Already nudged recently
     }
 
-    // Create notification
-    const notification = await createNotificationIfAllowed({
-      org_id: orgId,
-      user_id: targetUserId,
-      type: 'agent_suggestion',
-      title: nudgeType === 'stalled' ? 'Stalled Task' : nudgeType === 'overdue' ? 'Overdue Task' : nudgeType === 'upcoming_due' ? 'Due Soon' : 'Overdue Task',
-      body: message,
-      link: `/tasks?task=${taskIdentifier}`,
-      metadata: { task_id: taskId, nudge_type: nudgeType },
-    }, { channel: 'tasks' });
+    const [existingNotification] = await db
+      .select({
+        id: notifications.id,
+        metadata: notifications.metadata,
+      })
+      .from(notifications)
+      .where(and(
+        eq(notifications.org_id, orgId),
+        eq(notifications.user_id, targetUserId),
+        eq(notifications.type, 'agent_suggestion'),
+        eq(notifications.is_read, false),
+        gte(notifications.created_at, since),
+        sql`${notifications.metadata}->>'nudge_type' = ${nudgeType}`,
+      ))
+      .orderBy(sql`${notifications.created_at} DESC`)
+      .limit(1);
+
+    const digest = buildTaskNudgeDigest({
+      nudgeType,
+      taskId,
+      taskIdentifier,
+      existingMetadata: existingNotification?.metadata as Record<string, unknown> | null | undefined,
+    });
+
+    const notification = existingNotification
+      ? (await db.update(notifications)
+          .set({
+            title: digest.title,
+            body: digest.body,
+            link: digest.link,
+            metadata: digest.metadata,
+            updated_at: new Date(),
+          })
+          .where(eq(notifications.id, existingNotification.id))
+          .returning())[0] ?? null
+      : await createNotificationIfAllowed({
+          org_id: orgId,
+          user_id: targetUserId,
+          type: 'agent_suggestion',
+          title: digest.title,
+          body: digest.body,
+          link: digest.link,
+          metadata: digest.metadata,
+        }, { channel: 'tasks' });
 
     // Insert nudge record
     await db.insert(agentNudges).values({
@@ -384,7 +419,7 @@ async function processNudge(params: NudgeParams): Promise<void> {
     });
 
     // Emit notification to user via Socket.io
-    if (notification) {
+    if (notification && !existingNotification) {
       emitToUser(targetUserId, 'notification:new', notification);
     }
 

--- a/apps/api/test/inbox-route.test.ts
+++ b/apps/api/test/inbox-route.test.ts
@@ -292,3 +292,82 @@ test('POST /api/inbox/read scoped to current user only', async () => {
   await db.delete(notifications).where(eq(notifications.id, n.id));
   await db.delete(users).where(eq(users.id, otherUser.id));
 });
+
+test('GET /api/inbox supports multiple task notification kinds', async () => {
+  const inserted = await db.insert(notifications).values([
+    {
+      org_id: testOrgId,
+      user_id: userId,
+      type: 'task_assigned',
+      title: 'Assigned task',
+      is_read: false,
+    },
+    {
+      org_id: testOrgId,
+      user_id: userId,
+      type: 'task_updated',
+      title: 'Updated task',
+      is_read: false,
+    },
+    {
+      org_id: testOrgId,
+      user_id: userId,
+      type: 'mention',
+      title: 'Unrelated mention',
+      is_read: false,
+    },
+  ]).returning();
+  createdNotifIds.push(...inserted.map((row) => row.id));
+
+  const res = await app.request('/api/inbox?kind=task_assigned,task_updated');
+  assert.equal(res.status, 200);
+  const body = await res.json() as { items: { id: string; kind: string }[]; unread_count: number };
+  const insertedIds = new Set(inserted.slice(0, 2).map((row) => `notif:${row.id}`));
+  const matching = body.items.filter((item) => insertedIds.has(item.id));
+
+  assert.deepEqual(
+    new Set(matching.map((item) => item.kind)),
+    new Set(['task_assigned', 'task_updated']),
+  );
+  assert.equal(body.items.some((item) => item.id === `notif:${inserted[2].id}`), false);
+  assert.ok(body.unread_count >= 2);
+});
+
+test('POST /api/inbox/read can mark only the selected tab kinds read', async () => {
+  const [taskNotification, mentionNotification] = await db.insert(notifications).values([
+    {
+      org_id: testOrgId,
+      user_id: userId,
+      type: 'task_updated',
+      title: 'Scoped task update',
+      is_read: false,
+    },
+    {
+      org_id: testOrgId,
+      user_id: userId,
+      type: 'mention',
+      title: 'Scoped mention',
+      is_read: false,
+    },
+  ]).returning();
+  createdNotifIds.push(taskNotification.id, mentionNotification.id);
+
+  const res = await app.request('/api/inbox/read', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ all: true, kinds: ['task_assigned', 'task_updated'] }),
+  });
+  assert.equal(res.status, 200);
+
+  const [taskAfter] = await db.select().from(notifications).where(eq(notifications.id, taskNotification.id));
+  const [mentionAfter] = await db.select().from(notifications).where(eq(notifications.id, mentionNotification.id));
+  assert.equal(taskAfter.is_read, true);
+  assert.equal(mentionAfter.is_read, false);
+});
+
+test('GET /api/inbox rejects an invalid kind without broadening the query', async () => {
+  const res = await app.request('/api/inbox?kind=not-a-real-kind');
+  assert.equal(res.status, 400);
+  const body = await res.json() as { code?: string };
+  assert.equal(body.code, 'VALIDATION_ERROR');
+});

--- a/apps/web/src/app/(app)/inbox/page.tsx
+++ b/apps/web/src/app/(app)/inbox/page.tsx
@@ -1,8 +1,8 @@
 // apps/web/src/app/(app)/inbox/page.tsx
 'use client';
 
-import { useState, useCallback, useMemo } from 'react';
-import { useSearchParams } from 'next/navigation';
+import { useState, useCallback, useEffect, useMemo } from 'react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import useSWR from 'swr';
 import {
   AlertTriangle,
@@ -14,31 +14,19 @@ import {
   RotateCcw,
   XCircle,
 } from 'lucide-react';
-import { useInbox, type InboxItemKind } from '@/hooks/use-inbox';
+import { useInbox } from '@/hooks/use-inbox';
 import { InboxRow } from '@/components/inbox-row';
 import { AgentActionCard, type AgentAction } from '@/components/agent-action-card';
 import { api } from '@/lib/api';
 import { stripHtml } from '@/lib/strip-html';
-
-type Tab = 'all' | 'mentions' | 'dms' | 'tasks' | 'captures' | 'approvals';
-
-const TAB_TO_KIND: Record<Tab, InboxItemKind | undefined> = {
-  all: undefined,
-  mentions: 'mention',
-  dms: 'dm_unread',
-  tasks: 'task_assigned',
-  captures: 'work_capture',
-  approvals: 'pending_approval',
-};
-
-const TABS: { id: Tab; label: string }[] = [
-  { id: 'all', label: 'All' },
-  { id: 'mentions', label: 'Mentions' },
-  { id: 'dms', label: 'DMs' },
-  { id: 'tasks', label: 'Tasks' },
-  { id: 'captures', label: 'Captures' },
-  { id: 'approvals', label: 'Approvals' },
-];
+import {
+  inboxEmptyText,
+  inboxStatusText,
+  INBOX_TABS,
+  normalizeInboxTab,
+  TAB_TO_KINDS,
+  type InboxTab,
+} from '@/lib/inbox-view-model';
 
 type WorkIntent = {
   id: string;
@@ -492,15 +480,14 @@ function MessageObservationRow({ observation }: { observation: MessageObservatio
 
 export default function InboxPage() {
   const params = useSearchParams();
-  const initialTab = (params.get('tab') as Tab) ?? 'all';
-  const [tab, setTab] = useState<Tab>(initialTab);
+  const pathname = usePathname();
+  const router = useRouter();
+  const [tab, setTab] = useState<InboxTab>(() => normalizeInboxTab(params.get('tab')));
   const [retryingIntentId, setRetryingIntentId] = useState<string | null>(null);
   const [retryError, setRetryError] = useState<{ intentId: string; message: string } | null>(null);
 
-  // For 'tasks' we want both task_assigned and task_updated. Fetch all and filter
-  // client-side for that tab; for the others we pass kind to the API.
-  const apiKind = tab === 'tasks' ? undefined : TAB_TO_KIND[tab];
-  const { items, unreadCount, isLoading, error: inboxError, markRead, markAllRead, refresh } = useInbox(apiKind);
+  const inboxKinds = TAB_TO_KINDS[tab];
+  const { items, unreadCount, isLoading, error: inboxError, markRead, markAllRead, refresh } = useInbox(inboxKinds);
   const shouldLoadWorkIntents = tab === 'captures';
   const { data: workIntentData, error: workIntentsError, isLoading: workIntentsLoading, mutate: refreshWorkIntents } = useSWR(
     shouldLoadWorkIntents ? '/api/work-intents?limit=50' : null,
@@ -513,12 +500,11 @@ export default function InboxPage() {
     { refreshInterval: 15_000, revalidateOnFocus: true },
   );
 
-  const filtered = useMemo(() => {
-    if (tab === 'tasks') {
-      return items.filter((it) => it.kind === 'task_assigned' || it.kind === 'task_updated');
-    }
-    return items;
-  }, [items, tab]);
+  const filtered = items;
+  const markableNotificationCount = useMemo(
+    () => filtered.filter((item) => item.source === 'notification' && !item.read).length,
+    [filtered],
+  );
   const historicWorkIntents = useMemo(
     () => (workIntentData?.intents ?? []).filter((intent) => intent.status !== 'proposed'),
     [workIntentData?.intents],
@@ -596,6 +582,20 @@ export default function InboxPage() {
     [markRead],
   );
 
+  useEffect(() => {
+    setTab(normalizeInboxTab(params.get('tab')));
+  }, [params]);
+
+  const handleTabChange = useCallback((nextTab: InboxTab) => {
+    setTab(nextTab);
+    const nextParams = new URLSearchParams(params.toString());
+    if (nextTab === 'all') nextParams.delete('tab');
+    else nextParams.set('tab', nextTab);
+    nextParams.delete('action');
+    const query = nextParams.toString();
+    router.replace(query ? `${pathname}?${query}` : pathname, { scroll: false });
+  }, [params, pathname, router]);
+
   return (
     <div className="h-full min-h-0 overflow-y-auto overflow-x-hidden">
       <div className="max-w-[760px] mx-auto px-4 py-6 md:px-6 md:py-8">
@@ -608,17 +608,15 @@ export default function InboxPage() {
               Inbox
             </h1>
             <p className="text-[13px] mt-1" style={{ color: 'var(--muted)' }}>
-              {unreadCount > 0
-                ? `${unreadCount} unread item${unreadCount === 1 ? '' : 's'}`
-                : "You're caught up."}
+              {inboxStatusText(tab, unreadCount, isLoading)}
             </p>
           </div>
-          {unreadCount > 0 && (
+          {markableNotificationCount > 0 && (
             <button
               onClick={() => void markAllRead()}
               className="deft-pill min-h-[32px]"
             >
-              Mark all read
+              Mark notifications read
             </button>
           )}
         </header>
@@ -629,10 +627,10 @@ export default function InboxPage() {
           role="tablist"
           aria-label="Inbox sections"
         >
-          {TABS.map((t) => (
+          {INBOX_TABS.map((t) => (
             <button
               key={t.id}
-              onClick={() => setTab(t.id)}
+              onClick={() => handleTabChange(t.id)}
               className="deft-pill"
               data-active={tab === t.id}
               role="tab"
@@ -665,7 +663,7 @@ export default function InboxPage() {
             className="text-[13px] py-12 text-center rounded-lg"
             style={{ color: 'var(--muted)', border: '1px dashed var(--border)' }}
           >
-            Nothing here.
+            {inboxEmptyText(tab)}
           </div>
         ) : (
           <div className="flex flex-col gap-2">

--- a/apps/web/src/components/agent-action-card.tsx
+++ b/apps/web/src/components/agent-action-card.tsx
@@ -29,6 +29,7 @@ import { humanizeToolName } from '@/lib/tool-display';
 import { stripHtml } from '@/lib/strip-html';
 import {
   getAgentActionPresentation,
+  getSafeGenericParams,
   type ApprovalChipIconName,
   type ApprovalIconName,
 } from '@/lib/agent-action-presentation';
@@ -87,7 +88,7 @@ const INTENT_STATUS_LABELS: Record<string, string> = {
 };
 
 function GenericParams({ params }: { params: Record<string, any> }) {
-  const entries = Object.entries(params).filter(([, v]) => v !== undefined && v !== null && v !== '');
+  const entries = getSafeGenericParams(params);
   if (entries.length === 0) {
     return <p style={{ opacity: 0.6 }}>(no parameters)</p>;
   }

--- a/apps/web/src/hooks/use-inbox.ts
+++ b/apps/web/src/hooks/use-inbox.ts
@@ -48,12 +48,12 @@ async function fetchInbox(url: string): Promise<InboxResponse> {
   return (await res.json()) as InboxResponse;
 }
 
-export function useInbox(kind?: InboxItemKind) {
-  const url = kind ? `/api/inbox?kind=${kind}` : '/api/inbox';
+export function useInbox(kinds?: InboxItemKind[]) {
+  const kindQuery = kinds?.length ? kinds.join(',') : '';
+  const url = kindQuery ? `/api/inbox?kind=${encodeURIComponent(kindQuery)}` : '/api/inbox';
   const { data, mutate, isLoading, error } = useSWR<InboxResponse>(url, fetchInbox, {
     refreshInterval: 15_000,
     revalidateOnFocus: true,
-    fallbackData: { items: [], unread_count: 0, has_more: false, next_cursor: null },
   });
 
   const markRead = useCallback(async (ids: string[]) => {
@@ -62,9 +62,9 @@ export function useInbox(kind?: InboxItemKind) {
   }, [mutate]);
 
   const markAllRead = useCallback(async () => {
-    await api.post('/api/inbox/read', { all: true });
+    await api.post('/api/inbox/read', { all: true, kinds });
     void mutate();
-  }, [mutate]);
+  }, [kinds, mutate]);
 
   return {
     items: data?.items ?? [],

--- a/apps/web/src/lib/agent-action-presentation.test.ts
+++ b/apps/web/src/lib/agent-action-presentation.test.ts
@@ -1,0 +1,21 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { getSafeGenericParams } from './agent-action-presentation';
+
+test('generic approval details hide orchestration internals', () => {
+  const entries = getSafeGenericParams({
+    title: 'Publish update',
+    content: 'Ready for review',
+    idempotency_key: 'secret-dedupe-key',
+    proposal_node_id: 'node-1',
+    proposal_depends_on: ['node-0'],
+    source_message_id: 'message-1',
+    org_id: 'org-1',
+    task_id: 'task-1',
+  });
+
+  assert.deepEqual(entries, [
+    ['title', 'Publish update'],
+    ['content', 'Ready for review'],
+  ]);
+});

--- a/apps/web/src/lib/agent-action-presentation.ts
+++ b/apps/web/src/lib/agent-action-presentation.ts
@@ -59,6 +59,29 @@ export type ApprovalCardPresentation = {
   chips: Array<{ label: string; icon?: ApprovalChipIconName }>;
 };
 
+const INTERNAL_APPROVAL_PARAM_KEYS = new Set([
+  'idempotency_key',
+  'proposal_node_id',
+  'proposal_depends_on',
+  'source_message_id',
+  'source_space_id',
+  'origin_space_id',
+  'requested_by_user_id',
+  'agent_employee_id',
+  'org_id',
+  'user_id',
+]);
+
+export function getSafeGenericParams(params: Record<string, unknown>) {
+  return Object.entries(params).filter(([key, value]) => {
+    if (value === undefined || value === null || value === '') return false;
+    if (INTERNAL_APPROVAL_PARAM_KEYS.has(key)) return false;
+    if (key.startsWith('proposal_') || key.startsWith('debug_')) return false;
+    if (key.endsWith('_id') || key.endsWith('_ids')) return false;
+    return true;
+  });
+}
+
 function cleanText(value: unknown): string {
   if (typeof value !== 'string') return '';
   return stripHtml(value).replace(/\s+/g, ' ').trim();

--- a/apps/web/src/lib/inbox-view-model.test.ts
+++ b/apps/web/src/lib/inbox-view-model.test.ts
@@ -1,0 +1,21 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { inboxEmptyText, inboxStatusText, normalizeInboxTab, TAB_TO_KINDS } from './inbox-view-model';
+
+test('normalizes unsupported inbox tabs to all', () => {
+  assert.equal(normalizeInboxTab('approvals'), 'approvals');
+  assert.equal(normalizeInboxTab('made-up'), 'all');
+  assert.equal(normalizeInboxTab(null), 'all');
+});
+
+test('tasks request both assignment and update kinds', () => {
+  assert.deepEqual(TAB_TO_KINDS.tasks, ['task_assigned', 'task_updated']);
+});
+
+test('status copy describes the selected attention type', () => {
+  assert.equal(inboxStatusText('approvals', 2, false), '2 approvals waiting');
+  assert.equal(inboxStatusText('tasks', 0, false), 'No unread task updates.');
+  assert.equal(inboxStatusText('all', 1, false), '1 item needs attention');
+  assert.equal(inboxStatusText('all', 0, true), 'Checking what needs your attention...');
+  assert.equal(inboxEmptyText('mentions'), 'No unread mentions.');
+});

--- a/apps/web/src/lib/inbox-view-model.ts
+++ b/apps/web/src/lib/inbox-view-model.ts
@@ -1,0 +1,45 @@
+import type { InboxItemKind } from '@/hooks/use-inbox';
+
+export type InboxTab = 'all' | 'mentions' | 'dms' | 'tasks' | 'captures' | 'approvals';
+
+export const INBOX_TABS: { id: InboxTab; label: string }[] = [
+  { id: 'all', label: 'All' },
+  { id: 'mentions', label: 'Mentions' },
+  { id: 'dms', label: 'DMs' },
+  { id: 'tasks', label: 'Tasks' },
+  { id: 'captures', label: 'Captures' },
+  { id: 'approvals', label: 'Approvals' },
+];
+
+export const TAB_TO_KINDS: Record<InboxTab, InboxItemKind[] | undefined> = {
+  all: undefined,
+  mentions: ['mention'],
+  dms: ['dm_unread'],
+  tasks: ['task_assigned', 'task_updated'],
+  captures: ['work_capture'],
+  approvals: ['pending_approval'],
+};
+
+export function normalizeInboxTab(value: string | null): InboxTab {
+  return INBOX_TABS.some((tab) => tab.id === value) ? value as InboxTab : 'all';
+}
+
+export function inboxStatusText(tab: InboxTab, count: number, loading: boolean) {
+  if (loading) return 'Checking what needs your attention...';
+  const noun = count === 1 ? '' : 's';
+  if (tab === 'approvals') return count ? `${count} approval${noun} waiting` : 'No approvals waiting.';
+  if (tab === 'captures') return count ? `${count} capture${noun} waiting for review` : 'No captures need review.';
+  if (tab === 'dms') return count ? `${count} unread conversation${noun}` : 'No unread direct messages.';
+  if (tab === 'mentions') return count ? `${count} unread mention${noun}` : 'No unread mentions.';
+  if (tab === 'tasks') return count ? `${count} unread task update${noun}` : 'No unread task updates.';
+  return count ? `${count} item${noun} need${count === 1 ? 's' : ''} attention` : "You're caught up.";
+}
+
+export function inboxEmptyText(tab: InboxTab) {
+  if (tab === 'approvals') return 'No approvals are waiting for you.';
+  if (tab === 'captures') return 'No captured work needs review.';
+  if (tab === 'dms') return 'No unread direct messages.';
+  if (tab === 'mentions') return 'No unread mentions.';
+  if (tab === 'tasks') return 'No unread task updates.';
+  return "You're caught up.";
+}


### PR DESCRIPTION
## What changed
- give every Inbox tab its own URL, kinds, unread count, loading state, and empty state
- filter notification kinds before pagination and compute unread totals independently of the first page
- scope mark-read to the active notification kinds
- include both assigned and updated task attention
- bundle repeated task nudges per person, type, and day while preserving per-task audit rows
- hide orchestration internals from generic approval details

## Why
Inbox behaved like one global unread pile. Tabs repeated misleading counts, empty states flashed incorrectly, and repeated worker nudges created unnecessary noise.

## Validation
- full disposable-database API suite: 710/710 passing
- Inbox API coverage: 14/14 passing
- Inbox and approval-presentation logic: 4/4 passing
- notification digest logic: 3/3 passing
- desktop and 390px mobile browser dogfood across Tasks, Mentions, DMs, Captures, and Approvals