### PR TITLE
Fix agent employee approval action contract

### DIFF
--- a/apps/api/src/lib/agent-approval-resolver.ts
+++ b/apps/api/src/lib/agent-approval-resolver.ts
@@ -64,15 +64,11 @@ import {
   markWorkIntentDismissedForAction,
   markWorkIntentFailedForAction,
 } from './work-intents.js';
-export const MCP_ACTION_KINDS = new Set([
-  'task_create',
-  'task_update',
-  'message_post',
-  'send_message',
-  'memory_update',
-  'wiki_create',
-  'wiki_update',
-]);
+import {
+  MCP_ACTION_KINDS,
+  normalizeMcpApprovalAction,
+} from './mcp-approval-actions.js';
+export { MCP_ACTION_KINDS } from './mcp-approval-actions.js';
 
 export type ApprovalResolverError =
   | { status: 'error'; code: 'NOT_FOUND'; message: string }
@@ -156,15 +152,39 @@ async function dispatchAction(
     actionId,
     sourceReaderUserId: dispatchOpts?.sourceReaderUserId ?? null,
   } as const;
-  switch (actionName) {
+  const normalized = normalizeMcpApprovalAction(
+    actionName,
+    params,
+    ctx.employee_slug,
+  );
+  if (!normalized.ok) {
+    return {
+      content: [{ type: 'text', text: normalized.error }],
+      isError: true,
+    };
+  }
+
+  switch (normalized.action) {
     case 'task_create':
-      return executeTaskCreate(params as unknown as TaskCreateArgs, ctx, opts);
+      return executeTaskCreate(
+        normalized.params as unknown as TaskCreateArgs,
+        ctx,
+        opts,
+      );
     case 'task_update':
-      return executeTaskUpdate(params as unknown as TaskUpdateArgs, ctx, opts);
+      return executeTaskUpdate(
+        normalized.params as unknown as TaskUpdateArgs,
+        ctx,
+        opts,
+      );
     case 'message_post':
-      return executeMessagePost(params as unknown as MessagePostArgs, ctx, opts);
+      return executeMessagePost(
+        normalized.params as unknown as MessagePostArgs,
+        ctx,
+        opts,
+      );
     case 'send_message': {
-      const p = params as unknown as SendMessageArgs & {
+      const p = normalized.params as unknown as SendMessageArgs & {
         resolved_space_id?: string;
         parent_id?: string | null;
       };
@@ -193,13 +213,23 @@ async function dispatchAction(
       );
     }
     case 'memory_update':
-      return executeMemoryUpdate(params as unknown as MemoryUpdateArgs, ctx, opts);
+      return executeMemoryUpdate(
+        normalized.params as unknown as MemoryUpdateArgs,
+        ctx,
+        opts,
+      );
     case 'wiki_create':
-      return executeWikiCreate(params as unknown as WikiCreateArgs, ctx, opts);
+      return executeWikiCreate(
+        normalized.params as unknown as WikiCreateArgs,
+        ctx,
+        opts,
+      );
     case 'wiki_update':
-      return executeWikiUpdate(params as unknown as WikiUpdateArgs, ctx, opts);
-    default:
-      throw new Error(`Unsupported action: ${actionName}`);
+      return executeWikiUpdate(
+        normalized.params as unknown as WikiUpdateArgs,
+        ctx,
+        opts,
+      );
   }
 }
 

--- a/apps/api/src/lib/mcp-approval-actions.ts
+++ b/apps/api/src/lib/mcp-approval-actions.ts
@@ -1,0 +1,89 @@
+/**
+ * Action kinds that the native approval resolver can execute.
+ *
+ * Keep aliases here as compatibility shims only. New approval rows are
+ * normalized to a canonical action before they are written.
+ */
+export const CANONICAL_MCP_ACTION_KINDS = [
+  'task_create',
+  'task_update',
+  'message_post',
+  'send_message',
+  'memory_update',
+  'wiki_create',
+  'wiki_update',
+] as const;
+
+const MCP_ACTION_ALIASES = {
+  add_task_comment: 'task_update',
+} as const;
+
+export const MCP_ACTION_KINDS = new Set<string>([
+  ...CANONICAL_MCP_ACTION_KINDS,
+  ...Object.keys(MCP_ACTION_ALIASES),
+]);
+
+type NormalizedApprovalAction =
+  | {
+      ok: true;
+      action: (typeof CANONICAL_MCP_ACTION_KINDS)[number];
+      params: Record<string, unknown>;
+    }
+  | { ok: false; error: string };
+
+export function normalizeMcpApprovalAction(
+  rawAction: string,
+  rawParams: Record<string, unknown>,
+  employeeSlug: string,
+): NormalizedApprovalAction {
+  const action = rawAction.trim();
+
+  if (action === 'add_task_comment') {
+    const taskId =
+      typeof rawParams.task_id === 'string' ? rawParams.task_id.trim() : '';
+    const comment =
+      typeof rawParams.comment === 'string' ? rawParams.comment.trim() : '';
+    if (!taskId || !comment) {
+      return {
+        ok: false,
+        error: 'add_task_comment requires params.task_id and params.comment',
+      };
+    }
+
+    const { comment: _comment, patch: _patch, ...reviewMetadata } = rawParams;
+    return {
+      ok: true,
+      action: MCP_ACTION_ALIASES.add_task_comment,
+      params: {
+        ...reviewMetadata,
+        caller_employee_slug: employeeSlug,
+        task_id: taskId,
+        patch: { comment },
+      },
+    };
+  }
+
+  if (!CANONICAL_MCP_ACTION_KINDS.includes(
+    action as (typeof CANONICAL_MCP_ACTION_KINDS)[number],
+  )) {
+    return {
+      ok: false,
+      error:
+        `unsupported approval action "${action}". Use one of: ` +
+        `${CANONICAL_MCP_ACTION_KINDS.join(', ')}, add_task_comment`,
+    };
+  }
+
+  return {
+    ok: true,
+    action: action as (typeof CANONICAL_MCP_ACTION_KINDS)[number],
+    params: {
+      ...rawParams,
+      caller_employee_slug:
+        typeof rawParams.caller_employee_slug === 'string' &&
+        rawParams.caller_employee_slug.trim()
+          ? rawParams.caller_employee_slug
+          : employeeSlug,
+    },
+  };
+}

--- a/apps/api/src/lib/mcp-tools/cooperative.ts
+++ b/apps/api/src/lib/mcp-tools/cooperative.ts
@@ -34,6 +34,7 @@ import {
 } from '@deft/db/schema';
 import type { ToolContext, ToolResult } from './types.js';
 import { errorResult, textResult } from './types.js';
+import { normalizeMcpApprovalAction } from '../mcp-approval-actions.js';
 
 // ─── Cooperative knowledge ────────────────────────────────────────────────
 
@@ -107,6 +108,15 @@ export async function requestHumanApproval(
     return errorResult('action and summary are required');
   }
 
+  const normalized = normalizeMcpApprovalAction(
+    action,
+    args.params ?? {},
+    ctx.employee_slug,
+  );
+  if (!normalized.ok) {
+    return errorResult(normalized.error);
+  }
+
   const [emp] = await db
     .select({ created_by: agentEmployees.created_by })
     .from(agentEmployees)
@@ -128,11 +138,11 @@ export async function requestHumanApproval(
       user_id: emp.created_by,
       agent_employee_id: ctx.employee_id,
       source: 'mcp',
-      action,
+      action: normalized.action,
       params: {
+        ...normalized.params,
         summary,
         requested_by_agent: ctx.employee_slug,
-        ...(args.params ?? {}),
       },
       approval_tier: 'full',
       approval_status: 'pending',

--- a/apps/api/src/lib/mcp-tools/index.ts
+++ b/apps/api/src/lib/mcp-tools/index.ts
@@ -875,9 +875,20 @@ export const toolSchemas: ToolSchema[] = [
         ...CALLER_SLUG_PROP,
         action: {
           type: 'string',
+          enum: [
+            'task_create',
+            'task_update',
+            'message_post',
+            'send_message',
+            'memory_update',
+            'wiki_create',
+            'wiki_update',
+            'add_task_comment',
+          ],
           description:
-            'Short handle for the action you want approved (e.g. ' +
-            '"send_email", "deploy_to_prod"). Shown in the approval UI.',
+            'Native Deft action to review. Use add_task_comment as a ' +
+            'convenience alias with params.task_id and params.comment; it ' +
+            'is normalized to task_update before it enters the queue.',
         },
         summary: {
           type: 'string',

--- a/apps/api/test/agent-approval-resolver.test.ts
+++ b/apps/api/test/agent-approval-resolver.test.ts
@@ -264,6 +264,13 @@ async function teardownFixtures() {
     );
     if (TEST_PROJECT_ID) {
       await c.query(
+        `DELETE FROM task_comments
+         WHERE task_id IN (
+           SELECT id FROM tasks WHERE project_id = $1 AND created_by IN ($2, $3)
+         )`,
+        [TEST_PROJECT_ID, SHADOW_USER_ID, DEFTY_USER_ID],
+      );
+      await c.query(
         `DELETE FROM task_activity
          WHERE task_id IN (
            SELECT id FROM tasks WHERE project_id = $1 AND created_by IN ($2, $3)
@@ -292,8 +299,14 @@ async function teardownFixtures() {
       );
     }
     await c.query(
-      `DELETE FROM messages WHERE user_id = $1`,
-      [SHADOW_USER_ID],
+      `DELETE FROM messages WHERE user_id IN ($1, $2, $3, $4, $5)`,
+      [
+        APPROVER_USER_ID,
+        OUTSIDER_USER_ID,
+        SHADOW_USER_ID,
+        DEFTY_USER_ID,
+        FOREIGN_USER_ID,
+      ],
     );
     await c.query(
       `DELETE FROM messages
@@ -395,6 +408,50 @@ async function insertPendingTaskCreate(
       ],
     );
     return r.rows[0].id as string;
+  });
+}
+
+async function createApprovedResolverTask(title: string): Promise<string> {
+  const actionId = await insertPendingTaskCreate(title);
+  const { approveAction } = await import('../src/lib/agent-approval-resolver.js');
+  const result = await approveAction(actionId, APPROVER_USER_ID);
+  assert.equal(result.status, 'approved', `task setup failed: ${JSON.stringify(result)}`);
+
+  return withClient(async (c) => {
+    const row = await c.query(
+      `SELECT id FROM tasks WHERE title = $1 ORDER BY created_at DESC LIMIT 1`,
+      [title],
+    );
+    assert.equal(row.rows.length, 1, 'approved setup task should exist');
+    return row.rows[0].id as string;
+  });
+}
+
+async function insertLegacyPendingTaskComment(
+  taskId: string,
+  comment: string,
+): Promise<string> {
+  return withClient(async (c) => {
+    const row = await c.query(
+      `INSERT INTO agent_actions
+        (id, org_id, user_id, agent_employee_id, source, action, params,
+         approval_tier, approval_status)
+       VALUES (gen_random_uuid()::text, $1, $2, $3, 'mcp',
+         'add_task_comment', $4::jsonb, 'full', 'pending')
+       RETURNING id`,
+      [
+        ORG_ID,
+        SHADOW_USER_ID,
+        EMP_ID,
+        JSON.stringify({
+          task_id: taskId,
+          comment,
+          summary: 'Legacy task comment proposal',
+          requested_by_agent: EMP_SLUG,
+        }),
+      ],
+    );
+    return row.rows[0].id as string;
   });
 }
 
@@ -728,6 +785,110 @@ test('1b. approving task_create resolves assignee_name when assignee_id is absen
       [actionId],
     );
     assert.equal(action.rows[0].result.assignee_id, APPROVER_USER_ID);
+  });
+});
+
+test('1b2. request_human_approval normalizes add_task_comment and executes it', async () => {
+  const title = `resolver-comment-normalized-${Date.now()}`;
+  const taskId = await createApprovedResolverTask(title);
+  const comment = 'Normalized approval comment from the agent employee.';
+  const { requestHumanApproval } = await import('../src/lib/mcp-tools/cooperative.js');
+
+  const queued = await requestHumanApproval(
+    {
+      action: 'add_task_comment',
+      summary: 'Add the reviewed handoff note to the task.',
+      params: { task_id: taskId, comment },
+    },
+    {
+      org_id: ORG_ID,
+      employee_id: EMP_ID,
+      employee_slug: EMP_SLUG,
+      trust_level: 'conservative',
+    },
+  );
+
+  assert.equal(queued.isError, false, queued.content?.[0]?.text);
+  const queuedPayload = JSON.parse(queued.content![0]!.text);
+  const actionId = queuedPayload.action_id as string;
+
+  await withClient(async (c) => {
+    const action = await c.query(
+      `SELECT action, params FROM agent_actions WHERE id = $1`,
+      [actionId],
+    );
+    assert.equal(action.rows[0].action, 'task_update');
+    assert.equal(action.rows[0].params.task_id, taskId);
+    assert.equal(action.rows[0].params.patch.comment, comment);
+    assert.equal(action.rows[0].params.comment, undefined);
+  });
+
+  const { approveAction } = await import('../src/lib/agent-approval-resolver.js');
+  const approved = await approveAction(actionId, APPROVER_USER_ID);
+  assert.equal(approved.status, 'approved', JSON.stringify(approved));
+
+  await withClient(async (c) => {
+    const saved = await c.query(
+      `SELECT content FROM task_comments WHERE task_id = $1 AND content = $2`,
+      [taskId, comment],
+    );
+    assert.equal(saved.rows.length, 1, 'normalized comment should be written once');
+  });
+});
+
+test('1b3. legacy add_task_comment rows remain executable', async () => {
+  const title = `resolver-comment-legacy-${Date.now()}`;
+  const taskId = await createApprovedResolverTask(title);
+  const comment = 'Compatibility comment from a pre-fix approval row.';
+  const actionId = await insertLegacyPendingTaskComment(taskId, comment);
+  const { approveAction } = await import('../src/lib/agent-approval-resolver.js');
+
+  const approved = await approveAction(actionId, APPROVER_USER_ID);
+  assert.equal(approved.status, 'approved', JSON.stringify(approved));
+
+  await withClient(async (c) => {
+    const action = await c.query(
+      `SELECT approval_status, executed_at, error FROM agent_actions WHERE id = $1`,
+      [actionId],
+    );
+    assert.equal(action.rows[0].approval_status, 'approved');
+    assert.ok(action.rows[0].executed_at);
+    assert.equal(action.rows[0].error, null);
+
+    const saved = await c.query(
+      `SELECT content FROM task_comments WHERE task_id = $1 AND content = $2`,
+      [taskId, comment],
+    );
+    assert.equal(saved.rows.length, 1, 'legacy comment should be written once');
+  });
+});
+
+test('1b4. request_human_approval rejects actions without an executor', async () => {
+  const summary = `unsupported-approval-${Date.now()}`;
+  const { requestHumanApproval } = await import('../src/lib/mcp-tools/cooperative.js');
+
+  const result = await requestHumanApproval(
+    {
+      action: 'deploy_to_prod',
+      summary,
+      params: { environment: 'production' },
+    },
+    {
+      org_id: ORG_ID,
+      employee_id: EMP_ID,
+      employee_slug: EMP_SLUG,
+      trust_level: 'conservative',
+    },
+  );
+
+  assert.equal(result.isError, true);
+  assert.match(result.content?.[0]?.text ?? '', /unsupported approval action/i);
+  await withClient(async (c) => {
+    const row = await c.query(
+      `SELECT id FROM agent_actions WHERE params->>'summary' = $1`,
+      [summary],
+    );
+    assert.equal(row.rows.length, 0, 'unsupported action must not enter the queue');
   });
 });
 


### PR DESCRIPTION
## What changed

- centralizes the action kinds the native approval resolver can actually execute
- normalizes `add_task_comment` proposals into canonical `task_update` approvals
- keeps pre-fix `add_task_comment` rows executable so existing cards can be repaired
- rejects unsupported approval action names before they enter the inbox
- advertises only supported actions in the MCP tool schema
- adds integration coverage for canonicalization, legacy compatibility, execution, and rejection

## Root cause

`request_human_approval` accepted arbitrary action strings, while the native approval executor only knew a fixed set. Rita could therefore create a plausible approval card that Deft could never execute.

## Validation

- `pnpm --filter @deft/api typecheck`
- `pnpm --filter @deft/api build`
- `agent-approval-resolver.test.ts`: 21 passed
- `mcp-task-update-lifecycle.test.ts` + `mcp-server.test.ts`: 13 passed