### PR TITLE
Document reproducible demo deployment overlay

### DIFF
--- a/deploy/demo/Caddyfile.example
+++ b/deploy/demo/Caddyfile.example
@@ -1,0 +1,27 @@
+{$DEFT_PUBLIC_HOST:demo.example.com} {
+  encode zstd gzip
+
+  handle /health {
+    reverse_proxy deft:3001
+  }
+
+  handle /api/* {
+    reverse_proxy deft:3001
+  }
+
+  handle /socket.io/* {
+    reverse_proxy deft:3001
+  }
+
+  handle /.well-known/* {
+    reverse_proxy deft:3001
+  }
+
+  handle /oauth/* {
+    reverse_proxy deft:3001
+  }
+
+  handle {
+    reverse_proxy deft:3000
+  }
+}

--- a/deploy/demo/README.md
+++ b/deploy/demo/README.md
@@ -1,0 +1,40 @@
+# Demo deployment overlay
+
+This directory records the deployment-only files used by a public Deft demo.
+The examples contain no credentials and are not loaded automatically.
+
+## Install
+
+From the repository root on the server:
+
+```bash
+cp deploy/demo/Caddyfile.example Caddyfile
+cp deploy/demo/compose.demo.yml.example compose.demo.yml
+```
+
+Set the normal production secrets plus these public values in `.env`:
+
+```dotenv
+DEFT_PUBLIC_HOST=demo.example.com
+NEXT_PUBLIC_APP_URL=https://demo.example.com
+NEXT_PUBLIC_API_URL=https://demo.example.com
+NEXT_PUBLIC_WS_URL=https://demo.example.com
+```
+
+Keep provider keys in `.env`; do not add them to the Compose overlay.
+
+## Preflight and deploy
+
+```bash
+test -f Caddyfile && test -f compose.demo.yml
+docker compose -f docker-compose.yml -f compose.demo.yml config --quiet
+pnpm selfhost:bootstrap --prod --check-only
+docker compose -f docker-compose.yml -f compose.demo.yml up -d --build
+docker compose -f docker-compose.yml -f compose.demo.yml run --rm doctor
+docker compose -f docker-compose.yml -f compose.demo.yml run --rm smoke
+```
+
+Back up `.env`, `Caddyfile`, and `compose.demo.yml` outside the checkout before
+rebuilding or moving the VPS. The checked-in examples are the recovery source;
+the root copies remain server-local because they select the live hostname and
+deployment environment.

--- a/deploy/demo/compose.demo.yml.example
+++ b/deploy/demo/compose.demo.yml.example
@@ -1,0 +1,33 @@
+services:
+  deft:
+    ports: []
+    environment:
+      DATABASE_URL: postgres://postgres:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD required}@postgres:5432/deft
+      REDIS_URL: redis://redis:6379
+      API_PORT: 3001
+      NEXT_PUBLIC_APP_URL: ${NEXT_PUBLIC_APP_URL:?NEXT_PUBLIC_APP_URL required}
+      NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:?NEXT_PUBLIC_API_URL required}
+      NEXT_PUBLIC_WS_URL: ${NEXT_PUBLIC_WS_URL:?NEXT_PUBLIC_WS_URL required}
+      DEFT_PUBLIC_URL: ${NEXT_PUBLIC_APP_URL:?NEXT_PUBLIC_APP_URL required}
+      DEFT_WEB_URL: http://deft:3000
+      DEFT_API_URL: http://deft:3001
+      NODE_ENV: production
+
+  caddy:
+    image: caddy:2-alpine
+    restart: unless-stopped
+    ports:
+      - '80:80'
+      - '443:443'
+    environment:
+      DEFT_PUBLIC_HOST: ${DEFT_PUBLIC_HOST:?DEFT_PUBLIC_HOST required}
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+    depends_on:
+      - deft
+
+volumes:
+  caddy_data:
+  caddy_config:

--- a/docs/self-hosting-vps-domain-https.md
+++ b/docs/self-hosting-vps-domain-https.md
@@ -69,6 +69,12 @@ Only the reverse proxy should be public.
 
 ## 3. Reverse Proxy
 
+For a Docker-hosted demo where Caddy joins the Compose network, start from the
+secret-free templates in `deploy/demo/`. Copy them to the repository root as
+`Caddyfile` and `compose.demo.yml`, set `DEFT_PUBLIC_HOST` in `.env`, and include
+the overlay in every Compose command. The root copies are intentionally
+server-local; the examples are the versioned recovery source.
+
 Example Caddyfile:
 
 ```caddyfile


### PR DESCRIPTION
## Summary
- add secret-free Caddy and Compose overlay examples for public demo deployments
- document install, preflight, deploy, backup, and recovery steps
- link the VPS HTTPS runbook to the versioned deployment contract

Closes #101

## Verification
- docker compose config --quiet with the example overlay
- git diff --check