### PR TITLE
feat(tasks): scale table view with cursor queries

### DIFF
--- a/apps/api/src/lib/task-table-query.ts
+++ b/apps/api/src/lib/task-table-query.ts
@@ -1,0 +1,123 @@
+import { z } from 'zod';
+
+export const TASK_TABLE_SORT_FIELDS = [
+  'number', 'title', 'status', 'priority', 'assignee', 'start_date',
+  'due_date', 'estimation', 'labels', 'updated_at', 'project',
+] as const;
+
+export type TaskTableSortField = (typeof TASK_TABLE_SORT_FIELDS)[number];
+export type TaskTableSort = {
+  field: TaskTableSortField;
+  direction: 'asc' | 'desc';
+  nulls: 'first' | 'last';
+};
+
+const GROUP_FIELDS = ['status', 'priority', 'assignee', 'due_date', 'project', 'labels'] as const;
+
+function csv(value: string | undefined): string[] {
+  return value?.split(',').map((item) => item.trim()).filter(Boolean) ?? [];
+}
+
+function parseSort(value: string | undefined): TaskTableSort[] | null {
+  if (!value) return [];
+  const clauses = value.split(',');
+  if (clauses.length > 3) return null;
+  const parsed = clauses.map((clause) => {
+    const [field, direction, nulls] = clause.split(':');
+    if (!(TASK_TABLE_SORT_FIELDS as readonly string[]).includes(field ?? '')) return null;
+    if (direction !== 'asc' && direction !== 'desc') return null;
+    if (nulls !== 'first' && nulls !== 'last') return null;
+    return {
+      field: field as TaskTableSortField,
+      direction,
+      nulls,
+    } satisfies TaskTableSort;
+  });
+  return parsed.some((clause) => clause === null) ? null : parsed as TaskTableSort[];
+}
+
+function parseGroup(value: string | undefined): TaskTableSort | null {
+  if (!value) return null;
+  const [field, direction] = value.split(':');
+  if (!(GROUP_FIELDS as readonly string[]).includes(field ?? '')) return null;
+  return {
+    field: field as TaskTableSortField,
+    direction: direction === 'desc' ? 'desc' : 'asc',
+    nulls: 'last',
+  };
+}
+
+const rawQuerySchema = z.object({
+  project_id: z.string().min(1).optional(),
+  mine: z.enum(['true', 'false']).optional(),
+  assignee: z.string().optional(),
+  priority: z.string().optional(),
+  status: z.string().optional(),
+  labels: z.string().optional(),
+  due: z.enum(['overdue', 'today', 'this_week']).optional(),
+  date_from: z.iso.date().optional(),
+  date_to: z.iso.date().optional(),
+  sort: z.string().optional(),
+  group: z.string().optional(),
+  cursor: z.string().optional(),
+  page_size: z.coerce.number().int().min(1).max(200).default(100),
+});
+
+export function parseTaskTableQuery(input: Record<string, string | undefined>) {
+  const parsed = rawQuerySchema.safeParse(input);
+  if (!parsed.success) return { success: false as const, error: parsed.error };
+  if (!parsed.data.project_id && parsed.data.mine !== 'true') {
+    return { success: false as const, error: new Error('project_id or mine=true is required') };
+  }
+  const sorts = parseSort(parsed.data.sort);
+  const group = parseGroup(parsed.data.group);
+  if (sorts === null || (parsed.data.group && group === null)) {
+    return { success: false as const, error: new Error('Invalid sort or group clause') };
+  }
+  const priorities = csv(parsed.data.priority);
+  const statuses = csv(parsed.data.status);
+  if (priorities.some((value) => !['p0', 'p1', 'p2', 'p3'].includes(value))) {
+    return { success: false as const, error: new Error('Invalid priority filter') };
+  }
+  if (statuses.some((value) => !['backlog', 'todo', 'in_progress', 'in_review', 'done', 'cancelled'].includes(value))) {
+    return { success: false as const, error: new Error('Invalid status filter') };
+  }
+  return {
+    success: true as const,
+    data: {
+      projectId: parsed.data.project_id ?? null,
+      mine: parsed.data.mine === 'true',
+      assigneeIds: csv(parsed.data.assignee),
+      priorities,
+      statuses,
+      labelIds: csv(parsed.data.labels),
+      due: parsed.data.due ?? null,
+      dateFrom: parsed.data.date_from ?? null,
+      dateTo: parsed.data.date_to ?? null,
+      sorts,
+      group,
+      cursor: parsed.data.cursor ?? null,
+      pageSize: parsed.data.page_size,
+    },
+  };
+}
+
+const cursorSchema = z.object({
+  v: z.literal(1),
+  signature: z.string().min(1),
+  values: z.array(z.union([z.string(), z.number(), z.null()])),
+});
+
+export function encodeTaskTableCursor(signature: string, values: Array<string | number | null>): string {
+  return Buffer.from(JSON.stringify({ v: 1, signature, values }), 'utf8').toString('base64url');
+}
+
+export function decodeTaskTableCursor(value: string | null): { signature: string; values: Array<string | number | null> } | null {
+  if (!value) return null;
+  try {
+    const decoded = cursorSchema.parse(JSON.parse(Buffer.from(value, 'base64url').toString('utf8')));
+    return { signature: decoded.signature, values: decoded.values };
+  } catch {
+    return null;
+  }
+}

