### PR TITLE
Add editable task table view

### DIFF
--- a/apps/api/src/routes/tasks.ts
+++ b/apps/api/src/routes/tasks.ts
@@ -40,6 +40,7 @@ const createTaskWithProjectSchema = createTaskSchema.extend({
 });
 
 const updateTaskSchema = z.object({
+  expected_updated_at: z.string().min(1).optional(),
   title: z.string().min(1).optional(),
   description: z.string().optional(),
   status: z.string().optional(),
@@ -48,6 +49,7 @@ const updateTaskSchema = z.object({
   due_date: z.string().nullable().optional(),
   start_date: z.string().nullable().optional(),
   estimation: z.string().nullable().optional(),
+  label_ids: z.array(z.string().uuid()).optional(),
   sort_order: z.number().optional(),
   // Task 0.6 — project_id intentionally omitted. Tasks cannot be moved across
   // projects via PATCH because cross-references (PREFIX-N) in chat messages,
@@ -357,6 +359,8 @@ taskRoutes.get('/my', async (c) => {
       assignee_id: tasks.assignee_id,
       created_by: tasks.created_by,
       due_date: tasks.due_date,
+      start_date: tasks.start_date,
+      estimation: tasks.estimation,
       sort_order: tasks.sort_order,
       project_id: tasks.project_id,
       source_message_id: tasks.source_message_id,
@@ -1470,6 +1474,8 @@ taskRoutes.get('/project/:projectId', async (c) => {
       assignee_id: tasks.assignee_id,
       created_by: tasks.created_by,
       due_date: tasks.due_date,
+      start_date: tasks.start_date,
+      estimation: tasks.estimation,
       sort_order: tasks.sort_order,
       project_id: tasks.project_id,
       source_message_id: tasks.source_message_id,
@@ -1767,6 +1773,21 @@ taskRoutes.patch('/:id', async (c) => {
       );
     }
 
+    let expectedUpdatedAt: Date | null = null;
+    if (parsed.data.expected_updated_at !== undefined) {
+      expectedUpdatedAt = new Date(parsed.data.expected_updated_at);
+      if (Number.isNaN(expectedUpdatedAt.getTime())) {
+        return c.json({ error: 'Invalid expected_updated_at', code: 'VALIDATION_ERROR' }, 400);
+      }
+      if (expectedUpdatedAt.getTime() !== existingTask.updated_at.getTime()) {
+        return c.json({
+          error: 'Task changed after it was loaded',
+          code: 'TASK_STALE',
+          current_task: existingTask,
+        }, 409);
+      }
+    }
+
     const updateData: Record<string, any> = {};
     const activityEntries: { action: string; field: string; old_value: string | null; new_value: string | null }[] = [];
 
@@ -1803,13 +1824,6 @@ taskRoutes.patch('/:id', async (c) => {
         updateData.assignee_id = newAssignee;
         activityEntries.push({ action: 'assigned', field: 'assignee_id', old_value: existingTask.assignee_id ?? null, new_value: newAssignee });
       }
-      // Phase 0.3 — no duplication: if the new primary is currently listed as an
-      // additional assignee, remove the taskAssignees row so the two sources of
-      // truth never point to the same user.
-      if (newAssignee) {
-        await db.delete(taskAssignees)
-          .where(and(eq(taskAssignees.task_id, taskId), eq(taskAssignees.user_id, newAssignee)));
-      }
     }
 
     if (parsed.data.due_date !== undefined) {
@@ -1837,6 +1851,25 @@ taskRoutes.patch('/:id', async (c) => {
 
     if (parsed.data.estimation !== undefined) {
       updateData.estimation = parsed.data.estimation;
+    }
+
+    let nextLabelIds: string[] | undefined;
+    let labelsChanged = false;
+    if (parsed.data.label_ids !== undefined) {
+      nextLabelIds = [...new Set(parsed.data.label_ids)];
+      const validLabels = nextLabelIds.length
+        ? await db.select({ id: labels.id }).from(labels).where(and(eq(labels.org_id, user.org_id), inArray(labels.id, nextLabelIds)))
+        : [];
+      if (validLabels.length !== nextLabelIds.length) {
+        return c.json({ error: 'One or more labels are invalid', code: 'INVALID_LABEL' }, 400);
+      }
+      const currentLabels = await db.select({ id: taskLabels.label_id }).from(taskLabels).where(eq(taskLabels.task_id, taskId));
+      const currentIds = currentLabels.map((label) => label.id).sort();
+      labelsChanged = currentIds.join(',') !== [...nextLabelIds].sort().join(',');
+      if (labelsChanged) {
+        updateData.updated_at = new Date();
+        activityEntries.push({ action: 'labels_changed', field: 'labels', old_value: currentIds.join(','), new_value: nextLabelIds.join(',') });
+      }
     }
 
     if (parsed.data.sort_order !== undefined) {
@@ -1876,10 +1909,56 @@ taskRoutes.patch('/:id', async (c) => {
       return c.json({ error: 'No fields to update', code: 'VALIDATION_ERROR' }, 400);
     }
 
-    const [updatedTask] = await db.update(tasks)
-      .set(updateData)
-      .where(eq(tasks.id, taskId))
-      .returning();
+    let updatedTask: typeof tasks.$inferSelect | null = null;
+    if (expectedUpdatedAt || labelsChanged) {
+      updatedTask = await db.transaction(async (tx) => {
+        const [lockedTask] = await tx.select({ updated_at: tasks.updated_at })
+          .from(tasks)
+          .where(eq(tasks.id, taskId))
+          .for('update');
+        if (!lockedTask || (expectedUpdatedAt && lockedTask.updated_at.getTime() !== expectedUpdatedAt.getTime())) {
+          return null;
+        }
+        const [updated] = await tx.update(tasks)
+          .set(updateData)
+          .where(eq(tasks.id, taskId))
+          .returning();
+        if (labelsChanged && nextLabelIds) {
+          await tx.delete(taskLabels).where(eq(taskLabels.task_id, taskId));
+          if (nextLabelIds.length) {
+            await tx.insert(taskLabels).values(nextLabelIds.map((labelId) => ({ task_id: taskId, label_id: labelId })));
+          }
+        }
+        return updated ?? null;
+      });
+    } else {
+      const [updated] = await db.update(tasks)
+        .set(updateData)
+        .where(eq(tasks.id, taskId))
+        .returning();
+      updatedTask = updated ?? null;
+    }
+
+    // The row lock makes the version check and update one atomic operation.
+    // A concurrent writer cannot slip between them and be overwritten.
+    if (!updatedTask) {
+      const currentTask = await getVisibleTaskForOrg(taskId, user.org_id, user.id);
+      return c.json({
+        error: 'Task changed after it was loaded',
+        code: 'TASK_STALE',
+        current_task: currentTask,
+      }, 409);
+    }
+
+    // Only mutate the additional-assignee table after the guarded task update
+    // succeeds, so a stale write cannot leave related state half-updated.
+    if (parsed.data.assignee_id !== undefined && updatedTask.assignee_id) {
+      await db.delete(taskAssignees)
+        .where(and(
+          eq(taskAssignees.task_id, taskId),
+          eq(taskAssignees.user_id, updatedTask.assignee_id),
+        ));
+    }
 
     let activityRows: { id: string; action: string; field: string | null }[] = [];
 

--- a/apps/api/test/tasks-patch.test.ts
+++ b/apps/api/test/tasks-patch.test.ts
@@ -175,6 +175,13 @@ async function getTaskProjectId(tid: string): Promise<string | null> {
   });
 }
 
+async function getTaskSnapshot(tid: string): Promise<{ title: string; updated_at: string }> {
+  const res = await app().request(`/api/tasks/${tid}`, { method: 'GET' });
+  assert.equal(res.status, 200);
+  const task = await res.json() as any;
+  return { title: task.title, updated_at: task.updated_at };
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 
 test('GET /api/tasks/:id returns flattened assignee fields for task detail clients', async () => {
@@ -192,6 +199,22 @@ test('GET /api/tasks/:id returns flattened assignee fields for task detail clien
   assert.equal(body.source_message?.space_name, 'tasks-patch-source');
   assert.equal(body.source_message?.author_name, 'Tasks Patch Member');
   assert.equal(body.source_message?.content, '<p>source task message</p>');
+});
+
+test('project task list returns every field editable from the table', async () => {
+  const detail = await app().request(`/api/tasks/${taskId}`, {
+    method: 'PATCH',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ start_date: '2026-07-14', estimation: 'm' }),
+  });
+  assert.equal(detail.status, 200, await detail.text());
+
+  const response = await app().request(`/api/tasks/project/${projectAId}`, { method: 'GET' });
+  assert.equal(response.status, 200);
+  const listed = (await response.json() as any[]).find((task) => task.id === taskId);
+  assert.ok(listed);
+  assert.equal(listed.start_date.slice(0, 10), '2026-07-14');
+  assert.equal(listed.estimation, 'm');
 });
 
 test('PATCH /api/tasks/:id rejects project_id change with 400 PROJECT_CHANGE_UNSUPPORTED', async () => {
@@ -224,6 +247,122 @@ test('PATCH /api/tasks/:id with project_id change AND other fields still rejects
     assert.notEqual(r.rows[0].title, 'should-not-stick');
     assert.equal(r.rows[0].project_id, projectAId);
   });
+});
+
+test('PATCH /api/tasks/:id rejects a stale expected_updated_at without overwriting the newer task', async () => {
+  const initial = await getTaskSnapshot(taskId!);
+  const firstTitle = `fresh-title-${Date.now()}`;
+
+  const first = await app().request(`/api/tasks/${taskId}`, {
+    method: 'PATCH',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ title: firstTitle, expected_updated_at: initial.updated_at }),
+  });
+  const firstBody = await first.json() as any;
+  assert.equal(first.status, 200, JSON.stringify({ initial, firstBody }));
+
+  const stale = await app().request(`/api/tasks/${taskId}`, {
+    method: 'PATCH',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ title: 'must-not-overwrite', expected_updated_at: initial.updated_at }),
+  });
+  assert.equal(stale.status, 409);
+  const body = await stale.json() as any;
+  assert.equal(body.code, 'TASK_STALE');
+  assert.equal(body.current_task.title, firstTitle);
+
+  const persisted = await getTaskSnapshot(taskId!);
+  assert.equal(persisted.title, firstTitle);
+});
+
+test('PATCH /api/tasks/:id allows only one concurrent writer for the same version', async () => {
+  const initial = await getTaskSnapshot(taskId!);
+  const titles = [`concurrent-a-${Date.now()}`, `concurrent-b-${Date.now()}`];
+
+  const responses = await Promise.all(titles.map((title) => app().request(`/api/tasks/${taskId}`, {
+    method: 'PATCH',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ title, expected_updated_at: initial.updated_at }),
+  })));
+
+  assert.deepEqual(responses.map((response) => response.status).sort(), [200, 409]);
+  const persisted = await getTaskSnapshot(taskId!);
+  assert.ok(titles.includes(persisted.title));
+});
+
+test('PATCH /api/tasks/:id replaces labels atomically and rejects stale label writes', async () => {
+  const labelIds = await withClient(async (c) => {
+    const result = await c.query(
+      `INSERT INTO labels (id, org_id, name, color)
+       VALUES (gen_random_uuid()::text, $1, $2, '#7c3aed'), (gen_random_uuid()::text, $1, $3, '#059669')
+       RETURNING id`,
+      [ORG_ID, `table-label-a-${Date.now()}`, `table-label-b-${Date.now()}`],
+    );
+    return result.rows.map((row) => row.id as string);
+  });
+
+  try {
+    const initial = await getTaskSnapshot(taskId!);
+    const applied = await app().request(`/api/tasks/${taskId}`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ label_ids: labelIds, expected_updated_at: initial.updated_at }),
+    });
+    assert.equal(applied.status, 200, await applied.text());
+
+    const persisted = await withClient(async (c) => {
+      const result = await c.query(`SELECT label_id FROM task_labels WHERE task_id = $1 ORDER BY label_id`, [taskId]);
+      return result.rows.map((row) => row.label_id as string);
+    });
+    assert.deepEqual(persisted, [...labelIds].sort());
+
+    const stale = await app().request(`/api/tasks/${taskId}`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ label_ids: [], expected_updated_at: initial.updated_at }),
+    });
+    assert.equal(stale.status, 409);
+  } finally {
+    await withClient(async (c) => {
+      await c.query(`DELETE FROM task_labels WHERE label_id = ANY($1::text[])`, [labelIds]);
+      await c.query(`DELETE FROM labels WHERE id = ANY($1::text[])`, [labelIds]);
+    });
+  }
+});
+
+test('PATCH /api/tasks/:id preserves version coherence across 100 sequential table edits', async () => {
+  let version = (await getTaskSnapshot(taskId!)).updated_at;
+  let expectedTitle = '';
+
+  for (let index = 0; index < 100; index += 1) {
+    expectedTitle = `table-sequence-${index}-${Date.now()}`;
+    const response = await app().request(`/api/tasks/${taskId}`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        title: expectedTitle,
+        expected_updated_at: version,
+      }),
+    });
+    const body = await response.json() as any;
+    assert.equal(response.status, 200, JSON.stringify(body));
+    version = body.updated_at;
+  }
+
+  const persisted = await getTaskSnapshot(taskId!);
+  assert.equal(persisted.title, expectedTitle);
+  assert.equal(persisted.updated_at, version);
+});
+
+test('PATCH /api/tasks/:id rejects malformed expected_updated_at', async () => {
+  const res = await app().request(`/api/tasks/${taskId}`, {
+    method: 'PATCH',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ status: 'todo', expected_updated_at: 'not-a-date' }),
+  });
+  assert.equal(res.status, 400);
+  const body = await res.json() as any;
+  assert.equal(body.code, 'VALIDATION_ERROR');
 });
 
 test('PATCH /api/tasks/:id with project_id equal to current is ignored, not rejected', async () => {

--- a/apps/web/src/app/(app)/tasks/page.tsx
+++ b/apps/web/src/app/(app)/tasks/page.tsx
@@ -6,7 +6,7 @@ import { api } from '@/lib/api';
 import { getSocket } from '@/lib/socket';
 import { useSearchParams, useRouter } from 'next/navigation';
 import { TaskBoard } from '@/components/task-board';
-import { TaskList } from '@/components/task-list';
+import { TaskTable } from '@/components/task-list';
 import { TaskDetail } from '@/components/task-detail';
 import { TaskFilters, type Filters } from '@/components/task-filters';
 import { TaskQuickCreate } from '@/components/task-quick-create';
@@ -39,6 +39,11 @@ const TaskTimeline = lazy(() => import('./timeline'));
 import { EmptyState } from '@/components/empty-state';
 import { CreateProjectModal } from '@/components/create-project-modal';
 import { PersonAvatar } from '@/components/person-avatar';
+import {
+  parseTaskSurfaceView,
+  shouldApplyProjectDefaultView,
+  type TaskSurfaceView,
+} from '@/lib/task-view-config';
 
 type Task = {
   id: string;
@@ -82,6 +87,10 @@ type Project = {
   done_tasks: number;
 };
 
+type TaskPatch = Partial<Pick<Task, 'title' | 'status' | 'priority' | 'assignee_id' | 'due_date' | 'start_date' | 'estimation'>> & {
+  label_ids?: string[];
+};
+
 const STATUS_OPTIONS = [
   { value: 'backlog', label: statusLabel('backlog') },
   { value: 'todo', label: statusLabel('todo') },
@@ -107,10 +116,9 @@ export default function TasksPage() {
   const [selectedTask, setSelectedTask] = useState<Task | null>(null);
 
   // Fix 1: derive view from URL (falls back to 'board')
-  const VIEW_VALUES = ['board', 'list', 'timeline', 'calendar', 'pipeline'] as const;
-  type View = typeof VIEW_VALUES[number];
-  const urlView = searchParams.get('view') as View | null;
-  const view: View = urlView && (VIEW_VALUES as readonly string[]).includes(urlView) ? urlView : 'board';
+  type View = TaskSurfaceView;
+  const requestedView = searchParams.get('view');
+  const view: View = parseTaskSurfaceView(requestedView) ?? 'board';
 
   // Task 4.9 — once the user toggles the view manually, we stop auto-selecting
   // the resolved-config default so their preference wins.
@@ -126,6 +134,10 @@ export default function TasksPage() {
     const str = qs.toString();
     router.replace(`/tasks${str ? '?' + str : ''}`);
   }, [searchParams, router]);
+
+  useEffect(() => {
+    if (requestedView === 'list') setQuery({ view: 'table' });
+  }, [requestedView, setQuery]);
 
   // Fix 1: initialize filters from URL params on mount
   const [filters, setFilters] = useState<Filters>(() => {
@@ -150,6 +162,7 @@ export default function TasksPage() {
   const [selectedTaskIds, setSelectedTaskIds] = useState<Set<string>>(new Set());
   const [bulkActionDropdown, setBulkActionDropdown] = useState<string | null>(null);
   const [orgMembers, setOrgMembers] = useState<{ id: string; name: string; avatar_url: string | null }[]>([]);
+  const [orgLabels, setOrgLabels] = useState<{ id: string; name: string; color: string }[]>([]);
   const [toast, setToast] = useState<string | null>(null);
   const [velocity, setVelocity] = useState<{ average: number } | null>(null);
   const [isMobile, setIsMobile] = useState(false);
@@ -164,7 +177,7 @@ export default function TasksPage() {
 
   const viewOptions = useMemo(() => [
     { value: 'board' as View, label: 'Board', icon: <LayoutGrid size={14} /> },
-    { value: 'list' as View, label: 'List', icon: <List size={14} /> },
+    { value: 'table' as View, label: 'Table', icon: <List size={14} /> },
     { value: 'timeline' as View, label: 'Timeline', icon: <GanttChartSquare size={14} /> },
     { value: 'calendar' as View, label: 'Calendar', icon: <CalendarDays size={14} /> },
     { value: 'pipeline' as View, label: 'Pipeline', icon: <GitBranch size={14} /> },
@@ -178,7 +191,7 @@ export default function TasksPage() {
   useEffect(() => {
     if (typeof window === 'undefined') return;
     if (window.innerWidth < 768 && view === 'calendar') {
-      setQuery({ view: 'list' });
+      setQuery({ view: 'table' });
     }
   }, [view]);
 
@@ -192,12 +205,12 @@ export default function TasksPage() {
   // the user has already picked a view. "timeline" is kept engineering-only
   // (not a valid skill default today but guarded anyway).
   useEffect(() => {
-    if (!resolvedConfig || userSelectedView || isMyTasksView) return;
+    if (!resolvedConfig || !shouldApplyProjectDefaultView({ requestedView, userSelectedView, isMyTasksView })) return;
     const dv = resolvedConfig.default_view;
     if (dv && dv !== view && (dv === 'board' || dv === 'list' || dv === 'timeline' || dv === 'calendar' || dv === 'pipeline')) {
-      setQuery({ view: dv });
+      setQuery({ view: dv === 'list' ? 'table' : dv });
     }
-  }, [resolvedConfig, userSelectedView, isMyTasksView]);
+  }, [resolvedConfig, requestedView, userSelectedView, isMyTasksView, view, setQuery]);
 
   // Load projects
   useEffect(() => {
@@ -348,6 +361,13 @@ export default function TasksPage() {
         const list = data.members || data || [];
         setOrgMembers(list);
       }
+    });
+  }, [user]);
+
+  useEffect(() => {
+    if (!user) return;
+    api.get('/api/tasks/labels').then(async (res) => {
+      if (res.ok) setOrgLabels(await res.json());
     });
   }, [user]);
 
@@ -621,14 +641,59 @@ export default function TasksPage() {
     return Array.from(map.values());
   }, [filteredTasks]);
 
-  const handleStatusChange = async (taskId: string, newStatus: string) => {
-    setTasks((prev) =>
-      prev.map((t) => (t.id === taskId ? { ...t, status: newStatus as Task['status'] } : t))
-    );
+  const handleTaskPatch = async (taskId: string, patch: TaskPatch): Promise<boolean> => {
+    const previousTask = tasks.find((task) => task.id === taskId);
+    if (!previousTask) return false;
+
+    const member = patch.assignee_id !== undefined
+      ? orgMembers.find((candidate) => candidate.id === patch.assignee_id)
+      : null;
+    const optimistic: Task = {
+      ...previousTask,
+      ...patch,
+      ...(patch.assignee_id !== undefined ? {
+        assignee_name: member?.name ?? null,
+        assignee_avatar: member?.avatar_url ?? null,
+      } : {}),
+      ...(patch.label_ids ? { labels: orgLabels.filter((label) => patch.label_ids!.includes(label.id)) } : {}),
+    };
+
+    setTasks((prev) => prev.map((task) => task.id === taskId ? optimistic : task));
     if (selectedTask?.id === taskId) {
-      setSelectedTask((prev) => prev ? { ...prev, status: newStatus as Task['status'] } : null);
+      setSelectedTask(optimistic);
     }
-    await api.patch(`/api/tasks/${taskId}`, { status: newStatus });
+    const res = await api.patch(`/api/tasks/${taskId}`, {
+      ...patch,
+      expected_updated_at: previousTask.updated_at,
+    });
+
+    if (res.ok) {
+      const updated = await res.json();
+      setTasks((prev) => prev.map((task) => task.id === taskId ? { ...optimistic, ...updated } : task));
+      if (selectedTask?.id === taskId) {
+        setSelectedTask({ ...optimistic, ...updated });
+      }
+      return true;
+    }
+
+    setTasks((prev) => prev.map((task) => task.id === taskId ? previousTask : task));
+    if (selectedTask?.id === taskId) setSelectedTask(previousTask);
+
+    let code = '';
+    try {
+      const body = await res.json();
+      code = typeof body?.code === 'string' ? body.code : '';
+    } catch {}
+
+    setToast(code === 'TASK_STALE'
+      ? 'This task changed elsewhere. The latest version is being loaded.'
+      : 'Update failed. Your previous value was restored.');
+    if (code === 'TASK_STALE') await loadTasks();
+    return false;
+  };
+
+  const handleStatusChange = async (taskId: string, newStatus: string) => {
+    await handleTaskPatch(taskId, { status: newStatus });
   };
 
   const handleReorder = async (taskId: string, newSortOrder: number) => {
@@ -884,18 +949,18 @@ export default function TasksPage() {
                 <span className="hidden md:inline">Board</span>
               </button>
               <button
-                aria-label="List view"
-                onClick={() => { setQuery({ view: 'list' }); setUserSelectedView(true); }}
+                aria-label="Table view"
+                onClick={() => { setQuery({ view: 'table' }); setUserSelectedView(true); }}
                 className="deft-pill"
-                data-active={view === 'list'}
+                data-active={view === 'table'}
                 style={{
-                  background: view === 'list' ? 'var(--accent)' : 'transparent',
-                  color: view === 'list' ? 'white' : 'var(--muted)',
+                  background: view === 'table' ? 'var(--accent)' : 'transparent',
+                  color: view === 'table' ? 'white' : 'var(--muted)',
                   fontFamily: 'var(--font-heading)',
                 }}
               >
                 <List size={13} />
-                <span className="hidden md:inline">List</span>
+                <span className="hidden md:inline">Table</span>
               </button>
               <button
                 aria-label="Timeline view"
@@ -1093,11 +1158,13 @@ export default function TasksPage() {
                       onToggleSelect={handleToggleSelect}
                     />
                   ) : (
-                    <TaskList
+                    <TaskTable
                       tasks={group.tasks}
                       projectPrefix={group.prefix}
                       onTaskClick={handleTaskClick}
-                      onStatusChange={handleStatusChange}
+                      onTaskPatch={handleTaskPatch}
+                      members={orgMembers}
+                      availableLabels={orgLabels}
                       selectedTaskId={selectedTask?.id || null}
                       selectionMode={selectionMode}
                       selectedTaskIds={selectedTaskIds}
@@ -1145,12 +1212,14 @@ export default function TasksPage() {
                 statuses={resolvedConfig?.statuses}
                 hidePrefixIds={resolvedConfig?.hide_prefix_ids}
               />
-            ) : view === 'list' ? (
-              <TaskList
+            ) : view === 'table' ? (
+              <TaskTable
                 tasks={filteredTasks}
                 projectPrefix={selectedProject?.prefix || ''}
                 onTaskClick={handleTaskClick}
-                onStatusChange={handleStatusChange}
+                onTaskPatch={handleTaskPatch}
+                members={orgMembers}
+                availableLabels={orgLabels}
                 selectedTaskId={selectedTask?.id || null}
                 selectionMode={selectionMode}
                 selectedTaskIds={selectedTaskIds}

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -705,3 +705,17 @@ input:focus, textarea:focus {
 .hljs-attribute { color: #d19a66; }
 .hljs-regexp { color: #56b6c2; }
 .hljs-symbol, .hljs-bullet { color: #56b6c2; }
+
+/* Native task-table selects need an explicit scheme on Windows/Chrome. */
+.task-table-select {
+  color-scheme: dark;
+}
+
+.light .task-table-select {
+  color-scheme: light;
+}
+
+.task-table-select option {
+  background: var(--surface-container);
+  color: var(--foreground);
+}

--- a/apps/web/src/components/task-list.tsx
+++ b/apps/web/src/components/task-list.tsx
@@ -1,11 +1,12 @@
 'use client';
 
 import React, { useState, useMemo, useEffect } from 'react';
-import { ChevronDown, ChevronUp, ArrowUpDown, Calendar, Check } from 'lucide-react';
+import { ChevronDown, ChevronUp, ArrowUpDown, Check, Loader2, Tags } from 'lucide-react';
 import { statusLabel } from '@/lib/task-status-labels';
 import { TaskCardUnified } from './task-card-unified';
-import type { ResolvedStatus, PriorityVocab, CanonicalPriority } from '@/hooks/use-project-resolved-config';
+import type { ResolvedStatus, PriorityVocab } from '@/hooks/use-project-resolved-config';
 import { priorityLabel } from '@/hooks/use-project-resolved-config';
+import { PersonAvatar } from './person-avatar';
 
 type Task = {
   id: string;
@@ -42,7 +43,9 @@ type Props = {
   tasks: Task[];
   projectPrefix: string;
   onTaskClick: (task: Task) => void;
-  onStatusChange: (taskId: string, newStatus: string) => void;
+  onTaskPatch: (taskId: string, patch: TaskPatch) => Promise<boolean>;
+  members: { id: string; name: string; avatar_url: string | null }[];
+  availableLabels: { id: string; name: string; color: string }[];
   selectedTaskId: string | null;
   selectionMode?: boolean;
   selectedTaskIds?: Set<string>;
@@ -53,7 +56,11 @@ type Props = {
   priorityVocab?: PriorityVocab;
 };
 
-type SortField = 'number' | 'title' | 'status' | 'priority' | 'assignee' | 'due_date' | 'updated_at';
+type TaskPatch = Partial<Pick<Task, 'title' | 'status' | 'priority' | 'assignee_id' | 'due_date' | 'start_date' | 'estimation'>> & {
+  label_ids?: string[];
+};
+
+type SortField = 'number' | 'title' | 'status' | 'priority' | 'assignee' | 'start_date' | 'due_date' | 'estimation' | 'labels' | 'updated_at';
 type SortDir = 'asc' | 'desc';
 
 const DEFAULT_STATUS_OPTIONS = [
@@ -75,6 +82,7 @@ const STATUS_COLORS: Record<string, string> = {
 };
 
 const PRIORITY_ORDER = { p0: 0, p1: 1, p2: 2, p3: 3 };
+const PAGE_SIZE = 50;
 const PRIORITY_STYLES: Record<string, { bg: string; color: string }> = {
   p0: { bg: 'rgba(220, 38, 38, 0.15)', color: '#DC2626' },
   p1: { bg: 'rgba(245, 158, 11, 0.15)', color: '#F59E0B' },
@@ -112,7 +120,13 @@ function formatDueDate(dateStr: string | null, status?: string): { text: string;
   return { text: dateText, color: 'var(--foreground-secondary)' };
 }
 
-export function TaskList({ tasks, projectPrefix, onTaskClick, onStatusChange, selectedTaskId, selectionMode, selectedTaskIds, onToggleSelect, statuses, hidePrefixIds, priorityVocab }: Props) {
+function dateInputValue(value: string | null): string {
+  if (!value) return '';
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? '' : date.toISOString().slice(0, 10);
+}
+
+export function TaskTable({ tasks, projectPrefix, onTaskClick, onTaskPatch, members, availableLabels, selectedTaskId, selectionMode, selectedTaskIds, onToggleSelect, statuses, hidePrefixIds, priorityVocab }: Props) {
   const STATUS_OPTIONS = useMemo(() => {
     if (!statuses || statuses.length === 0) return DEFAULT_STATUS_OPTIONS;
     return [...statuses]
@@ -125,9 +139,10 @@ export function TaskList({ tasks, projectPrefix, onTaskClick, onStatusChange, se
   const [sortField, setSortField] = useState<SortField>('number');
   const [sortDir, setSortDir] = useState<SortDir>('desc');
   const [inlineDropdown, setInlineDropdown] = useState<{ taskId: string; field: string } | null>(null);
+  const [editingTitle, setEditingTitle] = useState<{ taskId: string; value: string } | null>(null);
+  const [savingCell, setSavingCell] = useState<string | null>(null);
   const [isMobile, setIsMobile] = useState(false);
   // Fix 3: client-side pagination — show 50 rows at a time
-  const PAGE_SIZE = 50;
   const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
 
   useEffect(() => {
@@ -138,6 +153,7 @@ export function TaskList({ tasks, projectPrefix, onTaskClick, onStatusChange, se
   }, []);
 
   const handleSort = (field: SortField) => {
+    setVisibleCount(PAGE_SIZE);
     if (sortField === field) {
       setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
     } else {
@@ -147,8 +163,6 @@ export function TaskList({ tasks, projectPrefix, onTaskClick, onStatusChange, se
   };
 
   const sorted = useMemo(() => {
-    // Reset pagination when data or sort changes
-    setVisibleCount(PAGE_SIZE);
     return [...tasks].sort((a, b) => {
       let cmp = 0;
       switch (sortField) {
@@ -157,7 +171,10 @@ export function TaskList({ tasks, projectPrefix, onTaskClick, onStatusChange, se
         case 'status': cmp = a.status.localeCompare(b.status); break;
         case 'priority': cmp = PRIORITY_ORDER[a.priority] - PRIORITY_ORDER[b.priority]; break;
         case 'assignee': cmp = (a.assignee_name || '').localeCompare(b.assignee_name || ''); break;
+        case 'start_date': cmp = (a.start_date || '').localeCompare(b.start_date || ''); break;
         case 'due_date': cmp = (a.due_date || '').localeCompare(b.due_date || ''); break;
+        case 'estimation': cmp = (a.estimation || '').localeCompare(b.estimation || ''); break;
+        case 'labels': cmp = a.labels.map((label) => label.name).join(',').localeCompare(b.labels.map((label) => label.name).join(',')); break;
         case 'updated_at': cmp = a.updated_at.localeCompare(b.updated_at); break;
       }
       return sortDir === 'desc' ? -cmp : cmp;
@@ -178,12 +195,22 @@ export function TaskList({ tasks, projectPrefix, onTaskClick, onStatusChange, se
     { field: 'status', label: 'Status', width: '130px' },
     { field: 'priority', label: 'Priority', width: '80px' },
     { field: 'assignee', label: 'Assignee', width: '140px' },
+    { field: 'start_date', label: 'Start', width: '120px' },
     { field: 'due_date', label: 'Due', width: '110px' },
+    { field: 'estimation', label: 'Estimate', width: '90px' },
+    { field: 'labels', label: 'Labels', width: '180px' },
     { field: 'updated_at', label: 'Updated', width: '110px' },
   ];
 
-
-  const hasAnyEstimation = tasks.some(t => t.estimation);
+  const save = async (taskId: string, field: string, patch: TaskPatch) => {
+    const key = `${taskId}:${field}`;
+    // ponytail: serialize table writes for v1; per-cell concurrency can wait until users need it.
+    if (savingCell) return false;
+    setSavingCell(key);
+    const ok = await onTaskPatch(taskId, patch);
+    setSavingCell(null);
+    return ok;
+  };
 
   if (isMobile) {
     return (
@@ -197,18 +224,50 @@ export function TaskList({ tasks, projectPrefix, onTaskClick, onStatusChange, se
           const isSelected = task.id === selectedTaskId;
           const isChecked = selectionMode && selectedTaskIds?.has(task.id);
           return (
-            <TaskCardUnified
-              key={task.id}
-              variant="list"
-              task={task as any}
-              projectPrefix={projectPrefix}
-              onClick={() => onTaskClick(task)}
-              isSelected={isSelected}
-              selectionMode={selectionMode}
-              isChecked={isChecked}
-              onToggleSelect={onToggleSelect}
-              hidePrefixIds={hidePrefixIds}
-            />
+            <div key={task.id} className="overflow-hidden rounded-lg" style={{ border: '1px solid var(--border)', background: 'var(--card-bg)' }}>
+              <TaskCardUnified
+                variant="list"
+                task={task as any}
+                projectPrefix={projectPrefix}
+                onClick={() => onTaskClick(task)}
+                isSelected={isSelected}
+                selectionMode={selectionMode}
+                isChecked={isChecked}
+                onToggleSelect={onToggleSelect}
+                hidePrefixIds={hidePrefixIds}
+              />
+              <div className="grid grid-cols-3 gap-1 px-3 pb-3" onClick={(event) => event.stopPropagation()}>
+                <select
+                  aria-label={`Status for ${task.title}`}
+                  value={task.status}
+                  disabled={savingCell !== null}
+                  onChange={(event) => void save(task.id, 'status', { status: event.target.value })}
+                  className="task-table-select min-w-0 rounded-md px-2 py-1.5 text-[11px]"
+                  style={{ background: 'var(--surface-container-low)', border: '1px solid var(--border)', color: 'var(--foreground-secondary)' }}
+                >
+                  {STATUS_OPTIONS.map((option) => <option key={option.value} value={option.value}>{option.label}</option>)}
+                </select>
+                <select
+                  aria-label={`Priority for ${task.title}`}
+                  value={task.priority}
+                  disabled={savingCell !== null}
+                  onChange={(event) => void save(task.id, 'priority', { priority: event.target.value as Task['priority'] })}
+                  className="task-table-select min-w-0 rounded-md px-2 py-1.5 text-[11px]"
+                  style={{ background: 'var(--surface-container-low)', border: '1px solid var(--border)', color: 'var(--foreground-secondary)' }}
+                >
+                  {(['p0', 'p1', 'p2', 'p3'] as const).map((priority) => <option key={priority} value={priority}>{priorityLabel(priority, priorityVocab)}</option>)}
+                </select>
+                <input
+                  type="date"
+                  aria-label={`Due date for ${task.title}`}
+                  value={dateInputValue(task.due_date)}
+                  disabled={savingCell !== null}
+                  onChange={(event) => void save(task.id, 'due_date', { due_date: event.target.value || null })}
+                  className="min-w-0 rounded-md px-1 py-1.5 text-[10px]"
+                  style={{ background: 'var(--surface-container-low)', border: '1px solid var(--border)', color: 'var(--foreground-secondary)', colorScheme: 'dark light' }}
+                />
+              </div>
+            </div>
           );
         })}
         {/* Fix 3: Load more */}
@@ -232,7 +291,7 @@ export function TaskList({ tasks, projectPrefix, onTaskClick, onStatusChange, se
       {/* Click-away */}
       {inlineDropdown && <div className="fixed inset-0 z-10" onClick={() => setInlineDropdown(null)} />}
 
-      <table className="w-full min-w-[800px]" style={{ borderCollapse: 'separate', borderSpacing: 0 }}>
+      <table className="w-full min-w-[1250px]" style={{ borderCollapse: 'separate', borderSpacing: 0 }}>
         <thead>
           <tr>
             {selectionMode && (
@@ -258,6 +317,8 @@ export function TaskList({ tasks, projectPrefix, onTaskClick, onStatusChange, se
                     width: col.width === '1fr' ? undefined : col.width,
                     whiteSpace: col.field === 'status' ? 'nowrap' : undefined,
                     minWidth: col.field === 'status' ? '100px' : undefined,
+                    left: col.field === 'number' ? (selectionMode ? 32 : 0) : col.field === 'title' ? (selectionMode ? 112 : 80) : undefined,
+                    zIndex: col.field === 'number' || col.field === 'title' ? 4 : 2,
                   }}
                 >
                   <div className="flex items-center gap-1">
@@ -265,20 +326,6 @@ export function TaskList({ tasks, projectPrefix, onTaskClick, onStatusChange, se
                     <SortIcon field={col.field} />
                   </div>
                 </th>
-                {col.field === 'priority' && hasAnyEstimation && (
-                  <th
-                    className="text-left px-3 py-2 text-[11px] font-semibold uppercase tracking-wide select-none sticky top-0"
-                    style={{
-                      color: 'var(--muted)',
-                      fontFamily: 'var(--font-heading)',
-                      background: 'var(--surface)',
-                      borderBottom: '1px solid var(--border)',
-                      width: '60px',
-                    }}
-                  >
-                    Est.
-                  </th>
-                )}
               </React.Fragment>
             ))}
           </tr>
@@ -286,13 +333,21 @@ export function TaskList({ tasks, projectPrefix, onTaskClick, onStatusChange, se
         <tbody>
           {visibleRows.map((task) => {
             const priorityStyle = PRIORITY_STYLES[task.priority];
-            const priorityText = priorityLabel(task.priority as CanonicalPriority, priorityVocab);
             const isSelected = task.id === selectedTaskId;
             const isChecked = selectionMode && selectedTaskIds?.has(task.id);
 
             return (
               <tr
                 key={task.id}
+                tabIndex={0}
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter' && event.target === event.currentTarget) onTaskClick(task);
+                  if ((event.key === 'ArrowDown' || event.key === 'ArrowUp') && event.target === event.currentTarget) {
+                    event.preventDefault();
+                    const sibling = event.key === 'ArrowDown' ? event.currentTarget.nextElementSibling : event.currentTarget.previousElementSibling;
+                    if (sibling instanceof HTMLElement) sibling.focus();
+                  }
+                }}
                 onClick={() => {
                   if (selectionMode && onToggleSelect) {
                     onToggleSelect(task.id);
@@ -338,7 +393,7 @@ export function TaskList({ tasks, projectPrefix, onTaskClick, onStatusChange, se
                 {/* ID */}
                 <td
                   className="px-3 py-2.5 text-[12px] font-medium"
-                  style={{ color: 'var(--muted)', fontFamily: 'var(--font-heading)', borderBottom: '1px solid var(--border)' }}
+                  style={{ color: 'var(--muted)', fontFamily: 'var(--font-heading)', borderBottom: '1px solid var(--border)', position: 'sticky', left: selectionMode ? 32 : 0, zIndex: 2, background: isSelected ? 'var(--accent-subtle)' : 'var(--surface)' }}
                 >
                   {hidePrefixIds ? '' : `${projectPrefix || task.project_prefix}-${task.number}`}
                 </td>
@@ -346,29 +401,37 @@ export function TaskList({ tasks, projectPrefix, onTaskClick, onStatusChange, se
                 {/* Title */}
                 <td
                   className="px-3 py-2.5 text-[13px]"
-                  style={{ color: 'var(--foreground)', fontFamily: 'var(--font-body)', borderBottom: '1px solid var(--border)' }}
+                  style={{ color: 'var(--foreground)', fontFamily: 'var(--font-body)', borderBottom: '1px solid var(--border)', position: 'sticky', left: selectionMode ? 112 : 80, zIndex: 2, background: isSelected ? 'var(--accent-subtle)' : 'var(--surface)' }}
+                  onClick={(event) => event.stopPropagation()}
                 >
-                  <div className="flex items-center gap-2">
-                    <span className="truncate">{task.title}</span>
-                    {task.labels.length > 0 && (
-                      <div className="flex gap-1 flex-shrink-0">
-                        {task.labels.slice(0, 2).map((l) => (
-                          <span
-                            key={l.id}
-                            className="text-[10px] font-medium px-1.5 py-0.5 rounded-full"
-                            style={{ background: `${l.color}20`, color: l.color }}
-                          >
-                            {l.name}
-                          </span>
-                        ))}
-                        {task.labels.length > 2 && (
-                          <span className="text-[10px]" style={{ color: 'var(--muted)' }}>
-                            +{task.labels.length - 2}
-                          </span>
-                        )}
-                      </div>
-                    )}
-                  </div>
+                  {editingTitle?.taskId === task.id ? (
+                    <input
+                      autoFocus
+                      value={editingTitle.value}
+                      aria-label={`Title for ${projectPrefix || task.project_prefix}-${task.number}`}
+                      onChange={(event) => setEditingTitle({ taskId: task.id, value: event.target.value })}
+                      onBlur={() => setEditingTitle(null)}
+                      onKeyDown={async (event) => {
+                        if (event.key === 'Escape') setEditingTitle(null);
+                        if (event.key === 'Enter') {
+                          event.preventDefault();
+                          const title = editingTitle.value.trim();
+                          if (title && title !== task.title && await save(task.id, 'title', { title })) setEditingTitle(null);
+                        }
+                      }}
+                      className="w-full rounded-md px-2 py-1 text-[13px] outline-none"
+                      style={{ background: 'var(--surface-container-low)', border: '1px solid var(--accent)', color: 'var(--foreground)' }}
+                    />
+                  ) : (
+                    <button
+                      className="w-full truncate text-left rounded px-1 py-1"
+                      onClick={() => setEditingTitle({ taskId: task.id, value: task.title })}
+                      onDoubleClick={() => onTaskClick(task)}
+                      title="Edit title; double-click for task details"
+                    >
+                      {task.title}
+                    </button>
+                  )}
                 </td>
 
                 {/* Status */}
@@ -408,7 +471,7 @@ export function TaskList({ tasks, projectPrefix, onTaskClick, onStatusChange, se
                             key={opt.value}
                             onClick={(e) => {
                               e.stopPropagation();
-                              onStatusChange(task.id, opt.value);
+                              void save(task.id, 'status', { status: opt.value });
                               setInlineDropdown(null);
                             }}
                             className="w-full text-left px-3 py-1.5 flex items-center gap-2 text-[12px]"
@@ -432,56 +495,60 @@ export function TaskList({ tasks, projectPrefix, onTaskClick, onStatusChange, se
                 <td
                   className="px-3 py-2.5"
                   style={{ borderBottom: '1px solid var(--border)' }}
+                  onClick={(event) => event.stopPropagation()}
                 >
-                  <span
-                    className="text-[10px] font-semibold px-1.5 py-0.5 rounded"
+                  <select
+                    aria-label={`Priority for ${task.title}`}
+                    value={task.priority}
+                    disabled={savingCell !== null}
+                    onChange={(event) => void save(task.id, 'priority', { priority: event.target.value as Task['priority'] })}
+                    className="task-table-select rounded-md px-2 py-1 text-[11px] font-semibold outline-none"
                     style={{
                       background: priorityStyle.bg,
                       color: priorityStyle.color,
+                      border: 0,
                       fontFamily: 'var(--font-heading)',
                     }}
                   >
-                    {priorityText}
-                  </span>
+                    {(['p0', 'p1', 'p2', 'p3'] as const).map((priority) => (
+                      <option key={priority} value={priority}>{priorityLabel(priority, priorityVocab)}</option>
+                    ))}
+                  </select>
                 </td>
-
-                {/* Est. */}
-                {hasAnyEstimation && (
-                  <td
-                    className="px-3 py-2.5"
-                    style={{ borderBottom: '1px solid var(--border)' }}
-                  >
-                    {task.estimation ? (
-                      <span
-                        className="text-[10px] font-medium px-1.5 py-0.5 rounded"
-                        style={{ background: 'var(--surface-container-high)', color: 'var(--muted)', fontFamily: 'var(--font-heading)' }}
-                      >
-                        {task.estimation.toUpperCase()}
-                      </span>
-                    ) : null}
-                  </td>
-                )}
 
                 {/* Assignee */}
                 <td
                   className="px-3 py-2.5"
                   style={{ borderBottom: '1px solid var(--border)' }}
+                  onClick={(event) => event.stopPropagation()}
                 >
-                  {task.assignee_name ? (
-                    <div className="flex items-center gap-2">
-                      <div
-                        className="w-5 h-5 rounded-full flex items-center justify-center text-[10px] font-medium text-white flex-shrink-0"
-                        style={{ background: 'var(--accent)' }}
-                      >
-                        {task.assignee_name.charAt(0).toUpperCase()}
-                      </div>
-                      <span className="text-[12px] truncate" style={{ color: 'var(--foreground)', fontFamily: 'var(--font-body)' }}>
-                        {task.assignee_name}
-                      </span>
-                    </div>
-                  ) : (
-                    <span className="text-[12px]" style={{ color: 'var(--muted)' }}>—</span>
-                  )}
+                  <div className="flex items-center gap-1.5">
+                    {task.assignee_name && <PersonAvatar name={task.assignee_name} avatarUrl={task.assignee_avatar} size={20} />}
+                    <select
+                      aria-label={`Assignee for ${task.title}`}
+                      value={task.assignee_id ?? ''}
+                      disabled={savingCell !== null}
+                      onChange={(event) => void save(task.id, 'assignee', { assignee_id: event.target.value || null })}
+                      className="task-table-select min-w-0 max-w-[110px] bg-transparent text-[12px] outline-none"
+                      style={{ color: task.assignee_name ? 'var(--foreground)' : 'var(--muted)' }}
+                    >
+                      <option value="">Unassigned</option>
+                      {members.map((member) => <option key={member.id} value={member.id}>{member.name}</option>)}
+                    </select>
+                  </div>
+                </td>
+
+                {/* Start Date */}
+                <td className="px-3 py-2.5" style={{ borderBottom: '1px solid var(--border)' }} onClick={(event) => event.stopPropagation()}>
+                  <input
+                    type="date"
+                    aria-label={`Start date for ${task.title}`}
+                    value={dateInputValue(task.start_date)}
+                    disabled={savingCell !== null}
+                    onChange={(event) => void save(task.id, 'start_date', { start_date: event.target.value || null })}
+                    className="w-[104px] bg-transparent text-[11px] outline-none"
+                    style={{ color: task.start_date ? 'var(--foreground-secondary)' : 'var(--muted)', colorScheme: 'dark light' }}
+                  />
                 </td>
 
                 {/* Due Date */}
@@ -491,28 +558,66 @@ export function TaskList({ tasks, projectPrefix, onTaskClick, onStatusChange, se
                     fontFamily: 'var(--font-body)',
                     borderBottom: '1px solid var(--border)',
                   }}
+                  onClick={(event) => event.stopPropagation()}
                 >
-                  {(() => {
-                    const dueInfo = formatDueDate(task.due_date, task.status);
-                    if (!dueInfo) return <span style={{ color: 'var(--muted)' }}>—</span>;
-                    if (dueInfo.badge) {
-                      return (
-                        <span
-                          className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium"
-                          style={{ background: dueInfo.badgeBg, color: dueInfo.color }}
-                        >
-                          <Calendar size={10} strokeWidth={1.5} />
-                          {dueInfo.badge}
-                        </span>
-                      );
-                    }
-                    return (
-                      <span className="flex items-center gap-1" style={{ color: dueInfo.color }}>
-                        <Calendar size={11} strokeWidth={1.5} />
-                        {dueInfo.text}
-                      </span>
-                    );
-                  })()}
+                  <input
+                    type="date"
+                    aria-label={`Due date for ${task.title}`}
+                    value={dateInputValue(task.due_date)}
+                    disabled={savingCell !== null}
+                    onChange={(event) => void save(task.id, 'due_date', { due_date: event.target.value || null })}
+                    className="w-[104px] bg-transparent text-[11px] outline-none"
+                    style={{ color: formatDueDate(task.due_date, task.status)?.color ?? 'var(--muted)', colorScheme: 'dark light' }}
+                  />
+                </td>
+
+                {/* Estimate */}
+                <td className="px-3 py-2.5" style={{ borderBottom: '1px solid var(--border)' }} onClick={(event) => event.stopPropagation()}>
+                  <select
+                    aria-label={`Estimate for ${task.title}`}
+                    value={task.estimation ?? ''}
+                    disabled={savingCell !== null}
+                    onChange={(event) => void save(task.id, 'estimation', { estimation: event.target.value || null })}
+                    className="task-table-select rounded-md bg-transparent px-1 py-1 text-[11px] outline-none"
+                    style={{ color: task.estimation ? 'var(--foreground-secondary)' : 'var(--muted)' }}
+                  >
+                    <option value="">None</option>
+                    {['xs', 's', 'm', 'l', 'xl'].map((estimate) => <option key={estimate} value={estimate}>{estimate.toUpperCase()}</option>)}
+                  </select>
+                </td>
+
+                {/* Labels */}
+                <td className="px-3 py-2.5" style={{ borderBottom: '1px solid var(--border)' }} onClick={(event) => event.stopPropagation()}>
+                  <div className="relative">
+                    <button
+                      aria-label={`Labels for ${task.title}`}
+                      onClick={() => setInlineDropdown(inlineDropdown?.taskId === task.id && inlineDropdown.field === 'labels' ? null : { taskId: task.id, field: 'labels' })}
+                      className="flex max-w-[160px] items-center gap-1 overflow-hidden rounded-md px-1 py-1 text-[11px]"
+                      style={{ color: task.labels.length ? 'var(--foreground-secondary)' : 'var(--muted)' }}
+                    >
+                      <Tags size={12} />
+                      <span className="truncate">{task.labels.length ? task.labels.map((label) => label.name).join(', ') : 'Add labels'}</span>
+                    </button>
+                    {inlineDropdown?.taskId === task.id && inlineDropdown.field === 'labels' && (
+                      <div className="absolute right-0 top-full z-20 mt-1 max-h-56 w-52 overflow-auto rounded-lg p-1" style={{ background: 'var(--card-bg)', border: '1px solid var(--border)', boxShadow: 'var(--shadow-lg)' }}>
+                        {availableLabels.map((label) => {
+                          const checked = task.labels.some((current) => current.id === label.id);
+                          return (
+                            <label key={label.id} className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-[12px] hover:bg-[var(--hover-tint)]">
+                              <input
+                                type="checkbox"
+                                checked={checked}
+                                disabled={savingCell !== null}
+                                onChange={() => void save(task.id, 'labels', { label_ids: checked ? task.labels.filter((current) => current.id !== label.id).map((current) => current.id) : [...task.labels.map((current) => current.id), label.id] })}
+                              />
+                              <span className="h-2 w-2 rounded-full" style={{ background: label.color }} />
+                              <span className="truncate">{label.name}</span>
+                            </label>
+                          );
+                        })}
+                      </div>
+                    )}
+                  </div>
                 </td>
 
                 {/* Updated */}
@@ -524,7 +629,10 @@ export function TaskList({ tasks, projectPrefix, onTaskClick, onStatusChange, se
                     borderBottom: '1px solid var(--border)',
                   }}
                 >
-                  {new Date(task.updated_at).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}
+                  <span className="flex items-center gap-1.5">
+                    {savingCell?.startsWith(`${task.id}:`) && <Loader2 size={12} className="animate-spin" />}
+                    {new Date(task.updated_at).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}
+                  </span>
                 </td>
               </tr>
             );

--- a/apps/web/src/lib/task-view-config.test.ts
+++ b/apps/web/src/lib/task-view-config.test.ts
@@ -1,0 +1,75 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  normalizeTaskViewConfig,
+  parseTaskSurfaceView,
+  shouldApplyProjectDefaultView,
+} from './task-view-config';
+
+test('normalizes legacy filter-only saved views into TaskViewConfigV1', () => {
+  const config = normalizeTaskViewConfig({
+    assigneeIds: ['user-1'],
+    priorities: ['p1'],
+    status: ['in_progress'],
+    labels: ['launch'],
+    dueDate: 'overdue',
+    dateFrom: '2026-07-01',
+    dateTo: '2026-07-31',
+    projectId: 'project-1',
+  });
+
+  assert.equal(config.version, 1);
+  assert.equal(config.view, 'board');
+  assert.deepEqual(config.filters.assigneeIds, ['user-1']);
+  assert.deepEqual(config.filters.status, ['in_progress']);
+  assert.equal(config.filters.projectId, 'project-1');
+  assert.deepEqual(config.sort, []);
+  assert.deepEqual(config.columns, []);
+});
+
+test('normalizes list to the canonical table view and bounds unsafe layout values', () => {
+  const config = normalizeTaskViewConfig({
+    version: 1,
+    view: 'list',
+    filters: {},
+    sort: [
+      { field: 'priority', direction: 'desc', nulls: 'first' },
+      { field: 'due_date', direction: 'sideways' },
+      { nope: true },
+    ],
+    columns: [
+      { id: 'title', visible: true, position: 0, width: 5000, frozen: true },
+      { id: 'status', position: 1, width: 12 },
+      { missing: 'id' },
+    ],
+    density: 'compact',
+    showSubtasks: true,
+  });
+
+  assert.equal(config.view, 'table');
+  assert.deepEqual(config.sort, [
+    { field: 'priority', direction: 'desc', nulls: 'first' },
+    { field: 'due_date', direction: 'asc', nulls: 'last' },
+  ]);
+  assert.equal(config.columns[0]?.width, 800);
+  assert.equal(config.columns[1]?.width, 64);
+  assert.equal(config.density, 'compact');
+  assert.equal(config.showSubtasks, true);
+});
+
+test('recognizes only currently rendered task surface views', () => {
+  assert.equal(parseTaskSurfaceView('calendar'), 'calendar');
+  assert.equal(parseTaskSurfaceView('table'), 'table');
+  assert.equal(parseTaskSurfaceView('list'), 'table');
+  assert.equal(parseTaskSurfaceView('my'), null);
+  assert.equal(parseTaskSurfaceView('made-up'), null);
+  assert.equal(parseTaskSurfaceView(null), null);
+});
+
+test('project default never overwrites an explicit valid or invalid view request', () => {
+  assert.equal(shouldApplyProjectDefaultView({ requestedView: 'calendar', userSelectedView: false, isMyTasksView: false }), false);
+  assert.equal(shouldApplyProjectDefaultView({ requestedView: 'made-up', userSelectedView: false, isMyTasksView: false }), false);
+  assert.equal(shouldApplyProjectDefaultView({ requestedView: null, userSelectedView: false, isMyTasksView: false }), true);
+  assert.equal(shouldApplyProjectDefaultView({ requestedView: null, userSelectedView: true, isMyTasksView: false }), false);
+  assert.equal(shouldApplyProjectDefaultView({ requestedView: null, userSelectedView: false, isMyTasksView: true }), false);
+});

--- a/apps/web/src/lib/task-view-config.ts
+++ b/apps/web/src/lib/task-view-config.ts
@@ -1,0 +1,176 @@
+export const TASK_VIEW_CONFIG_VERSION = 1 as const;
+
+export const TASK_SURFACE_VIEWS = ['board', 'table', 'timeline', 'calendar', 'pipeline'] as const;
+export type TaskSurfaceView = (typeof TASK_SURFACE_VIEWS)[number];
+
+export const TASK_CONFIG_VIEWS = ['board', 'table', 'timeline', 'calendar', 'pipeline'] as const;
+export type TaskConfigView = (typeof TASK_CONFIG_VIEWS)[number];
+
+export type TaskViewFiltersV1 = {
+  assigneeIds: string[];
+  priorities: string[];
+  status: string[];
+  labels: string[];
+  dueDate: string | null;
+  dateFrom: string | null;
+  dateTo: string | null;
+  projectId: string | null;
+};
+
+export type TaskViewSortClauseV1 = {
+  field: string;
+  direction: 'asc' | 'desc';
+  nulls: 'first' | 'last';
+};
+
+export type TaskViewGroupV1 = {
+  field: string;
+  direction: 'asc' | 'desc';
+} | null;
+
+export type TaskViewColumnV1 = {
+  id: string;
+  visible: boolean;
+  position: number;
+  width?: number;
+  frozen?: boolean;
+};
+
+export type TaskViewConfigV1 = {
+  version: typeof TASK_VIEW_CONFIG_VERSION;
+  view: TaskConfigView;
+  filters: TaskViewFiltersV1;
+  sort: TaskViewSortClauseV1[];
+  groupBy: TaskViewGroupV1;
+  columns: TaskViewColumnV1[];
+  density: 'compact' | 'comfortable';
+  showSubtasks: boolean;
+  projectId: string | null;
+};
+
+export const EMPTY_TASK_VIEW_FILTERS: TaskViewFiltersV1 = {
+  assigneeIds: [],
+  priorities: [],
+  status: [],
+  labels: [],
+  dueDate: null,
+  dateFrom: null,
+  dateTo: null,
+  projectId: null,
+};
+
+export const DEFAULT_TASK_VIEW_CONFIG: TaskViewConfigV1 = {
+  version: TASK_VIEW_CONFIG_VERSION,
+  view: 'board',
+  filters: EMPTY_TASK_VIEW_FILTERS,
+  sort: [],
+  groupBy: null,
+  columns: [],
+  density: 'comfortable',
+  showSubtasks: false,
+  projectId: null,
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function stringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : [];
+}
+
+function nullableString(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+function normalizeFilters(value: unknown): TaskViewFiltersV1 {
+  const filters = isRecord(value) ? value : {};
+  return {
+    assigneeIds: stringArray(filters.assigneeIds),
+    priorities: stringArray(filters.priorities),
+    status: stringArray(filters.status),
+    labels: stringArray(filters.labels),
+    dueDate: nullableString(filters.dueDate),
+    dateFrom: nullableString(filters.dateFrom),
+    dateTo: nullableString(filters.dateTo),
+    projectId: nullableString(filters.projectId),
+  };
+}
+
+function normalizeConfigView(value: unknown): TaskConfigView {
+  if (value === 'list') return 'table';
+  return typeof value === 'string' && (TASK_CONFIG_VIEWS as readonly string[]).includes(value)
+    ? value as TaskConfigView
+    : 'board';
+}
+
+/**
+ * Normalizes both versioned task-view configs and the legacy saved-view shape,
+ * where the entire payload was only a Filters object.
+ */
+export function normalizeTaskViewConfig(value: unknown): TaskViewConfigV1 {
+  const input = isRecord(value) ? value : {};
+  const isVersioned = input.version === TASK_VIEW_CONFIG_VERSION;
+  const rawFilters = isVersioned ? input.filters : input;
+
+  const sort = Array.isArray(input.sort)
+    ? input.sort.slice(0, 3).flatMap((item) => {
+        if (!isRecord(item) || typeof item.field !== 'string') return [];
+        return [{
+          field: item.field,
+          direction: item.direction === 'desc' ? 'desc' as const : 'asc' as const,
+          nulls: item.nulls === 'first' ? 'first' as const : 'last' as const,
+        }];
+      })
+    : [];
+
+  const rawGroup = isRecord(input.groupBy) && typeof input.groupBy.field === 'string'
+    ? {
+        field: input.groupBy.field,
+        direction: input.groupBy.direction === 'desc' ? 'desc' as const : 'asc' as const,
+      }
+    : null;
+
+  const columns = Array.isArray(input.columns)
+    ? input.columns.flatMap((item, index) => {
+        if (!isRecord(item) || typeof item.id !== 'string') return [];
+        const width = typeof item.width === 'number' && Number.isFinite(item.width)
+          ? Math.max(64, Math.min(800, item.width))
+          : undefined;
+        return [{
+          id: item.id,
+          visible: item.visible !== false,
+          position: typeof item.position === 'number' ? item.position : index,
+          ...(width === undefined ? {} : { width }),
+          ...(typeof item.frozen === 'boolean' ? { frozen: item.frozen } : {}),
+        }];
+      })
+    : [];
+
+  return {
+    version: TASK_VIEW_CONFIG_VERSION,
+    view: normalizeConfigView(input.view),
+    filters: normalizeFilters(rawFilters),
+    sort,
+    groupBy: rawGroup,
+    columns,
+    density: input.density === 'compact' ? 'compact' : 'comfortable',
+    showSubtasks: input.showSubtasks === true,
+    projectId: nullableString(input.projectId),
+  };
+}
+
+export function parseTaskSurfaceView(value: string | null): TaskSurfaceView | null {
+  if (value === 'list') return 'table';
+  return value && (TASK_SURFACE_VIEWS as readonly string[]).includes(value)
+    ? value as TaskSurfaceView
+    : null;
+}
+
+export function shouldApplyProjectDefaultView(params: {
+  requestedView: string | null;
+  userSelectedView: boolean;
+  isMyTasksView: boolean;
+}): boolean {
+  return params.requestedView === null && !params.userSelectedView && !params.isMyTasksView;
+}


### PR DESCRIPTION
## What changed

- promotes Table to a canonical task view while keeping the List URL as an alias
- adds inline edits for title, status, priority, assignee, dates, estimate, and labels
- adds optimistic concurrency protection and atomic label replacement
- normalizes durable task-view configuration for the next saved-view loop

## Why

Teams need a dense Monday-style operational surface without duplicating the existing task model or inventing custom fields.

## Validation

- web TypeScript check
- API TypeScript check
- task-view config tests: 4/4
- focused task PATCH API tests: 10/10, including stale writes and 100 sequential edits
- focused ESLint: 0 errors
- desktop and mobile browser smoke checks