### PR TITLE
Fix agent employee private-space boundaries

### DIFF
--- a/apps/api/src/lib/agent-context.ts
+++ b/apps/api/src/lib/agent-context.ts
@@ -9,6 +9,7 @@ import {
   taskActivity,
   taskRelationships,
   spaces,
+  spaceMembers,
   orgMembers,
   events,
   agentMemory,
@@ -86,6 +87,10 @@ export async function executeToolCall(
         eq(messages.org_id, orgId),
         eq(messages.is_deleted, false),
         ilike(messages.content, `%${params.query}%`),
+        or(
+          eq(spaces.type, 'public'),
+          sql`${spaceMembers.id} IS NOT NULL`,
+        ),
       ];
 
       // Filter by space name
@@ -95,7 +100,8 @@ export async function executeToolCall(
           .from(spaces)
           .where(and(eq(spaces.org_id, orgId), ilike(spaces.name, params.space_name)))
           .limit(1);
-        if (space) conditions.push(eq(messages.space_id, space.id));
+        if (!space) return { result: [], citations: [] };
+        conditions.push(eq(messages.space_id, space.id));
       }
 
       // Filter by author name
@@ -108,7 +114,8 @@ export async function executeToolCall(
             and(eq(orgMembers.org_id, orgId), ilike(users.name, `%${params.author_name}%`)),
           )
           .limit(1);
-        if (author) conditions.push(eq(messages.user_id, author.id));
+        if (!author) return { result: [], citations: [] };
+        conditions.push(eq(messages.user_id, author.id));
       }
 
       const results = await db
@@ -121,6 +128,17 @@ export async function executeToolCall(
         })
         .from(messages)
         .innerJoin(users, eq(messages.user_id, users.id))
+        .innerJoin(
+          spaces,
+          and(eq(spaces.id, messages.space_id), eq(spaces.org_id, orgId)),
+        )
+        .leftJoin(
+          spaceMembers,
+          and(
+            eq(spaceMembers.space_id, spaces.id),
+            eq(spaceMembers.user_id, _userId),
+          ),
+        )
         .where(and(...conditions))
         .orderBy(desc(messages.created_at))
         .limit(limit);

--- a/apps/api/src/lib/mcp-tools/context.ts
+++ b/apps/api/src/lib/mcp-tools/context.ts
@@ -25,6 +25,9 @@ import {
   users,
   wikiPages,
   messages,
+  agentEmployees,
+  spaces,
+  spaceMembers,
 } from '@deft/db/schema';
 import type { ToolContext, ToolResult } from './types.js';
 import { errorResult, textResult } from './types.js';
