### PR TITLE
Clarify task view portfolio

### DIFF
--- a/apps/web/src/app/(app)/tasks/page.tsx
+++ b/apps/web/src/app/(app)/tasks/page.tsx
@@ -6,7 +6,7 @@ import { api } from '@/lib/api';
 import { getSocket } from '@/lib/socket';
 import { useSearchParams, useRouter } from 'next/navigation';
 import { TaskBoard } from '@/components/task-board';
-import { TaskTable } from '@/components/task-list';
+import { TaskTable } from '@/components/task-table';
 import { TaskDetail } from '@/components/task-detail';
 import { TaskFilters, type Filters } from '@/components/task-filters';
 import { TaskQuickCreate } from '@/components/task-quick-create';
@@ -54,8 +54,7 @@ type Task = {
   number: number;
   title: string;
   description: string | null;
-  // Wide string — resolved skill configs define arbitrary status IDs
-  // (e.g. 'lead' / 'qualified' for Sales).
+  // Kept as a string at the API boundary; the current product vocabulary is fixed.
   status: string;
   priority: 'p0' | 'p1' | 'p2' | 'p3';
   assignee_id: string | null;
@@ -206,19 +205,22 @@ export default function TasksPage() {
     return () => window.removeEventListener('resize', check);
   }, []);
 
