### PR TITLE
Fix agent employee approval continuity

### DIFF
--- a/apps/api/src/lib/mcp-tools/cooperative.ts
+++ b/apps/api/src/lib/mcp-tools/cooperative.ts
@@ -31,6 +31,8 @@ import {
   agentActions,
   agentCooperativeLog,
   agentEmployees,
+  messages,
+  spaceMembers,
 } from '@deft/db/schema';
 import type { ToolContext, ToolResult } from './types.js';
 import { errorResult, textResult } from './types.js';
@@ -118,7 +120,10 @@ export async function requestHumanApproval(
   }
 
   const [emp] = await db
-    .select({ created_by: agentEmployees.created_by })
+    .select({
+      created_by: agentEmployees.created_by,
+      user_id: agentEmployees.user_id,
+    })
     .from(agentEmployees)
     .where(
       and(
@@ -131,12 +136,39 @@ export async function requestHumanApproval(
     return errorResult('employee lookup failed');
   }
 
+  const requestedSourceMessageId = typeof normalized.params.source_message_id === 'string'
+    ? normalized.params.source_message_id.trim()
+    : '';
+  let sourceMessageId: string | null = null;
+  if (requestedSourceMessageId) {
+    const [visibleSource] = await db
+      .select({ id: messages.id })
+      .from(messages)
+      .innerJoin(
+        spaceMembers,
+        and(
+          eq(spaceMembers.space_id, messages.space_id),
+          eq(spaceMembers.user_id, emp.user_id),
+        ),
+      )
+      .where(
+        and(
+          eq(messages.id, requestedSourceMessageId),
+          eq(messages.org_id, ctx.org_id),
+          eq(messages.is_deleted, false),
+        ),
+      )
+      .limit(1);
+    sourceMessageId = visibleSource?.id ?? null;
+  }
+
   const [row] = await db
     .insert(agentActions)
     .values({
       org_id: ctx.org_id,
       user_id: emp.created_by,
       agent_employee_id: ctx.employee_id,
+      message_id: sourceMessageId,
       source: 'mcp',
       action: normalized.action,
       params: {

--- a/apps/api/src/routes/agent.ts
+++ b/apps/api/src/routes/agent.ts
@@ -99,7 +99,20 @@ async function maybePostApprovalConfirmation(params: {
 
   const content = formatApprovalConfirmation(approvedActions);
 
-  const confirmationAuthorId = approvalMessage.user_id || params.actorUserId;
+  const proposingEmployeeId = approvedActions.find((row) => row.agent_employee_id)?.agent_employee_id;
+  const [proposingEmployee] = proposingEmployeeId
+    ? await db
+        .select({ user_id: agentEmployees.user_id })
+        .from(agentEmployees)
+        .where(and(
+          eq(agentEmployees.id, proposingEmployeeId),
+          eq(agentEmployees.org_id, params.orgId),
+        ))
+        .limit(1)
+    : [];
+  const confirmationAuthorId = proposingEmployee?.user_id
+    ?? approvalMessage.user_id
+    ?? params.actorUserId;
   const [actor] = await db
     .select({ name: users.name, avatar_url: users.avatar_url })
     .from(users)

--- a/apps/api/test/agent-actions-routes.test.ts
+++ b/apps/api/test/agent-actions-routes.test.ts
@@ -1078,9 +1078,9 @@ test('approval confirmation is authored by the proposing agent, not the human re
   const { actionId, approvalMessageId } = await withClient(async (c) => {
     const message = await c.query(
       `INSERT INTO messages (id, org_id, space_id, user_id, content, metadata)
-       VALUES (gen_random_uuid()::text, $1, $2, $3, 'Review the task draft below.', '{"is_agent_reply":true}'::jsonb)
+       VALUES (gen_random_uuid()::text, $1, $2, $3, 'Please create this task.', '{}'::jsonb)
        RETURNING id`,
-      [ORG_ID, VISIBLE_SPACE_ID, SHADOW_USER_ID],
+      [ORG_ID, VISIBLE_SPACE_ID, APPROVER_USER_ID],
     );
     const action = await c.query(
       `INSERT INTO agent_actions

--- a/apps/api/test/agent-approval-resolver.test.ts
+++ b/apps/api/test/agent-approval-resolver.test.ts
@@ -792,13 +792,23 @@ test('1b2. request_human_approval normalizes add_task_comment and executes it', 
   const title = `resolver-comment-normalized-${Date.now()}`;
   const taskId = await createApprovedResolverTask(title);
   const comment = 'Normalized approval comment from the agent employee.';
+  const sourceMessageId = await withClient(async (c) => {
+    const source = await c.query(
+      `INSERT INTO messages (id, org_id, space_id, user_id, content)
+       VALUES (gen_random_uuid()::text, $1, $2, $3, 'Please add the reviewed handoff note.')
+       RETURNING id`,
+      [ORG_ID, TEST_SPACE_ID, APPROVER_USER_ID],
+    );
+    SOURCE_MESSAGE_IDS.push(source.rows[0].id);
+    return source.rows[0].id as string;
+  });
   const { requestHumanApproval } = await import('../src/lib/mcp-tools/cooperative.js');
 
   const queued = await requestHumanApproval(
     {
       action: 'add_task_comment',
       summary: 'Add the reviewed handoff note to the task.',
-      params: { task_id: taskId, comment },
+      params: { task_id: taskId, comment, source_message_id: sourceMessageId },
     },
     {
       org_id: ORG_ID,
@@ -814,13 +824,14 @@ test('1b2. request_human_approval normalizes add_task_comment and executes it', 
 
   await withClient(async (c) => {
     const action = await c.query(
-      `SELECT action, params FROM agent_actions WHERE id = $1`,
+      `SELECT action, params, message_id FROM agent_actions WHERE id = $1`,
       [actionId],
     );
     assert.equal(action.rows[0].action, 'task_update');
     assert.equal(action.rows[0].params.task_id, taskId);
     assert.equal(action.rows[0].params.patch.comment, comment);
     assert.equal(action.rows[0].params.comment, undefined);
+    assert.equal(action.rows[0].message_id, sourceMessageId);
   });
 
   const { approveAction } = await import('../src/lib/agent-approval-resolver.js');


### PR DESCRIPTION
## Summary
- anchor MCP employee approvals to a validated source chat message
- author post-approval confirmations as the proposing employee
- cover source linkage and human-authored source prompts in regression tests

## Verification
- 44 focused approval/action tests
- 58 agent channel, recovery, people/team, MCP context, and bulk-task tests
- pnpm typecheck
- pnpm --filter @deft/web build