### PR TITLE
Make Agent Employee states truthful

### DIFF
--- a/apps/api/src/routes/agent-employees.ts
+++ b/apps/api/src/routes/agent-employees.ts
@@ -144,14 +144,53 @@ agentEmployeeRoutes.get('/', async (c) => {
       if (r.employee_id) lastTurnMap.set(r.employee_id, r.last_turn_at ?? null);
     }
 
+    const channelRows = await db
+      .select({
+        employee_id: agentChannelConnections.agent_employee_id,
+        status: agentChannelConnections.status,
+        last_seen_at: agentChannelConnections.last_seen_at,
+        last_error: agentChannelConnections.last_error,
+      })
+      .from(agentChannelConnections)
+      .where(eq(agentChannelConnections.org_id, user.org_id));
+    const channelMap = new Map(channelRows.map((row) => [row.employee_id, row]));
+
+    const skillStats = await db.execute(sql`
+      SELECT
+        aes.agent_employee_id AS employee_id,
+        COUNT(*)::int AS installed_skill_count,
+        BOOL_OR(s.slug = 'deft-workspace' AND s.is_deleted = false) AS has_workspace_skill
+      FROM agent_employee_skills aes
+      INNER JOIN skills s ON s.id = aes.skill_id
+      INNER JOIN agent_employees ae ON ae.id = aes.agent_employee_id
+      WHERE ae.org_id = ${user.org_id}
+        AND ae.is_deleted = false
+      GROUP BY aes.agent_employee_id
+    `);
+    const skillMap = new Map<string, { count: number; hasWorkspaceSkill: boolean }>();
+    for (const row of ((skillStats as any).rows ?? skillStats) as any[]) {
+      if (!row.employee_id) continue;
+      skillMap.set(row.employee_id, {
+        count: Number(row.installed_skill_count ?? 0),
+        hasWorkspaceSkill: row.has_workspace_skill === true,
+      });
+    }
+
     const enriched = employees.map((emp) => {
       const turn = turnMap.get(emp.id);
+      const channel = channelMap.get(emp.id);
+      const skill = skillMap.get(emp.id);
       return {
         ...emp,
         pending_action_count: pendingMap.get(emp.id) ?? 0,
         recent_turn_count_24h: turn?.cnt_24h ?? 0,
         last_turn_at: turn?.last_turn_at ?? lastTurnMap.get(emp.id) ?? null,
         avg_latency_ms_24h: turn?.avg_latency ?? null,
+        channel_status: channel?.status ?? null,
+        channel_last_seen_at: channel?.last_seen_at ?? null,
+        channel_last_error: channel?.last_error ?? null,
+        installed_skill_count: skill?.count ?? 0,
+        required_workspace_skill_installed: skill?.hasWorkspaceSkill ?? false,
       };
     });
 
@@ -915,6 +954,27 @@ async function issueMcpToken({
   return rawApiKey;
 }
 
+async function installRequiredWorkspaceSkill(employeeId: string) {
+  const [workspaceSkill] = await db
+    .select({ id: skills.id, version: skills.version })
+    .from(skills)
+    .where(and(eq(skills.slug, 'deft-workspace'), eq(skills.is_deleted, false)))
+    .limit(1);
+  if (!workspaceSkill) {
+    console.warn('[agent-employees] bundled deft-workspace skill is not seeded');
+    return false;
+  }
+  await db
+    .insert(agentEmployeeSkills)
+    .values({
+      agent_employee_id: employeeId,
+      skill_id: workspaceSkill.id,
+      installed_version: workspaceSkill.version,
+    })
+    .onConflictDoNothing();
+  return true;
+}
+
 agentEmployeeRoutes.post('/', async (c) => {
   try {
     const currentUser = c.get('user');
@@ -1004,6 +1064,8 @@ agentEmployeeRoutes.post('/', async (c) => {
       .update(users)
       .set({ agent_employee_id: employee!.id })
       .where(eq(users.id, agentUser!.id));
+
+    await installRequiredWorkspaceSkill(employee!.id);
 
     // 5. Always auto-generate the API key. Every agent in v1 is BYOA —
     // the same token is persisted on BOTH sides so the agent works

--- a/apps/api/src/scripts/seed-bundled-skills.ts
+++ b/apps/api/src/scripts/seed-bundled-skills.ts
@@ -77,6 +77,43 @@ export async function seedBundledSkills(
     log(`  upserted ${skill.slug}`);
   }
 
+  const workspaceBundle = BUNDLED_SKILLS.find((skill) => skill.slug === 'deft-workspace');
+  if (workspaceBundle) {
+    const [workspaceRow] = await db
+      .select({ id: skills.id })
+      .from(skills)
+      .where(and(
+        eq(skills.source, 'bundled'),
+        isNull(skills.org_id),
+        eq(skills.slug, workspaceBundle.slug),
+        eq(skills.is_deleted, false),
+      ))
+      .limit(1);
+    if (!workspaceRow) throw new Error('deft-workspace bundle was not available after seeding');
+    const backfill = await db.execute(sql`
+      INSERT INTO agent_employee_skills (
+        agent_employee_id,
+        skill_id,
+        installed_at,
+        installed_version
+      )
+      SELECT
+        ae.id,
+        ${workspaceRow.id},
+        NOW(),
+        ${workspaceBundle.version}
+      FROM agent_employees ae
+      WHERE ae.is_deleted = false
+      ON CONFLICT (agent_employee_id, skill_id) DO UPDATE
+        SET installed_version = EXCLUDED.installed_version
+      RETURNING agent_employee_id
+    `);
+    const backfilledRows = ((backfill as any).rows ?? backfill) as unknown[];
+    if (backfilledRows.length > 0) {
+      log(`[seed-bundled-skills] synchronized deft-workspace for ${backfilledRows.length} existing agent employees`);
+    }
+  }
+
   // Clean up orphaned bundled rows whose slugs are no longer in BUNDLED_SKILLS.
   // This catches stale rows from previous seed runs (e.g. retired capability
   // packs like `web-browsing` / `shell-exec` after Phase 9). We delete junction

--- a/apps/api/src/scripts/seed-pilot-workspace.ts
+++ b/apps/api/src/scripts/seed-pilot-workspace.ts
@@ -18,6 +18,7 @@ import { reconcileProjectTaskCountersForOrg } from '../lib/task-numbering.js';
 import {
   actionReceipts,
   agentEmployees,
+  agentEmployeeSkills,
   agentActions,
   crossReferences,
   events,
@@ -57,6 +58,7 @@ import {
   wikiLinks,
   wikiOpsLog,
   wikiPages,
+  skills,
 } from '@deft/db/schema';
 
 const TOM_TOKEN = process.env.SEED_TOM_MCP_TOKEN ?? 'tom-pilot-mcp-token-2026';
@@ -254,6 +256,26 @@ async function upsertAgentUser(params: {
       set: employeeValues,
     })
     .returning(), `agent employee ${params.slug}`);
+
+  const [workspaceSkill] = await db
+    .select({ id: skills.id, version: skills.version })
+    .from(skills)
+    .where(and(eq(skills.slug, 'deft-workspace'), eq(skills.is_deleted, false)))
+    .limit(1);
+  if (!workspaceSkill) {
+    throw new Error('Bundled deft-workspace skill is missing. Run seed-platform-bundles first.');
+  }
+  await db
+    .insert(agentEmployeeSkills)
+    .values({
+      agent_employee_id: employee.id,
+      skill_id: workspaceSkill.id,
+      installed_version: workspaceSkill.version,
+    })
+    .onConflictDoUpdate({
+      target: [agentEmployeeSkills.agent_employee_id, agentEmployeeSkills.skill_id],
+      set: { installed_version: workspaceSkill.version, installed_at: new Date() },
+    });
 
   const user = expectOne(await db
     .update(users)

--- a/apps/api/test/bundled-skills-seed.test.ts
+++ b/apps/api/test/bundled-skills-seed.test.ts
@@ -102,6 +102,25 @@ test('deft-workspace skill ships the 9 Phase-3 task tools', async () => {
   });
 });
 
+test('seeding backfills deft-workspace onto existing agent employees', async () => {
+  await withClient(async (c) => {
+    const res = await c.query<{ missing_count: string }>(
+      `SELECT count(*)::text AS missing_count
+       FROM agent_employees ae
+       WHERE ae.is_deleted = false
+         AND NOT EXISTS (
+           SELECT 1
+           FROM agent_employee_skills aes
+           INNER JOIN skills s ON s.id = aes.skill_id
+           WHERE aes.agent_employee_id = ae.id
+             AND s.slug = 'deft-workspace'
+             AND s.is_deleted = false
+         )`,
+    );
+    assert.equal(res.rows[0]!.missing_count, '0');
+  });
+});
+
 test('capability-pack bundled skills map 1:1 to available packs', async () => {
   const available = new Set(
     CAPABILITY_PACKS.filter((p) => !p.coming_soon).map((p) => p.slug),

--- a/apps/web/src/app/(app)/settings/agent-employees/page.tsx
+++ b/apps/web/src/app/(app)/settings/agent-employees/page.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useCallback, useState, useEffect } from 'react';
 import Link from 'next/link';
 import { api } from '@/lib/api';
 import { Trash2, X, Plus, ExternalLink } from 'lucide-react';
+import { agentConnectionStatus, agentEmployeeLifecycle } from '@/lib/agent-employee-status';
 
 type AgentEmployee = {
   id: string;
@@ -31,6 +32,10 @@ type AgentEmployee = {
   pending_action_count?: number;
   recent_turn_count_24h?: number;
   last_turn_at?: string | null;
+  channel_last_seen_at?: string | null;
+  channel_status?: string | null;
+  installed_skill_count?: number;
+  required_workspace_skill_installed?: boolean;
 };
 
 const ROLE_LABELS: Record<string, string> = {
@@ -54,156 +59,75 @@ const TRUST_LABELS: Record<string, string> = {
 
 const isSelfHosted = process.env.NEXT_PUBLIC_DEFT_SELF_HOSTED === 'true';
 
-function connectionStatus(lastHeartbeatAt: string | null): { label: string; color: string } {
-  if (!lastHeartbeatAt) return { label: 'Never connected', color: '#9ca3af' };
-  const elapsedMs = Date.now() - new Date(lastHeartbeatAt).getTime();
-  const elapsedMinutes = Math.max(0, Math.floor(elapsedMs / 60000));
-  if (elapsedMinutes < 5) return { label: 'Connected', color: '#10b981' };
-  if (elapsedMinutes < 60) return { label: `Last seen ${elapsedMinutes}m ago`, color: '#f59e0b' };
-  const elapsedHours = Math.floor(elapsedMinutes / 60);
-  if (elapsedHours < 24) return { label: `Last seen ${elapsedHours}h ago`, color: '#f59e0b' };
-  return { label: `Last seen ${Math.floor(elapsedHours / 24)}d ago`, color: '#ef4444' };
-}
-
 function runtimeLabel(value: string | null | undefined): string {
   return value ? value.replace(/_/g, ' ') : 'custom MCP';
 }
 
-function formatRelative(iso: string | null | undefined): string {
-  if (!iso) return 'never';
-  const elapsedMs = Date.now() - new Date(iso).getTime();
-  const elapsedMinutes = Math.max(0, Math.floor(elapsedMs / 60000));
-  if (elapsedMinutes < 1) return 'just now';
-  if (elapsedMinutes < 60) return `${elapsedMinutes}m ago`;
-  const elapsedHours = Math.floor(elapsedMinutes / 60);
-  if (elapsedHours < 24) return `${elapsedHours}h ago`;
-  return `${Math.floor(elapsedHours / 24)}d ago`;
-}
-
-function lifecycleStatus(emp: AgentEmployee): {
-  label: string;
-  detail: string;
-  color: string;
-  background: string;
-  border: string;
-} {
-  if (emp.unhealthy) {
-    return {
-      label: 'Needs attention',
-      detail: emp.unhealthy_reason || 'health check failed',
-      color: '#ef4444',
-      background: 'rgba(239,68,68,0.10)',
-      border: 'rgba(239,68,68,0.22)',
-    };
-  }
-  if (!emp.is_active) {
-    return {
-      label: 'Paused',
-      detail: 'will not pick up new work',
-      color: '#9ca3af',
-      background: 'rgba(156,163,175,0.10)',
-      border: 'rgba(156,163,175,0.22)',
-    };
-  }
-  if (emp.pending_action_count && emp.pending_action_count > 0) {
-    return {
-      label: 'Needs approval',
-      detail: `${emp.pending_action_count} pending`,
-      color: '#f59e0b',
-      background: 'rgba(245,158,11,0.12)',
-      border: 'rgba(245,158,11,0.28)',
-    };
-  }
-  if (emp.certification_status === 'verified') {
-    const recentWork = emp.last_work_outcome_at ?? emp.last_turn_at ?? emp.last_mcp_call_at;
-    return {
-      label: 'Working',
-      detail: `last activity ${formatRelative(recentWork)}`,
-      color: '#10b981',
-      background: 'rgba(16,185,129,0.12)',
-      border: 'rgba(16,185,129,0.26)',
-    };
-  }
-  if (emp.last_mcp_call_at || emp.certification_status === 'mcp_reachable') {
-    return {
-      label: 'Connected',
-      detail: 'ready for certification',
-      color: '#3b82f6',
-      background: 'rgba(59,130,246,0.11)',
-      border: 'rgba(59,130,246,0.24)',
-    };
-  }
-  if (emp.certification_status === 'challenge_issued') {
-    return {
-      label: 'Certifying',
-      detail: 'waiting for challenge response',
-      color: '#f59e0b',
-      background: 'rgba(245,158,11,0.12)',
-      border: 'rgba(245,158,11,0.28)',
-    };
-  }
-  if (emp.certification_status === 'token_issued') {
-    return {
-      label: 'Token issued',
-      detail: 'waiting for first MCP call',
-      color: '#8b5cf6',
-      background: 'rgba(139,92,246,0.11)',
-      border: 'rgba(139,92,246,0.24)',
-    };
-  }
-  return {
-    label: 'Draft',
-    detail: 'finish setup',
-    color: '#9ca3af',
-    background: 'rgba(156,163,175,0.10)',
-    border: 'rgba(156,163,175,0.22)',
-  };
-}
+const STATUS_TONES = {
+  green: { color: '#10b981', background: 'rgba(16,185,129,0.12)', border: 'rgba(16,185,129,0.26)' },
+  blue: { color: '#3b82f6', background: 'rgba(59,130,246,0.11)', border: 'rgba(59,130,246,0.24)' },
+  amber: { color: '#f59e0b', background: 'rgba(245,158,11,0.12)', border: 'rgba(245,158,11,0.28)' },
+  red: { color: '#ef4444', background: 'rgba(239,68,68,0.10)', border: 'rgba(239,68,68,0.22)' },
+  gray: { color: '#9ca3af', background: 'rgba(156,163,175,0.10)', border: 'rgba(156,163,175,0.22)' },
+  purple: { color: '#8b5cf6', background: 'rgba(139,92,246,0.11)', border: 'rgba(139,92,246,0.24)' },
+} as const;
 
 export default function AgentEmployeesPage() {
   const [employees, setEmployees] = useState<AgentEmployee[]>([]);
   const [loading, setLoading] = useState(true);
   const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
   const [togglingId, setTogglingId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
 
-  const fetchEmployees = async () => {
+  const fetchEmployees = useCallback(async () => {
+    setError(null);
     try {
       const res = await api.get('/api/agent-employees?expand=stats');
-      if (res.ok) {
-        setEmployees(await res.json());
-      }
+      if (!res.ok) throw new Error(`Could not load agent employees (${res.status})`);
+      setEmployees(await res.json());
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not load agent employees.');
     } finally {
       setLoading(false);
     }
-  };
-
-  useEffect(() => {
-    fetchEmployees();
   }, []);
 
+  useEffect(() => {
+    void fetchEmployees();
+    const timer = window.setInterval(() => { void fetchEmployees(); }, 15_000);
+    return () => window.clearInterval(timer);
+  }, [fetchEmployees]);
+
   const handleToggleActive = async (emp: AgentEmployee) => {
+    setError(null);
     setTogglingId(emp.id);
     try {
       const endpoint = emp.is_active
         ? `/api/agent-employees/${emp.id}/pause`
         : `/api/agent-employees/${emp.id}/resume`;
       const res = await api.post(endpoint);
-      if (res.ok) {
-        setEmployees((prev) =>
-          prev.map((e) => (e.id === emp.id ? { ...e, is_active: !e.is_active } : e))
-        );
-      }
+      if (!res.ok) throw new Error(`Could not ${emp.is_active ? 'pause' : 'resume'} ${emp.name} (${res.status})`);
+      setEmployees((prev) =>
+        prev.map((e) => (e.id === emp.id ? { ...e, is_active: !e.is_active } : e))
+      );
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not update the agent.');
     } finally {
       setTogglingId(null);
     }
   };
 
   const handleDelete = async (id: string) => {
-    const res = await api.delete(`/api/agent-employees/${id}`);
-    if (res.ok) {
+    setError(null);
+    try {
+      const res = await api.delete(`/api/agent-employees/${id}`);
+      if (!res.ok) throw new Error(`Could not delete the agent (${res.status})`);
       setEmployees((prev) => prev.filter((e) => e.id !== id));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not delete the agent.');
+    } finally {
+      setConfirmDelete(null);
     }
-    setConfirmDelete(null);
   };
 
   return (
@@ -245,6 +169,17 @@ export default function AgentEmployeesPage() {
         )}
       </div>
 
+      {error && (
+        <div
+          className="mb-4 flex items-center justify-between gap-3 rounded-lg px-3 py-2 text-[12px]"
+          style={{ color: 'var(--status-red)', background: 'rgba(239,68,68,0.08)', border: '1px solid rgba(239,68,68,0.18)' }}
+          role="alert"
+        >
+          <span>{error}</span>
+          <button type="button" className="deft-pill" onClick={() => void fetchEmployees()}>Retry</button>
+        </div>
+      )}
+
       {loading ? (
         <div className="py-12 text-center text-[13px]" style={{ color: 'var(--muted)' }}>
           Loading...
@@ -264,8 +199,10 @@ export default function AgentEmployeesPage() {
       ) : (
         <div className="space-y-2">
           {employees.map((emp) => {
-            const conn = connectionStatus(emp.last_mcp_call_at ?? emp.last_heartbeat_at);
-            const lifecycle = lifecycleStatus(emp);
+            const connection = agentConnectionStatus(emp);
+            const lifecycle = agentEmployeeLifecycle(emp);
+            const lifecycleTone = STATUS_TONES[lifecycle.tone];
+            const connectionTone = STATUS_TONES[connection.tone];
             return (
             <div
               key={emp.id}
@@ -297,12 +234,12 @@ export default function AgentEmployeesPage() {
                     <span
                       className="inline-flex items-center gap-1.5 text-[11px] px-2 py-0.5 rounded"
                       style={{
-                        color: lifecycle.color,
-                        background: lifecycle.background,
-                        border: `1px solid ${lifecycle.border}`,
+                        color: lifecycleTone.color,
+                        background: lifecycleTone.background,
+                        border: `1px solid ${lifecycleTone.border}`,
                       }}
                     >
-                      <span className="w-1.5 h-1.5 rounded-full" style={{ background: lifecycle.color }} />
+                      <span className="w-1.5 h-1.5 rounded-full" style={{ background: lifecycleTone.color }} />
                       {lifecycle.label}
                     </span>
                     <span className="text-[11px]" style={{ color: 'var(--muted)' }}>
@@ -324,16 +261,10 @@ export default function AgentEmployeesPage() {
                       {TRUST_LABELS[emp.trust_level] || emp.trust_level}
                     </span>
                     <span className="text-[11px]" style={{ color: 'var(--muted)' }}>
-                      {emp.daily_action_count ?? 0}/{emp.max_daily_actions} actions
-                    </span>
-                    <span className="text-[11px]" style={{ color: 'var(--muted)' }}>
                       {runtimeLabel(emp.runtime_kind)} / {emp.wake_mode}
                     </span>
                     <span className="text-[11px]" style={{ color: 'var(--muted)' }}>
-                      {emp.pending_action_count ?? 0} pending
-                    </span>
-                    <span className="text-[11px]" style={{ color: 'var(--muted)' }}>
-                      cert {emp.certification_status}
+                      {emp.installed_skill_count ?? 0} skill{emp.installed_skill_count === 1 ? '' : 's'}
                     </span>
                     <div className="flex items-center gap-1">
                       {emp.heartbeat_enabled && (
@@ -342,13 +273,16 @@ export default function AgentEmployeesPage() {
                         </span>
                       )}
                     </div>
+                    <span className="text-[11px]" style={{ color: 'var(--muted)' }}>
+                      {emp.daily_action_count ?? 0}/{emp.max_daily_actions} actions today
+                    </span>
                     <div className="flex items-center gap-1">
                       <div
                         className="w-2 h-2 rounded-full"
-                        style={{ background: conn.color }}
+                        style={{ background: connectionTone.color }}
                       />
                       <span className="text-[11px]" style={{ color: 'var(--muted)' }}>
-                        {conn.label}
+                        {connection.label}
                       </span>
                     </div>
                     {emp.unhealthy && (

--- a/apps/web/src/components/sidebar.tsx
+++ b/apps/web/src/components/sidebar.tsx
@@ -5,6 +5,7 @@ import { createPortal } from 'react-dom';
 import { useAuth } from '@/lib/auth-context';
 import { useChatContext } from '@/lib/chat-context';
 import { HUDDLES_ENABLED } from '@/lib/feature-flags';
+import { agentConnectionStatus } from '@/lib/agent-employee-status';
 import { registerOpenCreateSpace } from '@/lib/quick-actions';
 import { isSettingsItemActive, settingsNavGroups } from '@/lib/settings-navigation';
 import { useTheme } from './theme-provider';
@@ -56,6 +57,9 @@ type AgentEmployee = {
   unhealthy?: boolean;
   last_heartbeat_at?: string | null;
   last_mcp_call_at?: string | null;
+  channel_last_seen_at?: string | null;
+  channel_status?: string | null;
+  required_workspace_skill_installed?: boolean;
   pending_action_count?: number;
 };
 
@@ -118,11 +122,13 @@ function ChatSidebarContent({
   }, []);
 
   const agentStatusColor = (employee: AgentEmployee) => {
-    if (!employee.is_active || employee.unhealthy) return 'var(--outline)';
-    const lastContact = employee.last_mcp_call_at ?? employee.last_heartbeat_at;
-    if (!lastContact) return 'var(--status-amber)';
-    const elapsedMinutes = Math.floor((Date.now() - new Date(lastContact).getTime()) / 60000);
-    return elapsedMinutes < 15 ? 'var(--status-green)' : 'var(--status-amber)';
+    if (!employee.is_active || employee.unhealthy || employee.required_workspace_skill_installed === false) {
+      return 'var(--outline)';
+    }
+    const status = agentConnectionStatus(employee);
+    if (status.tone === 'green') return 'var(--status-green)';
+    if (status.tone === 'amber') return 'var(--status-amber)';
+    return 'var(--outline)';
   };
 
   const publicSpaces = spaces.filter((s) => s.type === 'public' || s.type === 'private');
@@ -421,6 +427,7 @@ function ChatSidebarContent({
                   )}
                   <div
                     className="absolute -bottom-0.5 -right-0.5 w-[10px] h-[10px] rounded-full"
+                    title={agentConnectionStatus(employee).label}
                     style={{
                       background: agentStatusColor(employee),
                       border: '2px solid var(--surface-container-low)',

--- a/apps/web/src/lib/agent-employee-status.test.ts
+++ b/apps/web/src/lib/agent-employee-status.test.ts
@@ -1,0 +1,63 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { agentConnectionStatus, agentEmployeeLifecycle } from './agent-employee-status';
+
+const NOW = Date.parse('2026-07-12T12:00:00Z');
+const base = {
+  is_active: true,
+  unhealthy: false,
+  required_workspace_skill_installed: true,
+};
+
+test('verified without runtime contact is not working', () => {
+  assert.deepEqual(
+    agentEmployeeLifecycle({ ...base, certification_status: 'verified' }, NOW),
+    { label: 'Ready to connect', detail: 'certified, but no runtime contact yet', tone: 'purple' },
+  );
+});
+
+test('working requires recent work, not merely configuration', () => {
+  const status = agentEmployeeLifecycle({
+    ...base,
+    certification_status: 'verified',
+    last_mcp_call_at: '2026-07-12T11:59:00Z',
+    last_turn_at: '2026-07-12T11:50:00Z',
+  }, NOW);
+  assert.equal(status.label, 'Working');
+});
+
+test('connected runtime without recent work is online', () => {
+  const status = agentEmployeeLifecycle({
+    ...base,
+    certification_status: 'verified',
+    channel_last_seen_at: '2026-07-12T11:58:00Z',
+  }, NOW);
+  assert.equal(status.label, 'Online');
+});
+
+test('missing required workspace skill blocks readiness', () => {
+  const status = agentEmployeeLifecycle({
+    ...base,
+    required_workspace_skill_installed: false,
+    certification_status: 'verified',
+    last_mcp_call_at: '2026-07-12T11:59:00Z',
+  }, NOW);
+  assert.equal(status.label, 'Setup incomplete');
+});
+
+test('latest channel contact drives connection status', () => {
+  const status = agentConnectionStatus({
+    ...base,
+    last_mcp_call_at: '2026-07-10T12:00:00Z',
+    channel_last_seen_at: '2026-07-12T11:59:00Z',
+  }, NOW);
+  assert.equal(status.label, 'Connected');
+});
+
+test('partial sidebar records are not mistaken for paused employees', () => {
+  const status = agentEmployeeLifecycle({
+    certification_status: 'verified',
+    required_workspace_skill_installed: true,
+  }, NOW);
+  assert.equal(status.label, 'Ready to connect');
+});

--- a/apps/web/src/lib/agent-employee-status.ts
+++ b/apps/web/src/lib/agent-employee-status.ts
@@ -1,0 +1,109 @@
+export type AgentEmployeeHealth = {
+  is_active?: boolean;
+  unhealthy?: boolean;
+  unhealthy_reason?: string | null;
+  certification_status?: string | null;
+  pending_action_count?: number;
+  last_mcp_call_at?: string | null;
+  last_heartbeat_at?: string | null;
+  last_turn_at?: string | null;
+  last_work_outcome_at?: string | null;
+  channel_last_seen_at?: string | null;
+  channel_status?: string | null;
+  required_workspace_skill_installed?: boolean;
+};
+
+export type AgentEmployeeLifecycle = {
+  label: string;
+  detail: string;
+  tone: 'green' | 'blue' | 'amber' | 'red' | 'gray' | 'purple';
+};
+
+function validTime(value?: string | null) {
+  if (!value) return 0;
+  const parsed = new Date(value).getTime();
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function latestTime(...values: Array<string | null | undefined>) {
+  return Math.max(0, ...values.map(validTime));
+}
+
+export function formatAgentAge(value?: string | null, now = Date.now()) {
+  const timestamp = validTime(value);
+  if (!timestamp) return 'never';
+  const elapsedMinutes = Math.max(0, Math.floor((now - timestamp) / 60_000));
+  if (elapsedMinutes < 1) return 'just now';
+  if (elapsedMinutes < 60) return `${elapsedMinutes}m ago`;
+  const hours = Math.floor(elapsedMinutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}
+
+export function latestAgentContact(emp: AgentEmployeeHealth) {
+  const values = [emp.last_mcp_call_at, emp.last_heartbeat_at, emp.channel_last_seen_at];
+  const timestamp = latestTime(...values);
+  if (!timestamp) return null;
+  return values.find((value) => validTime(value) === timestamp) ?? null;
+}
+
+export function agentEmployeeLifecycle(emp: AgentEmployeeHealth, now = Date.now()): AgentEmployeeLifecycle {
+  if (emp.unhealthy || emp.channel_status === 'error' || emp.channel_status === 'degraded') {
+    return {
+      label: 'Needs attention',
+      detail: emp.unhealthy_reason || 'runtime health check failed',
+      tone: 'red',
+    };
+  }
+  if (emp.is_active === false) return { label: 'Paused', detail: 'will not pick up new work', tone: 'gray' };
+
+  if (emp.required_workspace_skill_installed === false) {
+    return { label: 'Setup incomplete', detail: 'Deft Workspace skill is missing', tone: 'amber' };
+  }
+
+  const contact = latestAgentContact(emp);
+  const contactAt = validTime(contact);
+  const workAt = latestTime(emp.last_work_outcome_at, emp.last_turn_at);
+  const contactAge = contactAt ? Math.max(0, now - contactAt) : Number.POSITIVE_INFINITY;
+  const workAge = workAt ? Math.max(0, now - workAt) : Number.POSITIVE_INFINITY;
+
+  if (!contactAt) {
+    if (emp.certification_status === 'challenge_issued') {
+      return { label: 'Certifying', detail: 'waiting for the runtime challenge', tone: 'amber' };
+    }
+    if (emp.certification_status === 'verified' || emp.certification_status === 'mcp_reachable') {
+      return { label: 'Ready to connect', detail: 'certified, but no runtime contact yet', tone: 'purple' };
+    }
+    if (emp.certification_status === 'token_issued') {
+      return { label: 'Setup incomplete', detail: 'waiting for the first runtime call', tone: 'amber' };
+    }
+    return { label: 'Draft', detail: 'finish setup and connect a runtime', tone: 'gray' };
+  }
+
+  if ((emp.pending_action_count ?? 0) > 0) {
+    return {
+      label: 'Approval waiting',
+      detail: `${emp.pending_action_count} action${emp.pending_action_count === 1 ? '' : 's'} need review`,
+      tone: 'amber',
+    };
+  }
+
+  if (workAge < 15 * 60_000) {
+    return { label: 'Working', detail: `activity ${formatAgentAge(new Date(workAt).toISOString(), now)}`, tone: 'green' };
+  }
+  if (contactAge < 5 * 60_000) {
+    return { label: 'Online', detail: 'runtime connected and ready', tone: 'green' };
+  }
+  if (contactAge < 60 * 60_000) {
+    return { label: 'Idle', detail: `runtime seen ${formatAgentAge(contact, now)}`, tone: 'blue' };
+  }
+  return { label: 'Offline', detail: `last runtime contact ${formatAgentAge(contact, now)}`, tone: 'gray' };
+}
+
+export function agentConnectionStatus(emp: AgentEmployeeHealth, now = Date.now()) {
+  const contact = latestAgentContact(emp);
+  if (!contact) return { label: 'Never connected', tone: 'gray' as const };
+  const elapsedMinutes = Math.max(0, Math.floor((now - validTime(contact)) / 60_000));
+  if (elapsedMinutes < 5) return { label: 'Connected', tone: 'green' as const };
+  return { label: `Last seen ${formatAgentAge(contact, now)}`, tone: elapsedMinutes < 60 ? 'amber' as const : 'gray' as const };
+}


### PR DESCRIPTION
## Summary
- derive Agent Employee UI states from runtime, token-contact, work, and health evidence
- expand the agent employee API stats used by settings and navigation
- keep the required `deft-workspace` capability installed and synchronized
- make bundled skill and pilot seeding deterministic
- replace misleading online dots with the shared truthful status model

## Why
The previous UI could imply an employee was online from configuration alone. This change distinguishes setup, ready, online, working, idle, paused, unhealthy, and offline states using observable evidence.

## Validation
- agent employee status tests: 6/6
- web + API typecheck: pass
- web lint: pass
- full isolated API suite: 710/710 (integration branch certification)
- release builds: pass (integration branch certification)
- local browser dogfood: settings, sidebar, pause/resume, required capability state