### PR TITLE
Harden agent runtime operations

### DIFF
--- a/apps/api/src/lib/agent-activity.ts
+++ b/apps/api/src/lib/agent-activity.ts
@@ -1,0 +1,130 @@
+import { and, desc, eq } from 'drizzle-orm';
+import {
+  agentActions,
+  agentChannelEvents,
+  agentCooperativeLog,
+  agentMcpCallAudit,
+  agentSessionTurns,
+} from '@deft/db/schema';
+import { db } from './db.js';
+import { summarizeAgentChannelLifecycle } from './agent-channel-lifecycle.js';
+
+export type AgentActivityItem = {
+  id: string;
+  kind: 'delivery' | 'action' | 'tool_call' | 'session' | 'record';
+  label: string;
+  status: 'queued' | 'running' | 'approval_pending' | 'completed' | 'failed' | 'cancelled';
+  detail: string | null;
+  occurred_at: Date;
+  target_url: string | null;
+  error: string | null;
+  timing?: ReturnType<typeof summarizeAgentChannelLifecycle>;
+};
+
+function actionStatus(row: typeof agentActions.$inferSelect): AgentActivityItem['status'] {
+  if (row.error || row.approval_status === 'rejected' || row.approval_status === 'expired') return 'failed';
+  if (row.executed_at) return 'completed';
+  if (row.approval_status === 'pending') return 'approval_pending';
+  return 'running';
+}
+
+export async function loadAgentActivity(params: { orgId: string; employeeId: string; limit?: number }) {
+  const perSource = Math.min(Math.max(params.limit ?? 50, 1), 100);
+  const [events, actions, calls, sessions, records] = await Promise.all([
+    db.select().from(agentChannelEvents).where(and(
+      eq(agentChannelEvents.org_id, params.orgId),
+      eq(agentChannelEvents.agent_employee_id, params.employeeId),
+    )).orderBy(desc(agentChannelEvents.created_at)).limit(perSource),
+    db.select().from(agentActions).where(and(
+      eq(agentActions.org_id, params.orgId),
+      eq(agentActions.agent_employee_id, params.employeeId),
+    )).orderBy(desc(agentActions.created_at)).limit(perSource),
+    db.select().from(agentMcpCallAudit).where(and(
+      eq(agentMcpCallAudit.org_id, params.orgId),
+      eq(agentMcpCallAudit.employee_id, params.employeeId),
+    )).orderBy(desc(agentMcpCallAudit.created_at)).limit(perSource),
+    db.select().from(agentSessionTurns).where(and(
+      eq(agentSessionTurns.org_id, params.orgId),
+      eq(agentSessionTurns.employee_id, params.employeeId),
+    )).orderBy(desc(agentSessionTurns.created_at)).limit(perSource),
+    db.select().from(agentCooperativeLog).where(and(
+      eq(agentCooperativeLog.org_id, params.orgId),
+      eq(agentCooperativeLog.employee_id, params.employeeId),
+    )).orderBy(desc(agentCooperativeLog.created_at)).limit(perSource),
+  ]);
+
+  const items: AgentActivityItem[] = [
+    ...events.map((event): AgentActivityItem => {
+      const lifecycle = summarizeAgentChannelLifecycle(event);
+      const status = lifecycle.phase === 'queued' || lifecycle.phase === 'approval_pending'
+        ? lifecycle.phase
+        : lifecycle.phase === 'cancelled'
+          ? 'cancelled'
+          : lifecycle.phase === 'failed'
+          ? 'failed'
+          : lifecycle.phase === 'completed'
+            ? 'completed'
+            : 'running';
+      const query = event.space_id
+        ? `?space=${encodeURIComponent(event.space_id)}${event.thread_id ? `&thread=${encodeURIComponent(event.thread_id)}` : ''}`
+        : '';
+      return {
+        id: `delivery:${event.id}`,
+        kind: 'delivery',
+        label: event.kind,
+        status,
+        detail: event.source_kind ? `From ${event.source_kind}` : null,
+        occurred_at: event.updated_at,
+        target_url: event.space_id ? `/chat${query}` : null,
+        error: event.error,
+        timing: lifecycle,
+      };
+    }),
+    ...actions.map((action): AgentActivityItem => ({
+      id: `action:${action.id}`,
+      kind: 'action',
+      label: action.action.replaceAll('_', ' '),
+      status: actionStatus(action),
+      detail: action.source ? `Source: ${action.source}` : null,
+      occurred_at: action.executed_at ?? action.updated_at,
+      target_url: action.conversation_id
+        ? `/chat?space=${encodeURIComponent(action.conversation_id)}${action.message_id ? `&message=${encodeURIComponent(action.message_id)}` : ''}`
+        : null,
+      error: action.error,
+    })),
+    ...calls.map((call): AgentActivityItem => ({
+      id: `tool:${call.id}`,
+      kind: 'tool_call',
+      label: call.tool_name,
+      status: call.success ? 'completed' : 'failed',
+      detail: 'MCP tool call',
+      occurred_at: call.created_at,
+      target_url: null,
+      error: call.error,
+    })),
+    ...sessions.map((session): AgentActivityItem => ({
+      id: `session:${session.id}`,
+      kind: 'session',
+      label: session.trigger_kind,
+      status: session.result === 'success' ? 'completed' : 'failed',
+      detail: `${session.model_name ?? 'Agent runtime'} - ${session.latency_ms}ms`,
+      occurred_at: session.created_at,
+      target_url: session.space_id ? `/chat?space=${encodeURIComponent(session.space_id)}` : null,
+      error: session.error,
+    })),
+    ...records.map((record): AgentActivityItem => ({
+      id: `record:${record.id}`,
+      kind: 'record',
+      label: record.kind.replaceAll('_', ' '),
+      status: record.kind === 'action_attempt' ? 'running' : 'completed',
+      detail: record.summary,
+      occurred_at: record.created_at,
+      target_url: null,
+      error: null,
+    })),
+  ];
+
+  return items
+    .sort((a, b) => b.occurred_at.getTime() - a.occurred_at.getTime())
+    .slice(0, perSource);
+}

