### PR TITLE
Quiet Inbox attention and preserve activity history

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -8,6 +8,7 @@
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc --noEmit",
     "test": "tsx src/scripts/run-api-tests.ts",
+    "inbox:compact": "tsx src/scripts/compact-inbox-history.ts",
     "start": "node dist/server.js"
   },
   "dependencies": {

--- a/apps/api/src/lib/inbox-maintenance.ts
+++ b/apps/api/src/lib/inbox-maintenance.ts
@@ -1,0 +1,96 @@
+export const TASK_NUDGE_TYPES = ['stalled', 'overdue', 'upcoming_due'] as const;
+
+export type TaskNudgeType = (typeof TASK_NUDGE_TYPES)[number];
+
+export type InboxMaintenanceRow = {
+  id: string;
+  user_id: string;
+  title: string;
+  is_read: boolean;
+  metadata: unknown;
+  created_at: Date | string;
+};
+
+export type InboxCompactionGroup = {
+  key: string;
+  userId: string;
+  nudgeType: TaskNudgeType;
+  keep: InboxMaintenanceRow;
+  compact: InboxMaintenanceRow[];
+};
+
+function metadataRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {};
+}
+
+export function taskNudgeTypeForRow(row: InboxMaintenanceRow): TaskNudgeType | null {
+  const value = metadataRecord(row.metadata).nudge_type;
+  return TASK_NUDGE_TYPES.includes(value as TaskNudgeType) ? value as TaskNudgeType : null;
+}
+
+export function planLegacyTaskNudgeCompaction(
+  rows: InboxMaintenanceRow[],
+): InboxCompactionGroup[] {
+  const grouped = new Map<string, InboxMaintenanceRow[]>();
+
+  for (const row of rows) {
+    if (row.is_read) continue;
+    const nudgeType = taskNudgeTypeForRow(row);
+    if (!nudgeType) continue;
+    const key = `${row.user_id}:${nudgeType}`;
+    const group = grouped.get(key) ?? [];
+    group.push(row);
+    grouped.set(key, group);
+  }
+
+  return Array.from(grouped.entries())
+    .map(([key, group]) => {
+      const ordered = [...group].sort(
+        (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
+      );
+      const keep = ordered[0];
+      if (!keep) return null;
+      return {
+        key,
+        userId: keep.user_id,
+        nudgeType: taskNudgeTypeForRow(keep) as TaskNudgeType,
+        keep,
+        compact: ordered.slice(1),
+      } satisfies InboxCompactionGroup;
+    })
+    .filter((group): group is InboxCompactionGroup => group !== null && group.compact.length > 0)
+    .sort((a, b) => a.key.localeCompare(b.key));
+}
+
+export function addInboxCompactionMetadata(params: {
+  metadata: unknown;
+  runId: string;
+  compactedAt: string;
+  keptNotificationId: string;
+}) {
+  return {
+    ...metadataRecord(params.metadata),
+    inbox_compaction: {
+      run_id: params.runId,
+      compacted_at: params.compactedAt,
+      reason: 'superseded_task_nudge',
+      previous_is_read: false,
+      kept_notification_id: params.keptNotificationId,
+    },
+  };
+}
+
+export function removeInboxCompactionMetadata(metadata: unknown) {
+  const next = { ...metadataRecord(metadata) };
+  delete next.inbox_compaction;
+  return next;
+}
+
+export function inboxCompactionRunId(metadata: unknown): string | null {
+  const compaction = metadataRecord(metadata).inbox_compaction;
+  if (!compaction || typeof compaction !== 'object' || Array.isArray(compaction)) return null;
+  const runId = (compaction as Record<string, unknown>).run_id;
+  return typeof runId === 'string' && runId.length > 0 ? runId : null;
+}

--- a/apps/api/src/routes/inbox.ts
+++ b/apps/api/src/routes/inbox.ts
@@ -64,9 +64,20 @@ const NOTIF_KIND_MAP: Record<NotificationType, InboxItemKind> = {
   reminder: 'system',
   huddle_started: 'system',
   workload_imbalance: 'system',
-  agent_suggestion: 'system',
+  // Agent suggestions are task/work attention, not background system noise.
+  // This includes bundled overdue, stalled, and upcoming-due nudges.
+  agent_suggestion: 'task_updated',
   skill_update_available: 'system',
 };
+
+const ATTENTION_INBOX_KINDS = new Set<InboxItemKind>([
+  'mention',
+  'dm_unread',
+  'task_assigned',
+  'task_updated',
+  'blocked',
+  'pending_approval',
+]);
 
 const INBOX_KINDS = new Set<InboxItemKind>([
   'mention',
@@ -160,14 +171,16 @@ inboxRoutes.get('/', async (c) => {
     const user = c.get('user') as { id: string; org_id: string };
     const limit = Math.min(parseInt(c.req.query('limit') ?? '50', 10) || 50, 100);
     const cursor = c.req.query('cursor');
-    const requestedKinds = parseKindFilter(c.req.query('kind'));
+    const parsedKinds = parseKindFilter(c.req.query('kind'));
+    const requestedKinds = parsedKinds ?? ATTENTION_INBOX_KINDS;
     const countOnly = c.req.query('count_only') === '1';
+    const includeRead = c.req.query('include_read') === '1';
 
     if (requestedKinds && requestedKinds.size === 0) {
       return c.json({ error: 'Invalid inbox kind', code: 'VALIDATION_ERROR' }, 400);
     }
 
-    const wantsKind = (kind: InboxItemKind) => !requestedKinds || requestedKinds.has(kind);
+    const wantsKind = (kind: InboxItemKind) => requestedKinds.has(kind);
     const notificationTypes = notificationTypesForKinds(requestedKinds);
 
     const expiredActions = await db.update(agentActions)
@@ -187,6 +200,7 @@ inboxRoutes.get('/', async (c) => {
     const notificationWhere = and(
       eq(notifications.user_id, user.id),
       eq(notifications.org_id, user.org_id),
+      includeRead ? sql`TRUE` : eq(notifications.is_read, false),
       notificationTypes.length > 0 ? inArray(notifications.type, notificationTypes) : sql`FALSE`,
       cursor ? lt(notifications.created_at, new Date(cursor)) : sql`TRUE`,
     );
@@ -361,7 +375,7 @@ inboxRoutes.post('/read', async (c) => {
     if (body.all) {
       const requestedKinds = Array.isArray(body.kinds)
         ? new Set(body.kinds.filter((kind): kind is InboxItemKind => typeof kind === 'string' && INBOX_KINDS.has(kind as InboxItemKind)))
-        : null;
+        : ATTENTION_INBOX_KINDS;
       const notificationTypes = notificationTypesForKinds(requestedKinds);
       if (notificationTypes.length === 0) {
         return c.json({ success: true, updated: 0 });

--- a/apps/api/src/scripts/compact-inbox-history.ts
+++ b/apps/api/src/scripts/compact-inbox-history.ts
@@ -1,0 +1,141 @@
+import { randomUUID } from 'node:crypto';
+import { and, desc, eq } from 'drizzle-orm';
+import { notifications, orgs, users } from '@deft/db/schema';
+import { db } from '../lib/db.js';
+import {
+  addInboxCompactionMetadata,
+  inboxCompactionRunId,
+  planLegacyTaskNudgeCompaction,
+  removeInboxCompactionMetadata,
+} from '../lib/inbox-maintenance.js';
+
+type Args = {
+  orgSlug: string | null;
+  userEmail: string | null;
+  apply: boolean;
+  restoreRunId: string | null;
+};
+
+function readFlagValue(argv: string[], name: string) {
+  const inline = argv.find((arg) => arg.startsWith(`${name}=`));
+  if (inline) return inline.slice(name.length + 1);
+  const index = argv.indexOf(name);
+  return index >= 0 ? argv[index + 1] ?? null : null;
+}
+
+function parseArgs(argv: string[]): Args {
+  return {
+    orgSlug: readFlagValue(argv, '--org-slug'),
+    userEmail: readFlagValue(argv, '--user-email'),
+    apply: argv.includes('--apply'),
+    restoreRunId: readFlagValue(argv, '--restore'),
+  };
+}
+
+function usage() {
+  return [
+    'Usage:',
+    '  pnpm --filter @deft/api inbox:compact -- --org-slug <slug> [--user-email <email>]',
+    '  pnpm --filter @deft/api inbox:compact -- --org-slug <slug> [--user-email <email>] --apply',
+    '  pnpm --filter @deft/api inbox:compact -- --org-slug <slug> --restore <run-id>',
+    '',
+    'The default is a dry run. Apply marks only superseded unread task nudges as read.',
+    'Every changed row records a run id in metadata so the operation can be restored.',
+  ].join('\n');
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (!args.orgSlug || (args.apply && args.restoreRunId)) {
+    throw new Error(usage());
+  }
+
+  const [org] = await db.select({ id: orgs.id, name: orgs.name })
+    .from(orgs)
+    .where(eq(orgs.slug, args.orgSlug))
+    .limit(1);
+  if (!org) throw new Error(`Organization not found: ${args.orgSlug}`);
+
+  const rows = await db.select({
+    id: notifications.id,
+    user_id: notifications.user_id,
+    user_email: users.email,
+    title: notifications.title,
+    is_read: notifications.is_read,
+    metadata: notifications.metadata,
+    created_at: notifications.created_at,
+  })
+    .from(notifications)
+    .innerJoin(users, eq(users.id, notifications.user_id))
+    .where(and(
+      eq(notifications.org_id, org.id),
+      eq(notifications.type, 'agent_suggestion'),
+      args.userEmail ? eq(users.email, args.userEmail) : undefined,
+    ))
+    .orderBy(desc(notifications.created_at));
+
+  if (args.restoreRunId) {
+    const restorable = rows.filter((row) => inboxCompactionRunId(row.metadata) === args.restoreRunId);
+    if (restorable.length === 0) {
+      console.log(`No compacted notifications found for run ${args.restoreRunId}.`);
+      return;
+    }
+
+    await db.transaction(async (tx) => {
+      for (const row of restorable) {
+        await tx.update(notifications)
+          .set({
+            is_read: false,
+            metadata: removeInboxCompactionMetadata(row.metadata),
+            updated_at: new Date(),
+          })
+          .where(and(eq(notifications.id, row.id), eq(notifications.org_id, org.id)));
+      }
+    });
+    console.log(`Restored ${restorable.length} notification(s) in ${org.name}.`);
+    return;
+  }
+
+  const groups = planLegacyTaskNudgeCompaction(rows);
+  const compactRows = groups.flatMap((group) => group.compact.map((row) => ({ row, group })));
+  console.log(`Organization: ${org.name}`);
+  console.log(`Task-nudge groups with duplicates: ${groups.length}`);
+  for (const group of groups) {
+    const email = rows.find((row) => row.user_id === group.userId)?.user_email ?? group.userId;
+    console.log(`- ${email} / ${group.nudgeType}: keep "${group.keep.title}", compact ${group.compact.length}`);
+  }
+  console.log(`Superseded unread notifications: ${compactRows.length}`);
+
+  if (!args.apply || compactRows.length === 0) {
+    console.log(args.apply ? 'Nothing to change.' : 'Dry run only. Re-run with --apply to compact these rows.');
+    return;
+  }
+
+  const runId = `inbox-${new Date().toISOString().replaceAll(/[:.]/g, '-')}-${randomUUID().slice(0, 8)}`;
+  const compactedAt = new Date().toISOString();
+  await db.transaction(async (tx) => {
+    for (const { row, group } of compactRows) {
+      await tx.update(notifications)
+        .set({
+          is_read: true,
+          metadata: addInboxCompactionMetadata({
+            metadata: row.metadata,
+            runId,
+            compactedAt,
+            keptNotificationId: group.keep.id,
+          }),
+          updated_at: new Date(),
+        })
+        .where(and(eq(notifications.id, row.id), eq(notifications.org_id, org.id)));
+    }
+  });
+
+  console.log(`Compacted ${compactRows.length} notification(s).`);
+  console.log(`Restore with: pnpm --filter @deft/api inbox:compact -- --org-slug ${args.orgSlug} --restore ${runId}`);
+  console.log(`COMPACTION_RUN_ID=${runId}`);
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});

--- a/apps/api/test/inbox-maintenance.test.ts
+++ b/apps/api/test/inbox-maintenance.test.ts
@@ -1,0 +1,72 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  addInboxCompactionMetadata,
+  inboxCompactionRunId,
+  planLegacyTaskNudgeCompaction,
+  removeInboxCompactionMetadata,
+  type InboxMaintenanceRow,
+} from '../src/lib/inbox-maintenance.js';
+
+function row(overrides: Partial<InboxMaintenanceRow> & Pick<InboxMaintenanceRow, 'id'>): InboxMaintenanceRow {
+  return {
+    id: overrides.id,
+    user_id: overrides.user_id ?? 'user-1',
+    title: overrides.title ?? overrides.id,
+    is_read: overrides.is_read ?? false,
+    metadata: overrides.metadata ?? { nudge_type: 'overdue' },
+    created_at: overrides.created_at ?? '2026-07-12T00:00:00.000Z',
+  };
+}
+
+test('keeps the newest unread nudge per user and nudge type', () => {
+  const groups = planLegacyTaskNudgeCompaction([
+    row({ id: 'old', created_at: '2026-07-10T00:00:00.000Z' }),
+    row({ id: 'new', created_at: '2026-07-12T00:00:00.000Z' }),
+    row({ id: 'middle', created_at: '2026-07-11T00:00:00.000Z' }),
+  ]);
+
+  assert.equal(groups.length, 1);
+  assert.equal(groups[0].keep.id, 'new');
+  assert.deepEqual(groups[0].compact.map((candidate) => candidate.id), ['middle', 'old']);
+});
+
+test('does not cross user or nudge-type boundaries', () => {
+  const groups = planLegacyTaskNudgeCompaction([
+    row({ id: 'u1-overdue-new', user_id: 'user-1', created_at: '2026-07-12T00:00:00.000Z' }),
+    row({ id: 'u1-overdue-old', user_id: 'user-1', created_at: '2026-07-11T00:00:00.000Z' }),
+    row({ id: 'u2-overdue', user_id: 'user-2' }),
+    row({ id: 'u1-stalled', user_id: 'user-1', metadata: { nudge_type: 'stalled' } }),
+  ]);
+
+  assert.equal(groups.length, 1);
+  assert.equal(groups[0].key, 'user-1:overdue');
+  assert.deepEqual(groups[0].compact.map((candidate) => candidate.id), ['u1-overdue-old']);
+});
+
+test('ignores read rows and non-task agent suggestions', () => {
+  const groups = planLegacyTaskNudgeCompaction([
+    row({ id: 'read-old', is_read: true }),
+    row({ id: 'unread-new' }),
+    row({ id: 'duplicate-alert', metadata: { nudge_type: 'duplicate_detected' } }),
+    row({ id: 'seed-suggestion', metadata: { seed: 'pilot-living' } }),
+  ]);
+  assert.deepEqual(groups, []);
+});
+
+test('compaction metadata carries a restorable run id without losing existing metadata', () => {
+  const metadata = addInboxCompactionMetadata({
+    metadata: { nudge_type: 'overdue', task_id: 'task-1' },
+    runId: 'run-123',
+    compactedAt: '2026-07-12T01:00:00.000Z',
+    keptNotificationId: 'keeper',
+  });
+
+  assert.equal(inboxCompactionRunId(metadata), 'run-123');
+  assert.equal(metadata.nudge_type, 'overdue');
+  assert.equal(metadata.task_id, 'task-1');
+  assert.deepEqual(removeInboxCompactionMetadata(metadata), {
+    nudge_type: 'overdue',
+    task_id: 'task-1',
+  });
+});

--- a/apps/api/test/inbox-route.test.ts
+++ b/apps/api/test/inbox-route.test.ts
@@ -115,6 +115,61 @@ test('GET /api/inbox returns mention notifications', async () => {
   assert.equal(mention.kind, 'mention');
 });
 
+test('GET /api/inbox defaults to attention and keeps background activity separate', async () => {
+  const [background, nudge] = await db.insert(notifications).values([
+    {
+      org_id: testOrgId,
+      user_id: userId,
+      type: 'system',
+      title: 'Weekly background summary',
+      is_read: false,
+    },
+    {
+      org_id: testOrgId,
+      user_id: userId,
+      type: 'agent_suggestion',
+      title: '2 overdue tasks',
+      metadata: { nudge_type: 'overdue', task_ids: ['task-a', 'task-b'] },
+      is_read: false,
+    },
+  ]).returning();
+  createdNotifIds.push(background.id, nudge.id);
+
+  const attentionRes = await app.request('/api/inbox');
+  assert.equal(attentionRes.status, 200);
+  const attention = await attentionRes.json() as { items: { id: string; kind: string }[] };
+  assert.equal(attention.items.some((item) => item.id === `notif:${background.id}`), false);
+  assert.equal(
+    attention.items.find((item) => item.id === `notif:${nudge.id}`)?.kind,
+    'task_updated',
+  );
+
+  const activityRes = await app.request('/api/inbox?kind=system');
+  assert.equal(activityRes.status, 200);
+  const activity = await activityRes.json() as { items: { id: string }[] };
+  assert.equal(activity.items.some((item) => item.id === `notif:${background.id}`), true);
+  assert.equal(activity.items.some((item) => item.id === `notif:${nudge.id}`), false);
+});
+
+test('GET /api/inbox hides read queue rows unless history is requested', async () => {
+  const [readNotification] = await db.insert(notifications).values({
+    org_id: testOrgId,
+    user_id: userId,
+    type: 'task_updated',
+    title: 'Historical task update',
+    is_read: true,
+  }).returning();
+  createdNotifIds.push(readNotification.id);
+
+  const queueRes = await app.request('/api/inbox?kind=task_updated');
+  const queue = await queueRes.json() as { items: { id: string }[] };
+  assert.equal(queue.items.some((item) => item.id === `notif:${readNotification.id}`), false);
+
+  const historyRes = await app.request('/api/inbox?kind=task_updated&include_read=1');
+  const history = await historyRes.json() as { items: { id: string }[] };
+  assert.equal(history.items.some((item) => item.id === `notif:${readNotification.id}`), true);
+});
+
 test('GET /api/inbox surfaces DM unread', async () => {
   const [m] = await db.insert(messages).values({
     org_id: testOrgId,
@@ -268,6 +323,38 @@ test('POST /api/inbox/read with all=true marks everything read', async () => {
 
   const [after] = await db.select().from(notifications).where(eq(notifications.id, n.id));
   assert.equal(after.is_read, true);
+});
+
+test('POST /api/inbox/read with all=true leaves background activity unread', async () => {
+  const [attention, background] = await db.insert(notifications).values([
+    {
+      org_id: testOrgId,
+      user_id: userId,
+      type: 'task_updated',
+      title: 'Attention row',
+      is_read: false,
+    },
+    {
+      org_id: testOrgId,
+      user_id: userId,
+      type: 'system',
+      title: 'Background row',
+      is_read: false,
+    },
+  ]).returning();
+  createdNotifIds.push(attention.id, background.id);
+
+  const res = await app.request('/api/inbox/read', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ all: true }),
+  });
+  assert.equal(res.status, 200);
+
+  const [attentionAfter] = await db.select().from(notifications).where(eq(notifications.id, attention.id));
+  const [backgroundAfter] = await db.select().from(notifications).where(eq(notifications.id, background.id));
+  assert.equal(attentionAfter.is_read, true);
+  assert.equal(backgroundAfter.is_read, false);
 });
 
 test('POST /api/inbox/read scoped to current user only', async () => {

--- a/apps/web/src/app/(app)/inbox/page.tsx
+++ b/apps/web/src/app/(app)/inbox/page.tsx
@@ -11,6 +11,7 @@ import {
   CheckSquare,
   Clock3,
   ExternalLink,
+  History,
   RotateCcw,
   XCircle,
 } from 'lucide-react';
@@ -487,8 +488,11 @@ export default function InboxPage() {
   const [retryError, setRetryError] = useState<{ intentId: string; message: string } | null>(null);
 
   const inboxKinds = TAB_TO_KINDS[tab];
-  const { items, unreadCount, isLoading, error: inboxError, markRead, markAllRead, refresh } = useInbox(inboxKinds);
-  const shouldLoadWorkIntents = tab === 'captures';
+  const { items, unreadCount, isLoading, error: inboxError, markRead, markAllRead, refresh } = useInbox(
+    inboxKinds,
+    { includeRead: tab === 'activity' },
+  );
+  const shouldLoadWorkIntents = tab === 'activity';
   const { data: workIntentData, error: workIntentsError, isLoading: workIntentsLoading, mutate: refreshWorkIntents } = useSWR(
     shouldLoadWorkIntents ? '/api/work-intents?limit=50' : null,
     fetchWorkIntents,
@@ -589,7 +593,7 @@ export default function InboxPage() {
   const handleTabChange = useCallback((nextTab: InboxTab) => {
     setTab(nextTab);
     const nextParams = new URLSearchParams(params.toString());
-    if (nextTab === 'all') nextParams.delete('tab');
+    if (nextTab === 'attention') nextParams.delete('tab');
     else nextParams.set('tab', nextTab);
     nextParams.delete('action');
     const query = nextParams.toString();
@@ -611,7 +615,7 @@ export default function InboxPage() {
               {inboxStatusText(tab, unreadCount, isLoading)}
             </p>
           </div>
-          {markableNotificationCount > 0 && (
+          {tab !== 'activity' && markableNotificationCount > 0 && (
             <button
               onClick={() => void markAllRead()}
               className="deft-pill min-h-[32px]"
@@ -623,7 +627,7 @@ export default function InboxPage() {
 
         {/* Tab strip */}
         <nav
-          className="mb-5 flex gap-1.5 overflow-x-auto whitespace-nowrap"
+          className="mb-5 flex items-center gap-1.5 overflow-x-auto whitespace-nowrap"
           role="tablist"
           aria-label="Inbox sections"
         >
@@ -639,6 +643,18 @@ export default function InboxPage() {
               {t.label}
             </button>
           ))}
+          <span className="mx-0.5 h-5 w-px flex-shrink-0" style={{ background: 'var(--border)' }} />
+          <button
+            type="button"
+            onClick={() => handleTabChange('activity')}
+            className="deft-pill inline-flex items-center gap-1.5"
+            data-active={tab === 'activity'}
+            role="tab"
+            aria-selected={tab === 'activity'}
+          >
+            <History size={13} strokeWidth={1.7} />
+            Activity
+          </button>
         </nav>
 
         {/* Body */}
@@ -667,6 +683,11 @@ export default function InboxPage() {
           </div>
         ) : (
           <div className="flex flex-col gap-2">
+            {tab === 'activity' && filtered.length > 0 && (
+              <h2 className="mb-1 text-[11px] font-semibold uppercase tracking-[0.04em]" style={{ color: 'var(--muted)' }}>
+                Workspace activity
+              </h2>
+            )}
             {filtered.map((item) => {
               if ((item.kind === 'pending_approval' || item.kind === 'work_capture') && item.approval) {
                 const action: AgentAction = {
@@ -696,6 +717,11 @@ export default function InboxPage() {
                 />
               );
             })}
+            {shouldLoadWorkIntents && historicWorkIntents.length > 0 && (
+              <h2 className="mb-1 mt-4 text-[11px] font-semibold uppercase tracking-[0.04em]" style={{ color: 'var(--muted)' }}>
+                Capture outcomes
+              </h2>
+            )}
             {shouldLoadWorkIntents && historicWorkIntents
               .map((intent) => (
                 <WorkIntentRow
@@ -708,19 +734,21 @@ export default function InboxPage() {
                 />
               ))}
             {shouldLoadWorkIntents && observationTrail.length > 0 && (
-              <div className="mt-4 flex flex-col gap-2">
-                <div className="flex items-center justify-between">
-                  <h2 className="text-[13px] font-semibold" style={{ color: 'var(--foreground)' }}>
-                    Observation trail
-                  </h2>
-                  <span className="text-[12px]" style={{ color: 'var(--muted)' }}>
+              <details className="group mt-4 rounded-lg border px-3 py-2" style={{ borderColor: 'var(--border)', background: 'var(--surface)' }}>
+                <summary className="flex cursor-pointer list-none items-center justify-between gap-3">
+                  <span className="text-[12px] font-medium" style={{ color: 'var(--foreground-secondary)' }}>
+                    Processing details
+                  </span>
+                  <span className="text-[11px]" style={{ color: 'var(--muted)' }}>
                     Last {observationTrail.length}
                   </span>
+                </summary>
+                <div className="mt-3 flex flex-col gap-2">
+                  {observationTrail.map((observation) => (
+                    <MessageObservationRow key={observation.id} observation={observation} />
+                  ))}
                 </div>
-                {observationTrail.map((observation) => (
-                  <MessageObservationRow key={observation.id} observation={observation} />
-                ))}
-              </div>
+              </details>
             )}
           </div>
         )}

--- a/apps/web/src/components/notification-panel.tsx
+++ b/apps/web/src/components/notification-panel.tsx
@@ -45,7 +45,7 @@ export function NotificationPanel({ onClose }: Props) {
 
   const handleApprovalNav = (item: InboxItem) => {
     void markRead([item.id]);
-    router.push(`/inbox?tab=${item.kind === 'work_capture' ? 'captures' : 'approvals'}`);
+    router.push(`/inbox?tab=${item.kind === 'work_capture' ? 'activity' : 'approvals'}`);
     onClose();
   };
 

--- a/apps/web/src/hooks/use-inbox.ts
+++ b/apps/web/src/hooks/use-inbox.ts
@@ -48,9 +48,13 @@ async function fetchInbox(url: string): Promise<InboxResponse> {
   return (await res.json()) as InboxResponse;
 }
 
-export function useInbox(kinds?: InboxItemKind[]) {
+export function useInbox(kinds?: InboxItemKind[], options: { includeRead?: boolean } = {}) {
   const kindQuery = kinds?.length ? kinds.join(',') : '';
-  const url = kindQuery ? `/api/inbox?kind=${encodeURIComponent(kindQuery)}` : '/api/inbox';
+  const query = new URLSearchParams();
+  if (kindQuery) query.set('kind', kindQuery);
+  if (options.includeRead) query.set('include_read', '1');
+  const queryString = query.toString();
+  const url = queryString ? `/api/inbox?${queryString}` : '/api/inbox';
   const { data, mutate, isLoading, error } = useSWR<InboxResponse>(url, fetchInbox, {
     refreshInterval: 15_000,
     revalidateOnFocus: true,

--- a/apps/web/src/lib/inbox-view-model.test.ts
+++ b/apps/web/src/lib/inbox-view-model.test.ts
@@ -2,20 +2,29 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { inboxEmptyText, inboxStatusText, normalizeInboxTab, TAB_TO_KINDS } from './inbox-view-model';
 
-test('normalizes unsupported inbox tabs to all', () => {
+test('normalizes legacy and unsupported inbox tabs to the quieter model', () => {
   assert.equal(normalizeInboxTab('approvals'), 'approvals');
-  assert.equal(normalizeInboxTab('made-up'), 'all');
-  assert.equal(normalizeInboxTab(null), 'all');
+  assert.equal(normalizeInboxTab('mentions'), 'messages');
+  assert.equal(normalizeInboxTab('dms'), 'messages');
+  assert.equal(normalizeInboxTab('captures'), 'activity');
+  assert.equal(normalizeInboxTab('made-up'), 'attention');
+  assert.equal(normalizeInboxTab(null), 'attention');
 });
 
-test('tasks request both assignment and update kinds', () => {
-  assert.deepEqual(TAB_TO_KINDS.tasks, ['task_assigned', 'task_updated']);
+test('attention excludes background activity while tasks retain blockers', () => {
+  assert.deepEqual(TAB_TO_KINDS.tasks, ['task_assigned', 'task_updated', 'blocked']);
+  assert.equal(TAB_TO_KINDS.attention.includes('system'), false);
+  assert.equal(TAB_TO_KINDS.attention.includes('work_capture'), false);
+  assert.equal(TAB_TO_KINDS.activity.includes('system'), true);
+  assert.equal(TAB_TO_KINDS.activity.includes('work_capture'), true);
 });
 
 test('status copy describes the selected attention type', () => {
   assert.equal(inboxStatusText('approvals', 2, false), '2 approvals waiting');
   assert.equal(inboxStatusText('tasks', 0, false), 'No unread task updates.');
-  assert.equal(inboxStatusText('all', 1, false), '1 item needs attention');
-  assert.equal(inboxStatusText('all', 0, true), 'Checking what needs your attention...');
-  assert.equal(inboxEmptyText('mentions'), 'No unread mentions.');
+  assert.equal(inboxStatusText('attention', 1, false), '1 item needs attention');
+  assert.equal(inboxStatusText('attention', 0, true), 'Checking what needs your attention...');
+  assert.equal(inboxStatusText('activity', 12, false), 'Automation, capture, and delivery history.');
+  assert.equal(inboxEmptyText('messages'), 'No unread messages or mentions.');
+  assert.equal(inboxEmptyText('activity'), 'No background activity to show.');
 });

--- a/apps/web/src/lib/inbox-view-model.ts
+++ b/apps/web/src/lib/inbox-view-model.ts
@@ -1,45 +1,44 @@
 import type { InboxItemKind } from '@/hooks/use-inbox';
 
-export type InboxTab = 'all' | 'mentions' | 'dms' | 'tasks' | 'captures' | 'approvals';
+export type InboxTab = 'attention' | 'messages' | 'tasks' | 'approvals' | 'activity';
 
 export const INBOX_TABS: { id: InboxTab; label: string }[] = [
-  { id: 'all', label: 'All' },
-  { id: 'mentions', label: 'Mentions' },
-  { id: 'dms', label: 'DMs' },
+  { id: 'attention', label: 'Attention' },
+  { id: 'messages', label: 'Messages' },
   { id: 'tasks', label: 'Tasks' },
-  { id: 'captures', label: 'Captures' },
   { id: 'approvals', label: 'Approvals' },
 ];
 
-export const TAB_TO_KINDS: Record<InboxTab, InboxItemKind[] | undefined> = {
-  all: undefined,
-  mentions: ['mention'],
-  dms: ['dm_unread'],
-  tasks: ['task_assigned', 'task_updated'],
-  captures: ['work_capture'],
+export const TAB_TO_KINDS: Record<InboxTab, InboxItemKind[]> = {
+  attention: ['mention', 'dm_unread', 'task_assigned', 'task_updated', 'blocked', 'pending_approval'],
+  messages: ['mention', 'dm_unread'],
+  tasks: ['task_assigned', 'task_updated', 'blocked'],
   approvals: ['pending_approval'],
+  activity: ['cross_reference', 'wiki_update', 'system', 'work_capture'],
 };
 
 export function normalizeInboxTab(value: string | null): InboxTab {
-  return INBOX_TABS.some((tab) => tab.id === value) ? value as InboxTab : 'all';
+  if (value === 'all' || value === null) return 'attention';
+  if (value === 'mentions' || value === 'dms') return 'messages';
+  if (value === 'captures') return 'activity';
+  if (value === 'activity') return 'activity';
+  return INBOX_TABS.some((tab) => tab.id === value) ? value as InboxTab : 'attention';
 }
 
 export function inboxStatusText(tab: InboxTab, count: number, loading: boolean) {
   if (loading) return 'Checking what needs your attention...';
   const noun = count === 1 ? '' : 's';
   if (tab === 'approvals') return count ? `${count} approval${noun} waiting` : 'No approvals waiting.';
-  if (tab === 'captures') return count ? `${count} capture${noun} waiting for review` : 'No captures need review.';
-  if (tab === 'dms') return count ? `${count} unread conversation${noun}` : 'No unread direct messages.';
-  if (tab === 'mentions') return count ? `${count} unread mention${noun}` : 'No unread mentions.';
+  if (tab === 'activity') return 'Automation, capture, and delivery history.';
+  if (tab === 'messages') return count ? `${count} unread message update${noun}` : 'No unread message updates.';
   if (tab === 'tasks') return count ? `${count} unread task update${noun}` : 'No unread task updates.';
   return count ? `${count} item${noun} need${count === 1 ? 's' : ''} attention` : "You're caught up.";
 }
 
 export function inboxEmptyText(tab: InboxTab) {
   if (tab === 'approvals') return 'No approvals are waiting for you.';
-  if (tab === 'captures') return 'No captured work needs review.';
-  if (tab === 'dms') return 'No unread direct messages.';
-  if (tab === 'mentions') return 'No unread mentions.';
+  if (tab === 'activity') return 'No background activity to show.';
+  if (tab === 'messages') return 'No unread messages or mentions.';
   if (tab === 'tasks') return 'No unread task updates.';
   return "You're caught up.";
 }


### PR DESCRIPTION
## What changed

- makes Inbox and notification badges count only unread, actionable work by default
- consolidates Mentions and DMs into a single Messages queue
- keeps task nudges in Tasks while moving system summaries, wiki churn, classifier captures, and processing traces into Activity
- collapses raw observation details behind an advanced disclosure
- preserves legacy Inbox URLs through aliases
- adds a dry-run/apply/restore maintenance command for superseded legacy task nudges

## Why

The Inbox was treating audit history and background automation as daily obligations. In the Testers Tomatoes dogfood org this produced 50 apparent attention items, even though only six rows represented current user action.

## Validation

- full API suite: 719/719
- focused Inbox API: 14/14
- Inbox maintenance unit tests: 4/4
- Inbox view-model tests: 3/3
- root lint
- production monorepo build
- browser dogfood at desktop and 390px mobile
- live compaction rehearsal: dry run -> apply 30 rows -> restore 30 rows -> apply again -> idempotent dry run
