### PR TITLE
Harden Hermes bridge supervision

### DIFF
--- a/docs/hermes-agent-channel-service.md
+++ b/docs/hermes-agent-channel-service.md
@@ -1,0 +1,44 @@
+# Hermes Agent Channel service
+
+The Windows service wrapper keeps a Hermes agent employee connected to Deft. It runs the Node bridge under Task Scheduler and is designed to survive temporary Deft, network, and Hermes outages.
+
+## Install
+
+Create the service environment file using the quick config from the employee's Developer page, then run:
+
+```powershell
+.\scripts\hermes-channel-service.ps1 -Action Install -ConfigPath C:\path\to\service.env
+```
+
+The installer creates:
+
+- an at-logon trigger;
+- a five-minute watchdog trigger that starts a stopped service;
+- up to 999 Task Scheduler restart attempts;
+- one supervised bridge process (`MultipleInstances=IgnoreNew`);
+- a rotating 10 MB log with one retained previous file.
+
+The bridge also emits a heartbeat once per minute after a successful poll.
+
+## Operate
+
+```powershell
+# Includes task state, process count, log freshness, and the last log line.
+.\scripts\hermes-channel-service.ps1 -Action Status
+
+# No-op when healthy; otherwise stops stale processes and starts a clean service.
+.\scripts\hermes-channel-service.ps1 -Action Repair
+
+.\scripts\hermes-channel-service.ps1 -Action Stop
+.\scripts\hermes-channel-service.ps1 -Action Start
+```
+
+`Healthy=True` requires a running scheduled task, exactly one bridge process, and a log heartbeat written within the last three minutes. The service log lives at `%LOCALAPPDATA%\Deft\hermes-channel\service.log`.
+
+## Failure behavior
+
+- HTTP 429 and 5xx responses retry with bounded exponential backoff inside the bridge.
+- A bridge process exit is restarted by the PowerShell supervisor after five seconds.
+- A supervisor exit is restarted by Task Scheduler.
+- A stopped task is started by the five-minute watchdog trigger or immediately with `-Action Repair`.
+- Expected native stderr diagnostics are logged and never treated as fatal PowerShell errors.

--- a/scripts/hermes-agent-channel-bridge.mjs
+++ b/scripts/hermes-agent-channel-bridge.mjs
@@ -6,6 +6,7 @@ const DEFAULT_POLL_MS = 3000;
 const DEFAULT_LIMIT = 10;
 const DEFAULT_MAX_RETRIES = 5;
 const DEFAULT_RETRY_BASE_MS = 1000;
+const DEFAULT_HEARTBEAT_MS = 60000;
 
 function requiredEnv(env, key) {
   const value = env[key]?.trim();
@@ -34,6 +35,7 @@ export function configFromEnv(env = process.env) {
     limit: Math.min(positiveInteger(env.DEFT_CHANNEL_BATCH_SIZE, DEFAULT_LIMIT), 100),
     maxRetries: positiveInteger(env.DEFT_CHANNEL_MAX_RETRIES, DEFAULT_MAX_RETRIES),
     retryBaseMs: positiveInteger(env.DEFT_CHANNEL_RETRY_BASE_MS, DEFAULT_RETRY_BASE_MS),
+    heartbeatMs: positiveInteger(env.DEFT_CHANNEL_HEARTBEAT_MS, DEFAULT_HEARTBEAT_MS),
     once: ['1', 'true', 'yes'].includes((env.DEFT_CHANNEL_ONCE ?? '').toLowerCase()),
   };
 }
@@ -121,6 +123,8 @@ export class HermesAgentChannelBridge {
     this.fetch = options.fetchImpl ?? globalThis.fetch;
     this.log = options.logger ?? console;
     this.sleep = options.sleep ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
+    this.now = options.now ?? (() => Date.now());
+    this.lastHeartbeatAt = 0;
     this.stopped = false;
   }
 
@@ -283,12 +287,20 @@ export class HermesAgentChannelBridge {
     this.stopped = true;
   }
 