--- a/apps/api/src/routes/tasks.ts
+++ b/apps/api/src/routes/tasks.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import { z } from 'zod';
-import { eq, and, desc, asc, sql, inArray, ilike, or, isNull } from 'drizzle-orm';
+import { eq, and, desc, asc, sql, inArray, ilike, or, isNull, type SQL } from 'drizzle-orm';
 import { db } from '../lib/db.js';
 import { projects, tasks, taskComments, taskActivity, taskLabels, labels, users, projectSpaces, messages, taskRelationships, files, savedViews, taskWatchers, taskAssignees, taskReactions, wikiPages, wikiCitations, orgMembers, workflowRules, agentEmployees, agentActions, spaces, spaceMembers } from '@deft/db/schema';
 import { getIO, emitToUser } from '../socket.js';
@@ -16,6 +16,13 @@ import { publishAgentChannelEvent, type AgentChannelEventKind } from '../lib/age
 import { reserveNextTaskNumber } from '../lib/task-numbering.js';
 import { resolveAssignableAssigneeId } from '../lib/resolve-assignee.js';
 import { createNotificationIfAllowed } from '../lib/notification-policy.js';
+import {
+  decodeTaskTableCursor,
+  encodeTaskTableCursor,
+  parseTaskTableQuery,
+  type TaskTableSort,
+  type TaskTableSortField,
+} from '../lib/task-table-query.js';
 
 export const taskRoutes = new Hono();
 
@@ -101,7 +108,8 @@ async function getLabelsForTasks(taskIds: string[]) {
   })
     .from(taskLabels)
     .innerJoin(labels, eq(taskLabels.label_id, labels.id))
