### PR TITLE
Fix pilot comments and live agent reply updates

### DIFF
--- a/apps/api/src/lib/mcp-tools/writes.ts
+++ b/apps/api/src/lib/mcp-tools/writes.ts
@@ -31,6 +31,7 @@ import {
   spaceMembers,
   taskActivity,
   workflowRules,
+  users,
 } from '@deft/db/schema';
 import type { ToolContext, ToolResult } from './types.js';
 import { errorResult, textResult } from './types.js';
@@ -1004,12 +1005,40 @@ export async function executeSendMessage(opts: {
       })
       .returning();
 
+    const [author] = await db
+      .select({ name: users.name, avatar_url: users.avatar_url })
+      .from(users)
+      .where(eq(users.id, shadowUserId))
+      .limit(1);
+    const messageWithUser = {
+      ...row,
+      user_name: author?.name ?? ctx.employee_slug,
+      user_avatar: author?.avatar_url ?? null,
+      reactions: [],
+      reply_count: 0,
+      latest_reply_at: null,
+    };
+
     // Best-effort broadcast. Socket.io might not be initialized in tests.
     try {
       const { getIO } = await import('../../socket.js');
       const io = getIO();
       if (io && row) {
-        io.to(`space:${spaceId}`).emit('message:new', row);
+        io.to(`space:${spaceId}`).emit('message:new', messageWithUser);
+        if (parentId) {
+          const [replyStats] = await db
+            .select({
+              count: sql<number>`count(*)::int`,
+              latest: sql<string>`to_char(max(${messages.created_at}), 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')`,
+            })
+            .from(messages)
+            .where(and(eq(messages.parent_id, parentId), eq(messages.is_deleted, false)));
+          io.to(`space:${spaceId}`).emit('thread:updated', {
+            parent_id: parentId,
+            reply_count: replyStats?.count ?? 1,
+            latest_reply_at: replyStats?.latest ?? row.created_at,
+          });
+        }
       }
     } catch {
       // swallow — broadcast must not roll back the write.

--- a/apps/api/test/search-route-knowledge-groups.test.ts
+++ b/apps/api/test/search-route-knowledge-groups.test.ts
@@ -42,6 +42,7 @@ async function withClient<T>(fn: (c: pg.Client) => Promise<T>): Promise<T> {
 const SEARCH_TERM = `cloudflare${Date.now()}`;
 
 let wikiPageId: string;
+let hyphenatedWikiPageId: string;
 let decisionPageId: string;
 let noteId: string;
 let otherUserNoteId: string;
@@ -90,6 +91,16 @@ before(async () => {
       ],
     );
     seededIds.push({ table: 'wiki_pages', id: wikiPageId });
+
+    // Body-only hyphenated marker: Knowledge and global search must agree when
+    // users type the same phrase with spaces.
+    hyphenatedWikiPageId = `srkg-hyphen-wiki-${Date.now()}`;
+    await c.query(
+      `INSERT INTO wiki_pages (id, org_id, type, scope, title, slug, content, confidence, is_deleted, created_at, updated_at)
+       VALUES ($1, $2, 'resource', 'org', 'Pilot proof page', 'pilot-proof-page', $3, 1.0, false, NOW(), NOW())`,
+      [hyphenatedWikiPageId, ORG_ID, 'The durable proof marker is ruby-sunrise-2026.'],
+    );
+    seededIds.push({ table: 'wiki_pages', id: hyphenatedWikiPageId });
 
     // Seed decision page (type='decision') containing SEARCH_TERM
     decisionPageId = `srkg-decision-${Date.now()}`;
@@ -203,6 +214,16 @@ test('2. wiki group contains the seeded wiki concept page', async () => {
   const found = body.wiki.find((w: any) => w.id === wikiPageId);
   assert.ok(found, `Wiki group should contain the seeded wiki page (${wikiPageId})`);
   assert.ok(found.title, 'Wiki result should have a title');
+});
+
+test('global search finds a body-only hyphenated wiki phrase from spaced words', async () => {
+  const { status, body } = await callSearch('ruby sunrise');
+
+  assert.equal(status, 200);
+  assert.ok(
+    body.wiki.some((page: any) => page.id === hyphenatedWikiPageId),
+    'Global search should find ruby-sunrise-2026 when the user searches ruby sunrise',
+  );
 });
 
 test('3. decisions group contains the seeded decision page', async () => {

--- a/apps/web/src/components/task-detail.tsx
+++ b/apps/web/src/components/task-detail.tsx
@@ -641,6 +641,7 @@ export function TaskDetail({ taskId, projectPrefix, onClose, onUpdated, onDuplic
   const [submittingComment, setSubmittingComment] = useState(false);
   const commentEditor = useEditor({
     immediatelyRender: false,
+    onUpdate: ({ editor }) => setNewComment(editor.getText()),
     extensions: [
       ...createBaseExtensions({
         surface: 'task-comment',
@@ -1046,6 +1047,7 @@ export function TaskDetail({ taskId, projectPrefix, onClose, onUpdated, onDuplic
     const res = await api.post(`/api/tasks/${taskId}/comments`, { content: html });
     if (res.ok) {
       commentEditor?.commands.clearContent();
+      setNewComment('');
       loadComments();
     }
     setSubmittingComment(false);
@@ -2631,7 +2633,7 @@ export function TaskDetail({ taskId, projectPrefix, onClose, onUpdated, onDuplic
                       <div className="flex justify-end mt-1.5">
                         <button
                           onClick={handleAddComment}
-                          disabled={!(commentEditor?.getText() ?? '').trim() || submittingComment}
+                          disabled={!newComment.trim() || submittingComment}
                           className="text-[12px] font-medium px-3 py-1 rounded-md text-white disabled:opacity-50"
                           style={{
                             background: 'var(--accent)',


### PR DESCRIPTION
## Summary
- bridge TipTap comment state into React so submit enables reliably
- normalize BYOA message broadcasts and refresh thread counts in realtime
- prove global search resolves body-only hyphenated wiki phrases

## Verification
- web and API typechecks
- search-route-knowledge-groups (6/6)
- mcp-send-message (7/7)
- agent employee status (7/7)
- local browser comment submit + persisted render