@@ -276,11 +279,91 @@ export function invalidatePlatformContextCacheFor(employeeId: string) {
 
 // ─── Main handler ─────────────────────────────────────────────────────────
 
+async function canEmployeeAccessSpace(
+  employeeId: string,
+  orgId: string,
+  spaceId: string,
+): Promise<boolean> {
+  const [space] = await db
+    .select({ type: spaces.type })
+    .from(spaces)
+    .where(and(eq(spaces.id, spaceId), eq(spaces.org_id, orgId)))
+    .limit(1);
+
+  if (!space) return false;
+  if (space.type === 'public') return true;
+
+  const [employee] = await db
+    .select({ user_id: agentEmployees.user_id })
+    .from(agentEmployees)
+    .where(
+      and(
+        eq(agentEmployees.id, employeeId),
+        eq(agentEmployees.org_id, orgId),
+        eq(agentEmployees.is_active, true),
+      ),
+    )
+    .limit(1);
+  if (!employee) return false;
+
+  const [membership] = await db
+    .select({ id: spaceMembers.id })
+    .from(spaceMembers)
+    .where(
+      and(
+        eq(spaceMembers.space_id, spaceId),
+        eq(spaceMembers.user_id, employee.user_id),
+      ),
+    )
+    .limit(1);
+
+  return Boolean(membership);
+}
+
 export async function platformContext(
   args: PlatformContextArgs,
   ctx: ToolContext,
 ): Promise<ToolResult> {
   const trigger = args.trigger;
+  let triggerMessageContent = '';
+
+  try {
+    if (
+      trigger?.space_id &&
+      !(await canEmployeeAccessSpace(ctx.employee_id, ctx.org_id, trigger.space_id))
+    ) {
+      return errorResult('You do not have access to the requested space.');
+    }
+
+    if (trigger?.triggering_message_id) {
+      const [message] = await db
+        .select({ content: messages.content, space_id: messages.space_id })
+        .from(messages)
+        .where(
+          and(
+            eq(messages.id, trigger.triggering_message_id),
+            eq(messages.org_id, ctx.org_id),
+            eq(messages.is_deleted, false),
+          ),
+        )
+        .limit(1);
+
+      if (!message) {
+        return errorResult('The triggering message was not found.');
+      }
+      if (trigger.space_id && trigger.space_id !== message.space_id) {
+        return errorResult('The triggering message does not belong to the requested space.');
+      }
+      if (!(await canEmployeeAccessSpace(ctx.employee_id, ctx.org_id, message.space_id))) {
+        return errorResult('You do not have access to the triggering message.');
+      }
+
+      triggerMessageContent = message.content;
+    }
+  } catch {
+    return errorResult('Unable to validate the requested workspace context.');
+  }
+
   const key = cacheKey(ctx.employee_id, trigger);
   const cached = cacheGet(key);
   if (cached) {
@@ -345,13 +428,19 @@ export async function platformContext(
     }
 
     // ─── wiki snippet query source ───────────────────────────────
-    let queryText = '';
+    let queryText = triggerMessageContent;
     if (trigger?.triggering_message_id) {
       try {
         const [msg] = await db
           .select({ content: messages.content })
           .from(messages)
-          .where(eq(messages.id, trigger.triggering_message_id))
+          .where(
+            and(
+              eq(messages.id, trigger.triggering_message_id),
+              eq(messages.org_id, ctx.org_id),
+              eq(messages.is_deleted, false),
+            ),
+          )
           .limit(1);
         if (msg?.content) queryText = msg.content;
       } catch {

--- a/apps/api/src/lib/mcp-tools/context.ts
+++ b/apps/api/src/lib/mcp-tools/context.ts
@@ -25,14 +25,12 @@ import {
   users,
   wikiPages,
   messages,
-  agentEmployees,
-  spaces,
-  spaceMembers,
 } from '@deft/db/schema';
 import type { ToolContext, ToolResult } from './types.js';
 import { errorResult, textResult } from './types.js';
 import { retrieveContext, type ContextResult } from '../retrieve-context.js';
 import { listTeamSummaries, teamAccessForEmployee } from './team-context.js';
+import { employeeCanAccessSpace } from './employee-space-access.js';
 
 type TriggerDescriptor = {
   kind: string;
@@ -279,47 +277,6 @@ export function invalidatePlatformContextCacheFor(employeeId: string) {
 
 // ─── Main handler ─────────────────────────────────────────────────────────
 
-async function canEmployeeAccessSpace(
-  employeeId: string,
-  orgId: string,
-  spaceId: string,
-): Promise<boolean> {
-  const [space] = await db
-    .select({ type: spaces.type })
-    .from(spaces)
-    .where(and(eq(spaces.id, spaceId), eq(spaces.org_id, orgId)))
-    .limit(1);
-
-  if (!space) return false;
-  if (space.type === 'public') return true;
-
-  const [employee] = await db
-    .select({ user_id: agentEmployees.user_id })
-    .from(agentEmployees)
-    .where(
-      and(
-        eq(agentEmployees.id, employeeId),
-        eq(agentEmployees.org_id, orgId),
-        eq(agentEmployees.is_active, true),
-      ),
-    )
-    .limit(1);
-  if (!employee) return false;
-
-  const [membership] = await db
-    .select({ id: spaceMembers.id })
-    .from(spaceMembers)
-    .where(
-      and(
-        eq(spaceMembers.space_id, spaceId),
-        eq(spaceMembers.user_id, employee.user_id),
-      ),
-    )
-    .limit(1);
-
-  return Boolean(membership);
-}
-
 export async function platformContext(
   args: PlatformContextArgs,
   ctx: ToolContext,
@@ -330,7 +287,7 @@ export async function platformContext(
   try {
     if (
       trigger?.space_id &&
-      !(await canEmployeeAccessSpace(ctx.employee_id, ctx.org_id, trigger.space_id))
+      !(await employeeCanAccessSpace(ctx.employee_id, ctx.org_id, trigger.space_id))
     ) {
       return errorResult('You do not have access to the requested space.');
     }
@@ -354,7 +311,7 @@ export async function platformContext(
       if (trigger.space_id && trigger.space_id !== message.space_id) {
         return errorResult('The triggering message does not belong to the requested space.');
       }
-      if (!(await canEmployeeAccessSpace(ctx.employee_id, ctx.org_id, message.space_id))) {
+      if (!(await employeeCanAccessSpace(ctx.employee_id, ctx.org_id, message.space_id))) {
         return errorResult('You do not have access to the triggering message.');
       }
 

--- a/apps/api/src/lib/mcp-tools/employee-space-access.ts
+++ b/apps/api/src/lib/mcp-tools/employee-space-access.ts
@@ -1,0 +1,55 @@
+import { and, eq } from 'drizzle-orm';
+import { agentEmployees, spaceMembers, spaces } from '@deft/db/schema';
+import { db } from '../db.js';
+
+/**
+ * Public spaces are visible across the org. Private and DM spaces require the
+ * employee's shadow user to be an explicit member.
+ */
+export async function employeeCanAccessSpace(
+  employeeId: string,
+  orgId: string,
+  spaceId: string,
+): Promise<boolean> {
+  const [space] = await db
+    .select({ type: spaces.type })
+    .from(spaces)
+    .where(
+      and(
+        eq(spaces.id, spaceId),
+        eq(spaces.org_id, orgId),
+        eq(spaces.is_archived, false),
+      ),
+    )
+    .limit(1);
+
+  if (!space) return false;
+  if (space.type === 'public') return true;
+
+  const [employee] = await db
+    .select({ user_id: agentEmployees.user_id })
+    .from(agentEmployees)
+    .where(
+      and(
+        eq(agentEmployees.id, employeeId),
+        eq(agentEmployees.org_id, orgId),
+        eq(agentEmployees.is_active, true),
+        eq(agentEmployees.is_deleted, false),
+      ),
+    )
+    .limit(1);
+  if (!employee) return false;
+
+  const [membership] = await db
+    .select({ id: spaceMembers.id })
+    .from(spaceMembers)
+    .where(
+      and(
+        eq(spaceMembers.space_id, spaceId),
+        eq(spaceMembers.user_id, employee.user_id),
+      ),
+    )
+    .limit(1);
+
+  return Boolean(membership);
+}

--- a/apps/api/src/lib/mcp-tools/reports.ts
+++ b/apps/api/src/lib/mcp-tools/reports.ts
@@ -19,6 +19,9 @@
 import type { ToolContext, ToolResult } from './types.js';
 import { textResult, errorResult } from './types.js';
 import { executeToolCall } from '../agent-context.js';
+import { and, eq } from 'drizzle-orm';
+import { agentEmployees } from '@deft/db/schema';
+import { db } from '../db.js';
 
 function serialize(result: unknown): ToolResult {
   // executeToolCall may return error objects shaped `{ error: string }` — surface them as MCP errors.
@@ -28,16 +31,32 @@ function serialize(result: unknown): ToolResult {
   return textResult(result ?? {});
 }
 
+async function resolveEmployeeUserId(ctx: ToolContext): Promise<string | null> {
+  const [employee] = await db
+    .select({ user_id: agentEmployees.user_id })
+    .from(agentEmployees)
+    .where(
+      and(
+        eq(agentEmployees.id, ctx.employee_id),
+        eq(agentEmployees.org_id, ctx.org_id),
+      ),
+    )
+    .limit(1);
+  return employee?.user_id ?? null;
+}
+
 export async function taskDetail(args: {
   caller_employee_slug?: string;
   task_identifier: string;
 }, ctx: ToolContext): Promise<ToolResult> {
   if (!args.task_identifier) return errorResult('task_identifier is required');
+  const userId = await resolveEmployeeUserId(ctx);
+  if (!userId) return errorResult('agent employee identity could not be resolved');
   const { result } = await executeToolCall(
     'get_task_detail',
     { task_identifier: args.task_identifier },
     ctx.org_id,
-    ctx.employee_id,
+    userId,
     undefined,
     ctx.employee_id,
   );
@@ -52,6 +71,8 @@ export async function messagesSearch(args: {
   limit?: number;
 }, ctx: ToolContext): Promise<ToolResult> {
   if (!args.query) return errorResult('query is required');
+  const userId = await resolveEmployeeUserId(ctx);
+  if (!userId) return errorResult('agent employee identity could not be resolved');
   const { result } = await executeToolCall(
     'search_messages',
     {
@@ -61,7 +82,7 @@ export async function messagesSearch(args: {
       limit: args.limit,
     },
     ctx.org_id,
-    ctx.employee_id,
+    userId,
     undefined,
     ctx.employee_id,
   );
@@ -73,6 +94,8 @@ export async function projectProgress(args: {
   project_identifier?: string;
   project_name?: string;
 }, ctx: ToolContext): Promise<ToolResult> {
+  const userId = await resolveEmployeeUserId(ctx);
+  if (!userId) return errorResult('agent employee identity could not be resolved');
   const params: Record<string, unknown> = {};
   if (args.project_identifier) params.project_identifier = args.project_identifier;
   if (args.project_name) params.project_name = args.project_name;
@@ -80,7 +103,7 @@ export async function projectProgress(args: {
     'get_project_progress',
     params,
     ctx.org_id,
-    ctx.employee_id,
+    userId,
     undefined,
     ctx.employee_id,
   );
@@ -91,11 +114,13 @@ export async function teamWorkload(args: {
   caller_employee_slug?: string;
   days?: number;
 }, ctx: ToolContext): Promise<ToolResult> {
+  const userId = await resolveEmployeeUserId(ctx);
+  if (!userId) return errorResult('agent employee identity could not be resolved');
   const { result } = await executeToolCall(
     'get_team_workload',
     { days: args.days },
     ctx.org_id,
-    ctx.employee_id,
+    userId,
     undefined,
     ctx.employee_id,
   );

--- a/apps/api/src/lib/mcp-tools/space-memory.ts
+++ b/apps/api/src/lib/mcp-tools/space-memory.ts
@@ -8,24 +8,10 @@
  */
 import { and, eq } from 'drizzle-orm';
 import { db } from '../db.js';
-import { spaceMemory, spaces } from '@deft/db/schema';
+import { spaceMemory } from '@deft/db/schema';
 import type { ToolContext, ToolResult } from './types.js';
 import { errorResult, textResult } from './types.js';
-
-/** Phase 12 review fix: verify space belongs to the caller's org before any
- * read or write. Without this a bearer-authenticated employee could access
- * any space's memory bag globally by id-guessing. */
-async function verifySpaceInOrg(
-  spaceId: string,
-  orgId: string,
-): Promise<boolean> {
-  const [row] = await db
-    .select({ id: spaces.id })
-    .from(spaces)
-    .where(and(eq(spaces.id, spaceId), eq(spaces.org_id, orgId)))
-    .limit(1);
-  return !!row;
-}
+import { employeeCanAccessSpace } from './employee-space-access.js';
 
 // ─── space_memory_get ─────────────────────────────────────────────────────
 
@@ -43,9 +29,9 @@ export async function spaceMemoryGet(
   if (!args.key) return errorResult('space_memory_get requires key');
 
   try {
-    if (!(await verifySpaceInOrg(args.space_id, ctx.org_id))) {
+    if (!(await employeeCanAccessSpace(ctx.employee_id, ctx.org_id, args.space_id))) {
       return errorResult(
-        `space_memory_get: space ${args.space_id} not found in caller's org`,
+        `space_memory_get: space ${args.space_id} is not accessible to this employee`,
       );
     }
 
@@ -98,9 +84,9 @@ export async function spaceMemorySet(
   }
 
   try {
-    if (!(await verifySpaceInOrg(args.space_id, ctx.org_id))) {
+    if (!(await employeeCanAccessSpace(ctx.employee_id, ctx.org_id, args.space_id))) {
       return errorResult(
-        `space_memory_set: space ${args.space_id} not found in caller's org`,
+        `space_memory_set: space ${args.space_id} is not accessible to this employee`,
       );
     }
 

--- a/apps/api/src/lib/mcp-tools/wiki-create.ts
+++ b/apps/api/src/lib/mcp-tools/wiki-create.ts
@@ -19,6 +19,7 @@ import {
   shouldAutoExecute,
 } from '../agent-approval.js';
 import { invalidatePlatformContextCacheFor } from './context.js';
+import { employeeCanAccessSpace } from './employee-space-access.js';
 import { generateReceipt } from '../receipts.js';
 import { enqueue, QUEUE_NAMES } from '../queues.js';
 
@@ -57,19 +58,6 @@ async function getShadowUserId(employeeId: string): Promise<string | null> {
     .where(eq(agentEmployees.id, employeeId))
     .limit(1);
   return row?.user_id ?? null;
-}
-
-async function verifySpaceInOrg(spaceId: string, orgId: string): Promise<boolean> {
-  const [row] = await db
-    .select({ id: spaces.id })
-    .from(spaces)
-    .where(and(
-      eq(spaces.id, spaceId),
-      eq(spaces.org_id, orgId),
-      eq(spaces.is_archived, false),
-    ))
-    .limit(1);
-  return !!row;
 }
 
 async function verifyMessageVisibleToUser(
@@ -210,8 +198,11 @@ export async function executeWikiCreate(
     let sourceMessageExcerpt: string | null = null;
     let sourceSpaceId = args.source_space_id ?? args.space_id ?? null;
     let sourceUserId: string | null = null;
-    if (sourceSpaceId && !(await verifySpaceInOrg(sourceSpaceId, ctx.org_id))) {
-      return errorResult(`wiki_create: source space ${sourceSpaceId} not found in caller's org`);
+    if (
+      sourceSpaceId &&
+      !(await employeeCanAccessSpace(ctx.employee_id, ctx.org_id, sourceSpaceId))
+    ) {
+      return errorResult(`wiki_create: source space ${sourceSpaceId} is not accessible to this employee`);
     }
     if (scope === 'space' && !sourceSpaceId) {
       return errorResult('wiki_create: space_id or source_space_id is required when scope is space');
@@ -240,6 +231,11 @@ export async function executeWikiCreate(
         );
       }
       sourceSpaceId = source.space_id;
+      if (!(await employeeCanAccessSpace(ctx.employee_id, ctx.org_id, sourceSpaceId))) {
+        return errorResult(
+          `wiki_create: source message space ${sourceSpaceId} is not accessible to this employee`,
+        );
+      }
       sourceUserId = source.user_id;
       sourceMessageExcerpt = stripHtml(source.content).slice(0, 200);
     }
@@ -499,6 +495,13 @@ export async function executeWikiUpdate(
         return errorResult('wiki_update: cannot update another user-scoped page');
       }
     }
+    if (
+      existingPage.scope === 'space' &&
+      existingPage.space_id &&
+      !(await employeeCanAccessSpace(ctx.employee_id, ctx.org_id, existingPage.space_id))
+    ) {
+      return errorResult('wiki_update: page not found');
+    }
 
     const patch = args.patch;
     const update: Record<string, unknown> = {};
@@ -544,8 +547,11 @@ export async function executeWikiUpdate(
     }
     if (patch.space_id !== undefined) {
       const spaceId = patch.space_id || null;
-      if (spaceId && !(await verifySpaceInOrg(spaceId, ctx.org_id))) {
-        return errorResult(`wiki_update: space ${spaceId} not found in caller's org`);
+      if (
+        spaceId &&
+        !(await employeeCanAccessSpace(ctx.employee_id, ctx.org_id, spaceId))
+      ) {
+        return errorResult(`wiki_update: space ${spaceId} is not accessible to this employee`);
       }
       if (spaceId !== (existingPage.space_id ?? null)) {
         update.space_id = spaceId;
@@ -585,8 +591,11 @@ export async function executeWikiUpdate(
     let sourceMessageExcerpt: string | null = null;
     let sourceSpaceId = args.source_space_id ?? existingPage.origin_space_id ?? existingPage.space_id ?? null;
     let sourceUserId: string | null = null;
-    if (sourceSpaceId && !(await verifySpaceInOrg(sourceSpaceId, ctx.org_id))) {
-      return errorResult(`wiki_update: source space ${sourceSpaceId} not found in caller's org`);
+    if (
+      sourceSpaceId &&
+      !(await employeeCanAccessSpace(ctx.employee_id, ctx.org_id, sourceSpaceId))
+    ) {
+      return errorResult(`wiki_update: source space ${sourceSpaceId} is not accessible to this employee`);
     }
     if (args.source_message_id?.trim()) {
       const readerIds = [
@@ -612,6 +621,11 @@ export async function executeWikiUpdate(
         );
       }
       sourceSpaceId = source.space_id;
+      if (!(await employeeCanAccessSpace(ctx.employee_id, ctx.org_id, sourceSpaceId))) {
+        return errorResult(
+          `wiki_update: source message space ${sourceSpaceId} is not accessible to this employee`,
+        );
+      }
       sourceUserId = source.user_id;
       sourceMessageExcerpt = stripHtml(source.content).slice(0, 200);
     }

--- a/apps/api/src/lib/mcp-tools/writes.ts
+++ b/apps/api/src/lib/mcp-tools/writes.ts
@@ -47,6 +47,7 @@ import { isValidTransition } from '../task-status-machine.js';
 import { enqueue, QUEUE_NAMES } from '../queues.js';
 import { resolveAssigneeWithMatches } from '../resolve-assignee.js';
 import { createTaskBundle, type TaskBundleSubtaskInput } from '../task-bundle.js';
+import { employeeCanAccessSpace } from './employee-space-access.js';
 
 /**
  * Phase 7 — Insert an "auto-executed" agent_actions row up front so that
@@ -157,19 +158,6 @@ async function verifyProjectInOrg(
     .select({ id: projects.id })
     .from(projects)
     .where(and(eq(projects.id, projectId), eq(projects.org_id, orgId)))
-    .limit(1);
-  return !!row;
-}
-
-/** Resolves a space_id only if it belongs to the caller's org. */
-async function verifySpaceInOrg(
-  spaceId: string,
-  orgId: string,
-): Promise<boolean> {
-  const [row] = await db
-    .select({ id: spaces.id })
-    .from(spaces)
-    .where(and(eq(spaces.id, spaceId), eq(spaces.org_id, orgId)))
     .limit(1);
   return !!row;
 }
@@ -797,9 +785,9 @@ export async function executeMessagePost(
       );
     }
 
-    if (!(await verifySpaceInOrg(args.space_id, ctx.org_id))) {
+    if (!(await employeeCanAccessSpace(ctx.employee_id, ctx.org_id, args.space_id))) {
       return errorResult(
-        `message_post: space ${args.space_id} not found in caller's org`,
+        `message_post: space ${args.space_id} is not accessible to this employee`,
       );
     }
     if (args.parent_id) {
@@ -972,8 +960,8 @@ export async function sendMessage(
   }
 
   // Org-scope guard
-  if (!(await verifySpaceInOrg(spaceId, ctx.org_id))) {
-    return errorResult(`send_message: space ${spaceId} not found in caller's org`);
+  if (!(await employeeCanAccessSpace(ctx.employee_id, ctx.org_id, spaceId))) {
+    return errorResult(`send_message: space ${spaceId} is not accessible to this employee`);
   }
 
   if (!shouldAutoExecute('send_message', ctx.trust_level)) {
@@ -996,6 +984,10 @@ export async function executeSendMessage(opts: {
 }, execOpts?: { skipReceipt?: boolean }): Promise<ToolResult> {
   const { orgId, spaceId, content, parentId, ctx } = opts;
   try {
+    if (!(await employeeCanAccessSpace(ctx.employee_id, orgId, spaceId))) {
+      return errorResult(`send_message: space ${spaceId} is not accessible to this employee`);
+    }
+
     const shadowUserId = await getShadowUserId(ctx.employee_id);
     if (!shadowUserId) {
       return errorResult(`send_message: no shadow user for employee ${ctx.employee_id}`);

--- a/apps/api/test/mcp-message-privacy.test.ts
+++ b/apps/api/test/mcp-message-privacy.test.ts
@@ -3,6 +3,10 @@ import assert from 'node:assert/strict';
 import { randomUUID } from 'node:crypto';
 import pg from 'pg';
 import { messagesSearch } from '../src/lib/mcp-tools/reports.js';
+import {
+  _clearPlatformContextCache,
+  platformContext,
+} from '../src/lib/mcp-tools/context.js';
 import type { ToolContext } from '../src/lib/mcp-tools/types.js';
 
 const DATABASE_URL =
@@ -15,7 +19,17 @@ const EMPLOYEE_ID = `mcp-privacy-employee-${suffix}`;
 const PUBLIC_SPACE_ID = `mcp-privacy-public-${suffix}`;
 const JOINED_PRIVATE_SPACE_ID = `mcp-privacy-joined-${suffix}`;
 const HIDDEN_PRIVATE_SPACE_ID = `mcp-privacy-hidden-${suffix}`;
+const PUBLIC_MESSAGE_ID = `mcp-privacy-public-message-${suffix}`;
+const JOINED_PRIVATE_MESSAGE_ID = `mcp-privacy-joined-message-${suffix}`;
+const HIDDEN_PRIVATE_MESSAGE_ID = `mcp-privacy-hidden-message-${suffix}`;
 const MARKER = `mcp-privacy-marker-${suffix}`;
+
+const ctx: ToolContext = {
+  org_id: ORG_ID,
+  employee_id: EMPLOYEE_ID,
+  employee_slug: `privacy-${suffix}`,
+  trust_level: 'standard',
+};
 
 async function withClient<T>(fn: (client: pg.Client) => Promise<T>): Promise<T> {
   const client = new pg.Client({ connectionString: DATABASE_URL });
@@ -91,15 +105,18 @@ before(async () => {
     await client.query(
       `INSERT INTO messages (id, org_id, space_id, user_id, content)
        VALUES
-         (gen_random_uuid()::text, $1, $2, $5, $6),
-         (gen_random_uuid()::text, $1, $3, $5, $7),
-         (gen_random_uuid()::text, $1, $4, $5, $8)`,
+         ($6, $1, $2, $5, $9),
+         ($7, $1, $3, $5, $10),
+         ($8, $1, $4, $5, $11)`,
       [
         ORG_ID,
         PUBLIC_SPACE_ID,
         JOINED_PRIVATE_SPACE_ID,
         HIDDEN_PRIVATE_SPACE_ID,
         OWNER_ID,
+        PUBLIC_MESSAGE_ID,
+        JOINED_PRIVATE_MESSAGE_ID,
+        HIDDEN_PRIVATE_MESSAGE_ID,
         `${MARKER} public`,
         `${MARKER} joined private`,
         `${MARKER} hidden private`,
@@ -124,13 +141,6 @@ after(async () => {
 });
 
 test('messages_search hides private spaces the employee has not joined', async () => {
-  const ctx: ToolContext = {
-    org_id: ORG_ID,
-    employee_id: EMPLOYEE_ID,
-    employee_slug: `privacy-${suffix}`,
-    trust_level: 'standard',
-  };
-
   const result = await messagesSearch({ query: MARKER, limit: 10 }, ctx);
   assert.equal(result.isError, false, result.content[0]?.text);
   const rows = JSON.parse(result.content[0]!.text) as Array<{
@@ -150,4 +160,75 @@ test('messages_search hides private spaces the employee has not joined', async (
   );
   assert.equal(targeted.isError, false, targeted.content[0]?.text);
   assert.deepEqual(JSON.parse(targeted.content[0]!.text), []);
+});
+
+test('platform_context accepts public and joined-private trigger context', async () => {
+  _clearPlatformContextCache();
+  const publicResult = await platformContext(
+    {
+      caller_employee_slug: ctx.employee_slug,
+      trigger: {
+        kind: 'message',
+        space_id: PUBLIC_SPACE_ID,
+        triggering_message_id: PUBLIC_MESSAGE_ID,
+      },
+    },
+    ctx,
+  );
+  assert.equal(publicResult.isError, false, publicResult.content[0]?.text);
+
+  _clearPlatformContextCache();
+  const privateResult = await platformContext(
+    {
+      caller_employee_slug: ctx.employee_slug,
+      trigger: {
+        kind: 'message',
+        space_id: JOINED_PRIVATE_SPACE_ID,
+        triggering_message_id: JOINED_PRIVATE_MESSAGE_ID,
+      },
+    },
+    ctx,
+  );
+  assert.equal(privateResult.isError, false, privateResult.content[0]?.text);
+});
+
+test('platform_context rejects hidden private trigger context by space or message id', async () => {
+  _clearPlatformContextCache();
+  const hiddenSpaceResult = await platformContext(
+    {
+      caller_employee_slug: ctx.employee_slug,
+      trigger: { kind: 'channel_wake', space_id: HIDDEN_PRIVATE_SPACE_ID },
+    },
+    ctx,
+  );
+  assert.equal(hiddenSpaceResult.isError, true);
+  assert.match(hiddenSpaceResult.content[0]!.text, /do not have access/i);
+
+  _clearPlatformContextCache();
+  const hiddenMessageResult = await platformContext(
+    {
+      caller_employee_slug: ctx.employee_slug,
+      trigger: { kind: 'message', triggering_message_id: HIDDEN_PRIVATE_MESSAGE_ID },
+    },
+    ctx,
+  );
+  assert.equal(hiddenMessageResult.isError, true);
+  assert.match(hiddenMessageResult.content[0]!.text, /do not have access/i);
+});
+
+test('platform_context rejects a message and space pair that do not match', async () => {
+  _clearPlatformContextCache();
+  const result = await platformContext(
+    {
+      caller_employee_slug: ctx.employee_slug,
+      trigger: {
+        kind: 'message',
+        space_id: JOINED_PRIVATE_SPACE_ID,
+        triggering_message_id: PUBLIC_MESSAGE_ID,
+      },
+    },
+    ctx,
+  );
+  assert.equal(result.isError, true);
+  assert.match(result.content[0]!.text, /does not belong/i);
 });

--- a/apps/api/test/mcp-message-privacy.test.ts
+++ b/apps/api/test/mcp-message-privacy.test.ts
@@ -7,6 +7,9 @@ import {
   _clearPlatformContextCache,
   platformContext,
 } from '../src/lib/mcp-tools/context.js';
+import { spaceMemoryGet, spaceMemorySet } from '../src/lib/mcp-tools/space-memory.js';
+import { executeSendMessage, sendMessage } from '../src/lib/mcp-tools/writes.js';
+import { executeWikiCreate, executeWikiUpdate } from '../src/lib/mcp-tools/wiki-create.js';
 import type { ToolContext } from '../src/lib/mcp-tools/types.js';
 
 const DATABASE_URL =
@@ -22,6 +25,7 @@ const HIDDEN_PRIVATE_SPACE_ID = `mcp-privacy-hidden-${suffix}`;
 const PUBLIC_MESSAGE_ID = `mcp-privacy-public-message-${suffix}`;
 const JOINED_PRIVATE_MESSAGE_ID = `mcp-privacy-joined-message-${suffix}`;
 const HIDDEN_PRIVATE_MESSAGE_ID = `mcp-privacy-hidden-message-${suffix}`;
+const HIDDEN_WIKI_PAGE_ID = `mcp-privacy-hidden-wiki-${suffix}`;
 const MARKER = `mcp-privacy-marker-${suffix}`;
 
 const ctx: ToolContext = {
@@ -122,11 +126,31 @@ before(async () => {
         `${MARKER} hidden private`,
       ],
     );
+    await client.query(
+      `INSERT INTO space_memory
+         (id, org_id, space_id, key, value, updated_by_employee_id)
+       VALUES (gen_random_uuid()::text, $1, $2, 'hidden-key', $3::jsonb, $4)`,
+      [ORG_ID, HIDDEN_PRIVATE_SPACE_ID, JSON.stringify({ secret: MARKER }), EMPLOYEE_ID],
+    );
+    await client.query(
+      `INSERT INTO wiki_pages
+         (id, org_id, type, scope, title, slug, content, space_id, is_deleted)
+       VALUES ($1, $2, 'fact', 'space', 'Hidden privacy page', $3, $4, $5, false)`,
+      [
+        HIDDEN_WIKI_PAGE_ID,
+        ORG_ID,
+        `hidden-privacy-page-${suffix}`,
+        `${MARKER} hidden wiki content`,
+        HIDDEN_PRIVATE_SPACE_ID,
+      ],
+    );
   });
 });
 
 after(async () => {
   await withClient(async (client) => {
+    await client.query(`DELETE FROM wiki_pages WHERE id = $1`, [HIDDEN_WIKI_PAGE_ID]);
+    await client.query(`DELETE FROM space_memory WHERE org_id = $1`, [ORG_ID]);
     await client.query(`DELETE FROM messages WHERE org_id = $1`, [ORG_ID]);
     await client.query(
       `DELETE FROM space_members WHERE space_id IN ($1, $2, $3)`,
@@ -231,4 +255,85 @@ test('platform_context rejects a message and space pair that do not match', asyn
   );
   assert.equal(result.isError, true);
   assert.match(result.content[0]!.text, /does not belong/i);
+});
+
+test('space memory cannot be read or written in an unjoined private space', async () => {
+  const getResult = await spaceMemoryGet(
+    {
+      caller_employee_slug: ctx.employee_slug,
+      space_id: HIDDEN_PRIVATE_SPACE_ID,
+      key: 'hidden-key',
+    },
+    ctx,
+  );
+  assert.equal(getResult.isError, true);
+  assert.doesNotMatch(getResult.content[0]!.text, new RegExp(MARKER));
+
+  const setResult = await spaceMemorySet(
+    {
+      caller_employee_slug: ctx.employee_slug,
+      space_id: HIDDEN_PRIVATE_SPACE_ID,
+      key: 'injected-key',
+      value: { injected: true },
+    },
+    ctx,
+  );
+  assert.equal(setResult.isError, true);
+});
+
+test('message proposals and approved execution cannot target an unjoined private space', async () => {
+  const proposed = await sendMessage(
+    {
+      caller_employee_slug: ctx.employee_slug,
+      target: { space_id: HIDDEN_PRIVATE_SPACE_ID },
+      content: 'This must not be queued or posted.',
+    },
+    ctx,
+  );
+  assert.equal(proposed.isError, true);
+
+  const executed = await executeSendMessage({
+    orgId: ORG_ID,
+    spaceId: HIDDEN_PRIVATE_SPACE_ID,
+    content: 'This must not be posted by an old approval row.',
+    parentId: null,
+    ctx,
+  });
+  assert.equal(executed.isError, true);
+
+  const hiddenMessageCount = await withClient(async (client) => {
+    const result = await client.query<{ count: string }>(
+      `SELECT count(*)::text AS count
+       FROM messages
+       WHERE org_id = $1 AND space_id = $2 AND user_id = $3`,
+      [ORG_ID, HIDDEN_PRIVATE_SPACE_ID, EMPLOYEE_USER_ID],
+    );
+    return Number(result.rows[0]?.count ?? 0);
+  });
+  assert.equal(hiddenMessageCount, 0);
+});
+
+test('space-scoped wiki writes cannot target an unjoined private space', async () => {
+  const createResult = await executeWikiCreate(
+    {
+      caller_employee_slug: ctx.employee_slug,
+      title: 'Attempted hidden page',
+      content: 'This should never be written.',
+      scope: 'space',
+      space_id: HIDDEN_PRIVATE_SPACE_ID,
+    },
+    ctx,
+  );
+  assert.equal(createResult.isError, true);
+
+  const updateResult = await executeWikiUpdate(
+    {
+      caller_employee_slug: ctx.employee_slug,
+      page_id: HIDDEN_WIKI_PAGE_ID,
+      patch: { summary: 'This should never be written.' },
+    },
+    ctx,
+  );
+  assert.equal(updateResult.isError, true);
+  assert.match(updateResult.content[0]!.text, /page not found/i);
 });

--- a/apps/api/test/mcp-message-privacy.test.ts
+++ b/apps/api/test/mcp-message-privacy.test.ts
@@ -1,0 +1,153 @@
+import { after, before, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import pg from 'pg';
+import { messagesSearch } from '../src/lib/mcp-tools/reports.js';
+import type { ToolContext } from '../src/lib/mcp-tools/types.js';
+
+const DATABASE_URL =
+  process.env.DATABASE_URL || 'postgres://postgres:postgres@localhost:5432/deft';
+const suffix = randomUUID();
+const ORG_ID = randomUUID();
+const OWNER_ID = `mcp-privacy-owner-${suffix}`;
+const EMPLOYEE_USER_ID = `mcp-privacy-shadow-${suffix}`;
+const EMPLOYEE_ID = `mcp-privacy-employee-${suffix}`;
+const PUBLIC_SPACE_ID = `mcp-privacy-public-${suffix}`;
+const JOINED_PRIVATE_SPACE_ID = `mcp-privacy-joined-${suffix}`;
+const HIDDEN_PRIVATE_SPACE_ID = `mcp-privacy-hidden-${suffix}`;
+const MARKER = `mcp-privacy-marker-${suffix}`;
+
+async function withClient<T>(fn: (client: pg.Client) => Promise<T>): Promise<T> {
+  const client = new pg.Client({ connectionString: DATABASE_URL });
+  await client.connect();
+  try {
+    return await fn(client);
+  } finally {
+    await client.end();
+  }
+}
+
+before(async () => {
+  await withClient(async (client) => {
+    await client.query(
+      `INSERT INTO orgs (id, name, slug)
+       VALUES ($1, 'MCP Privacy Test', $2)`,
+      [ORG_ID, `mcp-privacy-${suffix}`],
+    );
+    await client.query(
+      `INSERT INTO users (id, email, name, is_agent)
+       VALUES
+         ($1, $3, 'Privacy Owner', false),
+         ($2, $4, 'Privacy Employee', true)`,
+      [
+        OWNER_ID,
+        EMPLOYEE_USER_ID,
+        `privacy-owner-${suffix}@test.local`,
+        `privacy-agent-${suffix}@test.local`,
+      ],
+    );
+    await client.query(
+      `INSERT INTO org_members (id, org_id, user_id, role, is_active)
+       VALUES
+         (gen_random_uuid()::text, $1, $2, 'owner', true),
+         (gen_random_uuid()::text, $1, $3, 'member', true)`,
+      [ORG_ID, OWNER_ID, EMPLOYEE_USER_ID],
+    );
+    await client.query(
+      `INSERT INTO agent_employees
+        (id, org_id, user_id, name, slug, role, system_prompt, trust_level,
+         is_byoa, is_active, created_by)
+       VALUES ($1, $2, $3, 'Privacy Employee', $4, 'project_manager',
+         'Privacy boundary test employee', 'standard', true, true, $5)`,
+      [EMPLOYEE_ID, ORG_ID, EMPLOYEE_USER_ID, `privacy-${suffix}`, OWNER_ID],
+    );
+    await client.query(
+      `INSERT INTO spaces (id, org_id, name, type, created_by)
+       VALUES
+         ($1, $4, 'privacy-public', 'public', $5),
+         ($2, $4, 'privacy-joined', 'private', $5),
+         ($3, $4, 'privacy-hidden', 'private', $5)`,
+      [
+        PUBLIC_SPACE_ID,
+        JOINED_PRIVATE_SPACE_ID,
+        HIDDEN_PRIVATE_SPACE_ID,
+        ORG_ID,
+        OWNER_ID,
+      ],
+    );
+    await client.query(
+      `INSERT INTO space_members (id, space_id, user_id)
+       VALUES
+         (gen_random_uuid()::text, $1, $3),
+         (gen_random_uuid()::text, $2, $3),
+         (gen_random_uuid()::text, $2, $4)`,
+      [PUBLIC_SPACE_ID, JOINED_PRIVATE_SPACE_ID, OWNER_ID, EMPLOYEE_USER_ID],
+    );
+    await client.query(
+      `INSERT INTO space_members (id, space_id, user_id)
+       VALUES (gen_random_uuid()::text, $1, $2)`,
+      [HIDDEN_PRIVATE_SPACE_ID, OWNER_ID],
+    );
+    await client.query(
+      `INSERT INTO messages (id, org_id, space_id, user_id, content)
+       VALUES
+         (gen_random_uuid()::text, $1, $2, $5, $6),
+         (gen_random_uuid()::text, $1, $3, $5, $7),
+         (gen_random_uuid()::text, $1, $4, $5, $8)`,
+      [
+        ORG_ID,
+        PUBLIC_SPACE_ID,
+        JOINED_PRIVATE_SPACE_ID,
+        HIDDEN_PRIVATE_SPACE_ID,
+        OWNER_ID,
+        `${MARKER} public`,
+        `${MARKER} joined private`,
+        `${MARKER} hidden private`,
+      ],
+    );
+  });
+});
+
+after(async () => {
+  await withClient(async (client) => {
+    await client.query(`DELETE FROM messages WHERE org_id = $1`, [ORG_ID]);
+    await client.query(
+      `DELETE FROM space_members WHERE space_id IN ($1, $2, $3)`,
+      [PUBLIC_SPACE_ID, JOINED_PRIVATE_SPACE_ID, HIDDEN_PRIVATE_SPACE_ID],
+    );
+    await client.query(`DELETE FROM spaces WHERE org_id = $1`, [ORG_ID]);
+    await client.query(`DELETE FROM agent_employees WHERE id = $1`, [EMPLOYEE_ID]);
+    await client.query(`DELETE FROM org_members WHERE org_id = $1`, [ORG_ID]);
+    await client.query(`DELETE FROM users WHERE id IN ($1, $2)`, [OWNER_ID, EMPLOYEE_USER_ID]);
+    await client.query(`DELETE FROM orgs WHERE id = $1`, [ORG_ID]);
+  });
+});
+
+test('messages_search hides private spaces the employee has not joined', async () => {
+  const ctx: ToolContext = {
+    org_id: ORG_ID,
+    employee_id: EMPLOYEE_ID,
+    employee_slug: `privacy-${suffix}`,
+    trust_level: 'standard',
+  };
+
+  const result = await messagesSearch({ query: MARKER, limit: 10 }, ctx);
+  assert.equal(result.isError, false, result.content[0]?.text);
+  const rows = JSON.parse(result.content[0]!.text) as Array<{
+    content: string;
+    space_name: string;
+  }>;
+
+  assert.deepEqual(
+    new Set(rows.map((row) => row.space_name)),
+    new Set(['privacy-public', 'privacy-joined']),
+  );
+  assert.ok(rows.every((row) => !row.content.includes('hidden private')));
+
+  const targeted = await messagesSearch(
+    { query: MARKER, space_name: 'privacy-hidden', limit: 10 },
+    ctx,
+  );
+  assert.equal(targeted.isError, false, targeted.content[0]?.text);
+  assert.deepEqual(JSON.parse(targeted.content[0]!.text), []);
+});


### PR DESCRIPTION
## Summary
- enforce public-or-membership visibility for agent message search and report wrappers
- reject inaccessible or mismatched space/message trigger context before platform-context cache reads
- apply the same employee-space boundary to channel memory, message proposals/execution, and space-scoped wiki writes
- resolve agent report access through the employee shadow user instead of the employee row id

## Why
Live Hermes dogfood proved that an employee outside a private space could recover an exact private phrase through `messages_search`. The follow-up audit found adjacent same-org-only guards that could expose channel memory or permit writes if a private space id was supplied directly or preserved in an older approval row.

## Validation
- 47 focused approval/message/wiki/privacy/graph tests passed
- 24 context/report/unread privacy tests passed
- API typecheck passed
- API production build passed
- regression coverage includes public spaces, joined private spaces, hidden private spaces, mismatched trigger pairs, proposal-time rejection, and approved-execution rejection