-    .where(inArray(taskLabels.task_id, taskIds));
+    .where(inArray(taskLabels.task_id, taskIds))
+    .orderBy(taskLabels.task_id, sql`lower(${labels.name})`, labels.id);
 
   const result = new Map<string, { id: string; name: string; color: string }[]>();
   for (const row of rows) {
@@ -676,6 +684,249 @@ taskRoutes.post('/bulk-delete', async (c) => {
   } catch (err) {
     console.error('Failed to bulk delete tasks:', err);
     return c.json({ error: 'Failed to bulk delete tasks', code: 'INTERNAL_ERROR' }, 500);
+  }
+});
+
+type TableOrderKey = Omit<TaskTableSort, 'field'> & { field: TaskTableSortField | 'id'; group?: boolean };
+
+function tableOrderExpression(key: TableOrderKey): SQL {
+  if (key.group && key.field === 'due_date') {
+    return sql`case
+      when ${tasks.due_date} is null then 'No due date'
+      when ${tasks.due_date} < current_date then 'Overdue'
+      when ${tasks.due_date} < current_date + interval '1 day' then 'Today'
+      when ${tasks.due_date} < current_date + interval '8 days' then 'Next 7 days'
+      else 'Later'
+    end`;
+  }
+  switch (key.field) {
+    case 'id': return sql`${tasks.id}`;
+    case 'number': return sql`${tasks.number}`;
+    case 'title': return sql`lower(${tasks.title})`;
+    case 'status': return sql`${tasks.status}`;
+    case 'priority': return sql`case ${tasks.priority} when 'p0' then 0 when 'p1' then 1 when 'p2' then 2 else 3 end`;
+    case 'assignee': return sql`lower(${users.name})`;
+    case 'start_date': return sql`${tasks.start_date}`;
+    case 'due_date': return sql`${tasks.due_date}`;
+    case 'estimation': return sql`${tasks.estimation}`;
+    case 'labels': return sql`(
+      select lower(${labels.name}) from ${taskLabels}
+      inner join ${labels} on ${labels.id} = ${taskLabels.label_id}
+      where ${taskLabels.task_id} = ${tasks.id}
+      order by lower(${labels.name}), ${labels.id}
+      limit 1
+    )`;
+    case 'updated_at': return sql`${tasks.updated_at}`;
+    case 'project': return sql`lower(${projects.name})`;
+  }
+}
+
+type TaskTableCursorRow = {
+  id: string;
+  number: number;
+  title: string;
+  status: string;
+  priority: 'p0' | 'p1' | 'p2' | 'p3';
+  assignee_name: string | null;
+  start_date: Date | string | null;
+  due_date: Date | string | null;
+  estimation: string | number | null;
+  labels: Array<{ name: string }>;
+  updated_at: Date | string;
+  project_name: string;
+  group_cursor_value: string | number | null;
+};
+
+function tableCursorValue(task: TaskTableCursorRow, key: TableOrderKey): string | number | null {
+  if (key.group) return task.group_cursor_value;
+  switch (key.field) {
+    case 'id': return task.id;
+    case 'number': return task.number;
+    case 'title': return task.title.toLowerCase();
+    case 'status': return task.status;
+    case 'priority': return ({ p0: 0, p1: 1, p2: 2, p3: 3 } as const)[task.priority];
+    case 'assignee': return task.assignee_name?.toLowerCase() ?? null;
+    case 'start_date': return task.start_date ? new Date(task.start_date).toISOString() : null;
+    case 'due_date': return task.due_date ? new Date(task.due_date).toISOString() : null;
+    case 'estimation': return task.estimation == null ? null : Number(task.estimation);
+    case 'labels': return task.labels[0]?.name.toLowerCase() ?? null;
+    case 'updated_at': return new Date(task.updated_at).toISOString();
+    case 'project': return task.project_name.toLowerCase();
+  }
+}
+
+function cursorAfter(expression: SQL, value: string | number | null, key: TableOrderKey): SQL {
+  if (value === null) {
+    return key.nulls === 'first' ? sql`${expression} is not null` : sql`false`;
+  }
+  const comparison = key.direction === 'desc'
+    ? sql`${expression} < ${value}`
+    : sql`${expression} > ${value}`;
+  return key.nulls === 'last'
+    ? sql`(${comparison} or ${expression} is null)`
+    : comparison;
+}
+
+function tableCursorCondition(keys: TableOrderKey[], values: Array<string | number | null>): SQL | null {
+  if (values.length !== keys.length) return null;
+  const branches = keys.map((key, index) => {
+    const prior = keys.slice(0, index).map((priorKey, priorIndex) => {
+      const expression = tableOrderExpression(priorKey);
+      const value = values[priorIndex];
+      return value === null ? sql`${expression} is null` : sql`${expression} = ${value}`;
+    });
+    return and(...prior, cursorAfter(tableOrderExpression(key), values[index]!, key))!;
+  });
+  return or(...branches)!;
+}
+
+// GET /api/tasks/table — the server-backed query used only by Table view.
+taskRoutes.get('/table', async (c) => {
+  try {
+    const user = c.get('user');
+    const parsed = parseTaskTableQuery(c.req.query());
+    if (!parsed.success) {
+      return c.json({ error: 'Invalid table query', code: 'VALIDATION_ERROR' }, 400);
+    }
+    const query = parsed.data;
+    const decodedCursor = decodeTaskTableCursor(query.cursor);
+    if (query.cursor && !decodedCursor) {
+      return c.json({ error: 'Invalid cursor', code: 'INVALID_CURSOR' }, 400);
+    }
+
+    if (query.projectId) {
+      const [project] = await db.select({ id: projects.id }).from(projects).where(and(
+        eq(projects.id, query.projectId),
+        eq(projects.org_id, user.org_id),
+      )).limit(1);
+      if (!project) return c.json({ error: 'Project not found', code: 'NOT_FOUND' }, 404);
+    }
+
+    const baseConditions: SQL[] = [
+      eq(tasks.org_id, user.org_id),
+      eq(tasks.is_deleted, false),
+      eq(tasks.is_template, false),
+      isNull(tasks.parent_task_id),
+      visibleTaskCondition(user.id)!,
+    ];
+    if (query.mine) baseConditions.push(eq(tasks.assignee_id, user.id));
+    if (query.projectId) baseConditions.push(eq(tasks.project_id, query.projectId));
+    if (query.assigneeIds.length) baseConditions.push(inArray(tasks.assignee_id, query.assigneeIds));
+    if (query.priorities.length) baseConditions.push(inArray(tasks.priority, query.priorities as Array<'p0' | 'p1' | 'p2' | 'p3'>));
+    if (query.statuses.length) baseConditions.push(inArray(tasks.status, query.statuses as Array<'backlog' | 'todo' | 'in_progress' | 'in_review' | 'done' | 'cancelled'>));
+    if (query.labelIds.length) baseConditions.push(sql`exists (
+      select 1 from ${taskLabels}
+      where ${taskLabels.task_id} = ${tasks.id}
+        and ${inArray(taskLabels.label_id, query.labelIds)}
+    )`);
+    if (query.due === 'overdue') baseConditions.push(sql`${tasks.due_date} < current_date`);
+    if (query.due === 'today') baseConditions.push(sql`${tasks.due_date} >= current_date and ${tasks.due_date} < current_date + interval '1 day'`);
+    if (query.due === 'this_week') baseConditions.push(sql`${tasks.due_date} >= current_date and ${tasks.due_date} < current_date + interval '8 days'`);
+    if (query.dateFrom) baseConditions.push(sql`${tasks.due_date} >= ${query.dateFrom}::date`);
+    if (query.dateTo) baseConditions.push(sql`${tasks.due_date} < (${query.dateTo}::date + interval '1 day')`);
+
+    const configured = query.sorts.length ? query.sorts : [{ field: 'number', direction: 'desc', nulls: 'last' } satisfies TaskTableSort];
+    const keys: TableOrderKey[] = [
+      ...(query.group ? [{ ...query.group, group: true }] : []),
+      ...configured.filter((sort) => sort.field !== query.group?.field),
+      { field: 'id', direction: 'asc', nulls: 'last' },
+    ];
+    const cursorSignature = JSON.stringify({
+      projectId: query.projectId,
+      mine: query.mine,
+      assigneeIds: query.assigneeIds,
+      priorities: query.priorities,
+      statuses: query.statuses,
+      labelIds: query.labelIds,
+      due: query.due,
+      dateFrom: query.dateFrom,
+      dateTo: query.dateTo,
+      keys,
+    });
+    const cursorValues = decodedCursor?.values ?? null;
+    if (decodedCursor && decodedCursor.signature !== cursorSignature) {
+      return c.json({ error: 'Cursor does not match query', code: 'INVALID_CURSOR' }, 400);
+    }
+    const pageConditions = [...baseConditions];
+    if (cursorValues) {
+      const cursorCondition = tableCursorCondition(keys, cursorValues);
+      if (!cursorCondition) return c.json({ error: 'Cursor does not match query', code: 'INVALID_CURSOR' }, 400);
+      pageConditions.push(cursorCondition);
+    }
+
+    const baseWhere = and(...baseConditions);
+    const [countRow] = await db.select({ total: sql<number>`count(*)::int` })
+      .from(tasks)
+      .innerJoin(projects, eq(tasks.project_id, projects.id))
+      .leftJoin(users, eq(tasks.assignee_id, users.id))
+      .where(baseWhere);
+
+    const rows = await db.select({
+      id: tasks.id,
+      number: tasks.number,
+      title: tasks.title,
+      description: tasks.description,
+      status: tasks.status,
+      priority: tasks.priority,
+      assignee_id: tasks.assignee_id,
+      created_by: tasks.created_by,
+      due_date: tasks.due_date,
+      start_date: tasks.start_date,
+      estimation: tasks.estimation,
+      sort_order: tasks.sort_order,
+      project_id: tasks.project_id,
+      source_message_id: tasks.source_message_id,
+      parent_task_id: tasks.parent_task_id,
+      is_deleted: tasks.is_deleted,
+      created_at: tasks.created_at,
+      updated_at: tasks.updated_at,
+      assignee_name: users.name,
+      assignee_avatar: users.avatar_url,
+      project_name: projects.name,
+      project_prefix: projects.prefix,
+      project_color: projects.color,
+      group_cursor_value: query.group
+        ? sql<string | number | null>`${tableOrderExpression({ ...query.group, group: true })}`
+        : sql<string | number | null>`null`,
+    })
+      .from(tasks)
+      .innerJoin(projects, eq(tasks.project_id, projects.id))
+      .leftJoin(users, eq(tasks.assignee_id, users.id))
+      .where(and(...pageConditions))
+      .orderBy(...keys.map((key) => sql`${tableOrderExpression(key)} ${sql.raw(key.direction.toUpperCase())} NULLS ${sql.raw(key.nulls.toUpperCase())}`))
+      .limit(query.pageSize + 1);
+
+    const pageRows = rows.slice(0, query.pageSize);
+    const taskIds = pageRows.map((task) => task.id);
+    const labelsMap = await getLabelsForTasks(taskIds);
+    const subtaskCounts = taskIds.length ? await db.select({
+      parent_task_id: tasks.parent_task_id,
+      total: sql<number>`count(*)::int`,
+      done: sql<number>`count(*) filter (where ${tasks.status} = 'done')::int`,
+    }).from(tasks).where(and(inArray(tasks.parent_task_id, taskIds), eq(tasks.is_deleted, false))).groupBy(tasks.parent_task_id) : [];
+    const subtaskMap = new Map(subtaskCounts.map((item) => [item.parent_task_id, item]));
+    const creatorIds = [...new Set(pageRows.map((task) => task.created_by))];
+    const creatorRows = creatorIds.length ? await db.select({ id: users.id, name: users.name }).from(users).where(inArray(users.id, creatorIds)) : [];
+    const creatorMap = new Map(creatorRows.map((creator) => [creator.id, creator.name]));
+    const enriched = pageRows.map((task) => ({
+      ...task,
+      creator_name: creatorMap.get(task.created_by) ?? null,
+      labels: labelsMap.get(task.id) ?? [],
+      subtask_count: subtaskMap.get(task.id)?.total ?? 0,
+      subtask_done_count: subtaskMap.get(task.id)?.done ?? 0,
+    }));
+    const last = enriched.at(-1);
+    const data = enriched.map(({ group_cursor_value: _groupCursorValue, ...task }) => task);
+    return c.json({
+      data,
+      total: countRow?.total ?? 0,
+      next_cursor: rows.length > query.pageSize && last
+        ? encodeTaskTableCursor(cursorSignature, keys.map((key) => tableCursorValue(last, key)))
+        : null,
+    });
+  } catch (err) {
+    console.error('Failed to query task table:', err);
+    return c.json({ error: 'Failed to query task table', code: 'INTERNAL_ERROR' }, 500);
   }
 });
 

