### PR TITLE
Harden agent runtime delivery status

### DIFF
--- a/apps/api/src/workers/handlers/agent-employee-message.ts
+++ b/apps/api/src/workers/handlers/agent-employee-message.ts
@@ -7,11 +7,14 @@ import type { JobData } from '../types.js';
 import { db } from '../../lib/db.js';
 import {
   agentActions,
+  agentChannelConnections,
   agentEmployees,
   messages,
+  notifications,
+  orgMembers,
   users,
 } from '@deft/db/schema';
-import { eq, and } from 'drizzle-orm';
+import { eq, and, lte, sql } from 'drizzle-orm';
 import { getIO } from '../../socket.js';
 import { ensureDeftyMembership } from '../../lib/ensure-defty-membership.js';
 import { publishAgentChannelEvent } from '../../lib/agent-channel.js';
@@ -22,6 +25,77 @@ interface AgentEmployeeMessageData {
   orgId: string;
   employeeId: string;
   isDM: boolean;
+}
+
+type AgentChannelState = {
+  id?: string;
+  status: string;
+  last_seen_at: Date | null;
+} | null;
+
+export function describeAgentDelivery(
+  employeeName: string,
+  connection: AgentChannelState,
+  now = Date.now(),
+) {
+  const lastSeenAt = connection?.last_seen_at?.getTime() ?? 0;
+  const isLive = connection?.status === 'connected' && now - lastSeenAt < 5 * 60_000;
+  if (isLive) {
+    return {
+      state: 'sent' as const,
+      content: `Sent to ${employeeName}. They will reply here when they pick it up.`,
+    };
+  }
+  if (lastSeenAt) {
+    return {
+      state: 'queued' as const,
+      content: `Queued for ${employeeName}. Their runtime is offline; Deft will deliver this when it reconnects.`,
+    };
+  }
+  return {
+    state: 'queued' as const,
+    content: `Queued for ${employeeName}. Connect their runtime to deliver it.`,
+  };
+}
+
+async function notifyAdminsOfQueuedRuntime(orgId: string, employeeId: string, employeeName: string) {
+  const admins = await db
+    .select({ userId: orgMembers.user_id })
+    .from(orgMembers)
+    .where(and(
+      eq(orgMembers.org_id, orgId),
+      eq(orgMembers.is_active, true),
+      sql`${orgMembers.role} IN ('owner', 'admin')`,
+    ));
+
+  for (const admin of admins) {
+    const [recent] = await db
+      .select({ id: notifications.id })
+      .from(notifications)
+      .where(and(
+        eq(notifications.org_id, orgId),
+        eq(notifications.user_id, admin.userId),
+        eq(notifications.type, 'system'),
+        sql`${notifications.metadata}->>'subtype' = 'agent_runtime_offline'`,
+        sql`${notifications.metadata}->>'agent_employee_id' = ${employeeId}`,
+        sql`${notifications.created_at} > now() - interval '24 hours'`,
+      ))
+      .limit(1);
+    if (recent) continue;
+
+    await db.insert(notifications).values({
+      org_id: orgId,
+      user_id: admin.userId,
+      type: 'system',
+      title: `${employeeName} is offline`,
+      body: 'New work is queued and will be delivered when the runtime reconnects.',
+      link: `/settings/agent-employees/${employeeId}/developer`,
+      metadata: {
+        subtype: 'agent_runtime_offline',
+        agent_employee_id: employeeId,
+      },
+    });
+  }
 }
 
 export async function handleAgentEmployeeMessage(job: JobData): Promise<void> {
@@ -112,23 +186,56 @@ export async function handleAgentEmployeeMessage(job: JobData): Promise<void> {
   try {
     const io = getIO();
     const deftyUserId = await ensureDeftyMembership(orgId);
-    const lastSeen = employee.last_mcp_call_at ?? employee.last_heartbeat_at ?? null;
-    const humanStatus = lastSeen
-      ? `${employee.name} will reply here when they pick it up.`
-      : `${employee.name} has not checked in yet, but this is waiting for them.`;
+    const [connection] = await db
+      .select({
+        id: agentChannelConnections.id,
+        status: agentChannelConnections.status,
+        last_seen_at: agentChannelConnections.last_seen_at,
+      })
+      .from(agentChannelConnections)
+      .where(and(
+        eq(agentChannelConnections.org_id, orgId),
+        eq(agentChannelConnections.agent_employee_id, employeeId),
+      ))
+      .limit(1);
+    const delivery = describeAgentDelivery(employee.name, connection ?? null);
+
+    if (delivery.state === 'queued') {
+      if (connection?.status === 'connected' && connection.id && connection.last_seen_at) {
+        await db.update(agentChannelConnections)
+          .set({ status: 'disconnected', last_error: 'Runtime contact timed out', updated_at: new Date() })
+          .where(and(
+            eq(agentChannelConnections.id, connection.id),
+            eq(agentChannelConnections.status, 'connected'),
+            lte(agentChannelConnections.last_seen_at, connection.last_seen_at),
+          ));
+      }
+      try {
+        await notifyAdminsOfQueuedRuntime(orgId, employeeId, employee.name);
+      } catch (alertError) {
+        console.warn(
+          '[agent-employee-message] offline runtime alert failed:',
+          alertError instanceof Error ? alertError.message : alertError,
+        );
+      }
+    }
+
     const [sysMsg] = await db
       .insert(messages)
       .values({
         org_id: orgId,
         space_id: spaceId,
         user_id: deftyUserId,
-        content: `Sent to ${employee.name}. ${humanStatus}`,
+        content: delivery.content,
         parent_id: triggerMsg.parent_id ?? null,
         metadata: {
           kind: 'system_note',
           subtype: 'byoa_mention_received',
           agent_employee_id: employeeId,
           wake_mode: employee.wake_mode,
+          delivery_state: delivery.state,
+          channel_status: connection?.status ?? 'never_connected',
+          channel_last_seen_at: connection?.last_seen_at ?? null,
           last_mcp_call_at: employee.last_mcp_call_at,
           last_heartbeat_at: employee.last_heartbeat_at,
         } as never,

--- a/apps/api/test/agent-employee-delivery-status.test.ts
+++ b/apps/api/test/agent-employee-delivery-status.test.ts
@@ -1,0 +1,31 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { describeAgentDelivery } from '../src/workers/handlers/agent-employee-message.js';
+
+const NOW = Date.parse('2026-07-13T12:00:00Z');
+
+test('reports sent only for a live channel connection', () => {
+  assert.deepEqual(describeAgentDelivery('Rita', {
+    status: 'connected',
+    last_seen_at: new Date('2026-07-13T11:59:00Z'),
+  }, NOW), {
+    state: 'sent',
+    content: 'Sent to Rita. They will reply here when they pick it up.',
+  });
+});
+
+test('reports queued when a known runtime is stale or disconnected', () => {
+  const result = describeAgentDelivery('Rita', {
+    status: 'connected',
+    last_seen_at: new Date('2026-07-13T11:50:00Z'),
+  }, NOW);
+  assert.equal(result.state, 'queued');
+  assert.match(result.content, /runtime is offline/);
+});
+
+test('gives setup guidance when the runtime never connected', () => {
+  assert.deepEqual(describeAgentDelivery('Rita', null, NOW), {
+    state: 'queued',
+    content: 'Queued for Rita. Connect their runtime to deliver it.',
+  });
+});

--- a/apps/web/src/lib/agent-employee-status.test.ts
+++ b/apps/web/src/lib/agent-employee-status.test.ts
@@ -61,3 +61,15 @@ test('partial sidebar records are not mistaken for paused employees', () => {
   }, NOW);
   assert.equal(status.label, 'Ready to connect');
 });
+
+test('explicit disconnect overrides a recent contact timestamp', () => {
+  const employee = {
+    ...base,
+    certification_status: 'verified',
+    channel_status: 'disconnected',
+    channel_last_seen_at: '2026-07-12T11:59:00Z',
+  };
+
+  assert.equal(agentEmployeeLifecycle(employee, NOW).label, 'Offline');
+  assert.equal(agentConnectionStatus(employee, NOW).label, 'Disconnected - last seen 1m ago');
+});

--- a/apps/web/src/lib/agent-employee-status.ts
+++ b/apps/web/src/lib/agent-employee-status.ts
@@ -57,6 +57,15 @@ export function agentEmployeeLifecycle(emp: AgentEmployeeHealth, now = Date.now(
   }
   if (emp.is_active === false) return { label: 'Paused', detail: 'will not pick up new work', tone: 'gray' };
 
+  if (emp.channel_status === 'disconnected') {
+    const contact = latestAgentContact(emp);
+    return {
+      label: 'Offline',
+      detail: contact ? `last runtime contact ${formatAgentAge(contact, now)}` : 'runtime is not connected',
+      tone: 'gray',
+    };
+  }
+
   if (emp.required_workspace_skill_installed === false) {
     return { label: 'Setup incomplete', detail: 'Deft Workspace skill is missing', tone: 'amber' };
   }
@@ -102,6 +111,12 @@ export function agentEmployeeLifecycle(emp: AgentEmployeeHealth, now = Date.now(
 
 export function agentConnectionStatus(emp: AgentEmployeeHealth, now = Date.now()) {
   const contact = latestAgentContact(emp);
+  if (emp.channel_status === 'disconnected') {
+    return {
+      label: contact ? `Disconnected - last seen ${formatAgentAge(contact, now)}` : 'Disconnected',
+      tone: 'gray' as const,
+    };
+  }
   if (!contact) return { label: 'Never connected', tone: 'gray' as const };
   const elapsedMinutes = Math.max(0, Math.floor((now - validTime(contact)) / 60_000));
   if (elapsedMinutes < 5) return { label: 'Connected', tone: 'green' as const };


### PR DESCRIPTION
## Summary
- distinguish live delivery from queued work in agent mentions
- alert org admins once per day when work reaches an offline runtime
- make explicit disconnects override fresh-looking timestamps in employee status

## Verification
- focused API delivery-state tests (3/3)
- focused web lifecycle tests (7/7)
- API and web typechecks
- idempotent Rita launcher scheduled-task smoke