### PR TITLE
Refresh agent status in the sidebar

### DIFF
--- a/apps/web/src/components/sidebar.tsx
+++ b/apps/web/src/components/sidebar.tsx
@@ -114,11 +114,18 @@ function ChatSidebarContent({
   const [agentEmployees, setAgentEmployees] = useState<AgentEmployee[]>([]);
 
   useEffect(() => {
-    api.get('/api/agent-employees?expand=stats').then(async (res) => {
-      if (res.ok) {
-        setAgentEmployees(await res.json());
-      }
-    });
+    let active = true;
+    const loadAgentEmployees = async () => {
+      const res = await api.get('/api/agent-employees?expand=stats');
+      if (active && res.ok) setAgentEmployees(await res.json());
+    };
+
+    void loadAgentEmployees();
+    const interval = window.setInterval(loadAgentEmployees, 30_000);
+    return () => {
+      active = false;
+      window.clearInterval(interval);
+    };
   }, []);
 
   const agentStatusColor = (employee: AgentEmployee) => {


### PR DESCRIPTION
## Summary
- refresh agent employee runtime state every 30 seconds in the sidebar
- stop stale connected/last-seen badges after a runtime replies or disconnects
- clean up the interval on unmount

## Verification
- web typecheck
- web lint