--- a/apps/api/test/task-table-query.test.ts
+++ b/apps/api/test/task-table-query.test.ts
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  decodeTaskTableCursor,
+  encodeTaskTableCursor,
+  parseTaskTableQuery,
+} from '../src/lib/task-table-query.js';
+
+test('table query accepts bounded filters, group, and three stable sorts', () => {
+  const parsed = parseTaskTableQuery({
+    project_id: 'project-1',
+    status: 'todo,in_progress',
+    priority: 'p0,p2',
+    group: 'assignee:asc',
+    sort: 'priority:asc:last,due_date:asc:last,number:desc:last',
+    page_size: '200',
+  });
+  assert.equal(parsed.success, true);
+  if (!parsed.success) return;
+  assert.deepEqual(parsed.data.statuses, ['todo', 'in_progress']);
+  assert.equal(parsed.data.sorts.length, 3);
+  assert.equal(parsed.data.group?.field, 'assignee');
+  assert.equal(parsed.data.pageSize, 200);
+});
+
+test('table query rejects missing scope, malformed clauses, and oversized pages', () => {
+  assert.equal(parseTaskTableQuery({}).success, false);
+  assert.equal(parseTaskTableQuery({ mine: 'true', sort: 'mystery:asc:last' }).success, false);
+  assert.equal(parseTaskTableQuery({ mine: 'true', sort: 'title:sideways:last' }).success, false);
+  assert.equal(parseTaskTableQuery({ mine: 'true', group: 'mystery:asc' }).success, false);
+  assert.equal(parseTaskTableQuery({ mine: 'true', priority: 'urgent' }).success, false);
+  assert.equal(parseTaskTableQuery({ mine: 'true', page_size: '201' }).success, false);
+});
+
+test('table cursors round-trip typed null-aware ordering values and fail closed', () => {
+  const values = ['todo', null, 42, 'task-id'];
+  assert.deepEqual(
+    decodeTaskTableCursor(encodeTaskTableCursor('project:test|number:desc', values)),
+    { signature: 'project:test|number:desc', values },
+  );
+  assert.equal(decodeTaskTableCursor('not-a-cursor'), null);
+});