--- a/apps/api/src/lib/agent-channel-lifecycle.ts
+++ b/apps/api/src/lib/agent-channel-lifecycle.ts
@@ -1,0 +1,111 @@
+export const AGENT_CHANNEL_EVENT_STATES = [
+  'pending',
+  'delivered',
+  'acknowledged',
+  'running',
+  'approval_pending',
+  'completed',
+  'failed',
+  'cancelled',
+] as const;
+
+export type AgentChannelEventState = (typeof AGENT_CHANNEL_EVENT_STATES)[number];
+export type AgentChannelLifecyclePhase = 'queued' | Exclude<AgentChannelEventState, 'pending'>;
+export type AgentChannelLifecycleSignal = Exclude<AgentChannelEventState, 'pending'>;
+
+type LifecycleRow = {
+  status: string;
+  created_at: Date;
+  updated_at: Date;
+  delivered_at: Date | null;
+  acked_at: Date | null;
+  completed_at: Date | null;
+  failed_at: Date | null;
+};
+
+type LifecyclePatch = Partial<Pick<LifecycleRow,
+  'status' | 'updated_at' | 'delivered_at' | 'acked_at' | 'completed_at' | 'failed_at'
+>> & { error?: string | null };
+
+const STATE_RANK: Record<AgentChannelEventState, number> = {
+  pending: 0,
+  delivered: 1,
+  acknowledged: 2,
+  running: 3,
+  approval_pending: 4,
+  completed: 5,
+  failed: 5,
+  cancelled: 5,
+};
+
+function isEventState(value: string): value is AgentChannelEventState {
+  return (AGENT_CHANNEL_EVENT_STATES as readonly string[]).includes(value);
+}
+
+/** Builds a monotonic lifecycle update. Terminal events never reopen or flip outcome. */
+export function buildAgentChannelLifecyclePatch(
+  event: LifecycleRow,
+  signal: AgentChannelLifecycleSignal,
+  now = new Date(),
+  error?: string | null,
+): LifecyclePatch {
+  const current = isEventState(event.status) ? event.status : 'pending';
+  if (current === 'completed' || current === 'failed' || current === 'cancelled') return {};
+  if (STATE_RANK[signal] < STATE_RANK[current]) return {};
+
+  const patch: LifecyclePatch = { status: signal, updated_at: now };
+  if (STATE_RANK[signal] >= STATE_RANK.delivered) {
+    patch.delivered_at = event.delivered_at ?? now;
+  }
+  if (STATE_RANK[signal] >= STATE_RANK.acknowledged) {
+    patch.acked_at = event.acked_at ?? now;
+  }
+  if (signal === 'completed') {
+    patch.completed_at = event.completed_at ?? now;
+    patch.failed_at = null;
+    patch.error = null;
+  } else if (signal === 'failed' || signal === 'cancelled') {
+    patch.failed_at = event.failed_at ?? now;
+    patch.completed_at = null;
+    patch.error = error ?? (signal === 'cancelled' ? 'Cancelled by an operator' : 'Runtime reported failure');
+  }
+  return patch;
+}
+
+export function summarizeAgentChannelLifecycle(event: LifecycleRow, now = new Date()) {
+  const status = isEventState(event.status) ? event.status : 'pending';
+  const terminalAt = event.completed_at ?? event.failed_at;
+  const elapsed = (end: Date | null, start: Date | null) =>
+    end && start ? Math.max(0, end.getTime() - start.getTime()) : null;
+
+  return {
+    phase: (status === 'pending' ? 'queued' : status) as AgentChannelLifecyclePhase,
+    queue_ms: elapsed(event.delivered_at, event.created_at),
+    acknowledge_ms: elapsed(event.acked_at, event.delivered_at),
+    execution_ms: elapsed(terminalAt, event.acked_at),
+    total_ms: elapsed(terminalAt, event.created_at),
+    age_ms: terminalAt ? null : Math.max(0, now.getTime() - event.created_at.getTime()),
+  };
+}
+
+function percentile(values: number[], ratio: number) {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  return sorted[Math.min(sorted.length - 1, Math.ceil(sorted.length * ratio) - 1)] ?? null;
+}
+
+export function summarizeAgentChannelMetrics(events: LifecycleRow[], now = new Date()) {
+  const summaries = events.map((event) => summarizeAgentChannelLifecycle(event, now));
+  const metric = (key: 'queue_ms' | 'acknowledge_ms' | 'total_ms') => {
+    const values = summaries.map((row) => row[key]).filter((value): value is number => value !== null);
+    return { p50_ms: percentile(values, 0.5), p95_ms: percentile(values, 0.95) };
+  };
+  const openAges = summaries.map((row) => row.age_ms).filter((value): value is number => value !== null);
+  return {
+    sample_count: events.length,
+    delivery: metric('queue_ms'),
+    acknowledgement: metric('acknowledge_ms'),
+    completion: metric('total_ms'),
+    oldest_open_age_ms: openAges.length ? Math.max(...openAges) : null,
+  };
+}

--- a/apps/api/src/lib/agent-channel.ts
+++ b/apps/api/src/lib/agent-channel.ts
@@ -10,6 +10,7 @@ import {
   agentEmployees,
 } from '@deft/db/schema';
 import { McpAuthError } from './mcp-token.js';
+import { getIO } from '../socket.js';
 
 export const AGENT_CHANNEL_PROTOCOL_VERSION = 'deft.agent_channel.v1';
 
@@ -217,6 +218,15 @@ export async function touchAgentChannelConnection(
     })
     .returning();
 
+  if (connection) {
+    getIO()?.to(`org:${principal.org_id}`).emit('agent:presence', {
+      employee_id: principal.employee_id,
+      status: connection.status,
+      runtime_kind: connection.runtime_kind,
+      last_seen_at: connection.last_seen_at?.toISOString() ?? now.toISOString(),
+      last_error: connection.last_error ?? null,
+    });
+  }
   return connection ?? null;
 }
 

--- a/apps/api/src/lib/agent-runtime-recovery.ts
+++ b/apps/api/src/lib/agent-runtime-recovery.ts
@@ -1,0 +1,48 @@
+export type AgentRuntimeRecovery = {
+  state: 'healthy' | 'setup_required' | 'offline' | 'delivery_failed' | 'backlogged';
+  title: string;
+  detail: string;
+  action: 'none' | 'regenerate_channel_token' | 'send_channel_test' | 'inspect_queue';
+};
+
+export function describeAgentRuntimeRecovery(input: {
+  hasChannelToken: boolean;
+  connectionStatus?: string | null;
+  lastSeenAt?: Date | null;
+  failedDeliveries: number;
+  pendingDeliveries: number;
+  now?: Date;
+}): AgentRuntimeRecovery {
+  const now = input.now ?? new Date();
+  const stale = !input.lastSeenAt || now.getTime() - input.lastSeenAt.getTime() > 2 * 60_000;
+  if (!input.hasChannelToken) return {
+    state: 'setup_required',
+    title: 'Connect this employee runtime',
+    detail: 'Generate a channel token, add it to the runtime, then send a test event.',
+    action: 'regenerate_channel_token',
+  };
+  if (input.failedDeliveries > 0) return {
+    state: 'delivery_failed',
+    title: `${input.failedDeliveries} delivery${input.failedDeliveries === 1 ? '' : 'ies'} need attention`,
+    detail: 'Inspect the failed event below, retry it after the runtime is healthy, or cancel it if the work is obsolete.',
+    action: 'inspect_queue',
+  };
+  if (input.connectionStatus !== 'connected' || stale) return {
+    state: 'offline',
+    title: 'Runtime is not checking in',
+    detail: 'Start the runtime and channel bridge, then send a test event. Deft will update this page when contact resumes.',
+    action: 'send_channel_test',
+  };
+  if (input.pendingDeliveries > 5) return {
+    state: 'backlogged',
+    title: `${input.pendingDeliveries} deliveries are waiting`,
+    detail: 'The runtime is connected but falling behind. Check its logs and daily action limits before adding more work.',
+    action: 'inspect_queue',
+  };
+  return {
+    state: 'healthy',
+    title: 'Runtime is ready',
+    detail: 'The employee is connected and no delivery failures need attention.',
+    action: 'none',
+  };
+}

