### PR TITLE
Add durable task table layouts

### DIFF
--- a/apps/api/src/routes/tasks.ts
+++ b/apps/api/src/routes/tasks.ts
@@ -768,7 +768,7 @@ taskRoutes.delete('/saved-views/:id', async (c) => {
     const user = c.get('user');
     const viewId = c.req.param('id');
     const [view] = await db.select().from(savedViews)
-      .where(and(eq(savedViews.id, viewId), eq(savedViews.user_id, user.id))).limit(1);
+      .where(and(eq(savedViews.id, viewId), eq(savedViews.org_id, user.org_id), eq(savedViews.user_id, user.id))).limit(1);
     if (!view) return c.json({ error: 'View not found', code: 'NOT_FOUND' }, 404);
     await db.delete(savedViews).where(eq(savedViews.id, viewId));
     return c.json({ success: true });

--- a/apps/api/src/routes/tasks.ts
+++ b/apps/api/src/routes/tasks.ts
@@ -739,6 +739,30 @@ taskRoutes.post('/saved-views', async (c) => {
   }
 });
 
+taskRoutes.patch('/saved-views/:id', async (c) => {
+  try {
+    const user = c.get('user');
+    const viewId = c.req.param('id');
+    const parsed = createViewSchema.partial().safeParse(await c.req.json());
+    if (!parsed.success || Object.keys(parsed.data).length === 0) {
+      return c.json({ error: 'Invalid input', code: 'VALIDATION_ERROR' }, 400);
+    }
+    const [view] = await db.update(savedViews).set({
+      ...parsed.data,
+      updated_at: new Date(),
+    }).where(and(
+      eq(savedViews.id, viewId),
+      eq(savedViews.org_id, user.org_id),
+      eq(savedViews.user_id, user.id),
+    )).returning();
+    if (!view) return c.json({ error: 'View not found', code: 'NOT_FOUND' }, 404);
+    return c.json(view);
+  } catch (err) {
+    console.error('Failed to update saved view:', err);
+    return c.json({ error: 'Failed to update saved view', code: 'INTERNAL_ERROR' }, 500);
+  }
+});
+
 taskRoutes.delete('/saved-views/:id', async (c) => {
   try {
     const user = c.get('user');

--- a/apps/web/src/app/(app)/tasks/page.tsx
+++ b/apps/web/src/app/(app)/tasks/page.tsx
@@ -770,6 +770,14 @@ export default function TasksPage() {
     setQuickCreateOpen(false);
   };
 
+  const handleInlineCreate = async (title: string, defaults: Record<string, unknown>) => {
+    if (!selectedProject) return false;
+    const res = await api.post(`/api/projects/${selectedProject.id}/tasks`, { title, ...defaults });
+    if (!res.ok) return false;
+    await loadTasks();
+    return true;
+  };
+
   const handleDuplicate = async (taskId: string) => {
     const res = await api.post(`/api/tasks/${taskId}/duplicate`);
     if (res.ok) {
@@ -1266,6 +1274,7 @@ export default function TasksPage() {
                 priorityVocab={resolvedConfig?.priority_vocab}
                 viewConfig={currentViewConfig}
                 onViewConfigChange={setLayoutConfig}
+                onInlineCreate={handleInlineCreate}
               />
             ) : view === 'calendar' ? (
               <TaskCalendarView

--- a/apps/web/src/app/(app)/tasks/page.tsx
+++ b/apps/web/src/app/(app)/tasks/page.tsx
@@ -40,9 +40,12 @@ import { EmptyState } from '@/components/empty-state';
 import { CreateProjectModal } from '@/components/create-project-modal';
 import { PersonAvatar } from '@/components/person-avatar';
 import {
+  DEFAULT_TASK_VIEW_CONFIG,
+  normalizeTaskViewConfig,
   parseTaskSurfaceView,
   shouldApplyProjectDefaultView,
   type TaskSurfaceView,
+  type TaskViewConfigV1,
 } from '@/lib/task-view-config';
 
 type Task = {
@@ -152,6 +155,10 @@ export default function TasksPage() {
       projectId: searchParams.get('filterProject') || null,
     };
   });
+  const [layoutConfig, setLayoutConfig] = useState<TaskViewConfigV1>(() => ({
+    ...DEFAULT_TASK_VIEW_CONFIG,
+    view: 'table',
+  }));
   const [loading, setLoading] = useState(true);
   const [projectDropdownOpen, setProjectDropdownOpen] = useState(false);
   const [quickCreateOpen, setQuickCreateOpen] = useState(false);
@@ -732,6 +739,32 @@ export default function TasksPage() {
     });
   }, [setQuery]);
 
+  const currentViewConfig = useMemo<TaskViewConfigV1>(() => ({
+    ...layoutConfig,
+    view,
+    filters,
+    projectId: selectedProject?.id ?? null,
+  }), [layoutConfig, view, filters, selectedProject?.id]);
+
+  const handleApplyViewConfig = useCallback((input: TaskViewConfigV1) => {
+    const config = normalizeTaskViewConfig(input);
+    setLayoutConfig(config);
+    setFilters(config.filters as Filters);
+    setUserSelectedView(true);
+    setQuery({
+      view: config.view,
+      project: config.projectId,
+      assignee: config.filters.assigneeIds.length ? config.filters.assigneeIds.join(',') : null,
+      priority: config.filters.priorities.length ? config.filters.priorities.join(',') : null,
+      status: config.filters.status.length ? config.filters.status.join(',') : null,
+      labels: config.filters.labels.length ? config.filters.labels.join(',') : null,
+      dueDate: config.filters.dueDate,
+      dateFrom: config.filters.dateFrom,
+      dateTo: config.filters.dateTo,
+      filterProject: config.filters.projectId,
+    });
+  }, [setQuery]);
+
   const handleTaskCreated = () => {
     loadTasks();
     setQuickCreateOpen(false);
@@ -1112,6 +1145,8 @@ export default function TasksPage() {
           projects={projects}
           statuses={resolvedConfig?.statuses}
           priorityVocab={resolvedConfig?.priority_vocab}
+          viewConfig={currentViewConfig}
+          onApplyViewConfig={handleApplyViewConfig}
         />
 
         {/* Board or List view */}
@@ -1169,6 +1204,8 @@ export default function TasksPage() {
                       selectionMode={selectionMode}
                       selectedTaskIds={selectedTaskIds}
                       onToggleSelect={handleToggleSelect}
+                      viewConfig={currentViewConfig}
+                      onViewConfigChange={setLayoutConfig}
                     />
                   )}
                 </div>
@@ -1227,6 +1264,8 @@ export default function TasksPage() {
                 statuses={resolvedConfig?.statuses}
                 hidePrefixIds={resolvedConfig?.hide_prefix_ids}
                 priorityVocab={resolvedConfig?.priority_vocab}
+                viewConfig={currentViewConfig}
+                onViewConfigChange={setLayoutConfig}
               />
             ) : view === 'calendar' ? (
               <TaskCalendarView

--- a/apps/web/src/components/task-filters.tsx
+++ b/apps/web/src/components/task-filters.tsx
@@ -3,15 +3,18 @@
 import { useState, useEffect } from 'react';
 import { useAuth } from '@/lib/auth-context';
 import { api } from '@/lib/api';
-import { ChevronDown, X, User, AlertTriangle, Calendar, FolderOpen, Bookmark, Save, SlidersHorizontal, CircleDashed, Tag } from 'lucide-react';
+import { ChevronDown, ChevronLeft, ChevronRight, X, User, AlertTriangle, Calendar, FolderOpen, Bookmark, Save, SlidersHorizontal, CircleDashed, Tag } from 'lucide-react';
 import { STATUS_LABELS, statusLabel } from '@/lib/task-status-labels';
 import type { PriorityVocab, ResolvedStatus, CanonicalPriority } from '@/hooks/use-project-resolved-config';
 import { priorityFullLabel } from '@/hooks/use-project-resolved-config';
 import { AppBottomSheet } from '@/components/overlay-primitives';
 import {
   isTaskTableColumnVisible,
+  moveTaskTableColumn,
   normalizeTaskViewConfig,
   setTaskTableColumnVisibility,
+  setTaskTableColumnWidth,
+  taskTableColumnConfig,
   TASK_TABLE_COLUMNS,
   type TaskViewConfigV1,
 } from '@/lib/task-view-config';
@@ -40,7 +43,7 @@ type Props = {
 
 type Member = { id: string; name: string; email: string; avatar_url: string | null };
 type Label = { id: string; name: string; color: string };
-type SavedView = { id: string; name: string; config: unknown };
+type SavedView = { id: string; name: string; config: unknown; user_id: string; is_shared: boolean };
 
 const PRIORITY_COLORS: Record<string, string> = {
   p0: '#DC2626',
@@ -78,6 +81,7 @@ export function TaskFilters({ filters, onChange, projects, statuses, priorityVoc
   const [savedViews, setSavedViews] = useState<SavedView[]>([]);
   const [saveViewName, setSaveViewName] = useState('');
   const [showSaveInput, setShowSaveInput] = useState(false);
+  const [saveShared, setSaveShared] = useState(false);
   const [activeSavedViewId, setActiveSavedViewId] = useState<string | null>(null);
   const [isMobile, setIsMobile] = useState(false);
 
@@ -120,19 +124,21 @@ export function TaskFilters({ filters, onChange, projects, statuses, priorityVoc
       name: saveViewName.trim(),
       config: viewConfig,
       project_id: viewConfig.projectId,
+      is_shared: saveShared,
     });
     if (res.ok) {
       const view = await res.json();
       setSavedViews(prev => [view, ...prev]);
       setSaveViewName('');
       setShowSaveInput(false);
+      setSaveShared(false);
       setActiveSavedViewId(view.id);
     }
   };
 
   const handleLoadView = (view: SavedView) => {
     onApplyViewConfig(normalizeTaskViewConfig(view.config));
-    setActiveSavedViewId(view.id);
+    setActiveSavedViewId(view.user_id === user?.id ? view.id : null);
     setOpenDropdown(null);
   };
 
@@ -1071,7 +1077,7 @@ export function TaskFilters({ filters, onChange, projects, statuses, priorityVoc
             <ChevronDown size={11} />
           </button>
           {openDropdown === 'views' && (
-            <div className="absolute right-0 top-full mt-1 w-64 rounded-lg py-1 z-20"
+              <div className="absolute right-0 top-full mt-1 w-80 max-w-[calc(100vw-2rem)] rounded-lg py-1 z-20"
               style={{ background: 'var(--card-bg)', border: '1px solid var(--border)', boxShadow: 'var(--shadow-lg)' }}>
               {savedViews.length === 0 ? (
                 <div className="px-3 py-2 text-[11px]" style={{ color: 'var(--muted)', fontFamily: 'var(--font-body)' }}>
@@ -1085,10 +1091,13 @@ export function TaskFilters({ filters, onChange, projects, statuses, priorityVoc
                     onMouseLeave={e => (e.currentTarget.style.background = 'transparent')}>
                     <button onClick={() => handleLoadView(v)} className="flex-1 text-left truncate">
                       {v.name}
+                      {v.is_shared && <span className="ml-1 text-[9px] uppercase" style={{ color: 'var(--muted)' }}>Shared</span>}
                     </button>
-                    <button onClick={(e) => handleDeleteView(v.id, e)} className="ml-1 p-0.5" style={{ color: 'var(--muted)' }}>
-                      <X size={10} />
-                    </button>
+                    {v.user_id === user?.id && (
+                      <button onClick={(e) => handleDeleteView(v.id, e)} className="ml-1 p-0.5" style={{ color: 'var(--muted)' }} aria-label={`Delete ${v.name}`}>
+                        <X size={10} />
+                      </button>
+                    )}
                   </div>
                 ))
               )}
@@ -1109,19 +1118,49 @@ export function TaskFilters({ filters, onChange, projects, statuses, priorityVoc
                       ))}
                     </div>
                   </div>
+                  <label className="flex items-center justify-between gap-2 text-[11px]" style={{ color: 'var(--foreground-secondary)' }}>
+                    Group rows
+                    <select
+                      value={viewConfig.groupBy?.field ?? ''}
+                      onChange={(event) => onApplyViewConfig({ ...viewConfig, groupBy: event.target.value ? { field: event.target.value, direction: 'asc' } : null })}
+                      className="task-table-select rounded-md px-2 py-1 text-[11px]"
+                      style={{ background: 'var(--surface-container-low)', border: '1px solid var(--border)' }}
+                    >
+                      <option value="">None</option>
+                      <option value="status">Status</option>
+                      <option value="priority">Priority</option>
+                      <option value="assignee">Assignee</option>
+                      <option value="due_date">Due date</option>
+                      <option value="project">Project</option>
+                      <option value="labels">First label</option>
+                    </select>
+                  </label>
                   <div>
                     <span className="text-[10px] font-semibold uppercase" style={{ color: 'var(--muted)' }}>Columns</span>
-                    <div className="mt-1 grid grid-cols-2 gap-1">
+                    <div className="mt-1 space-y-1">
                       {TASK_TABLE_COLUMNS.map((column) => (
-                        <label key={column.id} className="flex items-center gap-1.5 text-[11px]" style={{ color: 'var(--foreground-secondary)' }}>
+                        <div key={column.id} className="flex items-center gap-1 text-[11px]" style={{ color: 'var(--foreground-secondary)' }}>
                           <input
                             type="checkbox"
                             checked={isTaskTableColumnVisible(viewConfig, column.id)}
                             disabled={'required' in column && column.required}
                             onChange={(event) => onApplyViewConfig(setTaskTableColumnVisibility(viewConfig, column.id, event.target.checked))}
                           />
-                          {column.label}
-                        </label>
+                          <span className="min-w-0 flex-1 truncate">{column.label}</span>
+                          <button disabled={'required' in column && column.required} onClick={() => onApplyViewConfig(moveTaskTableColumn(viewConfig, column.id, -1))} aria-label={`Move ${column.label} left`} className="p-0.5 disabled:opacity-30"><ChevronLeft size={12} /></button>
+                          <button disabled={'required' in column && column.required} onClick={() => onApplyViewConfig(moveTaskTableColumn(viewConfig, column.id, 1))} aria-label={`Move ${column.label} right`} className="p-0.5 disabled:opacity-30"><ChevronRight size={12} /></button>
+                          <input
+                            type="number"
+                            min={64}
+                            max={800}
+                            step={8}
+                            value={taskTableColumnConfig(viewConfig, column.id).width ?? (column.width.endsWith('px') ? parseInt(column.width, 10) : 280)}
+                            onChange={(event) => onApplyViewConfig(setTaskTableColumnWidth(viewConfig, column.id, Number(event.target.value)))}
+                            aria-label={`${column.label} width`}
+                            className="w-14 rounded px-1 py-0.5 text-[10px]"
+                            style={{ background: 'var(--surface-container-low)', border: '1px solid var(--border)' }}
+                          />
+                        </div>
                       ))}
                     </div>
                   </div>
@@ -1136,6 +1175,7 @@ export function TaskFilters({ filters, onChange, projects, statuses, priorityVoc
               <div className="px-3 py-2" style={{ borderTop: '1px solid var(--border)' }}>
                 {canSaveCurrent ? (
                   showSaveInput ? (
+                    <div className="space-y-1">
                     <div className="flex gap-1">
                       <input
                         value={saveViewName}
@@ -1149,6 +1189,11 @@ export function TaskFilters({ filters, onChange, projects, statuses, priorityVoc
                       <button onClick={handleSaveView} className="p-1" style={{ color: 'var(--accent)' }}>
                         <Save size={12} />
                       </button>
+                    </div>
+                    <label className="flex items-center gap-1.5 text-[10px]" style={{ color: 'var(--muted)' }}>
+                      <input type="checkbox" checked={saveShared} onChange={(event) => setSaveShared(event.target.checked)} />
+                      Share with workspace
+                    </label>
                     </div>
                   ) : (
                     <button onClick={() => setShowSaveInput(true)}

--- a/apps/web/src/components/task-filters.tsx
+++ b/apps/web/src/components/task-filters.tsx
@@ -8,6 +8,13 @@ import { STATUS_LABELS, statusLabel } from '@/lib/task-status-labels';
 import type { PriorityVocab, ResolvedStatus, CanonicalPriority } from '@/hooks/use-project-resolved-config';
 import { priorityFullLabel } from '@/hooks/use-project-resolved-config';
 import { AppBottomSheet } from '@/components/overlay-primitives';
+import {
+  isTaskTableColumnVisible,
+  normalizeTaskViewConfig,
+  setTaskTableColumnVisibility,
+  TASK_TABLE_COLUMNS,
+  type TaskViewConfigV1,
+} from '@/lib/task-view-config';
 
 export type Filters = {
   assigneeIds: string[];
@@ -27,11 +34,13 @@ type Props = {
   /** Task 4.9 — resolved skill config drives status chips + priority labels. */
   statuses?: ResolvedStatus[];
   priorityVocab?: PriorityVocab;
+  viewConfig: TaskViewConfigV1;
+  onApplyViewConfig: (config: TaskViewConfigV1) => void;
 };
 
 type Member = { id: string; name: string; email: string; avatar_url: string | null };
 type Label = { id: string; name: string; color: string };
-type SavedView = { id: string; name: string; config: any };
+type SavedView = { id: string; name: string; config: unknown };
 
 const PRIORITY_COLORS: Record<string, string> = {
   p0: '#DC2626',
@@ -51,7 +60,7 @@ const DUE_DATE_OPTIONS = [
   { value: 'this_week', label: 'This week' },
 ];
 
-export function TaskFilters({ filters, onChange, projects, statuses, priorityVocab }: Props) {
+export function TaskFilters({ filters, onChange, projects, statuses, priorityVocab, viewConfig, onApplyViewConfig }: Props) {
   const { user } = useAuth();
   const PRIORITY_OPTIONS = (['p0', 'p1', 'p2', 'p3'] as CanonicalPriority[]).map((value) => ({
     value,
@@ -69,6 +78,7 @@ export function TaskFilters({ filters, onChange, projects, statuses, priorityVoc
   const [savedViews, setSavedViews] = useState<SavedView[]>([]);
   const [saveViewName, setSaveViewName] = useState('');
   const [showSaveInput, setShowSaveInput] = useState(false);
+  const [activeSavedViewId, setActiveSavedViewId] = useState<string | null>(null);
   const [isMobile, setIsMobile] = useState(false);
 
   useEffect(() => {
@@ -106,18 +116,35 @@ export function TaskFilters({ filters, onChange, projects, statuses, priorityVoc
 
   const handleSaveView = async () => {
     if (!saveViewName.trim()) return;
-    const res = await api.post('/api/tasks/saved-views', { name: saveViewName.trim(), config: filters });
+    const res = await api.post('/api/tasks/saved-views', {
+      name: saveViewName.trim(),
+      config: viewConfig,
+      project_id: viewConfig.projectId,
+    });
     if (res.ok) {
       const view = await res.json();
       setSavedViews(prev => [view, ...prev]);
       setSaveViewName('');
       setShowSaveInput(false);
+      setActiveSavedViewId(view.id);
     }
   };
 
   const handleLoadView = (view: SavedView) => {
-    onChange(view.config as Filters);
+    onApplyViewConfig(normalizeTaskViewConfig(view.config));
+    setActiveSavedViewId(view.id);
     setOpenDropdown(null);
+  };
+
+  const handleUpdateView = async () => {
+    if (!activeSavedViewId) return;
+    const res = await api.patch(`/api/tasks/saved-views/${activeSavedViewId}`, {
+      config: viewConfig,
+      project_id: viewConfig.projectId,
+    });
+    if (!res.ok) return;
+    const updated = await res.json();
+    setSavedViews((current) => current.map((view) => view.id === updated.id ? updated : view));
   };
 
   const handleDeleteView = async (id: string, e: React.MouseEvent) => {
@@ -125,6 +152,7 @@ export function TaskFilters({ filters, onChange, projects, statuses, priorityVoc
     const res = await api.delete(`/api/tasks/saved-views/${id}`);
     if (res.ok) {
       setSavedViews(prev => prev.filter(v => v.id !== id));
+      if (activeSavedViewId === id) setActiveSavedViewId(null);
     }
   };
 
@@ -137,6 +165,7 @@ export function TaskFilters({ filters, onChange, projects, statuses, priorityVoc
     filters.dateFrom !== null ||
     filters.dateTo !== null ||
     filters.projectId !== null;
+  const canSaveCurrent = hasActive || viewConfig.view === 'table';
 
   const activeFilterCount =
     filters.assigneeIds.length +
@@ -447,7 +476,7 @@ export function TaskFilters({ filters, onChange, projects, statuses, priorityVoc
                     </button>
                   </div>
                 ))}
-                {hasActive && (
+                {canSaveCurrent && (
                   <div className="mt-1">
                     {showSaveInput ? (
                       <div className="flex gap-1">
@@ -1063,9 +1092,49 @@ export function TaskFilters({ filters, onChange, projects, statuses, priorityVoc
                   </div>
                 ))
               )}
+              {viewConfig.view === 'table' && (
+                <div className="px-3 py-2 space-y-2" style={{ borderTop: '1px solid var(--border)' }}>
+                  <div className="flex items-center justify-between">
+                    <span className="text-[10px] font-semibold uppercase" style={{ color: 'var(--muted)' }}>Density</span>
+                    <div className="flex rounded-full p-0.5" style={{ background: 'var(--surface-container-low)' }}>
+                      {(['comfortable', 'compact'] as const).map((density) => (
+                        <button
+                          key={density}
+                          onClick={() => onApplyViewConfig({ ...viewConfig, density })}
+                          className="rounded-full px-2 py-1 text-[10px] font-medium capitalize"
+                          style={{ background: viewConfig.density === density ? 'var(--accent)' : 'transparent', color: viewConfig.density === density ? 'white' : 'var(--muted)' }}
+                        >
+                          {density}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                  <div>
+                    <span className="text-[10px] font-semibold uppercase" style={{ color: 'var(--muted)' }}>Columns</span>
+                    <div className="mt-1 grid grid-cols-2 gap-1">
+                      {TASK_TABLE_COLUMNS.map((column) => (
+                        <label key={column.id} className="flex items-center gap-1.5 text-[11px]" style={{ color: 'var(--foreground-secondary)' }}>
+                          <input
+                            type="checkbox"
+                            checked={isTaskTableColumnVisible(viewConfig, column.id)}
+                            disabled={'required' in column && column.required}
+                            onChange={(event) => onApplyViewConfig(setTaskTableColumnVisibility(viewConfig, column.id, event.target.checked))}
+                          />
+                          {column.label}
+                        </label>
+                      ))}
+                    </div>
+                  </div>
+                  {activeSavedViewId && (
+                    <button onClick={handleUpdateView} className="text-[11px] font-medium" style={{ color: 'var(--accent)' }}>
+                      Update saved view
+                    </button>
+                  )}
+                </div>
+              )}
               {/* Save current */}
               <div className="px-3 py-2" style={{ borderTop: '1px solid var(--border)' }}>
-                {hasActive ? (
+                {canSaveCurrent ? (
                   showSaveInput ? (
                     <div className="flex gap-1">
                       <input
@@ -1084,7 +1153,7 @@ export function TaskFilters({ filters, onChange, projects, statuses, priorityVoc
                   ) : (
                     <button onClick={() => setShowSaveInput(true)}
                       className="text-[11px] font-medium" style={{ color: 'var(--accent)', fontFamily: 'var(--font-heading)' }}>
-                      + Save current filter set as...
+                      + Save current view as...
                     </button>
                   )
                 ) : (

--- a/apps/web/src/components/task-list.tsx
+++ b/apps/web/src/components/task-list.tsx
@@ -9,6 +9,7 @@ import { priorityLabel } from '@/hooks/use-project-resolved-config';
 import { PersonAvatar } from './person-avatar';
 import {
   isTaskTableColumnVisible,
+  taskTableColumnConfig,
   TASK_TABLE_COLUMNS,
   type TaskTableColumnId,
   type TaskViewConfigV1,
@@ -62,6 +63,7 @@ type Props = {
   priorityVocab?: PriorityVocab;
   viewConfig: TaskViewConfigV1;
   onViewConfigChange: (config: TaskViewConfigV1) => void;
+  onInlineCreate?: (title: string, defaults: TaskPatch) => Promise<boolean>;
 };
 
 type TaskPatch = Partial<Pick<Task, 'title' | 'status' | 'priority' | 'assignee_id' | 'due_date' | 'start_date' | 'estimation'>> & {
@@ -70,6 +72,7 @@ type TaskPatch = Partial<Pick<Task, 'title' | 'status' | 'priority' | 'assignee_
 
 type SortField = 'number' | 'title' | 'status' | 'priority' | 'assignee' | 'start_date' | 'due_date' | 'estimation' | 'labels' | 'updated_at';
 type SortDir = 'asc' | 'desc';
+type GroupField = 'status' | 'priority' | 'assignee' | 'due_date' | 'project' | 'labels';
 
 const DEFAULT_STATUS_OPTIONS = [
   { value: 'backlog', label: statusLabel('backlog'), color: '#6b7280' },
@@ -134,7 +137,47 @@ function dateInputValue(value: string | null): string {
   return Number.isNaN(date.getTime()) ? '' : date.toISOString().slice(0, 10);
 }
 
-export function TaskTable({ tasks, projectPrefix, onTaskClick, onTaskPatch, members, availableLabels, selectedTaskId, selectionMode, selectedTaskIds, onToggleSelect, statuses, hidePrefixIds, priorityVocab, viewConfig, onViewConfigChange }: Props) {
+function sortValue(task: Task, field: SortField): string | number {
+  switch (field) {
+    case 'number': return task.number;
+    case 'title': return task.title;
+    case 'status': return task.status;
+    case 'priority': return PRIORITY_ORDER[task.priority];
+    case 'assignee': return task.assignee_name || '';
+    case 'start_date': return task.start_date || '';
+    case 'due_date': return task.due_date || '';
+    case 'estimation': return task.estimation || '';
+    case 'labels': return task.labels.map((label) => label.name).join(',');
+    case 'updated_at': return task.updated_at;
+  }
+}
+
+function dueBucket(value: string | null): string {
+  if (!value) return 'No due date';
+  const due = new Date(value);
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  due.setHours(0, 0, 0, 0);
+  const days = Math.round((due.getTime() - today.getTime()) / 86400000);
+  if (days < 0) return 'Overdue';
+  if (days === 0) return 'Today';
+  if (days <= 7) return 'Next 7 days';
+  return 'Later';
+}
+
+function taskGroup(task: Task, field: string): string {
+  switch (field as GroupField) {
+    case 'status': return statusLabel(task.status);
+    case 'priority': return task.priority.toUpperCase();
+    case 'assignee': return task.assignee_name || 'Unassigned';
+    case 'due_date': return dueBucket(task.due_date);
+    case 'project': return task.project_name;
+    case 'labels': return task.labels[0]?.name || 'No labels';
+    default: return '';
+  }
+}
+
+export function TaskTable({ tasks, projectPrefix, onTaskClick, onTaskPatch, members, availableLabels, selectedTaskId, selectionMode, selectedTaskIds, onToggleSelect, statuses, hidePrefixIds, priorityVocab, viewConfig, onViewConfigChange, onInlineCreate }: Props) {
   const STATUS_OPTIONS = useMemo(() => {
     if (!statuses || statuses.length === 0) return DEFAULT_STATUS_OPTIONS;
     return [...statuses]
@@ -144,14 +187,13 @@ export function TaskTable({ tasks, projectPrefix, onTaskClick, onTaskPatch, memb
 
   const statusColorFor = (id: string): string =>
     STATUS_OPTIONS.find((s) => s.value === id)?.color || STATUS_COLORS[id] || 'var(--muted)';
-  const configuredSort = viewConfig.sort[0];
-  const sortField: SortField = configuredSort && TASK_TABLE_COLUMNS.some((column) => column.id === configuredSort.field)
-    ? configuredSort.field as SortField
-    : 'number';
-  const sortDir: SortDir = configuredSort?.direction ?? 'desc';
+  const configuredSorts = viewConfig.sort.filter((clause): clause is typeof clause & { field: SortField } =>
+    TASK_TABLE_COLUMNS.some((column) => column.id === clause.field));
+  const primarySort = configuredSorts[0] ?? { field: 'number' as SortField, direction: 'desc' as SortDir, nulls: 'last' as const };
   const [inlineDropdown, setInlineDropdown] = useState<{ taskId: string; field: string } | null>(null);
   const [editingTitle, setEditingTitle] = useState<{ taskId: string; value: string } | null>(null);
   const [savingCell, setSavingCell] = useState<string | null>(null);
+  const [newTask, setNewTask] = useState<{ key: string; title: string } | null>(null);
   const [isMobile, setIsMobile] = useState(false);
   // Fix 3: client-side pagination — show 50 rows at a time
   const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
@@ -163,42 +205,52 @@ export function TaskTable({ tasks, projectPrefix, onTaskClick, onTaskPatch, memb
     return () => window.removeEventListener('resize', check);
   }, []);
 
-  const handleSort = (field: SortField) => {
+  const handleSort = (field: SortField, additive = false) => {
     setVisibleCount(PAGE_SIZE);
+    const existing = configuredSorts.find((clause) => clause.field === field);
+    const next = { field, direction: existing?.direction === 'asc' ? 'desc' as const : 'asc' as const, nulls: 'last' as const };
+    const sort = additive
+      ? [...configuredSorts.filter((clause) => clause.field !== field), next].slice(-3)
+      : [next];
     onViewConfigChange({
       ...viewConfig,
-      sort: [{ field, direction: sortField === field && sortDir === 'asc' ? 'desc' : 'asc', nulls: 'last' }],
+      sort,
     });
   };
 
-  const sorted = useMemo(() => {
-    return [...tasks].sort((a, b) => {
-      let cmp = 0;
-      switch (sortField) {
-        case 'number': cmp = a.number - b.number; break;
-        case 'title': cmp = a.title.localeCompare(b.title); break;
-        case 'status': cmp = a.status.localeCompare(b.status); break;
-        case 'priority': cmp = PRIORITY_ORDER[a.priority] - PRIORITY_ORDER[b.priority]; break;
-        case 'assignee': cmp = (a.assignee_name || '').localeCompare(b.assignee_name || ''); break;
-        case 'start_date': cmp = (a.start_date || '').localeCompare(b.start_date || ''); break;
-        case 'due_date': cmp = (a.due_date || '').localeCompare(b.due_date || ''); break;
-        case 'estimation': cmp = (a.estimation || '').localeCompare(b.estimation || ''); break;
-        case 'labels': cmp = a.labels.map((label) => label.name).join(',').localeCompare(b.labels.map((label) => label.name).join(',')); break;
-        case 'updated_at': cmp = a.updated_at.localeCompare(b.updated_at); break;
+  const sorted = [...tasks].sort((a, b) => {
+      const groupField = viewConfig.groupBy?.field;
+      if (groupField) {
+        const groupComparison = taskGroup(a, groupField).localeCompare(taskGroup(b, groupField));
+        if (groupComparison) return viewConfig.groupBy?.direction === 'desc' ? -groupComparison : groupComparison;
       }
-      return sortDir === 'desc' ? -cmp : cmp;
+      for (const clause of configuredSorts.length ? configuredSorts : [primarySort]) {
+        const left = sortValue(a, clause.field);
+        const right = sortValue(b, clause.field);
+        const cmp = typeof left === 'number' && typeof right === 'number'
+          ? left - right
+          : String(left).localeCompare(String(right));
+        if (cmp) return clause.direction === 'desc' ? -cmp : cmp;
+      }
+      return a.id.localeCompare(b.id);
     });
-  }, [tasks, sortField, sortDir]);
 
   // Fix 3: page-sliced rows
   const visibleRows = sorted.slice(0, visibleCount);
 
   const SortIcon = ({ field }: { field: SortField }) => {
-    if (sortField !== field) return <ArrowUpDown size={11} style={{ opacity: 0.3 }} />;
-    return sortDir === 'asc' ? <ChevronUp size={11} /> : <ChevronDown size={11} />;
+    const index = configuredSorts.findIndex((clause) => clause.field === field);
+    if (index < 0) return <ArrowUpDown size={11} style={{ opacity: 0.3 }} />;
+    return <span className="flex items-center gap-0.5">{configuredSorts[index]?.direction === 'asc' ? <ChevronUp size={11} /> : <ChevronDown size={11} />}{configuredSorts.length > 1 && <span>{index + 1}</span>}</span>;
   };
 
-  const columns = TASK_TABLE_COLUMNS.filter((column) => isTaskTableColumnVisible(viewConfig, column.id));
+  const columns = TASK_TABLE_COLUMNS
+    .filter((column) => isTaskTableColumnVisible(viewConfig, column.id))
+    .map((column) => {
+      const saved = taskTableColumnConfig(viewConfig, column.id);
+      return { ...column, ...saved, width: saved.width ?? column.width };
+    })
+    .sort((a, b) => a.position - b.position);
   const columnVisible = (id: TaskTableColumnId) => isTaskTableColumnVisible(viewConfig, id);
   const rowPadding = viewConfig.density === 'compact' ? 'py-1.5' : 'py-2.5';
 
@@ -211,6 +263,29 @@ export function TaskTable({ tasks, projectPrefix, onTaskClick, onTaskPatch, memb
     setSavingCell(null);
     return ok;
   };
+
+  const inlineCreateRow = (key: string, defaults: TaskPatch = {}) => !onInlineCreate ? null : (
+    <tr key={`create:${key}`}>
+      <td colSpan={columns.length + (selectionMode ? 1 : 0)} className="px-3 py-1.5" style={{ borderBottom: '1px solid var(--border)' }}>
+        <input
+          value={newTask?.key === key ? newTask.title : ''}
+          onFocus={() => setNewTask((current) => current?.key === key ? current : { key, title: '' })}
+          onChange={(event) => setNewTask({ key, title: event.target.value })}
+          onKeyDown={async (event) => {
+            if (event.key === 'Escape') setNewTask(null);
+            if (event.key === 'Enter' && newTask?.title.trim()) {
+              event.preventDefault();
+              if (await onInlineCreate(newTask.title.trim(), defaults)) setNewTask(null);
+            }
+          }}
+          placeholder="+ Add task"
+          aria-label={`Add task${key === 'all' ? '' : ` to ${key}`}`}
+          className="w-full bg-transparent px-1 py-1 text-[12px] outline-none"
+          style={{ color: 'var(--foreground)' }}
+        />
+      </td>
+    </tr>
+  );
 
   if (isMobile) {
     return (
@@ -307,14 +382,15 @@ export function TaskTable({ tasks, projectPrefix, onTaskClick, onTaskPatch, memb
             {columns.map((col) => (
               <React.Fragment key={col.id}>
                 <th
-                  onClick={() => handleSort(col.id)}
+                  onClick={(event) => handleSort(col.id, event.shiftKey)}
+                  title="Click to sort; Shift-click to add up to three sorts"
                   className="text-left px-3 py-2 text-[11px] font-semibold uppercase tracking-wide cursor-pointer select-none sticky top-0"
                   style={{
                     color: 'var(--muted)',
                     fontFamily: 'var(--font-heading)',
                     background: 'var(--surface)',
                     borderBottom: '1px solid var(--border)',
-                    width: col.width === '1fr' ? undefined : col.width,
+                    width: typeof col.width === 'number' ? `${col.width}px` : col.width === '1fr' ? undefined : col.width,
                     whiteSpace: col.id === 'status' ? 'nowrap' : undefined,
                     minWidth: col.id === 'status' ? '100px' : undefined,
                     left: col.id === 'number' ? (selectionMode ? 32 : 0) : col.id === 'title' ? (selectionMode ? 112 : 80) : undefined,
@@ -336,9 +412,26 @@ export function TaskTable({ tasks, projectPrefix, onTaskClick, onTaskPatch, memb
             const isSelected = task.id === selectedTaskId;
             const isChecked = selectionMode && selectedTaskIds?.has(task.id);
 
+            const group = viewConfig.groupBy ? taskGroup(task, viewConfig.groupBy.field) : null;
+            const rowIndex = visibleRows.indexOf(task);
+            const previous = visibleRows[rowIndex - 1];
+            const next = visibleRows[rowIndex + 1];
+            const showGroup = group && (!previous || taskGroup(previous, viewConfig.groupBy!.field) !== group);
+            const groupEnds = group && (!next || taskGroup(next, viewConfig.groupBy!.field) !== group);
+            const inherited: TaskPatch = viewConfig.groupBy?.field === 'status' ? { status: task.status }
+              : viewConfig.groupBy?.field === 'priority' ? { priority: task.priority }
+              : viewConfig.groupBy?.field === 'assignee' ? { assignee_id: task.assignee_id }
+              : {};
             return (
+              <React.Fragment key={task.id}>
+              {showGroup && (
+                <tr>
+                  <td colSpan={columns.length + (selectionMode ? 1 : 0)} className="sticky left-0 px-3 py-1.5 text-[11px] font-semibold uppercase" style={{ color: 'var(--muted)', background: 'var(--surface-container-low)', borderBottom: '1px solid var(--border)' }}>
+                    {group}
+                  </td>
+                </tr>
+              )}
               <tr
-                key={task.id}
                 tabIndex={0}
                 onKeyDown={(event) => {
                   if (event.key === 'Enter' && event.target === event.currentTarget) onTaskClick(task);
@@ -642,8 +735,11 @@ export function TaskTable({ tasks, projectPrefix, onTaskClick, onTaskPatch, memb
                   </span>
                 </td>
               </tr>
+              {groupEnds && inlineCreateRow(group, inherited)}
+              </React.Fragment>
             );
           })}
+          {!viewConfig.groupBy && inlineCreateRow('all')}
         </tbody>
       </table>
 

--- a/apps/web/src/components/task-list.tsx
+++ b/apps/web/src/components/task-list.tsx
@@ -7,6 +7,12 @@ import { TaskCardUnified } from './task-card-unified';
 import type { ResolvedStatus, PriorityVocab } from '@/hooks/use-project-resolved-config';
 import { priorityLabel } from '@/hooks/use-project-resolved-config';
 import { PersonAvatar } from './person-avatar';
+import {
+  isTaskTableColumnVisible,
+  TASK_TABLE_COLUMNS,
+  type TaskTableColumnId,
+  type TaskViewConfigV1,
+} from '@/lib/task-view-config';
 
 type Task = {
   id: string;
@@ -54,6 +60,8 @@ type Props = {
   statuses?: ResolvedStatus[];
   hidePrefixIds?: boolean;
   priorityVocab?: PriorityVocab;
+  viewConfig: TaskViewConfigV1;
+  onViewConfigChange: (config: TaskViewConfigV1) => void;
 };
 
 type TaskPatch = Partial<Pick<Task, 'title' | 'status' | 'priority' | 'assignee_id' | 'due_date' | 'start_date' | 'estimation'>> & {
@@ -126,7 +134,7 @@ function dateInputValue(value: string | null): string {
   return Number.isNaN(date.getTime()) ? '' : date.toISOString().slice(0, 10);
 }
 
-export function TaskTable({ tasks, projectPrefix, onTaskClick, onTaskPatch, members, availableLabels, selectedTaskId, selectionMode, selectedTaskIds, onToggleSelect, statuses, hidePrefixIds, priorityVocab }: Props) {
+export function TaskTable({ tasks, projectPrefix, onTaskClick, onTaskPatch, members, availableLabels, selectedTaskId, selectionMode, selectedTaskIds, onToggleSelect, statuses, hidePrefixIds, priorityVocab, viewConfig, onViewConfigChange }: Props) {
   const STATUS_OPTIONS = useMemo(() => {
     if (!statuses || statuses.length === 0) return DEFAULT_STATUS_OPTIONS;
     return [...statuses]
@@ -136,8 +144,11 @@ export function TaskTable({ tasks, projectPrefix, onTaskClick, onTaskPatch, memb
 
   const statusColorFor = (id: string): string =>
     STATUS_OPTIONS.find((s) => s.value === id)?.color || STATUS_COLORS[id] || 'var(--muted)';
-  const [sortField, setSortField] = useState<SortField>('number');
-  const [sortDir, setSortDir] = useState<SortDir>('desc');
+  const configuredSort = viewConfig.sort[0];
+  const sortField: SortField = configuredSort && TASK_TABLE_COLUMNS.some((column) => column.id === configuredSort.field)
+    ? configuredSort.field as SortField
+    : 'number';
+  const sortDir: SortDir = configuredSort?.direction ?? 'desc';
   const [inlineDropdown, setInlineDropdown] = useState<{ taskId: string; field: string } | null>(null);
   const [editingTitle, setEditingTitle] = useState<{ taskId: string; value: string } | null>(null);
   const [savingCell, setSavingCell] = useState<string | null>(null);
@@ -154,12 +165,10 @@ export function TaskTable({ tasks, projectPrefix, onTaskClick, onTaskPatch, memb
 
   const handleSort = (field: SortField) => {
     setVisibleCount(PAGE_SIZE);
-    if (sortField === field) {
-      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
-    } else {
-      setSortField(field);
-      setSortDir('asc');
-    }
+    onViewConfigChange({
+      ...viewConfig,
+      sort: [{ field, direction: sortField === field && sortDir === 'asc' ? 'desc' : 'asc', nulls: 'last' }],
+    });
   };
 
   const sorted = useMemo(() => {
@@ -189,18 +198,9 @@ export function TaskTable({ tasks, projectPrefix, onTaskClick, onTaskPatch, memb
     return sortDir === 'asc' ? <ChevronUp size={11} /> : <ChevronDown size={11} />;
   };
 
-  const columns: { field: SortField; label: string; width: string }[] = [
-    { field: 'number', label: 'ID', width: '80px' },
-    { field: 'title', label: 'Title', width: '1fr' },
-    { field: 'status', label: 'Status', width: '130px' },
-    { field: 'priority', label: 'Priority', width: '80px' },
-    { field: 'assignee', label: 'Assignee', width: '140px' },
-    { field: 'start_date', label: 'Start', width: '120px' },
-    { field: 'due_date', label: 'Due', width: '110px' },
-    { field: 'estimation', label: 'Estimate', width: '90px' },
-    { field: 'labels', label: 'Labels', width: '180px' },
-    { field: 'updated_at', label: 'Updated', width: '110px' },
-  ];
+  const columns = TASK_TABLE_COLUMNS.filter((column) => isTaskTableColumnVisible(viewConfig, column.id));
+  const columnVisible = (id: TaskTableColumnId) => isTaskTableColumnVisible(viewConfig, id);
+  const rowPadding = viewConfig.density === 'compact' ? 'py-1.5' : 'py-2.5';
 
   const save = async (taskId: string, field: string, patch: TaskPatch) => {
     const key = `${taskId}:${field}`;
@@ -291,7 +291,7 @@ export function TaskTable({ tasks, projectPrefix, onTaskClick, onTaskPatch, memb
       {/* Click-away */}
       {inlineDropdown && <div className="fixed inset-0 z-10" onClick={() => setInlineDropdown(null)} />}
 
-      <table className="w-full min-w-[1250px]" style={{ borderCollapse: 'separate', borderSpacing: 0 }}>
+      <table className="w-full min-w-[900px]" style={{ borderCollapse: 'separate', borderSpacing: 0 }}>
         <thead>
           <tr>
             {selectionMode && (
@@ -305,9 +305,9 @@ export function TaskTable({ tasks, projectPrefix, onTaskClick, onTaskPatch, memb
               />
             )}
             {columns.map((col) => (
-              <React.Fragment key={col.field}>
+              <React.Fragment key={col.id}>
                 <th
-                  onClick={() => handleSort(col.field)}
+                  onClick={() => handleSort(col.id)}
                   className="text-left px-3 py-2 text-[11px] font-semibold uppercase tracking-wide cursor-pointer select-none sticky top-0"
                   style={{
                     color: 'var(--muted)',
@@ -315,15 +315,15 @@ export function TaskTable({ tasks, projectPrefix, onTaskClick, onTaskPatch, memb
                     background: 'var(--surface)',
                     borderBottom: '1px solid var(--border)',
                     width: col.width === '1fr' ? undefined : col.width,
-                    whiteSpace: col.field === 'status' ? 'nowrap' : undefined,
-                    minWidth: col.field === 'status' ? '100px' : undefined,
-                    left: col.field === 'number' ? (selectionMode ? 32 : 0) : col.field === 'title' ? (selectionMode ? 112 : 80) : undefined,
-                    zIndex: col.field === 'number' || col.field === 'title' ? 4 : 2,
+                    whiteSpace: col.id === 'status' ? 'nowrap' : undefined,
+                    minWidth: col.id === 'status' ? '100px' : undefined,
+                    left: col.id === 'number' ? (selectionMode ? 32 : 0) : col.id === 'title' ? (selectionMode ? 112 : 80) : undefined,
+                    zIndex: col.id === 'number' || col.id === 'title' ? 4 : 2,
                   }}
                 >
                   <div className="flex items-center gap-1">
                     {col.label}
-                    <SortIcon field={col.field} />
+                    <SortIcon field={col.id} />
                   </div>
                 </th>
               </React.Fragment>
@@ -392,7 +392,8 @@ export function TaskTable({ tasks, projectPrefix, onTaskClick, onTaskPatch, memb
 
                 {/* ID */}
                 <td
-                  className="px-3 py-2.5 text-[12px] font-medium"
+                  hidden={!columnVisible('number')}
+                  className={`px-3 ${rowPadding} text-[12px] font-medium`}
                   style={{ color: 'var(--muted)', fontFamily: 'var(--font-heading)', borderBottom: '1px solid var(--border)', position: 'sticky', left: selectionMode ? 32 : 0, zIndex: 2, background: isSelected ? 'var(--accent-subtle)' : 'var(--surface)' }}
                 >
                   {hidePrefixIds ? '' : `${projectPrefix || task.project_prefix}-${task.number}`}
@@ -400,7 +401,8 @@ export function TaskTable({ tasks, projectPrefix, onTaskClick, onTaskPatch, memb
 
                 {/* Title */}
                 <td
-                  className="px-3 py-2.5 text-[13px]"
+                  hidden={!columnVisible('title')}
+                  className={`px-3 ${rowPadding} text-[13px]`}
                   style={{ color: 'var(--foreground)', fontFamily: 'var(--font-body)', borderBottom: '1px solid var(--border)', position: 'sticky', left: selectionMode ? 112 : 80, zIndex: 2, background: isSelected ? 'var(--accent-subtle)' : 'var(--surface)' }}
                   onClick={(event) => event.stopPropagation()}
                 >
@@ -436,7 +438,8 @@ export function TaskTable({ tasks, projectPrefix, onTaskClick, onTaskPatch, memb
 
                 {/* Status */}
                 <td
-                  className="px-3 py-2.5"
+                  hidden={!columnVisible('status')}
+                  className={`px-3 ${rowPadding}`}
                   style={{ borderBottom: '1px solid var(--border)', whiteSpace: 'nowrap', minWidth: '100px' }}
                 >
                   <div className="relative">
@@ -493,7 +496,8 @@ export function TaskTable({ tasks, projectPrefix, onTaskClick, onTaskPatch, memb
 
                 {/* Priority */}
                 <td
-                  className="px-3 py-2.5"
+                  hidden={!columnVisible('priority')}
+                  className={`px-3 ${rowPadding}`}
                   style={{ borderBottom: '1px solid var(--border)' }}
                   onClick={(event) => event.stopPropagation()}
                 >
@@ -518,7 +522,8 @@ export function TaskTable({ tasks, projectPrefix, onTaskClick, onTaskPatch, memb
 
                 {/* Assignee */}
                 <td
-                  className="px-3 py-2.5"
+                  hidden={!columnVisible('assignee')}
+                  className={`px-3 ${rowPadding}`}
                   style={{ borderBottom: '1px solid var(--border)' }}
                   onClick={(event) => event.stopPropagation()}
                 >
@@ -539,7 +544,7 @@ export function TaskTable({ tasks, projectPrefix, onTaskClick, onTaskPatch, memb
                 </td>
 
                 {/* Start Date */}
-                <td className="px-3 py-2.5" style={{ borderBottom: '1px solid var(--border)' }} onClick={(event) => event.stopPropagation()}>
+                <td hidden={!columnVisible('start_date')} className={`px-3 ${rowPadding}`} style={{ borderBottom: '1px solid var(--border)' }} onClick={(event) => event.stopPropagation()}>
                   <input
                     type="date"
                     aria-label={`Start date for ${task.title}`}
@@ -553,7 +558,8 @@ export function TaskTable({ tasks, projectPrefix, onTaskClick, onTaskPatch, memb
 
                 {/* Due Date */}
                 <td
-                  className="px-3 py-2.5 text-[12px]"
+                  hidden={!columnVisible('due_date')}
+                  className={`px-3 ${rowPadding} text-[12px]`}
                   style={{
                     fontFamily: 'var(--font-body)',
                     borderBottom: '1px solid var(--border)',
@@ -572,7 +578,7 @@ export function TaskTable({ tasks, projectPrefix, onTaskClick, onTaskPatch, memb
                 </td>
 
                 {/* Estimate */}
-                <td className="px-3 py-2.5" style={{ borderBottom: '1px solid var(--border)' }} onClick={(event) => event.stopPropagation()}>
+                <td hidden={!columnVisible('estimation')} className={`px-3 ${rowPadding}`} style={{ borderBottom: '1px solid var(--border)' }} onClick={(event) => event.stopPropagation()}>
                   <select
                     aria-label={`Estimate for ${task.title}`}
                     value={task.estimation ?? ''}
@@ -587,7 +593,7 @@ export function TaskTable({ tasks, projectPrefix, onTaskClick, onTaskPatch, memb
                 </td>
 
                 {/* Labels */}
-                <td className="px-3 py-2.5" style={{ borderBottom: '1px solid var(--border)' }} onClick={(event) => event.stopPropagation()}>
+                <td hidden={!columnVisible('labels')} className={`px-3 ${rowPadding}`} style={{ borderBottom: '1px solid var(--border)' }} onClick={(event) => event.stopPropagation()}>
                   <div className="relative">
                     <button
                       aria-label={`Labels for ${task.title}`}
@@ -622,7 +628,8 @@ export function TaskTable({ tasks, projectPrefix, onTaskClick, onTaskPatch, memb
 
                 {/* Updated */}
                 <td
-                  className="px-3 py-2.5 text-[12px]"
+                  hidden={!columnVisible('updated_at')}
+                  className={`px-3 ${rowPadding} text-[12px]`}
                   style={{
                     color: 'var(--muted)',
                     fontFamily: 'var(--font-body)',

--- a/apps/web/src/lib/task-view-config.test.ts
+++ b/apps/web/src/lib/task-view-config.test.ts
@@ -1,8 +1,11 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import {
+  DEFAULT_TASK_VIEW_CONFIG,
+  isTaskTableColumnVisible,
   normalizeTaskViewConfig,
   parseTaskSurfaceView,
+  setTaskTableColumnVisibility,
   shouldApplyProjectDefaultView,
 } from './task-view-config';
 
@@ -72,4 +75,11 @@ test('project default never overwrites an explicit valid or invalid view request
   assert.equal(shouldApplyProjectDefaultView({ requestedView: null, userSelectedView: false, isMyTasksView: false }), true);
   assert.equal(shouldApplyProjectDefaultView({ requestedView: null, userSelectedView: true, isMyTasksView: false }), false);
   assert.equal(shouldApplyProjectDefaultView({ requestedView: null, userSelectedView: false, isMyTasksView: true }), false);
+});
+
+test('column visibility defaults on and changes immutably', () => {
+  assert.equal(isTaskTableColumnVisible(DEFAULT_TASK_VIEW_CONFIG, 'labels'), true);
+  const next = setTaskTableColumnVisibility(DEFAULT_TASK_VIEW_CONFIG, 'labels', false);
+  assert.equal(isTaskTableColumnVisible(next, 'labels'), false);
+  assert.equal(DEFAULT_TASK_VIEW_CONFIG.columns.length, 0);
 });

--- a/apps/web/src/lib/task-view-config.test.ts
+++ b/apps/web/src/lib/task-view-config.test.ts
@@ -4,8 +4,10 @@ import {
   DEFAULT_TASK_VIEW_CONFIG,
   isTaskTableColumnVisible,
   normalizeTaskViewConfig,
+  moveTaskTableColumn,
   parseTaskSurfaceView,
   setTaskTableColumnVisibility,
+  setTaskTableColumnWidth,
   shouldApplyProjectDefaultView,
 } from './task-view-config';
 
@@ -82,4 +84,19 @@ test('column visibility defaults on and changes immutably', () => {
   const next = setTaskTableColumnVisibility(DEFAULT_TASK_VIEW_CONFIG, 'labels', false);
   assert.equal(isTaskTableColumnVisible(next, 'labels'), false);
   assert.equal(DEFAULT_TASK_VIEW_CONFIG.columns.length, 0);
+});
+
+test('column layout helpers bound widths and preserve frozen columns', () => {
+  const wide = setTaskTableColumnWidth(DEFAULT_TASK_VIEW_CONFIG, 'status', 5000);
+  assert.equal(wide.columns.find((column) => column.id === 'status')?.width, 800);
+  const frozen = moveTaskTableColumn(wide, 'status', -1);
+  assert.equal(frozen, wide);
+  const moved = moveTaskTableColumn(wide, 'assignee', -1);
+  const assignee = moved.columns.find((column) => column.id === 'assignee')!;
+  const priority = moved.columns.find((column) => column.id === 'priority')!;
+  const status = moved.columns.find((column) => column.id === 'status')!;
+  const title = moved.columns.find((column) => column.id === 'title')!;
+  assert.equal(title.position, 1);
+  assert.equal(status.position, 2);
+  assert.equal(assignee.position < priority.position, true);
 });

--- a/apps/web/src/lib/task-view-config.ts
+++ b/apps/web/src/lib/task-view-config.ts
@@ -36,6 +36,21 @@ export type TaskViewColumnV1 = {
   frozen?: boolean;
 };
 
+export const TASK_TABLE_COLUMNS = [
+  { id: 'number', label: 'ID', width: '80px', required: true },
+  { id: 'title', label: 'Title', width: '1fr', required: true },
+  { id: 'status', label: 'Status', width: '130px' },
+  { id: 'priority', label: 'Priority', width: '80px' },
+  { id: 'assignee', label: 'Assignee', width: '140px' },
+  { id: 'start_date', label: 'Start', width: '120px' },
+  { id: 'due_date', label: 'Due', width: '110px' },
+  { id: 'estimation', label: 'Estimate', width: '90px' },
+  { id: 'labels', label: 'Labels', width: '180px' },
+  { id: 'updated_at', label: 'Updated', width: '110px' },
+] as const;
+
+export type TaskTableColumnId = (typeof TASK_TABLE_COLUMNS)[number]['id'];
+
 export type TaskViewConfigV1 = {
   version: typeof TASK_VIEW_CONFIG_VERSION;
   view: TaskConfigView;
@@ -71,6 +86,22 @@ export const DEFAULT_TASK_VIEW_CONFIG: TaskViewConfigV1 = {
   projectId: null,
 };
 
+export function isTaskTableColumnVisible(config: TaskViewConfigV1, id: TaskTableColumnId): boolean {
+  return config.columns.find((column) => column.id === id)?.visible !== false;
+}
+
+export function setTaskTableColumnVisibility(
+  config: TaskViewConfigV1,
+  id: TaskTableColumnId,
+  visible: boolean,
+): TaskViewConfigV1 {
+  const existing = config.columns.some((column) => column.id === id);
+  const columns = existing
+    ? config.columns.map((column) => column.id === id ? { ...column, visible } : column)
+    : [...config.columns, { id, visible, position: TASK_TABLE_COLUMNS.findIndex((column) => column.id === id) }];
+  return { ...config, columns };
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
@@ -85,12 +116,15 @@ function nullableString(value: unknown): string | null {
 
 function normalizeFilters(value: unknown): TaskViewFiltersV1 {
   const filters = isRecord(value) ? value : {};
+  const dueDate = filters.dueDate === 'overdue' || filters.dueDate === 'today' || filters.dueDate === 'this_week'
+    ? filters.dueDate
+    : null;
   return {
     assigneeIds: stringArray(filters.assigneeIds),
     priorities: stringArray(filters.priorities),
     status: stringArray(filters.status),
     labels: stringArray(filters.labels),
-    dueDate: nullableString(filters.dueDate),
+    dueDate,
     dateFrom: nullableString(filters.dateFrom),
     dateTo: nullableString(filters.dateTo),
     projectId: nullableString(filters.projectId),

--- a/apps/web/src/lib/task-view-config.ts
+++ b/apps/web/src/lib/task-view-config.ts
@@ -51,6 +51,16 @@ export const TASK_TABLE_COLUMNS = [
 
 export type TaskTableColumnId = (typeof TASK_TABLE_COLUMNS)[number]['id'];
 
+export function taskTableColumnConfig(config: TaskViewConfigV1, id: TaskTableColumnId) {
+  const fallback = TASK_TABLE_COLUMNS.findIndex((column) => column.id === id);
+  const saved = config.columns.find((column) => column.id === id);
+  return {
+    visible: saved?.visible !== false,
+    position: saved?.position ?? fallback,
+    width: saved?.width,
+  };
+}
+
 export type TaskViewConfigV1 = {
   version: typeof TASK_VIEW_CONFIG_VERSION;
   view: TaskConfigView;
@@ -87,7 +97,7 @@ export const DEFAULT_TASK_VIEW_CONFIG: TaskViewConfigV1 = {
 };
 
 export function isTaskTableColumnVisible(config: TaskViewConfigV1, id: TaskTableColumnId): boolean {
-  return config.columns.find((column) => column.id === id)?.visible !== false;
+  return taskTableColumnConfig(config, id).visible;
 }
 
 export function setTaskTableColumnVisibility(
@@ -100,6 +110,43 @@ export function setTaskTableColumnVisibility(
     ? config.columns.map((column) => column.id === id ? { ...column, visible } : column)
     : [...config.columns, { id, visible, position: TASK_TABLE_COLUMNS.findIndex((column) => column.id === id) }];
   return { ...config, columns };
+}
+
+export function setTaskTableColumnWidth(
+  config: TaskViewConfigV1,
+  id: TaskTableColumnId,
+  width: number,
+): TaskViewConfigV1 {
+  const bounded = Math.max(64, Math.min(800, width));
+  const existing = config.columns.some((column) => column.id === id);
+  const columns = existing
+    ? config.columns.map((column) => column.id === id ? { ...column, width: bounded } : column)
+    : [...config.columns, { id, visible: true, position: TASK_TABLE_COLUMNS.findIndex((column) => column.id === id), width: bounded }];
+  return { ...config, columns };
+}
+
+export function moveTaskTableColumn(
+  config: TaskViewConfigV1,
+  id: TaskTableColumnId,
+  direction: -1 | 1,
+): TaskViewConfigV1 {
+  if (id === 'number' || id === 'title') return config;
+  const ordered = TASK_TABLE_COLUMNS.map((column) => ({
+    id: column.id,
+    position: taskTableColumnConfig(config, column.id).position,
+  })).sort((a, b) => a.position - b.position);
+  const index = ordered.findIndex((column) => column.id === id);
+  const target = index + direction;
+  if (index < 0 || target < 2 || target >= ordered.length) return config;
+  [ordered[index], ordered[target]] = [ordered[target]!, ordered[index]!];
+  const positions = new Map(ordered.map((column, position) => [column.id, position]));
+  return {
+    ...config,
+    columns: TASK_TABLE_COLUMNS.map((column) => {
+      const current = config.columns.find((candidate) => candidate.id === column.id);
+      return { id: column.id, visible: current?.visible !== false, position: positions.get(column.id)!, ...(current?.width ? { width: current.width } : {}) };
+    }),
+  };
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {


### PR DESCRIPTION
## Summary
- persist complete task table layouts, including filters, density, grouping, up to three sorts, column visibility/order/width, and project scope
- support personal and shared saved layouts with owner-only update/delete controls
- add group-aware inline task creation while keeping ID and Title frozen

## Verification
- web and API typecheck
- task-view config tests (6/6)
- focused ESLint (0 errors; one pre-existing any warning)
- browser dogfood: save/reload/restore, shared read-only visibility, grouping, multi-sort, column reordering/widths, grouped inline creation, mobile table cards
- test artifacts removed