+  logHeartbeat(eventCount) {
+    const now = this.now();
+    if (now - this.lastHeartbeatAt < this.config.heartbeatMs) return;
+    this.lastHeartbeatAt = now;
+    this.log.info?.(`[deft-channel] heartbeat (${eventCount} event${eventCount === 1 ? '' : 's'})`);
+  }
+
   async run() {
     const connection = await this.connect();
     this.log.info?.(`[deft-channel] connected as ${connection.employee?.slug ?? this.config.employeeSlug}`);
     do {
       try {
-        await this.pollOnce();
+        const eventCount = await this.pollOnce();
+        this.logHeartbeat(eventCount);
       } catch (error) {
         if (this.config.once) throw error;
         const message = error instanceof Error ? error.message : String(error);

--- a/scripts/hermes-agent-channel-bridge.test.mjs
+++ b/scripts/hermes-agent-channel-bridge.test.mjs
@@ -37,6 +37,7 @@ function config() {
     limit: 10,
     maxRetries: 2,
     retryBaseMs: 5,
+    heartbeatMs: 60000,
     once: true,
   };
 }
@@ -170,4 +171,24 @@ test('request retries a transient channel rate limit instead of killing the brid
   assert.equal(result.ok, true);
   assert.equal(attempts, 2);
   assert.deepEqual(sleeps, [5]);
+});
+
+test('heartbeat is rate-limited while proving the poll loop is alive', () => {
+  const messages = [];
+  let now = 100000;
+  const bridge = new HermesAgentChannelBridge(config(), {
+    now: () => now,
+    logger: { info: (message) => messages.push(message) },
+  });
+
+  bridge.logHeartbeat(0);
+  now += 1000;
+  bridge.logHeartbeat(0);
+  now += 60000;
+  bridge.logHeartbeat(2);
+
+  assert.deepEqual(messages, [
+    '[deft-channel] heartbeat (0 events)',
+    '[deft-channel] heartbeat (2 events)',
+  ]);
 });

--- a/scripts/hermes-channel-service.ps1
+++ b/scripts/hermes-channel-service.ps1
@@ -1,6 +1,6 @@
 [CmdletBinding()]
 param(
-  [ValidateSet('Install', 'Start', 'Stop', 'Status', 'Uninstall')]
+  [ValidateSet('Install', 'Start', 'Stop', 'Status', 'Repair', 'Uninstall')]
   [string]$Action = 'Status',
   [string]$ConfigPath,
   [string]$TaskName = 'Deft Hermes Agent Channel',
@@ -61,6 +61,20 @@ switch ($Action) {
     if (-not $ConfigPath) { throw 'Install requires -ConfigPath.' }
     $resolvedConfig = (Resolve-Path -LiteralPath $ConfigPath).Path
     Assert-Config $resolvedConfig
+
+    # Upgrades must replace the running copy as well as the files. Otherwise the
+    # old supervisor keeps the mutex and the newly registered task exits idle.
+    Stop-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+    Get-ServiceProcess | ForEach-Object { Stop-Process -Id $_.ProcessId -Force }
+    for ($attempt = 0; $attempt -lt 20; $attempt += 1) {
+      $existingTask = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+      if ((-not $existingTask -or [string]$existingTask.State -ne 'Running') -and @(Get-ServiceProcess).Count -eq 0) {
+        break
+      }
+      Start-Sleep -Milliseconds 250
+    }
+    Start-Sleep -Seconds 1
+
     New-Item -ItemType Directory -Force -Path $ServiceRoot | Out-Null
     Copy-Item -LiteralPath $runnerSource -Destination $runnerTarget -Force
     Copy-Item -LiteralPath $bridgeSource -Destination $bridgeTarget -Force
@@ -71,13 +85,15 @@ switch ($Action) {
     $taskAction = New-ScheduledTaskAction -Execute $powershell -Argument (
       '-NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "{0}" -ServiceRoot "{1}"' -f $runnerTarget, $ServiceRoot
     )
-    $trigger = New-ScheduledTaskTrigger -AtLogOn -User $env:USERNAME
-    $settings = New-ScheduledTaskSettingsSet -RestartCount 20 -RestartInterval (New-TimeSpan -Minutes 1) `
+    $logonTrigger = New-ScheduledTaskTrigger -AtLogOn -User $env:USERNAME
+    $watchdogTrigger = New-ScheduledTaskTrigger -Once -At (Get-Date).AddMinutes(1) `
+      -RepetitionInterval (New-TimeSpan -Minutes 5)
+    $settings = New-ScheduledTaskSettingsSet -RestartCount 999 -RestartInterval (New-TimeSpan -Minutes 1) `
       -ExecutionTimeLimit (New-TimeSpan -Days 3650) -MultipleInstances IgnoreNew -StartWhenAvailable `
       -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries
     $principal = New-ScheduledTaskPrincipal -UserId ([Security.Principal.WindowsIdentity]::GetCurrent().Name) `
       -LogonType Interactive -RunLevel Limited
-    Register-ScheduledTask -TaskName $TaskName -Action $taskAction -Trigger $trigger `
+    Register-ScheduledTask -TaskName $TaskName -Action $taskAction -Trigger @($logonTrigger, $watchdogTrigger) `
       -Settings $settings -Principal $principal -Description 'Runs the Deft Hermes Agent Channel bridge.' -Force | Out-Null
     Start-ScheduledTask -TaskName $TaskName
     Write-Output "Installed and started '$TaskName'."
@@ -95,13 +111,38 @@ switch ($Action) {
     $task = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
     $info = if ($task) { Get-ScheduledTaskInfo -TaskName $TaskName } else { $null }
     $processes = @(Get-ServiceProcess)
+    $logPath = Join-Path $ServiceRoot 'service.log'
+    $logItem = Get-Item -LiteralPath $logPath -ErrorAction SilentlyContinue
+    $taskState = if ($task) { [string]$task.State } else { 'NotInstalled' }
+    $logAgeSeconds = if ($logItem) {
+      [Math]::Round(((Get-Date) - $logItem.LastWriteTime).TotalSeconds)
+    } else { $null }
     [pscustomobject]@{
       Installed = [bool]$task
-      TaskState = if ($task) { [string]$task.State } else { 'NotInstalled' }
+      Healthy = [bool]($task -and $taskState -eq 'Running' -and $processes.Count -eq 1 -and $logItem -and $logAgeSeconds -le 180)
+      TaskState = $taskState
       ProcessCount = $processes.Count
       LastRunTime = $info.LastRunTime
       LastTaskResult = $info.LastTaskResult
       ConfigPresent = Test-Path -LiteralPath $configTarget
+      LastLogWriteTime = $logItem.LastWriteTime
+      LogAgeSeconds = $logAgeSeconds
+      LastLogLine = if ($logItem) { Get-Content -LiteralPath $logPath -Tail 1 } else { $null }
+    }
+  }
+  'Repair' {
+    $task = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+    if (-not $task) { throw "'$TaskName' is not installed. Run Install first." }
+    Assert-Config $configTarget
+    $logItem = Get-Item -LiteralPath (Join-Path $ServiceRoot 'service.log') -ErrorAction SilentlyContinue
+    $logIsFresh = $logItem -and ((Get-Date) - $logItem.LastWriteTime).TotalSeconds -le 180
+    if ([string]$task.State -ne 'Running' -or @(Get-ServiceProcess).Count -ne 1 -or -not $logIsFresh) {
+      Stop-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+      Get-ServiceProcess | ForEach-Object { Stop-Process -Id $_.ProcessId -Force }
+      Start-ScheduledTask -TaskName $TaskName
+      Write-Output "Repaired and started '$TaskName'."
+    } else {
+      Write-Output "'$TaskName' is healthy; no repair needed."
     }
   }
   'Uninstall' {

--- a/scripts/run-hermes-channel-service.ps1
+++ b/scripts/run-hermes-channel-service.ps1
@@ -1,14 +1,30 @@
 [CmdletBinding()]
 param(
   [string]$ServiceRoot = (Join-Path $env:LOCALAPPDATA 'Deft\hermes-channel'),
-  [int]$RestartDelaySeconds = 5
+  [int]$RestartDelaySeconds = 5,
+  [int]$MaxLogSizeMB = 10,
+  [string]$MutexName = 'Local\DeftHermesAgentChannel'
 )
 
 $ErrorActionPreference = 'Stop'
 $configPath = Join-Path $ServiceRoot 'service.env'
 $bridgePath = Join-Path $ServiceRoot 'hermes-agent-channel-bridge.mjs'
 $logPath = Join-Path $ServiceRoot 'service.log'
-$mutex = [Threading.Mutex]::new($false, 'Local\DeftHermesAgentChannel')
+$mutex = [Threading.Mutex]::new($false, $MutexName)
+
+function Rotate-ServiceLog {
+  if (-not (Test-Path -LiteralPath $logPath)) { return }
+  $maxBytes = [Math]::Max($MaxLogSizeMB, 1) * 1MB
+  if ((Get-Item -LiteralPath $logPath).Length -lt $maxBytes) { return }
+  $previousLogPath = "$logPath.1"
+  Remove-Item -LiteralPath $previousLogPath -Force -ErrorAction SilentlyContinue
+  Move-Item -LiteralPath $logPath -Destination $previousLogPath -Force
+}
+
+function Write-ServiceLog([string]$Message) {
+  Rotate-ServiceLog
+  "$(Get-Date -Format o) $Message" | Add-Content -LiteralPath $logPath -Encoding utf8
+}
 
 try {
   if (-not $mutex.WaitOne(0)) { exit 0 }
@@ -27,17 +43,27 @@ try {
 
   $node = (Get-Command node.exe -ErrorAction Stop).Source
   while ($true) {
-    "$(Get-Date -Format o) starting Hermes channel bridge" | Add-Content -LiteralPath $logPath -Encoding utf8
-    & $node $bridgePath 2>&1 | ForEach-Object {
-      "$_" | Add-Content -LiteralPath $logPath -Encoding utf8
+    Write-ServiceLog 'starting Hermes channel bridge'
+
+    # Native stderr contains expected retry diagnostics. Windows PowerShell turns
+    # redirected stderr into ErrorRecords, so keep it non-terminating while the
+    # bridge runs and let the supervisor react to the actual process exit code.
+    $previousErrorActionPreference = $ErrorActionPreference
+    try {
+      $ErrorActionPreference = 'Continue'
+      & $node $bridgePath 2>&1 | ForEach-Object {
+        "$_" | Add-Content -LiteralPath $logPath -Encoding utf8
+      }
+      $bridgeExitCode = $LASTEXITCODE
+    } finally {
+      $ErrorActionPreference = $previousErrorActionPreference
     }
-    $bridgeExitCode = $LASTEXITCODE
-    "$(Get-Date -Format o) bridge exited with code $bridgeExitCode; restarting in $RestartDelaySeconds seconds" |
-      Add-Content -LiteralPath $logPath -Encoding utf8
+
+    Write-ServiceLog "bridge exited with code $bridgeExitCode; restarting in $RestartDelaySeconds seconds"
     Start-Sleep -Seconds $RestartDelaySeconds
   }
 } catch {
-  "$(Get-Date -Format o) service failed: $($_.Exception.Message)" | Add-Content -LiteralPath $logPath -Encoding utf8
+  Write-ServiceLog "service failed: $($_.Exception.Message)"
   exit 1
 } finally {
   try { $mutex.ReleaseMutex() } catch {}


### PR DESCRIPTION
## What changed
- keep native stderr retry diagnostics from terminating the PowerShell supervisor
- add log rotation, minute heartbeats, health/status details, and a repair command
- add a five-minute watchdog trigger and 999 Task Scheduler restart attempts
- make in-place service upgrades stop the previous task/process before replacing files
- document installation, operation, and failure behavior

## Root cause
Windows PowerShell converted redirected native stderr into terminating ErrorRecords because the wrapper ran with `ErrorActionPreference=Stop`. A normal HTTP 502 retry warning could therefore kill the supervisor and leave the at-logon-only scheduled task dormant.

## Validation
- `node --test scripts/hermes-agent-channel-bridge.test.mjs` (8/8)
- PowerShell parser checks for both service scripts
- forced unreachable-channel test: 5 starts, 4 child exits, supervisor stayed alive, 0 fatal service errors
- live Rita service upgrade: two triggers, RestartCount=999, one bridge process, fresh heartbeat
- stopped-service repair and stale-heartbeat repair both returned to `Healthy=True`