### PR TITLE
Fix agent thread delivery and operator access

### DIFF
--- a/apps/api/src/lib/mentions.ts
+++ b/apps/api/src/lib/mentions.ts
@@ -4,18 +4,26 @@
 // Also handle @here and @all
 
 export function parseMentions(content: string): { userIds: string[]; here: boolean; all: boolean } {
-  const userIds: string[] = [];
+  const userIds = new Set<string>();
   let here = false;
   let all = false;
 
   const mentionRegex = /<@([^|>]+)\|[^>]+>/g;
   let match;
   while ((match = mentionRegex.exec(content)) !== null) {
-    userIds.push(match[1]!);
+    userIds.add(match[1]!);
+  }
+
+  // TipTap thread composers can submit the mention node before the web
+  // serializer converts it to the canonical <@id|name> marker.
+  const htmlMentionRegex = /<span\b[^>]*\bdata-mention-uuid=(?:"([^"]+)"|'([^']+)'|([^\s>]+))[^>]*>/gi;
+  while ((match = htmlMentionRegex.exec(content)) !== null) {
+    const userId = match[1] ?? match[2] ?? match[3];
+    if (userId) userIds.add(userId);
   }
 
   if (content.includes('@here')) here = true;
   if (content.includes('@all')) all = true;
 
-  return { userIds, here, all };
+  return { userIds: Array.from(userIds), here, all };
 }

--- a/apps/api/src/routes/agent-employees.ts
+++ b/apps/api/src/routes/agent-employees.ts
@@ -1687,6 +1687,11 @@ agentEmployeeRoutes.post('/:id/pause', async (c) => {
     const user = c.get('user');
     const id = c.req.param('id');
 
+    const role = await getOrgRole(user.id, user.org_id);
+    if (role !== 'owner' && role !== 'admin') {
+      return c.json({ error: 'Only owners or admins can pause agent employees', code: 'FORBIDDEN' }, 403);
+    }
+
     const [existing] = await db
       .select()
       .from(agentEmployees)
@@ -1712,6 +1717,11 @@ agentEmployeeRoutes.post('/:id/resume', async (c) => {
   try {
     const user = c.get('user');
     const id = c.req.param('id');
+
+    const role = await getOrgRole(user.id, user.org_id);
+    if (role !== 'owner' && role !== 'admin') {
+      return c.json({ error: 'Only owners or admins can resume agent employees', code: 'FORBIDDEN' }, 403);
+    }
 
     const [existing] = await db
       .select()

--- a/apps/api/test/agent-channel.test.ts
+++ b/apps/api/test/agent-channel.test.ts
@@ -427,6 +427,24 @@ test('operators can cancel and retry a live channel delivery', async () => {
   assert.equal(recorded?.error, null);
 });
 
+test('regular members cannot pause or resume an agent employee', async () => {
+  await db.update(orgMembers)
+    .set({ role: 'member' })
+    .where(and(eq(orgMembers.org_id, orgId), eq(orgMembers.user_id, humanUserId)));
+
+  try {
+    const pause = await operatorApp.request(`/api/agent-employees/${employeeId}/pause`, { method: 'POST' });
+    assert.equal(pause.status, 403, await pause.text());
+
+    const resume = await operatorApp.request(`/api/agent-employees/${employeeId}/resume`, { method: 'POST' });
+    assert.equal(resume.status, 403, await resume.text());
+  } finally {
+    await db.update(orgMembers)
+      .set({ role: 'owner' })
+      .where(and(eq(orgMembers.org_id, orgId), eq(orgMembers.user_id, humanUserId)));
+  }
+});
+
 test('POST /reply posts as the agent and is idempotent', async () => {
   const [fallbackAction] = await db.insert(agentActions).values({
     org_id: orgId,

--- a/apps/api/test/agent-mention-detection.test.ts
+++ b/apps/api/test/agent-mention-detection.test.ts
@@ -259,6 +259,32 @@ test('structured mention of BYOA agent (kind=agent, not Defty) does NOT trigger 
   assert.ok(employeeQueued, 'BYOA agent mention should enqueue agent-employee-message');
 });
 
+test('TipTap HTML mention in a thread reply dispatches to a BYOA employee', async () => {
+  const parentRes = await app.request(`/api/messages/${spaceId}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ content: 'Thread parent for employee dispatch' }),
+  });
+  assert.equal(parentRes.status, 201);
+  const parent = await parentRes.json() as { id: string };
+  createdMessageIds.push(parent.id);
+
+  const content = `<p><span data-type="mention" data-mention-uuid="${byoaAgentUserId}" data-mention-name="AMD BYOA Agent">@AMD BYOA Agent</span> please inspect this thread.</p>`;
+  const replyRes = await app.request(`/api/messages/${spaceId}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ content, parent_id: parent.id }),
+  });
+  assert.equal(replyRes.status, 201);
+  const reply = await replyRes.json() as { id: string };
+  createdMessageIds.push(reply.id);
+
+  assert.ok(
+    await findAgentEmployeeMessageJob(reply.id),
+    'TipTap mention in a thread reply should enqueue agent-employee-message',
+  );
+});
+
 test('structured mention of kind=human user does NOT trigger agent-reply dispatch', async () => {
   // Same mention format but pointing at a human user — should NOT trigger.
   const content = `Hey <@${humanUserId}|AMD Human>, what do you think?`;


### PR DESCRIPTION
## What changed
- recognize TipTap HTML mention nodes when thread replies are posted, so BYOA agent employees receive the same delivery as top-level mentions
- restrict pause and resume controls to workspace owners and admins
- add route-level regressions for thread delivery and member authorization

## Root cause
The API mention parser only accepted canonical `<@id|name>` markers, while the thread composer could submit TipTap `<span data-mention-uuid=...>` nodes. Pause and resume were also missing the role check already used by cancel and retry.

## Validation
- `pnpm --filter @deft/api typecheck`
- focused agent channel and mention tests: 18/18
- full API suite against disposable database: 748/748
- live diagnosis on demo.deft.ing, including pause/cancel/retry/resume recovery and an end-to-end Rita task workflow