### PR TITLE
fix: harden live agent employee delivery

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -56,7 +56,14 @@ import { skillsRoutes } from './routes/skills.js';
 import { taskTemplateRoutes } from './routes/task-templates.js';
 import { workIntentRoutes } from './routes/work-intents.js';
 import { authMiddleware } from './middleware/auth.js';
-import { authLimiter, agentLimiter, uploadLimiter, defaultLimiter, webhookLimiter } from './middleware/rate-limit.js';
+import {
+  authLimiter,
+  agentLimiter,
+  agentChannelLimiter,
+  uploadLimiter,
+  defaultLimiter,
+  webhookLimiter,
+} from './middleware/rate-limit.js';
 import { githubWebhookRoutes } from './routes/webhooks/github.js';
 
 const app = new Hono();
@@ -105,7 +112,7 @@ app.route('/mcp', mcpServerRoutes);
 
 // Phase 3 MCP server v1 — Gateway bearer auth, mounted before authMiddleware
 app.route('/api/mcp/v1', mcpServerV1Routes);
-app.use('/api/agent-channel/v1/*', agentLimiter);
+app.use('/api/agent-channel/v1/*', agentChannelLimiter);
 app.route('/api/agent-channel/v1', agentChannelRoutes);
 
 // Phase 10 — Prometheus metrics export, own bearer scheme, mounted before

--- a/apps/api/src/middleware/rate-limit.ts
+++ b/apps/api/src/middleware/rate-limit.ts
@@ -1,7 +1,7 @@
 // In-memory store — fine for single-instance self-host. If we ever ship
 // multi-instance, swap to the hono-rate-limiter Redis store.
 import { rateLimiter } from 'hono-rate-limiter';
-import { timingSafeEqual } from 'node:crypto';
+import { createHash, timingSafeEqual } from 'node:crypto';
 import type { Context, MiddlewareHandler } from 'hono';
 
 const isProduction = process.env.NODE_ENV === 'production';
