### PR TITLE
Add safe task table bulk operations

### DIFF
--- a/apps/api/src/routes/tasks.ts
+++ b/apps/api/src/routes/tasks.ts
@@ -69,6 +69,25 @@ const updateTaskSchema = z.object({
   metadata: z.record(z.string(), z.any()).nullable().optional(),
 });
 
+const bulkTaskIdsSchema = z.array(z.string().min(1)).min(1).max(50);
+const bulkTaskUpdateSchema = z.object({
+  task_ids: bulkTaskIdsSchema,
+  updates: z.object({
+    status: z.enum(['backlog', 'todo', 'in_progress', 'in_review', 'done', 'cancelled']).optional(),
+    priority: z.enum(['p0', 'p1', 'p2', 'p3']).optional(),
+    assignee_id: z.string().nullable().optional(),
+    due_date: z.string().nullable().optional(),
+    start_date: z.string().nullable().optional(),
+    estimation: z.string().max(100).nullable().optional(),
+    add_label_ids: z.array(z.string().uuid()).max(50).optional(),
+    remove_label_ids: z.array(z.string().uuid()).max(50).optional(),
+  }).refine((updates) => Object.values(updates).some((value) => value !== undefined), {
+    message: 'At least one update is required',
+  }),
+});
+
+const bulkTaskDeleteSchema = z.object({ task_ids: bulkTaskIdsSchema });
+
 async function validateAssignableAssigneeId(assigneeId: unknown, orgId: string): Promise<string | null | undefined> {
   if (assigneeId === undefined) return undefined;
   if (assigneeId === null || assigneeId === '') return null;
@@ -536,17 +555,33 @@ taskRoutes.post('/labels', async (c) => {
 taskRoutes.patch('/bulk', async (c) => {
   try {
     const user = c.get('user');
-    const body = await c.req.json();
-    const { task_ids, updates } = body;
+    const parsed = bulkTaskUpdateSchema.safeParse(await c.req.json());
+    if (!parsed.success) {
+      return c.json({ error: parsed.error.issues[0]?.message ?? 'Invalid bulk update', code: 'VALIDATION_ERROR' }, 400);
+    }
+    const taskIds = [...new Set(parsed.data.task_ids)];
+    const updates = parsed.data.updates;
 
-    if (!task_ids || !Array.isArray(task_ids) || task_ids.length === 0) {
-      return c.json({ error: 'task_ids required', code: 'VALIDATION_ERROR' }, 400);
-    }
-    if (task_ids.length > 50) {
-      return c.json({ error: 'Max 50 tasks per bulk operation', code: 'VALIDATION_ERROR' }, 400);
-    }
-    if (!updates || typeof updates !== 'object') {
-      return c.json({ error: 'updates required', code: 'VALIDATION_ERROR' }, 400);
+    const targetTasks = await db.select({
+      id: tasks.id,
+      project_id: tasks.project_id,
+      status: tasks.status,
+      priority: tasks.priority,
+      assignee_id: tasks.assignee_id,
+      due_date: tasks.due_date,
+      start_date: tasks.start_date,
+      estimation: tasks.estimation,
+    })
+      .from(tasks)
+      .innerJoin(projects, eq(tasks.project_id, projects.id))
+      .where(and(
+        inArray(tasks.id, taskIds),
+        eq(tasks.org_id, user.org_id),
+        eq(tasks.is_deleted, false),
+        visibleTaskCondition(user.id),
+      ));
+    if (targetTasks.length !== taskIds.length) {
+      return c.json({ error: 'One or more tasks were not found or are not accessible', code: 'TASK_NOT_FOUND' }, 404);
     }
 
     const nextAssigneeId = await validateAssignableAssigneeId(updates.assignee_id, user.org_id);
@@ -554,68 +589,123 @@ taskRoutes.patch('/bulk', async (c) => {
       return c.json({ error: 'Assignee must be an active user or healthy agent in this organization', code: 'INVALID_ASSIGNEE' }, 400);
     }
 
-    const updateData: Record<string, any> = { updated_at: new Date() };
-    if (updates.status) updateData.status = updates.status;
-    if (updates.assignee_id !== undefined) updateData.assignee_id = nextAssigneeId;
-    if (updates.priority) updateData.priority = updates.priority;
+    const parseDate = (value: string | null | undefined) => {
+      if (value === undefined || value === null || value === '') return value === undefined ? undefined : null;
+      const date = new Date(value);
+      return Number.isNaN(date.getTime()) ? undefined : date;
+    };
+    const nextDueDate = parseDate(updates.due_date);
+    const nextStartDate = parseDate(updates.start_date);
+    if ((updates.due_date && nextDueDate === undefined) || (updates.start_date && nextStartDate === undefined)) {
+      return c.json({ error: 'Dates must be valid ISO dates', code: 'VALIDATION_ERROR' }, 400);
+    }
 
-    await db.update(tasks)
-      .set(updateData)
-      .where(
-        and(
-          inArray(tasks.id, task_ids),
-          eq(tasks.org_id, user.org_id),
-        ),
-      );
-
-    for (const taskId of task_ids) {
-      if (updates.status) {
-        await db.insert(taskActivity).values({
-          org_id: user.org_id,
-          task_id: taskId,
-          user_id: user.id,
-          action: 'status_changed',
-          field: 'status',
-          new_value: updates.status,
-        });
-      }
-      if (updates.assignee_id !== undefined) {
-        await db.insert(taskActivity).values({
-          org_id: user.org_id,
-          task_id: taskId,
-          user_id: user.id,
-          action: 'assigned',
-          field: 'assignee_id',
-          new_value: nextAssigneeId,
-        });
-      }
-      if (updates.priority) {
-        await db.insert(taskActivity).values({
-          org_id: user.org_id,
-          task_id: taskId,
-          user_id: user.id,
-          action: 'priority_changed',
-          field: 'priority',
-          new_value: updates.priority,
-        });
+    if (updates.status) {
+      const config = await getProjectResolvedConfig(targetTasks[0]!.project_id);
+      const invalidTransition = targetTasks.find((task) => !isValidTransition(task.status, updates.status!, config));
+      if (invalidTransition) {
+        return c.json({ error: `Cannot move every selected task to ${updates.status}`, code: 'INVALID_STATUS_TRANSITION' }, 400);
       }
     }
+
+    const addLabelIds = [...new Set(updates.add_label_ids ?? [])];
+    const removeLabelIds = [...new Set(updates.remove_label_ids ?? [])];
+    if (addLabelIds.some((id) => removeLabelIds.includes(id))) {
+      return c.json({ error: 'A label cannot be added and removed in the same operation', code: 'VALIDATION_ERROR' }, 400);
+    }
+    const requestedLabelIds = [...new Set([...addLabelIds, ...removeLabelIds])];
+    if (requestedLabelIds.length) {
+      const validLabels = await db.select({ id: labels.id }).from(labels)
+        .where(and(eq(labels.org_id, user.org_id), inArray(labels.id, requestedLabelIds)));
+      if (validLabels.length !== requestedLabelIds.length) {
+        return c.json({ error: 'One or more labels are invalid', code: 'INVALID_LABEL' }, 400);
+      }
+    }
+    const currentLabelRows = requestedLabelIds.length
+      ? await db.select({ task_id: taskLabels.task_id, label_id: taskLabels.label_id }).from(taskLabels)
+        .where(and(inArray(taskLabels.task_id, taskIds), inArray(taskLabels.label_id, requestedLabelIds)))
+      : [];
+    const currentLabelKeys = new Set(currentLabelRows.map((row) => `${row.task_id}:${row.label_id}`));
+
+    const sameDate = (left: Date | null, right: Date | null | undefined) => right === undefined || left?.getTime() === right?.getTime();
+    const activityRows: Array<typeof taskActivity.$inferInsert> = [];
+    const changedIds = new Set<string>();
+    const canonicalChangedIds = new Set<string>();
+    const labelAdds: Array<{ task_id: string; label_id: string }> = [];
+    const labelRemoves: Array<{ task_id: string; label_id: string }> = [];
+    for (const task of targetTasks) {
+      const record = (action: string, field: string, oldValue: string | null, newValue: string | null) => {
+        changedIds.add(task.id);
+        canonicalChangedIds.add(task.id);
+        activityRows.push({ org_id: user.org_id, task_id: task.id, user_id: user.id, action, field, old_value: oldValue, new_value: newValue });
+      };
+      if (updates.status !== undefined && updates.status !== task.status) record('status_changed', 'status', task.status, updates.status);
+      if (updates.priority !== undefined && updates.priority !== task.priority) record('priority_changed', 'priority', task.priority, updates.priority);
+      if (updates.assignee_id !== undefined && nextAssigneeId !== task.assignee_id) record('assigned', 'assignee_id', task.assignee_id, nextAssigneeId ?? null);
+      if (updates.due_date !== undefined && !sameDate(task.due_date, nextDueDate)) record('due_date_changed', 'due_date', task.due_date?.toISOString() ?? null, nextDueDate?.toISOString() ?? null);
+      if (updates.start_date !== undefined && !sameDate(task.start_date, nextStartDate)) record('start_date_changed', 'start_date', task.start_date?.toISOString() ?? null, nextStartDate?.toISOString() ?? null);
+      if (updates.estimation !== undefined && updates.estimation !== task.estimation) record('estimation_changed', 'estimation', task.estimation, updates.estimation);
+      for (const labelId of addLabelIds) {
+        if (!currentLabelKeys.has(`${task.id}:${labelId}`)) {
+          labelAdds.push({ task_id: task.id, label_id: labelId });
+          changedIds.add(task.id);
+          activityRows.push({ org_id: user.org_id, task_id: task.id, user_id: user.id, action: 'label_added', field: 'labels', new_value: labelId });
+        }
+      }
+      for (const labelId of removeLabelIds) {
+        if (currentLabelKeys.has(`${task.id}:${labelId}`)) {
+          labelRemoves.push({ task_id: task.id, label_id: labelId });
+          changedIds.add(task.id);
+          activityRows.push({ org_id: user.org_id, task_id: task.id, user_id: user.id, action: 'label_removed', field: 'labels', old_value: labelId });
+        }
+      }
+    }
+
+    const updatedIds = [...changedIds];
+    if (!updatedIds.length) return c.json({ success: true, requested: taskIds.length, updated: 0, updated_ids: [] });
+
+    const updateData: Partial<typeof tasks.$inferInsert> = { updated_at: new Date() };
+    if (updates.status !== undefined) updateData.status = updates.status;
+    if (updates.priority !== undefined) updateData.priority = updates.priority;
+    if (updates.assignee_id !== undefined) updateData.assignee_id = nextAssigneeId ?? null;
+    if (updates.due_date !== undefined) updateData.due_date = nextDueDate ?? null;
+    if (updates.start_date !== undefined) updateData.start_date = nextStartDate ?? null;
+    if (updates.estimation !== undefined) updateData.estimation = updates.estimation;
+
+    await db.transaction(async (tx) => {
+      if (canonicalChangedIds.size) {
+        await tx.update(tasks).set(updateData).where(inArray(tasks.id, [...canonicalChangedIds]));
+      } else {
+        await tx.update(tasks).set({ updated_at: new Date() }).where(inArray(tasks.id, updatedIds));
+      }
+      if (labelAdds.length) await tx.insert(taskLabels).values(labelAdds).onConflictDoNothing();
+      if (labelRemoves.length) {
+        for (const row of labelRemoves) {
+          await tx.delete(taskLabels).where(and(eq(taskLabels.task_id, row.task_id), eq(taskLabels.label_id, row.label_id)));
+        }
+      }
+      if (updates.assignee_id !== undefined && nextAssigneeId) {
+        await tx.delete(taskAssignees).where(and(inArray(taskAssignees.task_id, updatedIds), eq(taskAssignees.user_id, nextAssigneeId)));
+      }
+      if (activityRows.length) await tx.insert(taskActivity).values(activityRows);
+    });
 
     // Task 5.5 — grouped notification for bulk assign.
     // When ≥3 tasks in one bulk op target the same user (excluding the
     // actor), write one notification (type=task_assigned) with
     // metadata.task_ids so the client can render a grouped chip +
     // deep-link to the filtered list.
-    if (nextAssigneeId && nextAssigneeId !== user.id && task_ids.length >= 3) {
+    const assignedIds = targetTasks.filter((task) => updates.assignee_id !== undefined && task.assignee_id !== nextAssigneeId).map((task) => task.id);
+    if (nextAssigneeId && nextAssigneeId !== user.id && assignedIds.length >= 3) {
       try {
         const notification = await createNotificationIfAllowed({
           org_id: user.org_id,
           user_id: nextAssigneeId,
           type: 'task_assigned',
-          title: `You were assigned ${task_ids.length} tasks`,
+          title: `You were assigned ${assignedIds.length} tasks`,
           body: null,
           link: `/tasks?mine=1`,
-          metadata: { task_ids, grouped: true, kind: 'bulk_assign' },
+          metadata: { task_ids: assignedIds, grouped: true, kind: 'bulk_assign' },
         }, { channel: 'tasks' });
         if (notification) {
           emitToUser(nextAssigneeId, 'notification:new', notification);
@@ -629,12 +719,12 @@ taskRoutes.patch('/bulk', async (c) => {
     const io = getIO();
     if (io) {
       io.to(`org:${user.org_id}`).emit('task:bulk_updated', {
-        task_ids,
+        task_ids: updatedIds,
         changes: updateData,
       });
     }
 
-    return c.json({ success: true, updated: task_ids.length });
+    return c.json({ success: true, requested: taskIds.length, updated: updatedIds.length, updated_ids: updatedIds });
   } catch (err) {
     console.error('Failed to bulk update tasks:', err);
     return c.json({ error: 'Failed to bulk update tasks', code: 'INTERNAL_ERROR' }, 500);
@@ -645,42 +735,39 @@ taskRoutes.patch('/bulk', async (c) => {
 taskRoutes.post('/bulk-delete', async (c) => {
   try {
     const user = c.get('user');
-    const body = await c.req.json();
-    const { task_ids } = body;
-
-    if (!task_ids || !Array.isArray(task_ids) || task_ids.length === 0) {
-      return c.json({ error: 'task_ids required', code: 'VALIDATION_ERROR' }, 400);
+    const parsed = bulkTaskDeleteSchema.safeParse(await c.req.json());
+    if (!parsed.success) {
+      return c.json({ error: parsed.error.issues[0]?.message ?? 'Invalid bulk delete', code: 'VALIDATION_ERROR' }, 400);
     }
-    if (task_ids.length > 50) {
-      return c.json({ error: 'Max 50 tasks per bulk operation', code: 'VALIDATION_ERROR' }, 400);
+    const taskIds = [...new Set(parsed.data.task_ids)];
+    const targetTasks = await db.select({ id: tasks.id, created_by: tasks.created_by, assignee_id: tasks.assignee_id })
+      .from(tasks)
+      .innerJoin(projects, eq(tasks.project_id, projects.id))
+      .where(and(inArray(tasks.id, taskIds), eq(tasks.org_id, user.org_id), eq(tasks.is_deleted, false), visibleTaskCondition(user.id)));
+    if (targetTasks.length !== taskIds.length) {
+      return c.json({ error: 'One or more tasks were not found or are not accessible', code: 'TASK_NOT_FOUND' }, 404);
+    }
+    const [member] = await db.select({ role: orgMembers.role }).from(orgMembers)
+      .where(and(eq(orgMembers.org_id, user.org_id), eq(orgMembers.user_id, user.id))).limit(1);
+    if (targetTasks.some((task) => !canDeleteTask(user, task, member?.role ?? null))) {
+      return c.json({ error: 'You cannot delete every selected task', code: 'FORBIDDEN' }, 403);
     }
 
-    await db.update(tasks)
-      .set({ is_deleted: true, updated_at: new Date() })
-      .where(
-        and(
-          inArray(tasks.id, task_ids),
-          eq(tasks.org_id, user.org_id),
-        ),
-      );
-
-    for (const taskId of task_ids) {
-      await db.insert(taskActivity).values({
-        org_id: user.org_id,
-        task_id: taskId,
-        user_id: user.id,
-        action: 'deleted',
-      });
-    }
+    await db.transaction(async (tx) => {
+      await tx.update(tasks).set({ is_deleted: true, updated_at: new Date() }).where(inArray(tasks.id, taskIds));
+      await tx.insert(taskActivity).values(taskIds.map((taskId) => ({
+        org_id: user.org_id, task_id: taskId, user_id: user.id, action: 'deleted',
+      })));
+    });
 
     const io = getIO();
     if (io) {
-      for (const taskId of task_ids) {
+      for (const taskId of taskIds) {
         io.to(`org:${user.org_id}`).emit('task:deleted', { id: taskId });
       }
     }
 
-    return c.json({ success: true, deleted: task_ids.length });
+    return c.json({ success: true, deleted: taskIds.length, deleted_ids: taskIds });
   } catch (err) {
     console.error('Failed to bulk delete tasks:', err);
     return c.json({ error: 'Failed to bulk delete tasks', code: 'INTERNAL_ERROR' }, 500);

--- a/apps/api/test/tasks-bulk-grouped-notify.test.ts
+++ b/apps/api/test/tasks-bulk-grouped-notify.test.ts
@@ -34,6 +34,9 @@ function randomLetters(n: number): string {
 
 let projectPrefix: string | null = null;
 let projectId: string | null = null;
+let hiddenProjectId: string | null = null;
+let hiddenTaskId: string | null = null;
+let labelId: string | null = null;
 const taskIds: string[] = [];
 let testApp: Hono | null = null;
 
@@ -76,7 +79,7 @@ before(async () => {
     );
     projectId = p.rows[0].id as string;
 
-    for (let i = 1; i <= 4; i++) {
+    for (let i = 1; i <= 50; i++) {
       const t = await c.query(
         `INSERT INTO tasks (id, org_id, project_id, number, title, status, priority, created_by, is_deleted)
          VALUES (gen_random_uuid()::text, $1, $2, $3, $4, 'todo', 'p2', $5, false)
@@ -85,6 +88,24 @@ before(async () => {
       );
       taskIds.push(t.rows[0].id as string);
     }
+    const hiddenProject = await c.query(
+      `INSERT INTO projects (id, org_id, name, prefix, lead_id, task_counter)
+       VALUES (gen_random_uuid()::text, $1, $2, $3, $4, 0) RETURNING id`,
+      [ORG_ID, `Hidden Bulk ${projectPrefix}`, `H${projectPrefix}`, ASSIGNEE_ID],
+    );
+    hiddenProjectId = hiddenProject.rows[0].id as string;
+    const hiddenTask = await c.query(
+      `INSERT INTO tasks (id, org_id, project_id, number, title, status, priority, created_by, is_deleted, metadata)
+       VALUES (gen_random_uuid()::text, $1, $2, 1, 'Hidden bulk task', 'todo', 'p2', $3, false, '{"visibility":"restricted"}'::jsonb)
+       RETURNING id`,
+      [ORG_ID, hiddenProjectId, ASSIGNEE_ID],
+    );
+    hiddenTaskId = hiddenTask.rows[0].id as string;
+    const label = await c.query(
+      `INSERT INTO labels (id, org_id, name, color) VALUES (gen_random_uuid()::text, $1, $2, '#7c3aed') RETURNING id`,
+      [ORG_ID, `Bulk label ${projectPrefix}`],
+    );
+    labelId = label.rows[0].id as string;
   });
 
   const { taskRoutes } = await import('../src/routes/tasks.js');
@@ -120,6 +141,12 @@ after(async () => {
     await c.query(`DELETE FROM task_assignees WHERE task_id IN (${fixtureTaskFilter})`, [ACTOR_ID]);
     await c.query(`DELETE FROM tasks WHERE id IN (${fixtureTaskFilter})`, [ACTOR_ID]);
     await c.query(`DELETE FROM projects WHERE id IN (${fixtureProjectFilter})`, [ACTOR_ID]);
+    if (hiddenTaskId) {
+      await c.query(`DELETE FROM task_activity WHERE task_id = $1`, [hiddenTaskId]);
+      await c.query(`DELETE FROM tasks WHERE id = $1`, [hiddenTaskId]);
+    }
+    if (hiddenProjectId) await c.query(`DELETE FROM projects WHERE id = $1`, [hiddenProjectId]);
+    if (labelId) await c.query(`DELETE FROM labels WHERE id = $1`, [labelId]);
     await c.query(
       `DELETE FROM notifications WHERE user_id IN ($1, $2)`,
       [ACTOR_ID, ASSIGNEE_ID],
@@ -236,5 +263,93 @@ test('bulk self-assign (actor==assignee) skips the notification even at ≥3', a
       [ACTOR_ID],
     );
     assert.equal(r.rows.length, 0, 'self-assign must not notify');
+  });
+});
+
+test('bulk update handles 1, 10, and 50 tasks and repeats as an idempotent no-op', async () => {
+  const one = taskIds.slice(0, 1);
+  const dueDate = '2026-08-20T00:00:00.000Z';
+  const startDate = '2026-08-18T00:00:00.000Z';
+  const body = { task_ids: one, updates: { due_date: dueDate, start_date: startDate, estimation: '2h', add_label_ids: [labelId] } };
+  const first = await testApp!.request('/api/tasks/bulk', {
+    method: 'PATCH', headers: { 'content-type': 'application/json' }, body: JSON.stringify(body),
+  });
+  assert.equal(first.status, 200);
+  assert.equal((await first.json() as any).updated, 1);
+
+  const activityBeforeRepeat = await withClient(async (c) => {
+    const row = await c.query(`SELECT count(*)::int AS count FROM task_activity WHERE task_id = $1`, [one[0]]);
+    return row.rows[0].count as number;
+  });
+  const repeat = await testApp!.request('/api/tasks/bulk', {
+    method: 'PATCH', headers: { 'content-type': 'application/json' }, body: JSON.stringify(body),
+  });
+  assert.equal(repeat.status, 200);
+  assert.equal((await repeat.json() as any).updated, 0);
+  await withClient(async (c) => {
+    const task = await c.query(`SELECT to_char(due_date, 'YYYY-MM-DD') AS due_date, to_char(start_date, 'YYYY-MM-DD') AS start_date, estimation FROM tasks WHERE id = $1`, [one[0]]);
+    assert.equal(task.rows[0].due_date, '2026-08-20');
+    assert.equal(task.rows[0].start_date, '2026-08-18');
+    assert.equal(task.rows[0].estimation, '2h');
+    const attached = await c.query(`SELECT 1 FROM task_labels WHERE task_id = $1 AND label_id = $2`, [one[0], labelId]);
+    assert.equal(attached.rows.length, 1);
+    const activity = await c.query(`SELECT count(*)::int AS count FROM task_activity WHERE task_id = $1`, [one[0]]);
+    assert.equal(activity.rows[0].count, activityBeforeRepeat);
+  });
+
+  const ten = await testApp!.request('/api/tasks/bulk', {
+    method: 'PATCH', headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ task_ids: taskIds.slice(0, 10), updates: { priority: 'p0' } }),
+  });
+  assert.equal(ten.status, 200);
+  assert.equal((await ten.json() as any).updated, 10);
+
+  const fifty = await testApp!.request('/api/tasks/bulk', {
+    method: 'PATCH', headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ task_ids: taskIds, updates: { status: 'in_progress' } }),
+  });
+  assert.equal(fifty.status, 200);
+  assert.equal((await fifty.json() as any).updated, 50);
+});
+
+test('mixed visible and inaccessible IDs fail atomically', async () => {
+  const visibleId = taskIds[0]!;
+  const before = await withClient(async (c) => {
+    const row = await c.query(`SELECT priority FROM tasks WHERE id = $1`, [visibleId]);
+    return row.rows[0].priority as string;
+  });
+  const response = await testApp!.request('/api/tasks/bulk', {
+    method: 'PATCH', headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ task_ids: [visibleId, hiddenTaskId], updates: { priority: 'p3' } }),
+  });
+  assert.equal(response.status, 404);
+  await withClient(async (c) => {
+    const row = await c.query(`SELECT priority FROM tasks WHERE id = $1`, [visibleId]);
+    assert.equal(row.rows[0].priority, before);
+  });
+});
+
+test('bulk delete is atomic across visibility boundaries and preserves history', async () => {
+  const visibleId = taskIds[49]!;
+  const rejected = await testApp!.request('/api/tasks/bulk-delete', {
+    method: 'POST', headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ task_ids: [visibleId, hiddenTaskId] }),
+  });
+  assert.equal(rejected.status, 404);
+  await withClient(async (c) => {
+    const row = await c.query(`SELECT is_deleted FROM tasks WHERE id = $1`, [visibleId]);
+    assert.equal(row.rows[0].is_deleted, false);
+  });
+
+  const deleted = await testApp!.request('/api/tasks/bulk-delete', {
+    method: 'POST', headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ task_ids: [visibleId] }),
+  });
+  assert.equal(deleted.status, 200);
+  assert.deepEqual((await deleted.json() as any).deleted_ids, [visibleId]);
+  await withClient(async (c) => {
+    const row = await c.query(`SELECT is_deleted, title FROM tasks WHERE id = $1`, [visibleId]);
+    assert.equal(row.rows[0].is_deleted, true);
+    assert.equal(row.rows[0].title, 'Bulk task 50');
   });
 });

--- a/apps/web/src/app/(app)/tasks/page.tsx
+++ b/apps/web/src/app/(app)/tasks/page.tsx
@@ -33,12 +33,13 @@ import {
   FileText,
 } from 'lucide-react';
 import { TabStrip } from '@/components/tab-strip';
-import { AppMenu } from '@/components/overlay-primitives';
+import { AppDialog, AppMenu } from '@/components/overlay-primitives';
 
 const TaskTimeline = lazy(() => import('./timeline'));
 import { EmptyState } from '@/components/empty-state';
 import { CreateProjectModal } from '@/components/create-project-modal';
 import { PersonAvatar } from '@/components/person-avatar';
+import ConfirmDialog from '@/components/confirm-dialog';
 import {
   DEFAULT_TASK_VIEW_CONFIG,
   normalizeTaskViewConfig,
@@ -162,12 +163,26 @@ export default function TasksPage() {
   const [loading, setLoading] = useState(true);
   const [projectDropdownOpen, setProjectDropdownOpen] = useState(false);
   const [quickCreateOpen, setQuickCreateOpen] = useState(false);
+  const [pasteCreateOpen, setPasteCreateOpen] = useState(false);
+  const [pasteTaskText, setPasteTaskText] = useState('');
+  const [pasteCreating, setPasteCreating] = useState(false);
   const [templatesDropdownOpen, setTemplatesDropdownOpen] = useState(false);
   const [quickCreateStatus, setQuickCreateStatus] = useState<string | undefined>(undefined);
   const [createProjectOpen, setCreateProjectOpen] = useState(false);
   const [selectionMode, setSelectionMode] = useState(false);
   const [selectedTaskIds, setSelectedTaskIds] = useState<Set<string>>(new Set());
   const [bulkActionDropdown, setBulkActionDropdown] = useState<string | null>(null);
+  const [bulkDueDate, setBulkDueDate] = useState('');
+  const [bulkStartDate, setBulkStartDate] = useState('');
+  const [bulkEstimate, setBulkEstimate] = useState('');
+  const [pendingBulkAction, setPendingBulkAction] = useState<{
+    title: string;
+    message: string;
+    confirmLabel: string;
+    updates?: Record<string, unknown>;
+    danger?: boolean;
+    success: string;
+  } | null>(null);
   const [orgMembers, setOrgMembers] = useState<{ id: string; name: string; avatar_url: string | null }[]>([]);
   const [orgLabels, setOrgLabels] = useState<{ id: string; name: string; color: string }[]>([]);
   const [toast, setToast] = useState<string | null>(null);
@@ -181,6 +196,7 @@ export default function TasksPage() {
     previousCursors: [] as Array<string | null>,
     loading: false,
   });
+  const pastedTaskTitles = useMemo(() => pasteTaskText.split(/\r?\n/).map((title) => title.trim()).filter(Boolean).slice(0, 50), [pasteTaskText]);
   const viewMenuButtonRef = useRef<HTMLButtonElement | null>(null);
   const [viewMenuOpen, setViewMenuOpen] = useState(false);
   useEffect(() => {
@@ -477,54 +493,77 @@ export default function TasksPage() {
     });
   }, []);
 
-  const handleBulkStatusChange = async (status: string) => {
-    const ids = Array.from(selectedTaskIds);
-    const res = await api.patch('/api/tasks/bulk', { task_ids: ids, updates: { status } });
-    if (res.ok) {
-      setSelectedTaskIds(new Set());
-      setSelectionMode(false);
-      setBulkActionDropdown(null);
-      await loadTasks();
-      setToast(`${ids.length} task${ids.length !== 1 ? 's' : ''} moved to ${statusLabel(status)}`);
-    }
+  const queueBulkUpdate = (title: string, change: string, updates: Record<string, unknown>, success: string) => {
+    const count = selectedTaskIds.size;
+    setBulkActionDropdown(null);
+    setPendingBulkAction({
+      title,
+      message: `${change} for ${count} selected task${count === 1 ? '' : 's'}?`,
+      confirmLabel: 'Apply change',
+      updates,
+      success,
+    });
   };
 
-  const handleBulkAssigneeChange = async (assigneeId: string | null) => {
+  const runPendingBulkAction = async () => {
+    if (!pendingBulkAction) return;
     const ids = Array.from(selectedTaskIds);
-    const res = await api.patch('/api/tasks/bulk', { task_ids: ids, updates: { assignee_id: assigneeId } });
+    const res = pendingBulkAction.danger
+      ? await api.post('/api/tasks/bulk-delete', { task_ids: ids })
+      : await api.patch('/api/tasks/bulk', { task_ids: ids, updates: pendingBulkAction.updates });
     if (res.ok) {
       setSelectedTaskIds(new Set());
       setSelectionMode(false);
       setBulkActionDropdown(null);
       await loadTasks();
-      const name = assigneeId ? orgMembers.find((m) => m.id === assigneeId)?.name || 'someone' : 'Unassigned';
-      setToast(`${ids.length} task${ids.length !== 1 ? 's' : ''} assigned to ${name}`);
+      setToast(pendingBulkAction.success);
+    } else {
+      const error = await res.json().catch(() => null) as { error?: string } | null;
+      setToast(error?.error ?? 'Bulk action failed');
     }
+    setPendingBulkAction(null);
   };
 
-  const handleBulkPriorityChange = async (priority: string) => {
-    const ids = Array.from(selectedTaskIds);
-    const res = await api.patch('/api/tasks/bulk', { task_ids: ids, updates: { priority } });
-    if (res.ok) {
-      setSelectedTaskIds(new Set());
-      setSelectionMode(false);
-      setBulkActionDropdown(null);
-      await loadTasks();
-      setToast(`${ids.length} task${ids.length !== 1 ? 's' : ''} set to ${priority.toUpperCase()}`);
-    }
+  const handleBulkStatusChange = (status: string) => {
+    queueBulkUpdate('Change task status', `Move them to ${statusLabel(status)}`, { status }, `${selectedTaskIds.size} tasks moved to ${statusLabel(status)}`);
   };
 
-  const handleBulkDelete = async () => {
-    const ids = Array.from(selectedTaskIds);
-    if (!confirm(`Delete ${ids.length} task${ids.length !== 1 ? 's' : ''}? This cannot be undone.`)) return;
-    const res = await api.post('/api/tasks/bulk-delete', { task_ids: ids });
-    if (res.ok) {
-      setSelectedTaskIds(new Set());
-      setSelectionMode(false);
-      setBulkActionDropdown(null);
-      await loadTasks();
-      setToast(`${ids.length} task${ids.length !== 1 ? 's' : ''} deleted`);
+  const handleBulkAssigneeChange = (assigneeId: string | null) => {
+    const name = assigneeId ? orgMembers.find((member) => member.id === assigneeId)?.name ?? 'selected owner' : 'Unassigned';
+    queueBulkUpdate('Change task owner', `Assign them to ${name}`, { assignee_id: assigneeId }, `${selectedTaskIds.size} tasks assigned to ${name}`);
+  };
+
+  const handleBulkPriorityChange = (priority: string) => {
+    queueBulkUpdate('Change task priority', `Set priority to ${priority.toUpperCase()}`, { priority }, `${selectedTaskIds.size} tasks set to ${priority.toUpperCase()}`);
+  };
+
+  const handleBulkDelete = () => {
+    const count = selectedTaskIds.size;
+    setPendingBulkAction({
+      title: 'Delete selected tasks?',
+      message: `Soft-delete ${count} selected task${count === 1 ? '' : 's'}? Their history will be preserved.`,
+      confirmLabel: 'Delete tasks',
+      danger: true,
+      success: `${count} task${count === 1 ? '' : 's'} deleted`,
+    });
+  };
+
+  const createPastedTasks = async () => {
+    if (!selectedProject || pastedTaskTitles.length === 0 || pasteCreating) return;
+    setPasteCreating(true);
+    const results = await Promise.all(pastedTaskTitles.map((title) =>
+      api.post(`/api/projects/${selectedProject.id}/tasks`, { title }),
+    ));
+    const created = results.filter((result) => result.ok).length;
+    setPasteCreating(false);
+    if (created === pastedTaskTitles.length) {
+      setPasteCreateOpen(false);
+      setPasteTaskText('');
     }
+    await loadTasks();
+    setToast(created === pastedTaskTitles.length
+      ? `${created} tasks created`
+      : `${created} of ${pastedTaskTitles.length} tasks created`);
   };
 
   // External callers (command palette, etc.) can request the quick-create
@@ -1209,6 +1248,14 @@ export default function TasksPage() {
                 </div>
               )}
               <button
+                onClick={() => setPasteCreateOpen(true)}
+                className="deft-pill min-h-[36px] px-3 text-[13px]"
+                style={{ color: 'var(--foreground)', border: '1px solid var(--border)' }}
+              >
+                <FileText size={14} />
+                Paste tasks
+              </button>
+              <button
                 onClick={() => {
                   setQuickCreateStatus(undefined);
                   setQuickCreateOpen(true);
@@ -1529,7 +1576,7 @@ export default function TasksPage() {
             <div className="fixed inset-0 z-40" onClick={() => setBulkActionDropdown(null)} />
           )}
           <div
-            className="fixed bottom-20 md:bottom-6 left-1/2 -translate-x-1/2 z-50 flex items-center gap-2 px-4 py-2.5 rounded-xl max-w-[calc(100vw-2rem)] overflow-x-auto"
+            className={`fixed bottom-20 md:bottom-6 left-1/2 -translate-x-1/2 z-50 flex items-center gap-2 px-4 py-2.5 rounded-xl max-w-[calc(100vw-2rem)] ${bulkActionDropdown ? 'overflow-visible' : 'overflow-x-auto'}`}
             style={{
               background: 'var(--card-bg)',
               border: '1px solid var(--border)',
@@ -1661,6 +1708,123 @@ export default function TasksPage() {
               )}
             </div>
 
+            {/* Dates, estimate, and labels */}
+            <div className="relative">
+              <button
+                onClick={() => setBulkActionDropdown(bulkActionDropdown === 'more' ? null : 'more')}
+                className="flex items-center gap-1 px-3 py-1.5 rounded-md text-[12px] font-medium"
+                style={{
+                  background: bulkActionDropdown === 'more' ? 'var(--hover-tint)' : 'var(--surface)',
+                  color: 'var(--foreground)',
+                  fontFamily: 'var(--font-heading)',
+                  border: '1px solid var(--border)',
+                }}
+              >
+                More
+                <ChevronDown size={12} />
+              </button>
+              {bulkActionDropdown === 'more' && (
+                <div
+                  className="absolute bottom-full right-0 mb-2 w-72 rounded-lg p-3 z-50 space-y-3 max-h-[60vh] overflow-y-auto"
+                  style={{ background: 'var(--card-bg)', border: '1px solid var(--border)', boxShadow: 'var(--shadow-lg)' }}
+                  onClick={(event) => event.stopPropagation()}
+                >
+                  <label className="block text-[11px] font-medium" style={{ color: 'var(--muted)' }}>
+                    Due date
+                    <div className="mt-1 flex gap-1">
+                      <input
+                        type="date"
+                        value={bulkDueDate}
+                        onChange={(event) => setBulkDueDate(event.target.value)}
+                        className="min-w-0 flex-1 rounded-md px-2 py-1.5 text-[12px]"
+                        style={{ background: 'var(--surface)', color: 'var(--foreground)', border: '1px solid var(--border)' }}
+                      />
+                      <button
+                        disabled={!bulkDueDate}
+                        onClick={() => queueBulkUpdate('Set due date', `Set due date to ${bulkDueDate}`, { due_date: bulkDueDate }, `${selectedTaskIds.size} task due dates updated`)}
+                        className="rounded-md px-2 text-[11px] disabled:opacity-40"
+                        style={{ background: 'var(--accent)', color: 'white' }}
+                      >Set</button>
+                      <button
+                        onClick={() => queueBulkUpdate('Clear due date', 'Remove their due dates', { due_date: null }, `${selectedTaskIds.size} task due dates cleared`)}
+                        className="rounded-md px-2 text-[11px]"
+                        style={{ color: 'var(--muted)', border: '1px solid var(--border)' }}
+                      >Clear</button>
+                    </div>
+                  </label>
+                  <label className="block text-[11px] font-medium" style={{ color: 'var(--muted)' }}>
+                    Start date
+                    <div className="mt-1 flex gap-1">
+                      <input
+                        type="date"
+                        value={bulkStartDate}
+                        onChange={(event) => setBulkStartDate(event.target.value)}
+                        className="min-w-0 flex-1 rounded-md px-2 py-1.5 text-[12px]"
+                        style={{ background: 'var(--surface)', color: 'var(--foreground)', border: '1px solid var(--border)' }}
+                      />
+                      <button
+                        disabled={!bulkStartDate}
+                        onClick={() => queueBulkUpdate('Set start date', `Set start date to ${bulkStartDate}`, { start_date: bulkStartDate }, `${selectedTaskIds.size} task start dates updated`)}
+                        className="rounded-md px-2 text-[11px] disabled:opacity-40"
+                        style={{ background: 'var(--accent)', color: 'white' }}
+                      >Set</button>
+                      <button
+                        onClick={() => queueBulkUpdate('Clear start date', 'Remove their start dates', { start_date: null }, `${selectedTaskIds.size} task start dates cleared`)}
+                        className="rounded-md px-2 text-[11px]"
+                        style={{ color: 'var(--muted)', border: '1px solid var(--border)' }}
+                      >Clear</button>
+                    </div>
+                  </label>
+                  <label className="block text-[11px] font-medium" style={{ color: 'var(--muted)' }}>
+                    Estimate
+                    <div className="mt-1 flex gap-1">
+                      <input
+                        value={bulkEstimate}
+                        onChange={(event) => setBulkEstimate(event.target.value)}
+                        placeholder="e.g. 2h"
+                        className="min-w-0 flex-1 rounded-md px-2 py-1.5 text-[12px]"
+                        style={{ background: 'var(--surface)', color: 'var(--foreground)', border: '1px solid var(--border)' }}
+                      />
+                      <button
+                        disabled={!bulkEstimate.trim()}
+                        onClick={() => queueBulkUpdate('Set estimate', `Set estimate to ${bulkEstimate.trim()}`, { estimation: bulkEstimate.trim() }, `${selectedTaskIds.size} task estimates updated`)}
+                        className="rounded-md px-2 text-[11px] disabled:opacity-40"
+                        style={{ background: 'var(--accent)', color: 'white' }}
+                      >Set</button>
+                      <button
+                        onClick={() => queueBulkUpdate('Clear estimate', 'Remove their estimates', { estimation: null }, `${selectedTaskIds.size} task estimates cleared`)}
+                        className="rounded-md px-2 text-[11px]"
+                        style={{ color: 'var(--muted)', border: '1px solid var(--border)' }}
+                      >Clear</button>
+                    </div>
+                  </label>
+                  {orgLabels.length > 0 && (
+                    <div>
+                      <div className="text-[11px] font-medium mb-1" style={{ color: 'var(--muted)' }}>Labels</div>
+                      <div className="space-y-1">
+                        {orgLabels.map((label) => (
+                          <div key={label.id} className="flex items-center gap-2 text-[12px]">
+                            <span className="h-2 w-2 rounded-full" style={{ background: label.color }} />
+                            <span className="min-w-0 flex-1 truncate" style={{ color: 'var(--foreground)' }}>{label.name}</span>
+                            <button
+                              onClick={() => queueBulkUpdate('Add label', `Add ${label.name}`, { add_label_ids: [label.id] }, `${label.name} added to selected tasks`)}
+                              className="px-2 py-1 rounded-md"
+                              style={{ color: 'var(--accent)', border: '1px solid var(--border)' }}
+                            >Add</button>
+                            <button
+                              onClick={() => queueBulkUpdate('Remove label', `Remove ${label.name}`, { remove_label_ids: [label.id] }, `${label.name} removed from selected tasks`)}
+                              className="px-2 py-1 rounded-md"
+                              style={{ color: 'var(--muted)', border: '1px solid var(--border)' }}
+                            >Remove</button>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+
             {/* Delete button */}
             <button
               onClick={handleBulkDelete}
@@ -1694,6 +1858,67 @@ export default function TasksPage() {
             </button>
           </div>
         </>
+      )}
+
+      {pasteCreateOpen && selectedProject && (
+        <AppDialog
+          open
+          onClose={() => !pasteCreating && setPasteCreateOpen(false)}
+          title="Paste task titles"
+          description="One title per line. Review the list before creating up to 50 tasks."
+          width={520}
+          footer={
+            <div className="flex items-center justify-between gap-3">
+              <span className="text-[12px]" style={{ color: 'var(--muted)' }}>
+                {pastedTaskTitles.length} task{pastedTaskTitles.length === 1 ? '' : 's'}
+              </span>
+              <div className="flex gap-2">
+                <button
+                  disabled={pasteCreating}
+                  onClick={() => setPasteCreateOpen(false)}
+                  className="rounded-lg px-4 py-2 text-[13px]"
+                  style={{ color: 'var(--foreground)', border: '1px solid var(--border)' }}
+                >Cancel</button>
+                <button
+                  disabled={pastedTaskTitles.length === 0 || pasteCreating}
+                  onClick={() => void createPastedTasks()}
+                  className="rounded-lg px-4 py-2 text-[13px] text-white disabled:opacity-40"
+                  style={{ background: 'var(--accent)' }}
+                >{pasteCreating ? 'Creating...' : `Create ${pastedTaskTitles.length}`}</button>
+              </div>
+            </div>
+          }
+        >
+          <textarea
+            autoFocus
+            value={pasteTaskText}
+            onChange={(event) => setPasteTaskText(event.target.value)}
+            placeholder={'Confirm sample count\nDraft buyer update\nSchedule launch review'}
+            className="h-40 w-full resize-y rounded-lg p-3 text-[13px] outline-none"
+            style={{ background: 'var(--surface)', color: 'var(--foreground)', border: '1px solid var(--border)' }}
+          />
+          {pastedTaskTitles.length > 0 && (
+            <div className="mt-3 max-h-36 overflow-y-auto rounded-lg p-2" style={{ background: 'var(--surface)' }}>
+              {pastedTaskTitles.map((title, index) => (
+                <div key={`${title}-${index}`} className="flex gap-2 py-1 text-[12px]" style={{ color: 'var(--foreground)' }}>
+                  <span style={{ color: 'var(--muted)' }}>{index + 1}.</span>
+                  <span>{title}</span>
+                </div>
+              ))}
+            </div>
+          )}
+        </AppDialog>
+      )}
+
+      {pendingBulkAction && (
+        <ConfirmDialog
+          title={pendingBulkAction.title}
+          message={pendingBulkAction.message}
+          confirmLabel={pendingBulkAction.confirmLabel}
+          danger={pendingBulkAction.danger}
+          onConfirm={() => void runPendingBulkAction()}
+          onCancel={() => setPendingBulkAction(null)}
+        />
       )}
 
       {/* Toast notification */}


### PR DESCRIPTION
## What changed
- hardened task bulk update/delete with tenant visibility, validation, atomic failure, idempotent no-ops, activity, notifications, and socket receipts
- added exact confirmation previews for status, owner, priority, dates, estimates, labels, and soft deletion
- added reviewed multiline task creation using the existing canonical create route
- fixed bulk menu overflow so menu actions reliably reach their confirmation dialogs

## Why
The task table needs trustworthy high-volume editing before it can replace spreadsheet-style work tracking. These changes keep bulk operations governed, explicit, and recoverable without introducing a second task creation path.

## Validation
- API typecheck
- web typecheck
- focused bulk test suite: 6/6, including 1/10/50 writes, idempotency, visibility-boundary atomicity, grouped notification behavior, and soft delete
- targeted ESLint: 0 errors (existing warnings remain)
- clean-browser dogfood: paste 2 tasks, bulk priority preview/apply, persisted-value verification, bulk soft-delete, cleanup
- mobile responsive check with no page-level overflow