-  const viewOptions = useMemo(() => [
+  const primaryViewOptions = useMemo(() => [
     { value: 'board' as View, label: 'Board', icon: <LayoutGrid size={14} /> },
     { value: 'table' as View, label: 'Table', icon: <List size={14} /> },
     { value: 'timeline' as View, label: 'Timeline', icon: <GanttChartSquare size={14} /> },
     { value: 'calendar' as View, label: 'Calendar', icon: <CalendarDays size={14} /> },
-    { value: 'pipeline' as View, label: 'Pipeline', icon: <GitBranch size={14} /> },
   ], []);
 
-  const activeViewOption = viewOptions.find((option) => option.value === view) ?? viewOptions[0]!;
-  const mobileViewOptions = viewOptions.filter((option) => option.value !== 'calendar');
+  const activeViewOption = primaryViewOptions.find((option) => option.value === view) ?? {
+    value: 'pipeline' as View,
+    label: 'Pipeline',
+    icon: <GitBranch size={14} />,
+  };
+  const mobileViewOptions = primaryViewOptions.filter((option) => option.value !== 'calendar');
 
-  // Mobile-spillover P2-2: calendar cells (~55px wide) can't fit task content
-  // on mobile. Auto-redirect to list view when width < 768 and calendar is active.
+  // Calendar cells cannot preserve useful task context on a narrow viewport.
+  // Keep direct links durable on desktop and use Table as the mobile fallback.
   useEffect(() => {
     if (typeof window === 'undefined') return;
     if (window.innerWidth < 768 && view === 'calendar') {
@@ -229,12 +231,10 @@ export default function TasksPage() {
   const currentProjectId = searchParams.get('project');
   const isMyTasksView = searchParams.get('view') === 'my';
 
-  // Task 4.9 — resolved skill config drives status/vocab/view/prefix
+  // Central project defaults keep status labels and view behavior consistent.
   const { config: resolvedConfig } = useProjectResolvedConfig(selectedProject?.id ?? null);
 
-  // Auto-select the project's default view once when the config loads, unless
-  // the user has already picked a view. "timeline" is kept engineering-only
-  // (not a valid skill default today but guarded anyway).
+  // Auto-select the project's default view once unless the user picked one.
   useEffect(() => {
     if (!resolvedConfig || !shouldApplyProjectDefaultView({ requestedView, userSelectedView, isMyTasksView })) return;
     const dv = resolvedConfig.default_view;
@@ -925,7 +925,7 @@ export default function TasksPage() {
     setSelectedProject(project);
     setProjectDropdownOpen(false);
     setSelectedTask(null);
-    // Task 4.9 — re-enable auto-default-view for the new project's skill config.
+    // Let the newly selected project apply its default view once.
     setUserSelectedView(false);
     router.push(`/tasks?project=${project.id}`);
   };
@@ -1097,76 +1097,23 @@ export default function TasksPage() {
               className="hidden md:flex items-center"
               style={{}}
             >
-              <button
-                aria-label="Board view"
-                onClick={() => { setQuery({ view: 'board' }); setUserSelectedView(true); }}
-                className="deft-pill"
-                data-active={view === 'board'}
-                style={{
-                  background: view === 'board' ? 'var(--accent)' : 'transparent',
-                  color: view === 'board' ? 'white' : 'var(--muted)',
-                  fontFamily: 'var(--font-heading)',
-                }}
-              >
-                <LayoutGrid size={13} />
-                <span className="hidden md:inline">Board</span>
-              </button>
-              <button
-                aria-label="Table view"
-                onClick={() => { setQuery({ view: 'table' }); setUserSelectedView(true); }}
-                className="deft-pill"
-                data-active={view === 'table'}
-                style={{
-                  background: view === 'table' ? 'var(--accent)' : 'transparent',
-                  color: view === 'table' ? 'white' : 'var(--muted)',
-                  fontFamily: 'var(--font-heading)',
-                }}
-              >
-                <List size={13} />
-                <span className="hidden md:inline">Table</span>
-              </button>
-              <button
-                aria-label="Timeline view"
-                onClick={() => { setQuery({ view: 'timeline' }); setUserSelectedView(true); }}
-                className="deft-pill"
-                data-active={view === 'timeline'}
-                style={{
-                  background: view === 'timeline' ? 'var(--accent)' : 'transparent',
-                  color: view === 'timeline' ? 'white' : 'var(--muted)',
-                  fontFamily: 'var(--font-heading)',
-                }}
-              >
-                <GanttChartSquare size={13} />
-                <span className="hidden md:inline">Timeline</span>
-              </button>
-              <button
-                aria-label="Calendar view"
-                onClick={() => { setQuery({ view: 'calendar' }); setUserSelectedView(true); }}
-                className="deft-pill"
-                data-active={view === 'calendar'}
-                style={{
-                  background: view === 'calendar' ? 'var(--accent)' : 'transparent',
-                  color: view === 'calendar' ? 'white' : 'var(--muted)',
-                  fontFamily: 'var(--font-heading)',
-                }}
-              >
-                <CalendarDays size={13} />
-                <span className="hidden md:inline">Calendar</span>
-              </button>
-              <button
-                aria-label="Pipeline view"
-                onClick={() => { setQuery({ view: 'pipeline' }); setUserSelectedView(true); }}
-                className="deft-pill"
-                data-active={view === 'pipeline'}
-                style={{
-                  background: view === 'pipeline' ? 'var(--accent)' : 'transparent',
-                  color: view === 'pipeline' ? 'white' : 'var(--muted)',
-                  fontFamily: 'var(--font-heading)',
-                }}
-              >
-                <GitBranch size={13} />
-                <span className="hidden md:inline">Pipeline</span>
-              </button>
+              {primaryViewOptions.map((option) => (
+                <button
+                  key={option.value}
+                  aria-label={`${option.label} view`}
+                  onClick={() => { setQuery({ view: option.value }); setUserSelectedView(true); }}
+                  className="deft-pill"
+                  data-active={view === option.value}
+                  style={{
+                    background: view === option.value ? 'var(--accent)' : 'transparent',
+                    color: view === option.value ? 'white' : 'var(--muted)',
+                    fontFamily: 'var(--font-heading)',
+                  }}
+                >
+                  {option.icon}
+                  <span className="hidden md:inline">{option.label}</span>
+                </button>
+              ))}
             </TabStrip>
 
             {/* Select toggle */}
@@ -1287,7 +1234,7 @@ export default function TasksPage() {
           onApplyViewConfig={handleApplyViewConfig}
         />
 
-        {/* Board or List view */}
+        {/* Primary and secondary task views */}
         <div className="flex-1 overflow-hidden">
           {isMyTasksView ? (
             /* My Tasks: grouped by project */
@@ -1350,7 +1297,7 @@ export default function TasksPage() {
               ))}
             </div>
           ) : (
-            /* Project view: single board/list/timeline */
+            /* Project view: one canonical renderer per task view */
             <div className="flex flex-col h-full">
               {/* Fix 2: scope label so users always know what they're seeing */}
               {!isMobile && (

--- a/apps/web/src/components/task-filters.tsx
+++ b/apps/web/src/components/task-filters.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from 'react';
 import { useAuth } from '@/lib/auth-context';
 import { api } from '@/lib/api';
-import { ChevronDown, ChevronLeft, ChevronRight, X, User, AlertTriangle, Calendar, FolderOpen, Bookmark, Save, SlidersHorizontal, CircleDashed, Tag } from 'lucide-react';
+import { ChevronDown, ChevronLeft, ChevronRight, X, User, AlertTriangle, Calendar, FolderOpen, Bookmark, Save, SlidersHorizontal, CircleDashed, Tag, GitBranch } from 'lucide-react';
 import { STATUS_LABELS, statusLabel } from '@/lib/task-status-labels';
 import type { PriorityVocab, ResolvedStatus, CanonicalPriority } from '@/hooks/use-project-resolved-config';
 import { priorityFullLabel } from '@/hooks/use-project-resolved-config';
@@ -34,7 +34,7 @@ type Props = {
   filters: Filters;
   onChange: (filters: Filters) => void;
   projects?: { id: string; name: string; prefix: string; color: string | null }[];
-  /** Task 4.9 — resolved skill config drives status chips + priority labels. */
+  /** Resolved project vocabulary drives status chips and priority labels. */
   statuses?: ResolvedStatus[];
   priorityVocab?: PriorityVocab;
   viewConfig: TaskViewConfigV1;
@@ -462,9 +462,23 @@ export function TaskFilters({ filters, onChange, projects, statuses, priorityVoc
 
               <div style={{ borderTop: '1px solid var(--border)' }} className="my-1" />
 
-              {/* Saved views (mobile) */}
+              {/* Secondary and saved views (mobile) */}
               <div className="px-3 py-1.5">
-                <p className="text-[10px] font-semibold uppercase tracking-wide mb-1.5" style={{ color: 'var(--muted)', fontFamily: 'var(--font-heading)' }}>Saved views</p>
+                <p className="text-[10px] font-semibold uppercase tracking-wide mb-1.5" style={{ color: 'var(--muted)', fontFamily: 'var(--font-heading)' }}>Views</p>
+                <button
+                  onClick={() => { onApplyViewConfig({ ...viewConfig, view: 'pipeline' }); setOpenDropdown(null); }}
+                  className="w-full px-2 py-1.5 text-left text-[12px] rounded-md flex items-center gap-2"
+                  style={{
+                    color: viewConfig.view === 'pipeline' ? 'var(--accent)' : 'var(--foreground)',
+                    background: viewConfig.view === 'pipeline' ? 'var(--accent-subtle)' : 'transparent',
+                    fontFamily: 'var(--font-body)',
+                  }}
+                >
+                  <GitBranch size={12} />
+                  Pipeline
+                  <span className="ml-auto text-[10px]" style={{ color: 'var(--muted)' }}>Business stages</span>
+                </button>
+                {savedViews.length > 0 && <div className="my-1" style={{ borderTop: '1px solid var(--border)' }} />}
                 {savedViews.map(v => (
                   <div
                     key={v.id}
@@ -1054,7 +1068,7 @@ export function TaskFilters({ filters, onChange, projects, statuses, priorityVoc
           </div>
         )}
 
-        {/* Saved views */}
+        {/* Secondary and saved views */}
         <div className="relative ml-auto">
           <button
             onClick={() => setOpenDropdown(openDropdown === 'views' ? null : 'views')}
@@ -1079,6 +1093,20 @@ export function TaskFilters({ filters, onChange, projects, statuses, priorityVoc
           {openDropdown === 'views' && (
               <div className="absolute right-0 top-full mt-1 w-80 max-w-[calc(100vw-2rem)] rounded-lg py-1 z-20"
               style={{ background: 'var(--card-bg)', border: '1px solid var(--border)', boxShadow: 'var(--shadow-lg)' }}>
+              <button
+                onClick={() => { onApplyViewConfig({ ...viewConfig, view: 'pipeline' }); setOpenDropdown(null); }}
+                className="w-full px-3 py-2 text-left text-[12px] flex items-center gap-2"
+                style={{
+                  color: viewConfig.view === 'pipeline' ? 'var(--accent)' : 'var(--foreground)',
+                  background: viewConfig.view === 'pipeline' ? 'var(--accent-subtle)' : 'transparent',
+                  fontFamily: 'var(--font-body)',
+                }}
+              >
+                <GitBranch size={13} />
+                <span className="font-medium">Pipeline</span>
+                <span className="ml-auto text-[10px]" style={{ color: 'var(--muted)' }}>Business stages</span>
+              </button>
+              <div className="my-1" style={{ borderTop: '1px solid var(--border)' }} />
               {savedViews.length === 0 ? (
                 <div className="px-3 py-2 text-[11px]" style={{ color: 'var(--muted)', fontFamily: 'var(--font-body)' }}>
                   No saved views yet.

--- a/apps/web/src/components/task-pipeline-view.tsx
+++ b/apps/web/src/components/task-pipeline-view.tsx
@@ -3,15 +3,14 @@
 /**
  * Task 4.10 — Pipeline view.
  *
- * Horizontal stages (one per resolved-config status). Wider cards than the
- * board variant so Sales/CRM-style `contact_name` + `deal_value` metadata
- * can render inline. v1 is read-only: clicking a card opens the detail
+ * Secondary business-stage view over the fixed task status vocabulary.
+ * Wider cards can expose legacy/imported `contact_name` + `deal_value`
+ * metadata inline. v1 is read-only: clicking a card opens the detail
  * panel, dragging between stages is NOT wired yet — the API accepts PATCH
  * status so follow-up work can add dnd-kit wiring.
  *
- * Column footer shows a sum of deal_value + task count so Sales skill users
- * can eyeball pipeline weight at a glance. Other skill kinds (Marketing
- * campaign, Engineering) see only the count.
+ * Column footer shows a sum of deal_value + task count when that metadata is
+ * available; ordinary projects see only the count.
  *
  * Mobile (< md): collapses to a single-column view with a stage select
  * above, mirroring the Board view's status-tab pattern (Mobile-spillover P2-1).
@@ -105,7 +104,7 @@ export function TaskPipelineView<T extends PipelineTask>({
     return (
       <div className="flex items-center justify-center h-full" style={{ color: 'var(--muted)' }}>
         <p className="text-[13px]" style={{ fontFamily: 'var(--font-body)' }}>
-          Attach a skill with a pipeline (e.g. Sales) to use this view.
+          No workflow stages are available for this project.
         </p>
       </div>
     );

--- a/apps/web/src/components/task-table.tsx
+++ b/apps/web/src/components/task-table.tsx
@@ -57,7 +57,7 @@ type Props = {
   selectionMode?: boolean;
   selectedTaskIds?: Set<string>;
   onToggleSelect?: (taskId: string) => void;
-  /** Task 4.9 — resolved skill config drives status dropdown + prefix + priority labels. */
+  /** Resolved project vocabulary drives status, prefix, and priority labels. */
   statuses?: ResolvedStatus[];
   hidePrefixIds?: boolean;
   priorityVocab?: PriorityVocab;

--- a/apps/web/src/hooks/use-project-resolved-config.ts
+++ b/apps/web/src/hooks/use-project-resolved-config.ts
@@ -6,7 +6,7 @@
  *   docs/superpowers/specs/2026-04-18-simplify-skills-templates-design.md
  *
  * Preserves the `{ config, loading, error, refresh }` return shape so
- * consumers (task-board, task-card, task-list, task-filters,
+ * consumers (task-board, task-card, task-table, task-filters,
  * task-pipeline-view, task-quick-create, task-detail, tasks/page) keep
  * compiling without changes. Every project renders the same engineering
  * vocabulary and `config` is always non-null (fixes the Marketing board

--- a/apps/web/src/lib/task-view-config.test.ts
+++ b/apps/web/src/lib/task-view-config.test.ts
@@ -63,12 +63,20 @@ test('normalizes list to the canonical table view and bounds unsafe layout value
 });
 
 test('recognizes only currently rendered task surface views', () => {
+  assert.equal(parseTaskSurfaceView('board'), 'board');
   assert.equal(parseTaskSurfaceView('calendar'), 'calendar');
+  assert.equal(parseTaskSurfaceView('timeline'), 'timeline');
+  assert.equal(parseTaskSurfaceView('pipeline'), 'pipeline');
   assert.equal(parseTaskSurfaceView('table'), 'table');
   assert.equal(parseTaskSurfaceView('list'), 'table');
   assert.equal(parseTaskSurfaceView('my'), null);
   assert.equal(parseTaskSurfaceView('made-up'), null);
   assert.equal(parseTaskSurfaceView(null), null);
+});
+
+test('preserves pipeline in saved view configuration', () => {
+  const config = normalizeTaskViewConfig({ version: 1, view: 'pipeline', filters: {} });
+  assert.equal(config.view, 'pipeline');
 });
 
 test('project default never overwrites an explicit valid or invalid view request', () => {

--- a/docs/superpowers/specs/2026-07-13-task-view-portfolio-decision.md
+++ b/docs/superpowers/specs/2026-07-13-task-view-portfolio-decision.md
@@ -1,0 +1,22 @@
+# Task View Portfolio Decision
+
+## Decision
+
+Deft exposes four primary task views in the task header:
+
+- **Board** for status flow and drag-and-drop planning.
+- **Table** for dense editing, sorting, grouping, and saved operational views.
+- **Timeline** for date sequencing and dependency context.
+- **Calendar** for due-date planning.
+
+**Pipeline** remains available under **Views** as a secondary business-stage lens. Direct `?view=pipeline` links and saved Pipeline views remain valid.
+
+## Why
+
+Pipeline currently reuses task status columns and optionally displays imported business metadata. That is useful, but it is not distinct enough from Board to occupy permanent primary navigation for every team. Moving it under Views keeps the capability without presenting two similar top-level flows.
+
+The former List renderer is now the canonical Table renderer. Legacy `?view=list` links continue to normalize to `?view=table`; no second List implementation remains.
+
+## Revisit
+
+Promote Pipeline again only when Deft has durable typed business fields and pipeline-specific interaction beyond status columns, such as stage probability, value, or forecast behavior.


### PR DESCRIPTION
## What changed
- keep Board, Table, Timeline, and Calendar as the four primary task views
- move Pipeline into the existing Views menu while preserving direct and saved Pipeline links
- rename the legacy task-list renderer to task-table
- document the view portfolio decision and extend normalization coverage

## Why
Pipeline remains useful for business-stage work, but its current behavior overlaps Board and does not justify permanent top-level navigation for every team. The former List renderer is now the canonical Table and should be named accordingly.

## Validation
- task-view-config tests: 7 passed
- web typecheck
- web lint
- production web build
- desktop and mobile browser dogfood: view discovery, project/filter preservation, legacy list normalization, history navigation, and overflow checks