### PR TITLE
fix: expose task comments to agent runtimes

### DIFF
--- a/apps/api/src/lib/mcp-tools/index.ts
+++ b/apps/api/src/lib/mcp-tools/index.ts
@@ -440,6 +440,14 @@ export const toolSchemas: ToolSchema[] = [
             },
             priority: { type: 'string', enum: ['p0', 'p1', 'p2', 'p3'] },
             assignee_id: { type: ['string', 'null'] },
+            due_date: {
+              type: ['string', 'null'],
+              description: 'ISO-8601 due date, or null to clear it.',
+            },
+            comment: {
+              type: 'string',
+              description: 'Add this text as a task comment without replacing the task description.',
+            },
           },
           additionalProperties: false,
         },

--- a/apps/api/test/mcp-server.test.ts
+++ b/apps/api/test/mcp-server.test.ts
@@ -164,6 +164,7 @@ test('3. POST /tools/list with valid bearer returns tool catalog', async () => {
   const memoryRecall = body.tools.find((t: any) => t.name === 'memory_recall');
   const wikiSearch = body.tools.find((t: any) => t.name === 'wiki_search');
   const platformContext = body.tools.find((t: any) => t.name === 'platform_context');
+  const taskUpdate = body.tools.find((t: any) => t.name === 'task_update');
   assert.ok(memoryRecall?.inputSchema?.properties?.space_id, 'memory_recall exposes space_id');
   assert.ok(memoryRecall?.inputSchema?.properties?.include_org, 'memory_recall exposes include_org');
   assert.ok(wikiSearch?.inputSchema?.properties?.space_id, 'wiki_search exposes space_id');
@@ -172,6 +173,14 @@ test('3. POST /tools/list with valid bearer returns tool catalog', async () => {
     String(platformContext?.description ?? ''),
     /context_packets/,
     'platform_context advertises context_packets',
+  );
+  assert.ok(
+    taskUpdate?.inputSchema?.properties?.patch?.properties?.comment,
+    'task_update advertises task comments to agent runtimes',
+  );
+  assert.ok(
+    taskUpdate?.inputSchema?.properties?.patch?.properties?.due_date,
+    'task_update advertises due-date changes to agent runtimes',
   );
 });
 


### PR DESCRIPTION
## Summary
- advertise `comment` and `due_date` in the agent employee `task_update` MCP schema
- keep the public tool contract aligned with fields already supported by the executor
- add catalog regression coverage

## Root cause
Live Rita/Hermes task dogfood asked for a task comment. The executor supports `patch.comment`, but the MCP JSON schema omitted it (and `due_date`), so the runtime explicitly reported that no comment action was available and rewrote the task description instead.

## Verification
- `pnpm --filter @deft/api typecheck`
- `mcp-server.test.ts` and `mcp-task-update-lifecycle.test.ts` (13 passed)
- live post-deploy rerun will require Rita to comment and transition the task without changing its description