--- a/apps/api/test/task-table-route.test.ts
+++ b/apps/api/test/task-table-route.test.ts
@@ -1,0 +1,119 @@
+import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
+import { after, before, test } from 'node:test';
+import pg from 'pg';
+import { Hono } from 'hono';
+
+import { taskRoutes } from '../src/routes/tasks.js';
+
+const DATABASE_URL = process.env.DATABASE_URL!;
+const ORG_ID = crypto.randomUUID();
+const OTHER_ORG_ID = crypto.randomUUID();
+const USER_ID = crypto.randomUUID();
+const OTHER_USER_ID = crypto.randomUUID();
+const PROJECT_ID = crypto.randomUUID();
+const OTHER_PROJECT_ID = crypto.randomUUID();
+
+const app = new Hono();
+app.use('*', async (c, next) => {
+  c.set('user', { id: USER_ID, org_id: ORG_ID, email: 'table-route@test.local', name: 'Table Route User' });
+  await next();
+});
+app.route('/api/tasks', taskRoutes);
+
+async function withClient<T>(fn: (client: pg.Client) => Promise<T>) {
+  const client = new pg.Client({ connectionString: DATABASE_URL });
+  await client.connect();
+  try { return await fn(client); } finally { await client.end(); }
+}
+
+before(async () => {
+  await withClient(async (client) => {
+    await client.query(
+      `INSERT INTO orgs (id, name, slug) VALUES ($1, 'Table Route Org', $2), ($3, 'Other Table Org', $4)`,
+      [ORG_ID, `table-${ORG_ID}`, OTHER_ORG_ID, `table-${OTHER_ORG_ID}`],
+    );
+    await client.query(
+      `INSERT INTO users (id, email, name, email_verified) VALUES
+       ($1, $2, 'Table User', true), ($3, $4, 'Other Table User', true)`,
+      [USER_ID, `table-${USER_ID}@test.local`, OTHER_USER_ID, `table-${OTHER_USER_ID}@test.local`],
+    );
+    await client.query(
+      `INSERT INTO org_members (id, org_id, user_id, role, is_active) VALUES
+       ($1, $2, $3, 'owner', true), ($4, $5, $6, 'owner', true)`,
+      [crypto.randomUUID(), ORG_ID, USER_ID, crypto.randomUUID(), OTHER_ORG_ID, OTHER_USER_ID],
+    );
+    await client.query(
+      `INSERT INTO projects (id, org_id, name, prefix, lead_id, task_counter) VALUES
+       ($1, $2, 'Table Project', 'TBL', $3, 6), ($4, $5, 'Other Project', 'OTH', $6, 1)`,
+      [PROJECT_ID, ORG_ID, USER_ID, OTHER_PROJECT_ID, OTHER_ORG_ID, OTHER_USER_ID],
+    );
+    await client.query(
+      `INSERT INTO tasks (id, org_id, project_id, number, title, status, priority, created_by, is_deleted)
+       SELECT gen_random_uuid()::text, $1, $2, n, 'Table task ' || n,
+         CASE WHEN n % 2 = 0 THEN 'todo'::task_status ELSE 'in_progress'::task_status END,
+         CASE WHEN n % 3 = 0 THEN 'p0'::task_priority ELSE 'p2'::task_priority END,
+         $3, false
+       FROM generate_series(1, 6) n`,
+      [ORG_ID, PROJECT_ID, USER_ID],
+    );
+    await client.query(
+      `UPDATE tasks SET due_date = CASE number
+        WHEN 1 THEN current_date - interval '1 day'
+        WHEN 2 THEN current_date
+        WHEN 3 THEN current_date + interval '1 day'
+        WHEN 4 THEN current_date + interval '10 days'
+        WHEN 6 THEN current_date - interval '2 days'
+        ELSE NULL END
+       WHERE project_id = $1`,
+      [PROJECT_ID],
+    );
+  });
+});
+
+after(async () => {
+  await withClient(async (client) => {
+    await client.query(`DELETE FROM tasks WHERE project_id IN ($1, $2)`, [PROJECT_ID, OTHER_PROJECT_ID]);
+    await client.query(`DELETE FROM projects WHERE id IN ($1, $2)`, [PROJECT_ID, OTHER_PROJECT_ID]);
+    await client.query(`DELETE FROM org_members WHERE org_id IN ($1, $2)`, [ORG_ID, OTHER_ORG_ID]);
+    await client.query(`DELETE FROM users WHERE id IN ($1, $2)`, [USER_ID, OTHER_USER_ID]);
+    await client.query(`DELETE FROM orgs WHERE id IN ($1, $2)`, [ORG_ID, OTHER_ORG_ID]);
+  });
+});
+
+test('table route paginates deterministically without duplicate or skipped tasks', async () => {
+  const first = await app.request(`/api/tasks/table?project_id=${PROJECT_ID}&sort=number:desc:last&page_size=2`);
+  assert.equal(first.status, 200);
+  const firstBody = await first.json() as { data: Array<{ id: string; number: number }>; total: number; next_cursor: string };
+  assert.equal(firstBody.total, 6);
+  assert.deepEqual(firstBody.data.map((task) => task.number), [6, 5]);
+
+  const second = await app.request(`/api/tasks/table?project_id=${PROJECT_ID}&sort=number:desc:last&page_size=2&cursor=${encodeURIComponent(firstBody.next_cursor)}`);
+  assert.equal(second.status, 200);
+  const secondBody = await second.json() as { data: Array<{ id: string; number: number }> };
+  assert.deepEqual(secondBody.data.map((task) => task.number), [4, 3]);
+  assert.equal(new Set([...firstBody.data, ...secondBody.data].map((task) => task.id)).size, 4);
+});
+
+test('table cursor is rejected when the query order changes', async () => {
+  const first = await app.request(`/api/tasks/table?project_id=${PROJECT_ID}&sort=number:desc:last&page_size=2`);
+  const body = await first.json() as { next_cursor: string };
+  const changed = await app.request(`/api/tasks/table?project_id=${PROJECT_ID}&sort=title:asc:last&page_size=2&cursor=${encodeURIComponent(body.next_cursor)}`);
+  assert.equal(changed.status, 400);
+});
+
+test('table route keeps database-computed due-date groups stable across pages', async () => {
+  const first = await app.request(`/api/tasks/table?project_id=${PROJECT_ID}&group=due_date:asc&page_size=3`);
+  const firstBody = await first.json() as { data: Array<{ id: string; number: number }>; next_cursor: string };
+  assert.deepEqual(firstBody.data.map((task) => task.number), [4, 3, 5]);
+
+  const second = await app.request(`/api/tasks/table?project_id=${PROJECT_ID}&group=due_date:asc&page_size=3&cursor=${encodeURIComponent(firstBody.next_cursor)}`);
+  const secondBody = await second.json() as { data: Array<{ id: string; number: number }> };
+  assert.deepEqual(secondBody.data.map((task) => task.number), [6, 1, 2]);
+  assert.equal(new Set([...firstBody.data, ...secondBody.data].map((task) => task.id)).size, 6);
+});
+
+test('table route rejects a project outside the active organization', async () => {
+  const response = await app.request(`/api/tasks/table?project_id=${OTHER_PROJECT_ID}`);
+  assert.equal(response.status, 404);
+});

