### PR TITLE
Keep Hermes channel service alive across transient failures

### DIFF
--- a/scripts/hermes-channel-service.ps1
+++ b/scripts/hermes-channel-service.ps1
@@ -73,7 +73,8 @@ switch ($Action) {
     )
     $trigger = New-ScheduledTaskTrigger -AtLogOn -User $env:USERNAME
     $settings = New-ScheduledTaskSettingsSet -RestartCount 20 -RestartInterval (New-TimeSpan -Minutes 1) `
-      -ExecutionTimeLimit (New-TimeSpan -Days 3650) -MultipleInstances IgnoreNew -StartWhenAvailable
+      -ExecutionTimeLimit (New-TimeSpan -Days 3650) -MultipleInstances IgnoreNew -StartWhenAvailable `
+      -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries
     $principal = New-ScheduledTaskPrincipal -UserId ([Security.Principal.WindowsIdentity]::GetCurrent().Name) `
       -LogonType Interactive -RunLevel Limited
     Register-ScheduledTask -TaskName $TaskName -Action $taskAction -Trigger $trigger `

--- a/scripts/run-hermes-channel-service.ps1
+++ b/scripts/run-hermes-channel-service.ps1
@@ -1,6 +1,7 @@
 [CmdletBinding()]
 param(
-  [string]$ServiceRoot = (Join-Path $env:LOCALAPPDATA 'Deft\hermes-channel')
+  [string]$ServiceRoot = (Join-Path $env:LOCALAPPDATA 'Deft\hermes-channel'),
+  [int]$RestartDelaySeconds = 5
 )
 
 $ErrorActionPreference = 'Stop'
@@ -25,12 +26,16 @@ try {
   }
 
   $node = (Get-Command node.exe -ErrorAction Stop).Source
-  "$(Get-Date -Format o) starting Hermes channel bridge" | Add-Content -LiteralPath $logPath -Encoding utf8
-  & $node $bridgePath 2>&1 | ForEach-Object {
-    "$_" | Add-Content -LiteralPath $logPath -Encoding utf8
+  while ($true) {
+    "$(Get-Date -Format o) starting Hermes channel bridge" | Add-Content -LiteralPath $logPath -Encoding utf8
+    & $node $bridgePath 2>&1 | ForEach-Object {
+      "$_" | Add-Content -LiteralPath $logPath -Encoding utf8
+    }
+    $bridgeExitCode = $LASTEXITCODE
+    "$(Get-Date -Format o) bridge exited with code $bridgeExitCode; restarting in $RestartDelaySeconds seconds" |
+      Add-Content -LiteralPath $logPath -Encoding utf8
+    Start-Sleep -Seconds $RestartDelaySeconds
   }
-  $bridgeExitCode = $LASTEXITCODE
-  exit $bridgeExitCode
 } catch {
   "$(Get-Date -Format o) service failed: $($_.Exception.Message)" | Add-Content -LiteralPath $logPath -Encoding utf8
   exit 1


### PR DESCRIPTION
## Summary
- keep the Hermes bridge wrapper resident when Node exits
- retry after transient bridge failures instead of relying solely on Task Scheduler
- allow the scheduled task to start and continue on battery power

## Verification
- PowerShell parser validation
- installed the updated scheduled task
- force-killed the bridge process and confirmed automatic restart with a new PID
- confirmed Rita reconnected after restart