--- a/apps/api/src/routes/agent-channel.ts
+++ b/apps/api/src/routes/agent-channel.ts
@@ -9,7 +9,7 @@
 import { Hono } from 'hono';
 import type { Context } from 'hono';
 import { z } from 'zod';
-import { and, eq, sql } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 import { db } from '../lib/db.js';
 import {
   agentActions,
@@ -30,6 +30,7 @@ import {
   type AgentChannelPrincipal,
 } from '../lib/agent-channel.js';
 import { executeSendMessage } from '../lib/mcp-tools/writes.js';
+import { buildAgentChannelLifecyclePatch } from '../lib/agent-channel-lifecycle.js';
 
 export const agentChannelRoutes = new Hono();
 
@@ -51,7 +52,7 @@ const replySchema = z.object({
 });
 
 const statusSchema = z.object({
-  state: z.enum(['idle', 'typing', 'working', 'degraded', 'error']),
+  state: z.enum(['idle', 'typing', 'working', 'approval_pending', 'degraded', 'error']),
   event_id: z.string().optional(),
   detail: z.string().max(2000).optional(),
   caller_employee_slug: z.string().optional(),
@@ -202,19 +203,22 @@ agentChannelRoutes.post('/ack', async (c) => {
     return errorResponse(c, 404, 'NOT_FOUND', 'Channel event not found');
   }
 
-  const now = new Date();
-  const patch =
-    parsed.data.state === 'completed'
-      ? { status: 'completed', acked_at: event.acked_at ?? now, completed_at: now, error: null, updated_at: now }
-      : parsed.data.state === 'failed'
-        ? { status: 'failed', acked_at: event.acked_at ?? now, failed_at: now, error: parsed.data.error ?? parsed.data.detail ?? 'Runtime reported failure', updated_at: now }
-        : { status: 'delivered', acked_at: now, updated_at: now };
+  const patch = buildAgentChannelLifecyclePatch(
+    event,
+    parsed.data.state === 'received' ? 'acknowledged' : parsed.data.state,
+    new Date(),
+    parsed.data.error ?? parsed.data.detail,
+  );
 
-  const [updated] = await db
-    .update(agentChannelEvents)
-    .set(patch)
-    .where(eq(agentChannelEvents.id, event.id))
-    .returning();
+  let updated = event;
+  if (Object.keys(patch).length > 0) {
+    const [updatedRow] = await db
+      .update(agentChannelEvents)
+      .set(patch)
+      .where(eq(agentChannelEvents.id, event.id))
+      .returning();
+    if (updatedRow) updated = updatedRow;
+  }
 
   await touchAgentChannelConnection(principal, {
     status: parsed.data.state === 'failed' ? 'degraded' : 'connected',
@@ -353,16 +357,18 @@ agentChannelRoutes.post('/reply', async (c) => {
     })
     .where(eq(agentChannelDeliveryAttempts.id, claim.id));
 
-  await db
-    .update(agentChannelEvents)
-    .set({
-      status: result.isError ? 'failed' : 'completed',
-      completed_at: result.isError ? null : new Date(),
-      failed_at: result.isError ? new Date() : null,
-      error: result.isError ? text : null,
-      updated_at: new Date(),
-    })
-    .where(eq(agentChannelEvents.id, event.id));
+  const lifecyclePatch = buildAgentChannelLifecyclePatch(
+    event,
+    result.isError ? 'failed' : 'completed',
+    new Date(),
+    result.isError ? text : null,
+  );
+  if (Object.keys(lifecyclePatch).length > 0) {
+    await db
+      .update(agentChannelEvents)
+      .set(lifecyclePatch)
+      .where(eq(agentChannelEvents.id, event.id));
+  }
 
   await touchAgentChannelConnection(principal, {
     status: result.isError ? 'degraded' : 'connected',
@@ -401,13 +407,21 @@ agentChannelRoutes.post('/status', async (c) => {
   });
 
   if (parsed.data.event_id) {
-    await db.execute(sql`
-      UPDATE agent_channel_events
-      SET updated_at = now()
-      WHERE id = ${parsed.data.event_id}
-        AND org_id = ${principal.org_id}
-        AND agent_employee_id = ${principal.employee_id}
-    `);
+    const event = await getEventForPrincipal(parsed.data.event_id, principal);
+    const signal = parsed.data.state === 'approval_pending'
+      ? 'approval_pending'
+      : parsed.data.state === 'working' || parsed.data.state === 'typing'
+        ? 'running'
+        : null;
+    if (event && signal) {
+      const lifecyclePatch = buildAgentChannelLifecyclePatch(event, signal);
+      if (Object.keys(lifecyclePatch).length > 0) {
+        await db
+          .update(agentChannelEvents)
+          .set(lifecyclePatch)
+          .where(eq(agentChannelEvents.id, event.id));
+      }
+    }
   }
 
   return c.json({

--- a/apps/api/src/routes/agent-employees.ts
+++ b/apps/api/src/routes/agent-employees.ts
@@ -31,6 +31,9 @@ import {
   publishAgentChannelEvent,
 } from '../lib/agent-channel.js';
 import { markWorkIntentsExpiredForActions } from '../lib/work-intents.js';
+import { summarizeAgentChannelLifecycle, summarizeAgentChannelMetrics } from '../lib/agent-channel-lifecycle.js';
+import { loadAgentActivity } from '../lib/agent-activity.js';
+import { describeAgentRuntimeRecovery } from '../lib/agent-runtime-recovery.js';
 
 export const agentEmployeeRoutes = new Hono();
 
@@ -1747,18 +1750,93 @@ agentEmployeeRoutes.get('/:id/activity', async (c) => {
       return c.json({ error: 'Agent employee not found', code: 'NOT_FOUND' }, 404);
     }
 
-    const actions = await db
-      .select()
-      .from(agentActions)
-      .where(eq(agentActions.agent_employee_id, id))
-      .orderBy(desc(agentActions.created_at))
-      .limit(50);
-
-    return c.json(actions);
+    const limit = Math.min(Math.max(Number.parseInt(c.req.query('limit') ?? '50', 10) || 50, 1), 100);
+    return c.json(await loadAgentActivity({ orgId: user.org_id, employeeId: id, limit }));
   } catch (err) {
     console.error('Failed to get agent employee activity:', err);
     return c.json({ error: 'Failed to get activity', code: 'INTERNAL_ERROR' }, 500);
   }
+});
+
+agentEmployeeRoutes.post('/:id/channel-events/:eventId/retry', async (c) => {
+  const user = c.get('user');
+  const id = c.req.param('id');
+  const eventId = c.req.param('eventId');
+  const role = await getOrgRole(user.id, user.org_id);
+  if (role !== 'owner' && role !== 'admin') {
+    return c.json({ error: 'Only owners or admins can retry deliveries', code: 'FORBIDDEN' }, 403);
+  }
+
+  const [event] = await db.select().from(agentChannelEvents).where(and(
+    eq(agentChannelEvents.id, eventId),
+    eq(agentChannelEvents.agent_employee_id, id),
+    eq(agentChannelEvents.org_id, user.org_id),
+  )).limit(1);
+  if (!event) return c.json({ error: 'Channel event not found', code: 'NOT_FOUND' }, 404);
+  if (event.status !== 'failed' && event.status !== 'cancelled') {
+    return c.json({ error: 'Only failed or cancelled deliveries can be retried', code: 'INVALID_STATE' }, 409);
+  }
+
+  const [updated] = await db.update(agentChannelEvents).set({
+    status: 'pending',
+    delivered_at: null,
+    acked_at: null,
+    completed_at: null,
+    failed_at: null,
+    error: null,
+    updated_at: new Date(),
+  }).where(and(
+    eq(agentChannelEvents.id, eventId),
+    eq(agentChannelEvents.agent_employee_id, id),
+    eq(agentChannelEvents.org_id, user.org_id),
+    or(eq(agentChannelEvents.status, 'failed'), eq(agentChannelEvents.status, 'cancelled')),
+  )).returning();
+  if (!updated) {
+    return c.json({ error: 'Delivery state changed before it could be retried', code: 'INVALID_STATE' }, 409);
+  }
+  return c.json({ event: updated });
+});
+
+agentEmployeeRoutes.post('/:id/channel-events/:eventId/cancel', async (c) => {
+  const user = c.get('user');
+  const id = c.req.param('id');
+  const eventId = c.req.param('eventId');
+  const role = await getOrgRole(user.id, user.org_id);
+  if (role !== 'owner' && role !== 'admin') {
+    return c.json({ error: 'Only owners or admins can cancel deliveries', code: 'FORBIDDEN' }, 403);
+  }
+
+  const [event] = await db.select().from(agentChannelEvents).where(and(
+    eq(agentChannelEvents.id, eventId),
+    eq(agentChannelEvents.agent_employee_id, id),
+    eq(agentChannelEvents.org_id, user.org_id),
+  )).limit(1);
+  if (!event) return c.json({ error: 'Channel event not found', code: 'NOT_FOUND' }, 404);
+  if (['completed', 'failed', 'cancelled'].includes(event.status)) {
+    return c.json({ error: 'Terminal deliveries cannot be cancelled', code: 'INVALID_STATE' }, 409);
+  }
+
+  const [updated] = await db.update(agentChannelEvents).set({
+    status: 'cancelled',
+    error: 'Cancelled by an operator',
+    failed_at: new Date(),
+    updated_at: new Date(),
+  }).where(and(
+    eq(agentChannelEvents.id, eventId),
+    eq(agentChannelEvents.agent_employee_id, id),
+    eq(agentChannelEvents.org_id, user.org_id),
+    or(
+      eq(agentChannelEvents.status, 'pending'),
+      eq(agentChannelEvents.status, 'delivered'),
+      eq(agentChannelEvents.status, 'acknowledged'),
+      eq(agentChannelEvents.status, 'running'),
+      eq(agentChannelEvents.status, 'approval_pending'),
+    ),
+  )).returning();
+  if (!updated) {
+    return c.json({ error: 'Delivery state changed before it could be cancelled', code: 'INVALID_STATE' }, 409);
+  }
+  return c.json({ event: updated });
 });
 
 // The legacy retry-provision endpoint and the agents.files.* RPC routes
@@ -1862,13 +1940,18 @@ agentEmployeeRoutes.get('/:id/developer', async (c) => {
         source_id: agentChannelEvents.source_id,
         delivery_count: agentChannelEvents.delivery_count,
         error: agentChannelEvents.error,
+        delivered_at: agentChannelEvents.delivered_at,
+        acked_at: agentChannelEvents.acked_at,
+        completed_at: agentChannelEvents.completed_at,
+        failed_at: agentChannelEvents.failed_at,
         created_at: agentChannelEvents.created_at,
         updated_at: agentChannelEvents.updated_at,
       })
       .from(agentChannelEvents)
       .where(and(eq(agentChannelEvents.agent_employee_id, id), eq(agentChannelEvents.org_id, user.org_id)))
       .orderBy(desc(agentChannelEvents.created_at))
-      .limit(15);
+      .limit(100);
+    const activity = await loadAgentActivity({ orgId: user.org_id, employeeId: id, limit: 30 });
 
     const challengeEvidence = latestChallenge
       ? await loadCertificationChallengeEvidence({
@@ -1918,7 +2001,11 @@ agentEmployeeRoutes.get('/:id/developer', async (c) => {
       diagnostics: {
         recent_mcp_calls: recentMcpCalls,
         recent_cooperative_log: recentCooperativeLog,
-        recent_channel_events: recentChannelEvents,
+        recent_channel_events: recentChannelEvents.slice(0, 15).map((event) => ({
+          ...event,
+          lifecycle: summarizeAgentChannelLifecycle(event),
+        })),
+        activity,
       },
       mcp_endpoint_url: mcpEndpointUrl(),
       mcp_token_masked: employee.mcp_token_hash ? '********' : null,
@@ -1933,9 +2020,21 @@ agentEmployeeRoutes.get('/:id/developer', async (c) => {
         queue: {
           pending: channelQueue.pending ?? 0,
           delivered: channelQueue.delivered ?? 0,
+          acknowledged: channelQueue.acknowledged ?? 0,
+          running: channelQueue.running ?? 0,
+          approval_pending: channelQueue.approval_pending ?? 0,
           completed: channelQueue.completed ?? 0,
           failed: channelQueue.failed ?? 0,
+          cancelled: channelQueue.cancelled ?? 0,
         },
+        metrics: summarizeAgentChannelMetrics(recentChannelEvents),
+        recovery: describeAgentRuntimeRecovery({
+          hasChannelToken: Boolean(activeChannelToken),
+          connectionStatus: channelConnection?.status,
+          lastSeenAt: channelConnection?.last_seen_at,
+          failedDeliveries: channelQueue.failed ?? 0,
+          pendingDeliveries: channelQueue.pending ?? 0,
+        }),
       },
     });
   } catch (err) {

--- a/apps/api/src/workers/handlers/agent-employee-heartbeat.ts
+++ b/apps/api/src/workers/handlers/agent-employee-heartbeat.ts
@@ -153,6 +153,23 @@ async function detectActionLoop(
   }
 }
 
+/** Atomically claim a due window so concurrent workers cannot queue duplicates. */
+async function claimHeartbeatWindow(employeeId: string): Promise<boolean> {
+  const [claimed] = await db
+    .update(agentEmployees)
+    .set({ last_heartbeat_at: new Date() })
+    .where(
+      and(
+        eq(agentEmployees.id, employeeId),
+        eq(agentEmployees.is_active, true),
+        eq(agentEmployees.heartbeat_enabled, true),
+        sql`(${agentEmployees.last_heartbeat_at} IS NULL OR ${agentEmployees.last_heartbeat_at} + (${agentEmployees.heartbeat_interval_min} || ' minutes')::interval < NOW())`,
+      ),
+    )
+    .returning({ id: agentEmployees.id });
+  return Boolean(claimed);
+}
+
 export async function handleAgentEmployeeHeartbeat(_job: JobData): Promise<void> {
   // Phase 9: no kind filter — every active employee with heartbeat
   // enabled and a due window is a candidate. The handler re-derives the
@@ -174,6 +191,9 @@ export async function handleAgentEmployeeHeartbeat(_job: JobData): Promise<void>
 
   for (const employee of dueEmployees) {
     const cadenceMinutes = employee.heartbeat_interval_min;
+
+    // The due scan is advisory; this update is the overlap lock.
+    if (!(await claimHeartbeatWindow(employee.id))) continue;
 
     // ─── Guard: unhealthy circuit breaker ───────────────────────────────
     if (employee.unhealthy) {

--- a/apps/api/test/agent-channel-lifecycle.test.ts
+++ b/apps/api/test/agent-channel-lifecycle.test.ts
@@ -1,0 +1,100 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  buildAgentChannelLifecyclePatch,
+  summarizeAgentChannelLifecycle,
+  summarizeAgentChannelMetrics,
+} from '../src/lib/agent-channel-lifecycle.js';
+
+const created = new Date('2026-07-13T10:00:00.000Z');
+
+function event(status = 'pending') {
+  return {
+    status,
+    created_at: created,
+    updated_at: created,
+    delivered_at: null,
+    acked_at: null,
+    completed_at: null,
+    failed_at: null,
+  };
+}
+
+test('channel lifecycle moves monotonically from queued to completed', () => {
+  const deliveredAt = new Date(created.getTime() + 100);
+  const delivered = { ...event(), ...buildAgentChannelLifecyclePatch(event(), 'delivered', deliveredAt) };
+  const ackedAt = new Date(created.getTime() + 250);
+  const acknowledged = {
+    ...delivered,
+    ...buildAgentChannelLifecyclePatch(delivered, 'acknowledged', ackedAt),
+  };
+  const completedAt = new Date(created.getTime() + 1_000);
+  const completed = {
+    ...acknowledged,
+    ...buildAgentChannelLifecyclePatch(acknowledged, 'completed', completedAt),
+  };
+
+  assert.equal(completed.status, 'completed');
+  assert.equal(completed.delivered_at, deliveredAt);
+  assert.equal(completed.acked_at, ackedAt);
+  assert.equal(completed.completed_at, completedAt);
+  assert.deepEqual(summarizeAgentChannelLifecycle(completed), {
+    phase: 'completed',
+    queue_ms: 100,
+    acknowledge_ms: 150,
+    execution_ms: 750,
+    total_ms: 1_000,
+    age_ms: null,
+  });
+});
+
+test('terminal events cannot reopen or change outcome', () => {
+  const completed = {
+    ...event('completed'),
+    delivered_at: new Date(created.getTime() + 100),
+    acked_at: new Date(created.getTime() + 200),
+    completed_at: new Date(created.getTime() + 300),
+  };
+  assert.deepEqual(buildAgentChannelLifecyclePatch(completed, 'running'), {});
+  assert.deepEqual(buildAgentChannelLifecyclePatch(completed, 'failed', new Date(), 'late error'), {});
+});
+
+test('failure records all observable timing boundaries', () => {
+  const failedAt = new Date(created.getTime() + 500);
+  const patch = buildAgentChannelLifecyclePatch(event(), 'failed', failedAt, 'runtime unavailable');
+  assert.equal(patch.status, 'failed');
+  assert.equal(patch.delivered_at, failedAt);
+  assert.equal(patch.acked_at, failedAt);
+  assert.equal(patch.failed_at, failedAt);
+  assert.equal(patch.error, 'runtime unavailable');
+});
+
+test('queued lifecycle reports age without inventing unavailable timings', () => {
+  assert.deepEqual(
+    summarizeAgentChannelLifecycle(event(), new Date(created.getTime() + 2_000)),
+    {
+      phase: 'queued',
+      queue_ms: null,
+      acknowledge_ms: null,
+      execution_ms: null,
+      total_ms: null,
+      age_ms: 2_000,
+    },
+  );
+});
+
+test('channel metrics expose median, tail, and oldest open delivery age', () => {
+  const complete = (total: number) => ({
+    ...event('completed'),
+    delivered_at: new Date(created.getTime() + 100),
+    acked_at: new Date(created.getTime() + 200),
+    completed_at: new Date(created.getTime() + total),
+  });
+  const metrics = summarizeAgentChannelMetrics(
+    [complete(500), complete(1_000), complete(2_000), event()],
+    new Date(created.getTime() + 3_000),
+  );
+  assert.equal(metrics.sample_count, 4);
+  assert.deepEqual(metrics.completion, { p50_ms: 1_000, p95_ms: 2_000 });
+  assert.equal(metrics.oldest_open_age_ms, 3_000);
+});

--- a/apps/api/test/agent-channel.test.ts
+++ b/apps/api/test/agent-channel.test.ts
@@ -33,10 +33,18 @@ import {
 } from '@deft/db';
 import { agentChannelRoutes } from '../src/routes/agent-channel.js';
 import { publishAgentChannelEvent } from '../src/lib/agent-channel.js';
+import { loadAgentActivity } from '../src/lib/agent-activity.js';
 import { projectRoutes } from '../src/routes/projects.js';
+import { agentEmployeeRoutes } from '../src/routes/agent-employees.js';
 
 const app = new Hono();
 app.route('/api/agent-channel/v1', agentChannelRoutes);
+const operatorApp = new Hono();
+operatorApp.use('*', async (c, next) => {
+  c.set('user', { id: humanUserId, org_id: orgId, email: 'channel-human@test.local', name: 'Channel Human' });
+  await next();
+});
+operatorApp.route('/api/agent-employees', agentEmployeeRoutes);
 
 let orgId: string;
 let humanUserId: string;
@@ -324,6 +332,99 @@ test('POST /ack records received/completed state and cursor', async () => {
   assert.equal(closedFallback?.approval_status, 'approved');
   assert.ok(closedFallback?.executed_at);
   assert.equal((closedFallback?.result as any)?.channel_event_id, event.id);
+});
+
+test('channel lifecycle records acknowledgement, work, and approval without regressing terminal state', async () => {
+  const event = await publishMessageEvent('agent-channel-lifecycle-route');
+  await app.request('/api/agent-channel/v1/events?limit=10', {
+    headers: { authorization: `Bearer ${bearer}` },
+  });
+
+  const acknowledge = await app.request('/api/agent-channel/v1/ack', {
+    method: 'POST',
+    headers: { authorization: `Bearer ${bearer}`, 'content-type': 'application/json' },
+    body: JSON.stringify({ event_id: event.id, state: 'received' }),
+  });
+  assert.equal(acknowledge.status, 200);
+
+  for (const state of ['working', 'approval_pending']) {
+    const response = await app.request('/api/agent-channel/v1/status', {
+      method: 'POST',
+      headers: { authorization: `Bearer ${bearer}`, 'content-type': 'application/json' },
+      body: JSON.stringify({ event_id: event.id, state }),
+    });
+    assert.equal(response.status, 200, `status ${state} should be accepted`);
+  }
+
+  const complete = await app.request('/api/agent-channel/v1/ack', {
+    method: 'POST',
+    headers: { authorization: `Bearer ${bearer}`, 'content-type': 'application/json' },
+    body: JSON.stringify({ event_id: event.id, state: 'completed' }),
+  });
+  assert.equal(complete.status, 200);
+
+  const lateWork = await app.request('/api/agent-channel/v1/status', {
+    method: 'POST',
+    headers: { authorization: `Bearer ${bearer}`, 'content-type': 'application/json' },
+    body: JSON.stringify({ event_id: event.id, state: 'working' }),
+  });
+  assert.equal(lateWork.status, 200);
+
+  const [recorded] = await db
+    .select()
+    .from(agentChannelEvents)
+    .where(eq(agentChannelEvents.id, event.id))
+    .limit(1);
+  assert.equal(recorded?.status, 'completed');
+  assert.ok(recorded?.delivered_at);
+  assert.ok(recorded?.acked_at);
+  assert.ok(recorded?.completed_at);
+});
+
+test('agent activity merges delivery and action records into one ordered stream', async () => {
+  const event = await publishMessageEvent('agent-channel-activity-stream');
+  const [action] = await db.insert(agentActions).values({
+    org_id: orgId,
+    user_id: humanUserId,
+    agent_employee_id: employeeId,
+    conversation_id: spaceId,
+    source: 'test',
+    action: 'create_task',
+    params: { title: 'Activity test' },
+    approval_tier: 'quick',
+    approval_status: 'pending',
+  }).returning({ id: agentActions.id });
+
+  const activity = await loadAgentActivity({ orgId, employeeId, limit: 20 });
+  const delivery = activity.find((item) => item.id === `delivery:${event.id}`);
+  const proposedAction = activity.find((item) => item.id === `action:${action!.id}`);
+
+  assert.equal(delivery?.kind, 'delivery');
+  assert.equal(delivery?.status, 'queued');
+  assert.equal(delivery?.target_url, `/chat?space=${spaceId}&thread=${sourceMessageId}`);
+  assert.equal(proposedAction?.kind, 'action');
+  assert.equal(proposedAction?.status, 'approval_pending');
+  assert.equal(proposedAction?.target_url, `/chat?space=${spaceId}`);
+});
+
+test('operators can cancel and retry a live channel delivery', async () => {
+  const event = await publishMessageEvent('agent-channel-operator-control');
+  const cancel = await operatorApp.request(`/api/agent-employees/${employeeId}/channel-events/${event.id}/cancel`, {
+    method: 'POST',
+  });
+  assert.equal(cancel.status, 200, await cancel.text());
+
+  let [recorded] = await db.select().from(agentChannelEvents).where(eq(agentChannelEvents.id, event.id)).limit(1);
+  assert.equal(recorded?.status, 'cancelled');
+
+  const retry = await operatorApp.request(`/api/agent-employees/${employeeId}/channel-events/${event.id}/retry`, {
+    method: 'POST',
+  });
+  assert.equal(retry.status, 200, await retry.text());
+
+  [recorded] = await db.select().from(agentChannelEvents).where(eq(agentChannelEvents.id, event.id)).limit(1);
+  assert.equal(recorded?.status, 'pending');
+  assert.equal(recorded?.error, null);
 });
 
 test('POST /reply posts as the agent and is idempotent', async () => {

--- a/apps/api/test/agent-runtime-recovery.test.ts
+++ b/apps/api/test/agent-runtime-recovery.test.ts
@@ -1,0 +1,14 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { describeAgentRuntimeRecovery } from '../src/lib/agent-runtime-recovery.js';
+
+const now = new Date('2026-07-13T12:00:00Z');
+const base = { hasChannelToken: true, connectionStatus: 'connected', lastSeenAt: now, failedDeliveries: 0, pendingDeliveries: 0, now };
+
+test('runtime recovery prioritizes setup, failures, offline state, and backlog', () => {
+  assert.equal(describeAgentRuntimeRecovery({ ...base, hasChannelToken: false }).action, 'regenerate_channel_token');
+  assert.equal(describeAgentRuntimeRecovery({ ...base, failedDeliveries: 2 }).action, 'inspect_queue');
+  assert.equal(describeAgentRuntimeRecovery({ ...base, lastSeenAt: new Date(now.getTime() - 180_000) }).state, 'offline');
+  assert.equal(describeAgentRuntimeRecovery({ ...base, pendingDeliveries: 6 }).state, 'backlogged');
+  assert.equal(describeAgentRuntimeRecovery(base).state, 'healthy');
+});

--- a/apps/api/test/phase8-heartbeat-routing.test.ts
+++ b/apps/api/test/phase8-heartbeat-routing.test.ts
@@ -187,3 +187,61 @@ test('handler queues a heartbeat_tick agent_actions row when guards pass', async
     });
   }
 });
+
+test('concurrent scans queue one tick for the same heartbeat window', async () => {
+  const orgId = crypto.randomUUID();
+  const userId = `phase9-overlap-user-${crypto.randomUUID()}`;
+  const employeeId = `phase9-overlap-${crypto.randomUUID()}`;
+
+  await withClient(async (c) => {
+    await c.query(
+      `INSERT INTO orgs (id, name, slug) VALUES ($1, 'Heartbeat Overlap Org', $2)`,
+      [orgId, `heartbeat-overlap-${orgId.slice(0, 8)}`],
+    );
+    await c.query(
+      `INSERT INTO users (id, email, name, is_agent) VALUES ($1, $2, 'Heartbeat Overlap Shadow', true)`,
+      [userId, `${userId}@test.local`],
+    );
+    await c.query(
+      `INSERT INTO agent_employees
+         (id, org_id, user_id, name, slug, role, system_prompt, trust_level,
+          is_byoa, is_active, heartbeat_enabled, heartbeat_interval_min,
+          max_daily_actions, daily_action_count, last_heartbeat_at, created_by)
+       VALUES
+         ($1, $2, $3, 'Overlap Employee', $4, 'project_manager', 'test', 'standard',
+          true, true, true, 5, 50, 0, NOW() - INTERVAL '1 hour', $3)`,
+      [employeeId, orgId, userId, `slug-${employeeId}`],
+    );
+  });
+
+  try {
+    const { handleAgentEmployeeHeartbeat } = await import(
+      '../src/workers/handlers/agent-employee-heartbeat.js'
+    );
+    const job = { kind: 'agent-employee-heartbeat', payload: {} } as Parameters<
+      typeof handleAgentEmployeeHeartbeat
+    >[0];
+    await Promise.all([
+      handleAgentEmployeeHeartbeat(job),
+      handleAgentEmployeeHeartbeat(job),
+    ]);
+
+    const count = await withClient(async (c) => {
+      const r = await c.query<{ count: string }>(
+        `SELECT count(*)::text AS count FROM agent_actions
+          WHERE agent_employee_id = $1 AND action = 'heartbeat_tick'`,
+        [employeeId],
+      );
+      return Number(r.rows[0].count);
+    });
+    assert.equal(count, 1);
+  } finally {
+    await withClient(async (c) => {
+      await c.query(`DELETE FROM agent_actions WHERE agent_employee_id = $1`, [employeeId]);
+      await c.query(`DELETE FROM agent_heartbeat_turns WHERE agent_employee_id = $1`, [employeeId]);
+      await c.query(`DELETE FROM agent_employees WHERE id = $1`, [employeeId]);
+      await c.query(`DELETE FROM users WHERE id = $1`, [userId]);
+      await c.query(`DELETE FROM orgs WHERE id = $1`, [orgId]);
+    });
+  }
+});

--- a/apps/web/src/app/(app)/settings/agent-employees/[id]/developer/page.tsx
+++ b/apps/web/src/app/(app)/settings/agent-employees/[id]/developer/page.tsx
@@ -9,7 +9,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { api } from '@/lib/api';
-import { Check, Copy, Loader2, Play, RefreshCw, RotateCcw, Terminal } from 'lucide-react';
+import { Check, Copy, Loader2, Play, RefreshCw, RotateCcw, Terminal, X } from 'lucide-react';
 
 type DeveloperPayload = {
   employee: {
@@ -88,6 +88,16 @@ type DeveloperPayload = {
       created_at: string;
       updated_at: string;
     }>;
+    activity: Array<{
+      id: string;
+      kind: 'delivery' | 'action' | 'tool_call' | 'session' | 'record';
+      label: string;
+      status: 'queued' | 'running' | 'approval_pending' | 'completed' | 'failed' | 'cancelled';
+      detail?: string | null;
+      occurred_at: string;
+      target_url?: string | null;
+      error?: string | null;
+    }>;
   };
   mcp_endpoint_url: string;
   mcp_token_masked: string | null;
@@ -115,6 +125,20 @@ type DeveloperPayload = {
       delivered: number;
       completed: number;
       failed: number;
+      cancelled: number;
+    };
+    metrics: {
+      sample_count: number;
+      delivery: { p50_ms: number | null; p95_ms: number | null };
+      acknowledgement: { p50_ms: number | null; p95_ms: number | null };
+      completion: { p50_ms: number | null; p95_ms: number | null };
+      oldest_open_age_ms: number | null;
+    };
+    recovery: {
+      state: 'healthy' | 'setup_required' | 'offline' | 'delivery_failed' | 'backlogged';
+      title: string;
+      detail: string;
+      action: 'none' | 'regenerate_channel_token' | 'send_channel_test' | 'inspect_queue';
     };
   };
 };
@@ -147,6 +171,7 @@ export default function DeveloperPage() {
   const [certBusy, setCertBusy] = useState(false);
   const [certResult, setCertResult] = useState<string | null>(null);
   const [channelTestBusy, setChannelTestBusy] = useState(false);
+  const [queueBusy, setQueueBusy] = useState<string | null>(null);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -268,6 +293,20 @@ export default function DeveloperPage() {
     }
   };
 
+  const controlDelivery = async (eventId: string, action: 'retry' | 'cancel') => {
+    setQueueBusy(eventId);
+    setError(null);
+    try {
+      const res = await api.post(`/api/agent-employees/${employeeId}/channel-events/${eventId}/${action}`);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      await load();
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setQueueBusy(null);
+    }
+  };
+
   const copy = async (label: string, value: string | null | undefined) => {
     if (!value) return;
     try {
@@ -362,6 +401,17 @@ export default function DeveloperPage() {
       )}
       {error && <div className="mb-3 rounded border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs">{error}</div>}
 
+      <div className={`mb-4 rounded border px-3 py-2 text-xs ${data.channel.recovery.state === 'healthy' ? 'border-emerald-500/25 bg-emerald-500/10' : 'border-amber-500/30 bg-amber-500/10'}`}>
+        <div className="font-medium">{data.channel.recovery.title}</div>
+        <div className="mt-0.5 text-muted-foreground">{data.channel.recovery.detail}</div>
+        {data.channel.recovery.action === 'regenerate_channel_token' && (
+          <button type="button" onClick={regenerateChannelToken} className="mt-2 rounded border border-border px-2 py-1 hover:bg-accent">Generate token</button>
+        )}
+        {data.channel.recovery.action === 'send_channel_test' && (
+          <button type="button" onClick={startChannelTest} className="mt-2 rounded border border-border px-2 py-1 hover:bg-accent">Send test event</button>
+        )}
+      </div>
+
       <section className="space-y-3">
         <Field
           label="Employee slug"
@@ -453,6 +503,10 @@ export default function DeveloperPage() {
         <Field
           label="Channel status"
           value={`${channelConnectionLabel} - pending ${data.channel.queue.pending} - failed ${data.channel.queue.failed}`}
+        />
+        <Field
+          label="Channel latency"
+          value={`${data.channel.metrics.sample_count} samples - deliver ${formatMs(data.channel.metrics.delivery.p50_ms)}/${formatMs(data.channel.metrics.delivery.p95_ms)} p50/p95 - complete ${formatMs(data.channel.metrics.completion.p50_ms)}/${formatMs(data.channel.metrics.completion.p95_ms)}`}
         />
         <div className="grid grid-cols-12 gap-2 items-center">
           <div className="col-span-3 text-xs text-muted-foreground">Channel test</div>
@@ -607,6 +661,17 @@ export default function DeveloperPage() {
       </section>
 
       <section className="mt-6 grid gap-4 md:grid-cols-2">
+        <div className="md:col-span-2">
+          <LogPanel
+            title="Agent activity"
+            empty="No employee activity recorded yet."
+            rows={data.diagnostics.activity.map((row) => ({
+              id: row.id,
+              main: `${row.status.replaceAll('_', ' ')} · ${row.label}`,
+              sub: `${new Date(row.occurred_at).toLocaleString()}${row.detail ? ` · ${row.detail}` : ''}${row.error ? ` · ${row.error}` : ''}`,
+            }))}
+          />
+        </div>
         <LogPanel
           title="Recent MCP calls"
           empty="No MCP calls recorded yet."
@@ -632,6 +697,15 @@ export default function DeveloperPage() {
             id: row.id,
             main: `${row.status} ${row.kind}`,
             sub: `${new Date(row.created_at).toLocaleString()} - delivery count ${row.delivery_count}${row.error ? ` - ${row.error}` : ''}`,
+            actions: row.status === 'failed' || row.status === 'cancelled' ? (
+              <button type="button" onClick={() => controlDelivery(row.id, 'retry')} disabled={queueBusy === row.id} className="inline-flex items-center gap-1 rounded border border-border px-2 py-1 text-[11px] hover:bg-accent disabled:opacity-50">
+                <RotateCcw className="size-3" /> Retry
+              </button>
+            ) : ['pending', 'delivered', 'acknowledged', 'running', 'approval_pending'].includes(row.status) ? (
+              <button type="button" onClick={() => controlDelivery(row.id, 'cancel')} disabled={queueBusy === row.id} className="inline-flex items-center gap-1 rounded border border-border px-2 py-1 text-[11px] hover:bg-accent disabled:opacity-50">
+                <X className="size-3" /> Cancel
+              </button>
+            ) : undefined,
           }))}
         />
       </section>
@@ -704,7 +778,7 @@ function LogPanel({
 }: {
   title: string;
   empty: string;
-  rows: Array<{ id: string; main: string; sub: string }>;
+  rows: Array<{ id: string; main: string; sub: string; actions?: React.ReactNode }>;
 }) {
   return (
     <div>
@@ -713,9 +787,12 @@ function LogPanel({
         {rows.length === 0 ? (
           <div className="px-3 py-2 text-xs text-muted-foreground">{empty}</div>
         ) : rows.map((row) => (
-          <div key={row.id} className="border-b border-border px-3 py-2 last:border-b-0">
-            <div className="text-xs font-medium">{row.main}</div>
-            <div className="mt-0.5 truncate text-[11px] text-muted-foreground">{row.sub}</div>
+          <div key={row.id} className="flex items-center justify-between gap-3 border-b border-border px-3 py-2 last:border-b-0">
+            <div className="min-w-0">
+              <div className="text-xs font-medium">{row.main}</div>
+              <div className="mt-0.5 truncate text-[11px] text-muted-foreground">{row.sub}</div>
+            </div>
+            {row.actions}
           </div>
         ))}
       </div>
@@ -739,4 +816,10 @@ function CodeBlock({ value, onCopy }: { value: string; onCopy?: () => void }) {
       )}
     </div>
   );
+}
+
+function formatMs(value: number | null) {
+  if (value === null) return '--';
+  if (value < 1_000) return `${value}ms`;
+  return `${(value / 1_000).toFixed(1)}s`;
 }

--- a/apps/web/src/app/(app)/settings/agent-employees/page.tsx
+++ b/apps/web/src/app/(app)/settings/agent-employees/page.tsx
@@ -23,6 +23,7 @@ import {
   type AgentEmployeeFleetFilter,
 } from '@/lib/agent-employee-fleet';
 import { agentConnectionStatus, agentEmployeeLifecycle } from '@/lib/agent-employee-status';
+import { getSocket } from '@/lib/socket';
 
 type AgentEmployee = {
   id: string;
@@ -138,6 +139,19 @@ export default function AgentEmployeesPage() {
     const timer = window.setInterval(() => { void fetchEmployees(); }, 15_000);
     return () => window.clearInterval(timer);
   }, [fetchEmployees]);
+
+  useEffect(() => {
+    const token = window.localStorage.getItem('deft-access-token');
+    if (!token) return;
+    const socket = getSocket(token);
+    const onPresence = (event: { employee_id: string; status: string; last_seen_at: string }) => {
+      setEmployees((current) => current.map((employee) => employee.id === event.employee_id
+        ? { ...employee, channel_status: event.status, channel_last_seen_at: event.last_seen_at }
+        : employee));
+    };
+    socket.on('agent:presence', onPresence);
+    return () => { socket.off('agent:presence', onPresence); };
+  }, []);
 
   const fleetCounts = useMemo(() => countAgentEmployeeFleet(employees), [employees]);
   const visibleEmployees = useMemo(

--- a/apps/web/src/components/sidebar.tsx
+++ b/apps/web/src/components/sidebar.tsx
@@ -46,6 +46,7 @@ import { SavedMessages } from './saved-messages';
 import { CreateProjectModal } from './create-project-modal';
 import { useInboxCount } from '@/hooks/use-inbox-count';
 import { AppMenu, type AppMenuItem } from './overlay-primitives';
+import { getSocket } from '@/lib/socket';
 
 type AgentEmployee = {
   id: string;
@@ -126,6 +127,19 @@ function ChatSidebarContent({
       active = false;
       window.clearInterval(interval);
     };
+  }, []);
+
+  useEffect(() => {
+    const token = window.localStorage.getItem('deft-access-token');
+    if (!token) return;
+    const socket = getSocket(token);
+    const onPresence = (event: { employee_id: string; status: string; last_seen_at: string }) => {
+      setAgentEmployees((current) => current.map((employee) => employee.id === event.employee_id
+        ? { ...employee, channel_status: event.status, channel_last_seen_at: event.last_seen_at }
+        : employee));
+    };
+    socket.on('agent:presence', onPresence);
+    return () => { socket.off('agent:presence', onPresence); };
   }, []);
 
   const agentStatusColor = (employee: AgentEmployee) => {


### PR DESCRIPTION
## What changed

- formalize the Agent Channel lifecycle from queued delivery through acknowledgement, execution, approval, completion, failure, or cancellation
- merge delivery, governed action, MCP, session, and cooperative records into one employee activity feed
- add admin queue retry/cancel controls with atomic state transitions
- emit realtime runtime presence with polling fallback
- expose recent delivery latency and guided recovery on the Developer page
- prevent concurrent heartbeat workers from queueing duplicate ticks
- verify the existing attention/background Inbox split without rebuilding it

## Why

Agent employee operation was spread across separate logs and ambiguous connection states. Operators could not quickly tell whether work was queued, running, awaiting approval, failed, or safe to retry. Concurrent heartbeat scans also had a duplicate-work race.

## Impact

Admins get a clearer operational surface and safe recovery controls. Employee presence updates immediately, delivery timing is visible, lifecycle transitions are monotonic, and heartbeat scheduling is overlap-safe. Core Inbox behavior remains unchanged.

## Validation

- 43 focused API tests passed across lifecycle, channel routes, recovery, Inbox, and heartbeat safeguards
- `pnpm --filter @deft/api typecheck`
- `pnpm --filter @deft/web typecheck`
- desktop dogfood of Agent Employees and Developer diagnostics
- mobile diagnostics check at 390px with no horizontal overflow
- `git diff --check`

## Boundaries

This does not add autonomous Phase 8 heartbeats, automatic exponential backoff, a separate dead-letter store, or long-term SLO persistence. Heartbeats remain guarded BYOA work pickup.