--- a/apps/web/src/app/(app)/tasks/page.tsx
+++ b/apps/web/src/app/(app)/tasks/page.tsx
@@ -173,6 +173,14 @@ export default function TasksPage() {
   const [toast, setToast] = useState<string | null>(null);
   const [velocity, setVelocity] = useState<{ average: number } | null>(null);
   const [isMobile, setIsMobile] = useState(false);
+  const [tablePage, setTablePage] = useState({
+    serverBacked: false,
+    total: 0,
+    cursor: null as string | null,
+    nextCursor: null as string | null,
+    previousCursors: [] as Array<string | null>,
+    loading: false,
+  });
   const viewMenuButtonRef = useRef<HTMLButtonElement | null>(null);
   const [viewMenuOpen, setViewMenuOpen] = useState(false);
   useEffect(() => {
@@ -257,7 +265,45 @@ export default function TasksPage() {
   }, [currentProjectId, projects]);
 
   // Load tasks when project changes (or for My Tasks view)
-  const loadTasks = useCallback(async () => {
+  const loadTasks = useCallback(async (cursor: string | null = null) => {
+    if (view === 'table') {
+      const params = new URLSearchParams();
+      if (isMyTasksView) params.set('mine', 'true');
+      const projectId = isMyTasksView ? filters.projectId : selectedProject?.id;
+      if (projectId) params.set('project_id', projectId);
+      if (filters.assigneeIds.length) params.set('assignee', filters.assigneeIds.join(','));
+      if (filters.priorities.length) params.set('priority', filters.priorities.join(','));
+      if (filters.status.length) params.set('status', filters.status.join(','));
+      if (filters.labels.length) params.set('labels', filters.labels.join(','));
+      if (filters.dueDate) params.set('due', filters.dueDate);
+      if (filters.dateFrom) params.set('date_from', filters.dateFrom);
+      if (filters.dateTo) params.set('date_to', filters.dateTo);
+      if (layoutConfig.sort.length) {
+        params.set('sort', layoutConfig.sort.slice(0, 3).map((sort) => `${sort.field}:${sort.direction}:${sort.nulls}`).join(','));
+      }
+      if (layoutConfig.groupBy) params.set('group', `${layoutConfig.groupBy.field}:${layoutConfig.groupBy.direction}`);
+      if (cursor) params.set('cursor', cursor);
+      params.set('page_size', isMobile ? '50' : '200');
+
+      setTablePage((current) => ({ ...current, loading: true }));
+      const tableResponse = await api.get(`/api/tasks/table?${params}`);
+      if (tableResponse.ok) {
+        const page = await tableResponse.json();
+        setTasks(page.data);
+        setTablePage((current) => ({
+          ...current,
+          serverBacked: true,
+          total: page.total,
+          cursor,
+          nextCursor: page.next_cursor,
+          previousCursors: cursor === null ? [] : current.previousCursors,
+          loading: false,
+        }));
+        return;
+      }
+      // Keep the pre-Loop-3 loader as a safe rollback path.
+      setTablePage((current) => ({ ...current, serverBacked: false, loading: false }));
+    }
     if (isMyTasksView) {
       // Load all tasks assigned to the current user across all projects
       const res = await api.get('/api/tasks/my');
@@ -273,7 +319,7 @@ export default function TasksPage() {
       const data = await res.json();
       setTasks(data);
     }
-  }, [selectedProject, isMyTasksView]);
+  }, [selectedProject, isMyTasksView, view, filters, layoutConfig.sort, layoutConfig.groupBy, isMobile]);
 
   useEffect(() => {
     loadTasks();
@@ -297,10 +343,18 @@ export default function TasksPage() {
 
     const onCreated = (payload: Task) => {
       if (!isInScope(payload)) return;
+      if (view === 'table') {
+        void loadTasks(tablePage.cursor);
+        return;
+      }
       setTasks((prev) => (prev.some((t) => t.id === payload.id) ? prev : [...prev, payload]));
     };
 
     const onUpdated = (payload: Partial<Task> & { id: string }) => {
+      if (view === 'table') {
+        void loadTasks(tablePage.cursor);
+        return;
+      }
       setTasks((prev) => {
         const idx = prev.findIndex((t) => t.id === payload.id);
         if (idx === -1) {
@@ -317,6 +371,11 @@ export default function TasksPage() {
     };
 
     const onDeleted = (payload: { id: string }) => {
+      if (view === 'table') {
+        void loadTasks(tablePage.cursor);
+        setSelectedTask((prev) => (prev && prev.id === payload.id ? null : prev));
+        return;
+      }
       setTasks((prev) => prev.filter((t) => t.id !== payload.id));
       setSelectedTask((prev) => (prev && prev.id === payload.id ? null : prev));
     };
@@ -326,6 +385,10 @@ export default function TasksPage() {
     // shifted (new in-scope items after bulk assign).
     const onBulkUpdated = (payload: { task_ids: string[]; changes: Partial<Task> }) => {
       if (!payload || !Array.isArray(payload.task_ids)) return;
+      if (view === 'table') {
+        void loadTasks(tablePage.cursor);
+        return;
+      }
       const ids = new Set(payload.task_ids);
       setTasks((prev) => {
         let touched = false;
@@ -357,7 +420,7 @@ export default function TasksPage() {
       socket.off('task:bulk_updated', onBulkUpdated);
       socket.off('task:deleted', onDeleted);
     };
-  }, [selectedProject, isMyTasksView, user?.id, loadTasks]);
+  }, [selectedProject, isMyTasksView, user?.id, loadTasks, view, tablePage.cursor]);
 
   // Load org members for assignee dropdown in bulk actions
   useEffect(() => {
@@ -745,6 +808,26 @@ export default function TasksPage() {
     filters,
     projectId: selectedProject?.id ?? null,
   }), [layoutConfig, view, filters, selectedProject?.id]);
+
+  const handleTableNextPage = useCallback(async () => {
+    if (!tablePage.nextCursor || tablePage.loading) return;
+    const next = tablePage.nextCursor;
+    setTablePage((current) => ({
+      ...current,
+      previousCursors: [...current.previousCursors, current.cursor],
+    }));
+    await loadTasks(next);
+  }, [tablePage.nextCursor, tablePage.loading, loadTasks]);
+
+  const handleTablePreviousPage = useCallback(async () => {
+    if (!tablePage.previousCursors.length || tablePage.loading) return;
+    const previous = tablePage.previousCursors.at(-1) ?? null;
+    setTablePage((current) => ({
+      ...current,
+      previousCursors: current.previousCursors.slice(0, -1),
+    }));
+    await loadTasks(previous);
+  }, [tablePage.previousCursors, tablePage.loading, loadTasks]);
 
   const handleApplyViewConfig = useCallback((input: TaskViewConfigV1) => {
     const config = normalizeTaskViewConfig(input);
@@ -1228,7 +1311,8 @@ export default function TasksPage() {
                   <span className="text-[11px]" style={{ color: 'var(--muted)', fontFamily: 'var(--font-body)' }}>
                     Showing{' '}
                     <span style={{ color: 'var(--foreground-secondary)', fontWeight: 500 }}>
-                      {filteredTasks.length} {filteredTasks.length === 1 ? 'task' : 'tasks'}
+                      {view === 'table' && tablePage.serverBacked ? tablePage.total : filteredTasks.length}{' '}
+                      {(view === 'table' && tablePage.serverBacked ? tablePage.total : filteredTasks.length) === 1 ? 'task' : 'tasks'}
                     </span>
                     {selectedProject ? (
                       <> in <span style={{ color: 'var(--foreground-secondary)', fontWeight: 500 }}>{selectedProject.name}</span></>
@@ -1275,6 +1359,15 @@ export default function TasksPage() {
                 viewConfig={currentViewConfig}
                 onViewConfigChange={setLayoutConfig}
                 onInlineCreate={handleInlineCreate}
+                pagination={tablePage.serverBacked ? {
+                  page: tablePage.previousCursors.length + 1,
+                  total: tablePage.total,
+                  hasPrevious: tablePage.previousCursors.length > 0,
+                  hasNext: Boolean(tablePage.nextCursor),
+                  loading: tablePage.loading,
+                  onPrevious: handleTablePreviousPage,
+                  onNext: handleTableNextPage,
+                } : undefined}
               />
             ) : view === 'calendar' ? (
               <TaskCalendarView

--- a/apps/web/src/components/task-list.tsx
+++ b/apps/web/src/components/task-list.tsx
@@ -64,6 +64,15 @@ type Props = {
   viewConfig: TaskViewConfigV1;
   onViewConfigChange: (config: TaskViewConfigV1) => void;
   onInlineCreate?: (title: string, defaults: TaskPatch) => Promise<boolean>;
+  pagination?: {
+    page: number;
+    total: number;
+    hasPrevious: boolean;
+    hasNext: boolean;
+    loading: boolean;
+    onPrevious: () => void;
+    onNext: () => void;
+  };
 };
 
 type TaskPatch = Partial<Pick<Task, 'title' | 'status' | 'priority' | 'assignee_id' | 'due_date' | 'start_date' | 'estimation'>> & {
@@ -177,7 +186,7 @@ function taskGroup(task: Task, field: string): string {
   }
 }
 
-export function TaskTable({ tasks, projectPrefix, onTaskClick, onTaskPatch, members, availableLabels, selectedTaskId, selectionMode, selectedTaskIds, onToggleSelect, statuses, hidePrefixIds, priorityVocab, viewConfig, onViewConfigChange, onInlineCreate }: Props) {
+export function TaskTable({ tasks, projectPrefix, onTaskClick, onTaskPatch, members, availableLabels, selectedTaskId, selectionMode, selectedTaskIds, onToggleSelect, statuses, hidePrefixIds, priorityVocab, viewConfig, onViewConfigChange, onInlineCreate, pagination }: Props) {
   const STATUS_OPTIONS = useMemo(() => {
     if (!statuses || statuses.length === 0) return DEFAULT_STATUS_OPTIONS;
     return [...statuses]
@@ -235,8 +244,9 @@ export function TaskTable({ tasks, projectPrefix, onTaskClick, onTaskPatch, memb
       return a.id.localeCompare(b.id);
     });
 
-  // Fix 3: page-sliced rows
-  const visibleRows = sorted.slice(0, visibleCount);
+  // Server-backed pages already arrive in cursor order. Re-sorting a page here
+  // can move rows across page boundaries and cause skips or duplicates.
+  const visibleRows = pagination ? tasks : sorted.slice(0, visibleCount);
 
   const SortIcon = ({ field }: { field: SortField }) => {
     const index = configuredSorts.findIndex((clause) => clause.field === field);
@@ -286,6 +296,28 @@ export function TaskTable({ tasks, projectPrefix, onTaskClick, onTaskPatch, memb
       </td>
     </tr>
   );
+
+  const paginationControls = pagination && (pagination.hasPrevious || pagination.hasNext) ? (
+    <div className="flex items-center justify-center gap-3 py-3 text-[12px]" style={{ color: 'var(--muted)' }}>
+      <button
+        disabled={!pagination.hasPrevious || pagination.loading}
+        onClick={pagination.onPrevious}
+        className="rounded-full px-3 py-1.5 font-medium disabled:opacity-35"
+        style={{ border: '1px solid var(--border)', color: 'var(--foreground-secondary)' }}
+      >
+        Previous
+      </button>
+      <span>Page {pagination.page} · {pagination.total} tasks</span>
+      <button
+        disabled={!pagination.hasNext || pagination.loading}
+        onClick={pagination.onNext}
+        className="rounded-full px-3 py-1.5 font-medium disabled:opacity-35"
+        style={{ border: '1px solid var(--border)', color: 'var(--foreground-secondary)' }}
+      >
+        Next
+      </button>
+    </div>
+  ) : null;
 
   if (isMobile) {
     return (
@@ -345,8 +377,8 @@ export function TaskTable({ tasks, projectPrefix, onTaskClick, onTaskPatch, memb
             </div>
           );
         })}
-        {/* Fix 3: Load more */}
-        {visibleCount < sorted.length && (
+        {paginationControls}
+        {!pagination && visibleCount < sorted.length && (
           <div className="flex justify-center py-3">
             <button
               onClick={() => setVisibleCount(c => c + PAGE_SIZE)}
@@ -748,8 +780,8 @@ export function TaskTable({ tasks, projectPrefix, onTaskClick, onTaskPatch, memb
           <p className="text-[14px]" style={{ fontFamily: 'var(--font-body)' }}>No tasks match the current filters</p>
         </div>
       )}
-      {/* Fix 3: Load more button */}
-      {visibleCount < sorted.length && (
+      {paginationControls}
+      {!pagination && visibleCount < sorted.length && (
         <div className="flex justify-center py-4">
           <button
             onClick={() => setVisibleCount(c => c + PAGE_SIZE)}


### PR DESCRIPTION
## Summary
- add a validated, tenant-scoped server query for the task table
- preserve saved grouping/sorting/filtering with stable cursor pagination
- keep other task views on the existing loader as a rollback path
- add responsive page controls and bounded row rendering

## Verification
- API and web typechecks
- targeted web lint
- 7 focused parser/route tests
- 10,000-task traversal: 50 pages, 10,000 unique rows, p95 249ms
- desktop inline edit and 205-task pagination dogfood
- mobile table cards with no horizontal overflow