@@ -20,6 +20,10 @@ const AUTH_LIMIT_PER_MINUTE = positiveIntFromEnv(
 const AGENT_LIMIT_PER_MINUTE = positiveIntFromEnv(
   'DEFT_AGENT_RATE_LIMIT_PER_MINUTE',
   isProduction ? 30 : 300,
+);
+const AGENT_CHANNEL_LIMIT_PER_MINUTE = positiveIntFromEnv(
+  'DEFT_AGENT_CHANNEL_RATE_LIMIT_PER_MINUTE',
+  isProduction ? 180 : 600,
 );
 const UPLOAD_LIMIT_PER_MINUTE = positiveIntFromEnv(
   'DEFT_UPLOAD_RATE_LIMIT_PER_MINUTE',
@@ -50,6 +54,14 @@ function ipKey(c: Context): string {
   return c.req.header('x-forwarded-for')?.split(',')[0]?.trim() ||
          c.req.header('x-real-ip') ||
          'unknown';
+}
+
+function agentChannelKey(c: Context): string {
+  const authorization = c.req.header('authorization')?.trim();
+  if (authorization) {
+    return `channel:${createHash('sha256').update(authorization).digest('hex').slice(0, 32)}`;
+  }
+  return `ip:${ipKey(c)}`;
 }
 
 export function shouldBypassRateLimitForAudit(c: Context): boolean {
@@ -102,6 +114,20 @@ export const agentLimiter = withAuditBypass(rateLimiter({
   handler: (c) => c.json({
     error: 'Agent rate limit hit. Pause for a minute or talk to your admin about quota.',
     code: 'AGENT_RATE_LIMITED',
+  }, 429),
+}));
+
+// Agent Channel clients poll continuously and may share one office/NAT IP.
+// Isolate each channel credential so one employee cannot exhaust another's
+// budget, and leave enough headroom for ack/status/reply bursts around events.
+export const agentChannelLimiter = withAuditBypass(rateLimiter({
+  windowMs: 60 * 1000,
+  limit: AGENT_CHANNEL_LIMIT_PER_MINUTE,
+  standardHeaders: 'draft-7',
+  keyGenerator: agentChannelKey,
+  handler: (c) => c.json({
+    error: 'Agent Channel rate limit hit. Retry shortly.',
+    code: 'AGENT_CHANNEL_RATE_LIMITED',
   }, 429),
 }));
 

--- a/apps/api/src/routes/agent-channel.ts
+++ b/apps/api/src/routes/agent-channel.ts
@@ -45,7 +45,7 @@ const ackSchema = z.object({
 const replySchema = z.object({
   event_id: z.string().min(1),
   content: z.string().min(1).max(16000),
-  thread_id: z.string().optional(),
+  thread_id: z.string().nullable().optional(),
   idempotency_key: z.string().min(1).max(300).optional(),
   caller_employee_slug: z.string().optional(),
 });
@@ -254,7 +254,12 @@ agentChannelRoutes.post('/reply', async (c) => {
 
   const idempotencyKey = parsed.data.idempotency_key
     ?? `reply:${event.id}:${Buffer.from(parsed.data.content).toString('base64url').slice(0, 64)}`;
-  const parentId = parsed.data.thread_id ?? event.thread_id ?? event.source_id ?? null;
+  const payload = (event.payload ?? {}) as Record<string, unknown>;
+  const isTopLevelDm = payload.is_dm === true && !payload.parent_id;
+  const hasExplicitThreadId = Object.prototype.hasOwnProperty.call(parsed.data, 'thread_id');
+  const parentId = hasExplicitThreadId
+    ? (parsed.data.thread_id ?? null)
+    : (isTopLevelDm ? null : (event.thread_id ?? event.source_id ?? null));
   const requestJson = {
     event_id: event.id,
     content: parsed.data.content,

--- a/apps/api/src/workers/handlers/agent-employee-message.ts
+++ b/apps/api/src/workers/handlers/agent-employee-message.ts
@@ -72,6 +72,10 @@ export async function handleAgentEmployeeMessage(job: JobData): Promise<void> {
       approval_status: 'pending',
     }).returning({ id: agentActions.id });
 
+    const replyThreadId = isDM
+      ? (triggerMsg.parent_id ?? null)
+      : (triggerMsg.parent_id ?? messageId);
+
     await publishAgentChannelEvent({
       orgId,
       employeeId,
@@ -79,14 +83,14 @@ export async function handleAgentEmployeeMessage(job: JobData): Promise<void> {
       sourceKind: 'message',
       sourceId: messageId,
       spaceId,
-      threadId: triggerMsg.parent_id ?? messageId,
+      threadId: replyThreadId,
       actorUserId: author!.id,
       idempotencyKey: `message:${messageId}:employee:${employeeId}`,
       payload: {
         message_id: messageId,
         space_id: spaceId,
         parent_id: triggerMsg.parent_id ?? null,
-        reply_thread_id: triggerMsg.parent_id ?? messageId,
+        reply_thread_id: replyThreadId,
         author_id: author!.id,
         author_name: author!.name,
         content: triggerMsg.content,

--- a/apps/api/test/agent-channel.test.ts
+++ b/apps/api/test/agent-channel.test.ts
@@ -326,3 +326,42 @@ test('POST /reply posts as the agent and is idempotent', async () => {
   assert.ok(closedFallback?.executed_at);
   assert.equal((closedFallback?.result as any)?.channel_event_id, event.id);
 });
+
+test('POST /reply keeps a top-level DM response inline', async () => {
+  const { event } = await publishAgentChannelEvent({
+    orgId,
+    employeeId,
+    kind: 'message.created',
+    sourceKind: 'message',
+    sourceId: sourceMessageId,
+    spaceId,
+    threadId: sourceMessageId,
+    actorUserId: humanUserId,
+    idempotencyKey: 'agent-channel-inline-dm-reply',
+    payload: {
+      message_id: sourceMessageId,
+      content: 'hello in a top-level DM',
+      is_dm: true,
+      parent_id: null,
+    },
+  });
+  const content = 'Inline employee reply';
+  const res = await app.request('/api/agent-channel/v1/reply', {
+    method: 'POST',
+    headers: { authorization: `Bearer ${bearer}`, 'content-type': 'application/json' },
+    body: JSON.stringify({
+      event_id: event.id,
+      content,
+      idempotency_key: 'inline-dm-reply-once',
+    }),
+  });
+  const body = await res.json() as any;
+  assert.equal(res.status, 200, JSON.stringify(body));
+
+  const [reply] = await db
+    .select({ parent_id: messages.parent_id })
+    .from(messages)
+    .where(and(eq(messages.org_id, orgId), eq(messages.content, content)))
+    .limit(1);
+  assert.equal(reply?.parent_id, null);
+});

--- a/apps/api/test/rate-limit-audit-bypass.test.ts
+++ b/apps/api/test/rate-limit-audit-bypass.test.ts
@@ -77,3 +77,61 @@ test('production default app limiter allows normal chatty UI bursts', async () =
   if (oldDefaultLimit === undefined) delete process.env.DEFT_DEFAULT_RATE_LIMIT_PER_MINUTE;
   else process.env.DEFT_DEFAULT_RATE_LIMIT_PER_MINUTE = oldDefaultLimit;
 });
+
+test('agent channel limiter isolates credentials that share one public IP', async () => {
+  const oldNodeEnv = process.env.NODE_ENV;
+  const oldChannelLimit = process.env.DEFT_AGENT_CHANNEL_RATE_LIMIT_PER_MINUTE;
+
+  process.env.NODE_ENV = 'production';
+  process.env.DEFT_AGENT_CHANNEL_RATE_LIMIT_PER_MINUTE = '2';
+
+  const { agentChannelLimiter } = await import(`../src/middleware/rate-limit.js?channel-isolation=${Date.now()}`);
+  const app = new Hono();
+  app.use('*', agentChannelLimiter);
+  app.get('/ok', (c) => c.json({ ok: true }));
+
+  const sharedIp = '203.0.113.55';
+  for (let i = 0; i < 2; i += 1) {
+    const res = await app.request('/ok', {
+      headers: { authorization: 'Bearer employee-one', 'x-forwarded-for': sharedIp },
+    });
+    assert.equal(res.status, 200);
+  }
+  const limited = await app.request('/ok', {
+    headers: { authorization: 'Bearer employee-one', 'x-forwarded-for': sharedIp },
+  });
+  assert.equal(limited.status, 429);
+
+  const otherEmployee = await app.request('/ok', {
+    headers: { authorization: 'Bearer employee-two', 'x-forwarded-for': sharedIp },
+  });
+  assert.equal(otherEmployee.status, 200, 'another channel credential must keep its own budget');
+
+  process.env.NODE_ENV = oldNodeEnv;
+  if (oldChannelLimit === undefined) delete process.env.DEFT_AGENT_CHANNEL_RATE_LIMIT_PER_MINUTE;
+  else process.env.DEFT_AGENT_CHANNEL_RATE_LIMIT_PER_MINUTE = oldChannelLimit;
+});
+
+test('production agent channel budget covers polling plus normal event bursts', async () => {
+  const oldNodeEnv = process.env.NODE_ENV;
+  const oldChannelLimit = process.env.DEFT_AGENT_CHANNEL_RATE_LIMIT_PER_MINUTE;
+
+  process.env.NODE_ENV = 'production';
+  delete process.env.DEFT_AGENT_CHANNEL_RATE_LIMIT_PER_MINUTE;
+
+  const { agentChannelLimiter } = await import(`../src/middleware/rate-limit.js?channel-budget=${Date.now()}`);
+  const app = new Hono();
+  app.use('*', agentChannelLimiter);
+  app.get('/ok', (c) => c.json({ ok: true }));
+
+  for (let i = 0; i < 90; i += 1) {
+    const res = await app.request('/ok', {
+      headers: { authorization: 'Bearer normal-channel-runtime' },
+    });
+    assert.equal(res.status, 200, `request ${i + 1} should fit the normal channel budget`);
+  }
+
+  process.env.NODE_ENV = oldNodeEnv;
+  if (oldChannelLimit === undefined) delete process.env.DEFT_AGENT_CHANNEL_RATE_LIMIT_PER_MINUTE;
+  else process.env.DEFT_AGENT_CHANNEL_RATE_LIMIT_PER_MINUTE = oldChannelLimit;
+});

--- a/scripts/hermes-agent-channel-bridge.mjs
+++ b/scripts/hermes-agent-channel-bridge.mjs
@@ -4,6 +4,8 @@ import { pathToFileURL } from 'node:url';
 
 const DEFAULT_POLL_MS = 3000;
 const DEFAULT_LIMIT = 10;
+const DEFAULT_MAX_RETRIES = 5;
+const DEFAULT_RETRY_BASE_MS = 1000;
 
 function requiredEnv(env, key) {
   const value = env[key]?.trim();
@@ -30,6 +32,8 @@ export function configFromEnv(env = process.env) {
     hermesModel: env.HERMES_API_MODEL?.trim() || 'hermes-agent',
     pollMs: positiveInteger(env.DEFT_CHANNEL_POLL_MS, DEFAULT_POLL_MS),
     limit: Math.min(positiveInteger(env.DEFT_CHANNEL_BATCH_SIZE, DEFAULT_LIMIT), 100),
+    maxRetries: positiveInteger(env.DEFT_CHANNEL_MAX_RETRIES, DEFAULT_MAX_RETRIES),
+    retryBaseMs: positiveInteger(env.DEFT_CHANNEL_RETRY_BASE_MS, DEFAULT_RETRY_BASE_MS),
     once: ['1', 'true', 'yes'].includes((env.DEFT_CHANNEL_ONCE ?? '').toLowerCase()),
   };
 }
@@ -116,25 +120,48 @@ export class HermesAgentChannelBridge {
     this.config = config;
     this.fetch = options.fetchImpl ?? globalThis.fetch;
     this.log = options.logger ?? console;
+    this.sleep = options.sleep ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
     this.stopped = false;
   }
 
   async request(url, init = {}) {
-    const response = await this.fetch(url, init);
-    const text = await response.text();
-    let body = null;
-    if (text.trim()) {
+    for (let attempt = 0; ; attempt += 1) {
+      let response;
       try {
-        body = JSON.parse(text);
-      } catch {
-        body = { raw: text };
+        response = await this.fetch(url, init);
+      } catch (error) {
+        if (attempt >= this.config.maxRetries) throw error;
+        const delayMs = this.config.retryBaseMs * (2 ** attempt);
+        this.log.warn?.(`[deft-channel] transport error; retrying in ${delayMs}ms`);
+        await this.sleep(delayMs);
+        continue;
       }
-    }
-    if (!response.ok) {
+
+      const text = await response.text();
+      let body = null;
+      if (text.trim()) {
+        try {
+          body = JSON.parse(text);
+        } catch {
+          body = { raw: text };
+        }
+      }
+      if (response.ok) return body ?? {};
+
+      const retryable = response.status === 429 || response.status >= 500;
+      if (retryable && attempt < this.config.maxRetries) {
+        const retryAfterSeconds = Number.parseFloat(response.headers.get('retry-after') ?? '');
+        const delayMs = Number.isFinite(retryAfterSeconds) && retryAfterSeconds > 0
+          ? Math.ceil(retryAfterSeconds * 1000)
+          : this.config.retryBaseMs * (2 ** attempt);
+        this.log.warn?.(`[deft-channel] HTTP ${response.status}; retrying in ${delayMs}ms`);
+        await this.sleep(delayMs);
+        continue;
+      }
+
       const message = body?.error?.message || body?.error || body?.raw || `HTTP ${response.status}`;
       throw new Error(typeof message === 'string' ? message : JSON.stringify(message));
     }
-    return body ?? {};
   }
 
   channel(path, init = {}) {
@@ -177,12 +204,16 @@ export class HermesAgentChannelBridge {
   }
 
   async reply(event, content) {
+    const isTopLevelDm = event.payload?.is_dm === true && !event.payload?.parent_id;
+    const threadId = isTopLevelDm
+      ? null
+      : (event.thread_id ?? event.payload?.reply_thread_id ?? undefined);
     return this.channel('/reply', {
       method: 'POST',
       body: JSON.stringify({
         event_id: event.id,
         content,
-        thread_id: event.thread_id ?? event.payload?.reply_thread_id ?? undefined,
+        thread_id: threadId,
         idempotency_key: `hermes-channel:${event.id}`,
         caller_employee_slug: this.config.employeeSlug,
       }),
@@ -256,9 +287,15 @@ export class HermesAgentChannelBridge {
     const connection = await this.connect();
     this.log.info?.(`[deft-channel] connected as ${connection.employee?.slug ?? this.config.employeeSlug}`);
     do {
-      await this.pollOnce();
+      try {
+        await this.pollOnce();
+      } catch (error) {
+        if (this.config.once) throw error;
+        const message = error instanceof Error ? error.message : String(error);
+        this.log.warn?.(`[deft-channel] poll failed; staying alive: ${message}`);
+      }
       if (this.config.once || this.stopped) break;
-      await new Promise((resolve) => setTimeout(resolve, this.config.pollMs));
+      await this.sleep(this.config.pollMs);
     } while (!this.stopped);
   }
 }

--- a/scripts/hermes-agent-channel-bridge.test.mjs
+++ b/scripts/hermes-agent-channel-bridge.test.mjs
@@ -35,6 +35,8 @@ function config() {
     hermesModel: 'Maya',
     pollMs: 1,
     limit: 10,
+    maxRetries: 2,
+    retryBaseMs: 5,
     once: true,
   };
 }
@@ -115,4 +117,57 @@ test('processEvent reports runtime failures to the channel', async () => {
   const terminalCalls = calls.slice(-2);
   assert.equal(terminalCalls[0].body.state, 'failed');
   assert.equal(terminalCalls[1].body.state, 'degraded');
+});
+
+test('top-level DM replies stay in the main conversation instead of opening a thread', async () => {
+  const calls = [];
+  const dmEvent = {
+    ...event,
+    id: 'event-dm',
+    thread_id: null,
+    payload: { content: 'hello', is_dm: true, parent_id: null, reply_thread_id: null },
+  };
+  const fetchImpl = async (url, init = {}) => {
+    calls.push({ url, body: init.body ? JSON.parse(init.body) : null });
+    if (url.includes('/v1/responses')) {
+      return jsonResponse({
+        output_text: '{"reply":"Hello back.","summary":"Replied.","outcome":"completed"}',
+      });
+    }
+    return jsonResponse({ ok: true });
+  };
+  const bridge = new HermesAgentChannelBridge(config(), {
+    fetchImpl,
+    logger: { info() {}, error() {} },
+  });
+
+  await bridge.processEvent(dmEvent);
+  const replyCall = calls.find((call) => call.url.endsWith('/reply'));
+  assert.ok(replyCall);
+  assert.equal(replyCall.body.thread_id, null);
+});
+
+test('request retries a transient channel rate limit instead of killing the bridge', async () => {
+  let attempts = 0;
+  const sleeps = [];
+  const fetchImpl = async () => {
+    attempts += 1;
+    if (attempts === 1) {
+      return new Response(JSON.stringify({ error: 'slow down' }), {
+        status: 429,
+        headers: { 'content-type': 'application/json', 'retry-after': '0' },
+      });
+    }
+    return jsonResponse({ ok: true, employee: { slug: 'maya' } });
+  };
+  const bridge = new HermesAgentChannelBridge(config(), {
+    fetchImpl,
+    sleep: async (ms) => sleeps.push(ms),
+    logger: { info() {}, warn() {}, error() {} },
+  });
+
+  const result = await bridge.connect();
+  assert.equal(result.ok, true);
+  assert.equal(attempts, 2);
+  assert.deepEqual(sleeps, [5]);
 });


### PR DESCRIPTION
## Summary
- add a dedicated Agent Channel rate limit keyed by channel credentials instead of shared client IP
- keep Hermes/BYOA delivery bridges alive through 429, 5xx, and transient transport failures
- keep top-level agent DM replies inline while preserving threads for group mentions and threaded conversations

## Why
Real Rita/Hermes dogfood on `demo.deft.ing` showed that the normal polling cadence plus acknowledgement and reply calls could exhaust the generic 30 requests/minute agent budget. Multiple employees behind one NAT would also share that budget. The bridge then exited on the first 429, leaving the employee apparently connected but silent.

## Verification
- `node --test scripts/hermes-agent-channel-bridge.test.mjs` (7 passed)
- focused API tests for Agent Channel and rate limiting (11 passed)
- `pnpm --filter @deft/api typecheck`
- `git diff --check`

The full API test command correctly refused to run without a disposable `DEFT_TEST_DATABASE_URL`; the focused database-backed tests ran against the configured test harness and cleaned up after themselves.