### PR TITLE
Harden agent mentions and completion receipts

### DIFF
--- a/apps/api/src/lib/agent-action-confirmation.ts
+++ b/apps/api/src/lib/agent-action-confirmation.ts
@@ -24,7 +24,8 @@ export function summarizeConfirmedAction(action: ConfirmedAction) {
   const title = titleFrom(params, result);
 
   switch (action.action) {
-    case 'create_task': {
+    case 'create_task':
+    case 'task_create': {
       const identifier = typeof result.identifier === 'string'
         ? result.identifier
         : typeof result.prefix === 'string' && typeof result.number === 'number'

--- a/apps/api/src/lib/agent-mention-normalization.ts
+++ b/apps/api/src/lib/agent-mention-normalization.ts
@@ -1,0 +1,75 @@
+export type AgentMentionIdentity = {
+  userId: string;
+  name: string;
+  slug: string;
+};
+
+export type PlainAgentMentionResolution = {
+  content: string;
+  resolvedUserIds: string[];
+  ambiguousAliases: string[];
+};
+
+function escapeRegex(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function aliasesForAgent(agent: AgentMentionIdentity) {
+  const fullName = agent.name.trim().toLowerCase();
+  const firstName = fullName.split(/\s+/)[0] ?? '';
+  return Array.from(new Set([
+    fullName,
+    firstName,
+    agent.slug.trim().toLowerCase(),
+  ].filter(Boolean)));
+}
+
+/**
+ * Turn exact, unambiguous plain-text agent handles into the canonical mention
+ * marker used by chat. This keeps pasted/typed `@Rita` messages on the same
+ * dispatch path as autocomplete selections without introducing fuzzy routing.
+ */
+export function normalizePlainAgentMentions(
+  content: string,
+  agents: AgentMentionIdentity[],
+): PlainAgentMentionResolution {
+  const ownersByAlias = new Map<string, AgentMentionIdentity[]>();
+  for (const agent of agents) {
+    for (const alias of aliasesForAgent(agent)) {
+      const owners = ownersByAlias.get(alias) ?? [];
+      if (!owners.some((owner) => owner.userId === agent.userId)) owners.push(agent);
+      ownersByAlias.set(alias, owners);
+    }
+  }
+
+  let normalized = content;
+  const resolvedUserIds = new Set<string>();
+  const ambiguousAliases = new Set<string>();
+  const aliases = Array.from(ownersByAlias.keys()).sort((a, b) => b.length - a.length);
+
+  for (const alias of aliases) {
+    const aliasPattern = escapeRegex(alias).replace(/\\ /g, '\\s+');
+    const pattern = new RegExp(`(^|[^a-z0-9_])@(${aliasPattern})(?=$|[^a-z0-9_-])`, 'gi');
+    if (!pattern.test(normalized)) continue;
+    pattern.lastIndex = 0;
+
+    const owners = ownersByAlias.get(alias) ?? [];
+    if (owners.length !== 1) {
+      ambiguousAliases.add(alias);
+      continue;
+    }
+
+    const agent = owners[0]!;
+    normalized = normalized.replace(
+      pattern,
+      (_match, prefix) => `${prefix}<@${agent.userId}|${agent.name}>`,
+    );
+    resolvedUserIds.add(agent.userId);
+  }
+
+  return {
+    content: normalized,
+    resolvedUserIds: Array.from(resolvedUserIds),
+    ambiguousAliases: Array.from(ambiguousAliases),
+  };
+}

--- a/apps/api/src/routes/messages.ts
+++ b/apps/api/src/routes/messages.ts
@@ -12,6 +12,7 @@ import { requireSpaceMembership } from '../lib/space-membership.js';
 import { DEFTY_EMAIL, ensureDeftyMembership } from '../lib/ensure-defty-membership.js';
 import { enqueueChatObservation } from '../lib/chat-observation.js';
 import { createNotificationIfAllowed } from '../lib/notification-policy.js';
+import { normalizePlainAgentMentions } from '../lib/agent-mention-normalization.js';
 
 export const messageRoutes = new Hono();
 
@@ -388,8 +389,7 @@ messageRoutes.post('/:spaceId', async (c) => {
     }
 
     // Normalize plain @defty / @deft / @agent (case-insensitive) into structured
-    // mentions so the renderer styles them as pills uniformly. Skip if a
-    // structured Defty mention is already present.
+    // mentions so the renderer styles them as pills uniformly.
     let normalizedContent = parsed.data.content;
     if (!/<@[^|]+\|Defty?>/i.test(normalizedContent)) {
       const hasLegacyAgent = /(^|[^a-z0-9_])@(defty|deft|agent)\b/i.test(normalizedContent);
@@ -400,6 +400,38 @@ messageRoutes.post('/:spaceId', async (c) => {
           (_match, prefix) => `${prefix}<@${deftyUserId}|Defty>`,
         );
       }
+    }
+
+    const plainMentionScan = normalizedContent.replace(/<@[^>]+>/g, '');
+    if (/(^|[^a-z0-9_])@[a-z0-9]/i.test(plainMentionScan)) {
+      const agentIdentities = await db
+        .select({
+          userId: agentEmployees.user_id,
+          name: agentEmployees.name,
+          slug: agentEmployees.slug,
+        })
+        .from(agentEmployees)
+        .innerJoin(users, eq(agentEmployees.user_id, users.id))
+        .where(and(
+          eq(agentEmployees.org_id, user.org_id),
+          eq(agentEmployees.is_active, true),
+        ));
+      const plainAgentMentions = normalizePlainAgentMentions(
+        normalizedContent,
+        agentIdentities.flatMap((agent) => agent.userId ? [{
+          userId: agent.userId,
+          name: agent.name,
+          slug: agent.slug,
+        }] : []),
+      );
+      if (plainAgentMentions.ambiguousAliases.length > 0) {
+        const handles = plainAgentMentions.ambiguousAliases.map((alias) => `@${alias}`).join(', ');
+        return c.json({
+          error: `${handles} matches more than one active agent. Choose the intended agent from the mention menu.`,
+          code: 'AMBIGUOUS_AGENT_MENTION',
+        }, 409);
+      }
+      normalizedContent = plainAgentMentions.content;
     }
 
     const [message] = await db.insert(messages).values({
@@ -459,8 +491,8 @@ messageRoutes.post('/:spaceId', async (c) => {
     }
 
     // Parse mentions and create notifications
-    const { userIds: directMentionedUserIds } = parseMentions(parsed.data.content);
-    const groupMentionedUserIds = await resolveGroupMentionUserIds(parsed.data.content, user.org_id);
+    const { userIds: directMentionedUserIds } = parseMentions(normalizedContent);
+    const groupMentionedUserIds = await resolveGroupMentionUserIds(normalizedContent, user.org_id);
     const mentionedUserIds = Array.from(new Set([
       ...directMentionedUserIds,
       ...groupMentionedUserIds,
@@ -482,7 +514,7 @@ messageRoutes.post('/:spaceId', async (c) => {
           user_id: mentionedUserId,
           type: 'mention',
           title: `${userData?.name ?? 'Someone'} mentioned you`,
-          body: parsed.data.content.slice(0, 200),
+          body: normalizedContent.slice(0, 200),
           link: `/spaces/${spaceId}?message=${message!.id}`,
         }, { channel: 'chat', spaceId, isMention: true });
 
@@ -510,7 +542,7 @@ messageRoutes.post('/:spaceId', async (c) => {
             user_id: parentMessage.user_id,
             type: 'mention',
             title: `${userData?.name ?? 'Someone'} replied to your message`,
-            body: parsed.data.content.slice(0, 200),
+            body: normalizedContent.slice(0, 200),
             link: `/spaces/${spaceId}?message=${parsed.data.parent_id}`,
           }, { channel: 'chat', spaceId, isMention: true });
 
@@ -553,7 +585,7 @@ messageRoutes.post('/:spaceId', async (c) => {
             sql`${spaceMembers.user_id} != ${user.id}`,
           ));
 
-        const plainContent = parsed.data.content.replace(/<[^>]+>/g, '').slice(0, 200);
+        const plainContent = normalizedContent.replace(/<[^>]+>/g, '').slice(0, 200);
 
         for (const member of members) {
           // Don't duplicate if already notified via mention
@@ -600,7 +632,7 @@ messageRoutes.post('/:spaceId', async (c) => {
     }
     // Backwards-compat fallback: legacy `<@agent|Deft>` and freeform `@defty`/`@deft`/`@agent` still trigger Defty.
     const legacyAgentMentionRegex = /@(agent|defty|deft)\b|<@agent\|Defty?>/i;
-    if (!agentMentioned && legacyAgentMentionRegex.test(parsed.data.content)) {
+    if (!agentMentioned && legacyAgentMentionRegex.test(normalizedContent)) {
       agentMentioned = true;
     }
     // Auto-trigger Defty in DM-with-Defty / agent_conversation spaces — no mention required.
@@ -644,7 +676,7 @@ messageRoutes.post('/:spaceId', async (c) => {
           orgId: user.org_id,
           userId: user.id,
           orgName: org?.name ?? 'Unknown',
-          content: parsed.data.content,
+          content: normalizedContent,
         });
       } catch (err) {
         // Don't block message sending if Redis/queue is down
@@ -733,12 +765,12 @@ messageRoutes.post('/:spaceId', async (c) => {
 
     // Cross-reference detection — check for task identifier patterns like PROJ-42
     const TASK_ID_PATTERN = /([A-Z]+-\d+)/g;
-    if (TASK_ID_PATTERN.test(parsed.data.content)) {
+    if (TASK_ID_PATTERN.test(normalizedContent)) {
       try {
         await enqueue(QUEUE_NAMES.AGENT_JOBS, 'cross-reference', {
           messageId: message!.id,
           spaceId,
-          content: parsed.data.content,
+          content: normalizedContent,
           orgId: user.org_id,
           userId: user.id,
         });

--- a/apps/api/test/agent-action-confirmation.test.ts
+++ b/apps/api/test/agent-action-confirmation.test.ts
@@ -13,6 +13,11 @@ test('confirmation copy names concrete task, wiki, note, and message outcomes', 
     result: { prefix: 'MKT', number: 42, title: 'Run field trial', subtasks: [{}, {}] },
   }), 'Created MKT-42: Run field trial with 2 subtasks.');
   assert.equal(summarizeConfirmedAction({
+    action: 'task_create',
+    params: { title: 'Prepare buyer brief' },
+    result: { identifier: 'BUY-17', title: 'Prepare buyer brief' },
+  }), 'Created BUY-17: Prepare buyer brief.');
+  assert.equal(summarizeConfirmedAction({
     action: 'wiki_write',
     params: { title: 'Watering guide' },
     result: { action: 'created', slug: 'watering-guide' },

--- a/apps/api/test/agent-mention-detection.test.ts
+++ b/apps/api/test/agent-mention-detection.test.ts
@@ -259,6 +259,30 @@ test('structured mention of BYOA agent (kind=agent, not Defty) does NOT trigger 
   assert.ok(employeeQueued, 'BYOA agent mention should enqueue agent-employee-message');
 });
 
+test('plain-text BYOA agent name is normalized and dispatches to the employee', async () => {
+  const content = 'Hey @AMD BYOA Agent, can you help?';
+
+  const res = await app.request(`/api/messages/${spaceId}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ content }),
+  });
+
+  assert.equal(res.status, 201);
+  const body = await res.json() as { id: string; content: string };
+  createdMessageIds.push(body.id);
+  assert.match(body.content, new RegExp(`<@${byoaAgentUserId}\\|AMD BYOA Agent>`));
+  assert.ok(
+    await findAgentEmployeeMessageJob(body.id),
+    'typed agent name should enqueue agent-employee-message',
+  );
+  assert.equal(
+    await findAgentReplyJob(body.id),
+    false,
+    'typed BYOA name should not wake Defty',
+  );
+});
+
 test('TipTap HTML mention in a thread reply dispatches to a BYOA employee', async () => {
   const parentRes = await app.request(`/api/messages/${spaceId}`, {
     method: 'POST',

--- a/apps/api/test/agent-mention-normalization.test.ts
+++ b/apps/api/test/agent-mention-normalization.test.ts
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { normalizePlainAgentMentions } from '../src/lib/agent-mention-normalization.js';
+
+test('resolves exact typed agent names and slugs into structured mentions', () => {
+  const agents = [{ userId: 'rita-user', name: 'Rita', slug: 'research-agent' }];
+
+  assert.deepEqual(normalizePlainAgentMentions('@Rita review this', agents), {
+    content: '<@rita-user|Rita> review this',
+    resolvedUserIds: ['rita-user'],
+    ambiguousAliases: [],
+  });
+  assert.equal(
+    normalizePlainAgentMentions('<p>Ask @research-agent today.</p>', agents).content,
+    '<p>Ask <@rita-user|Rita> today.</p>',
+  );
+});
+
+test('does not resolve email fragments or fuzzy names', () => {
+  const agents = [{ userId: 'rita-user', name: 'Rita', slug: 'rita' }];
+  const content = 'Email owner@rita.com or ask @Rit later.';
+  assert.equal(normalizePlainAgentMentions(content, agents).content, content);
+});
+
+test('flags ambiguous aliases instead of choosing an employee', () => {
+  const result = normalizePlainAgentMentions('@Rita take this', [
+    { userId: 'rita-one', name: 'Rita Singh', slug: 'rita-ops' },
+    { userId: 'rita-two', name: 'Rita Shah', slug: 'rita-sales' },
+  ]);
+
+  assert.equal(result.content, '@Rita take this');
+  assert.deepEqual(result.resolvedUserIds, []);
+  assert.deepEqual(result.ambiguousAliases, ['rita']);
+});

--- a/apps/web/src/components/thread-panel.tsx
+++ b/apps/web/src/components/thread-panel.tsx
@@ -149,7 +149,7 @@ function renderContent(content: string) {
     .replace(/<@([^|]+)\|([^>]+)>/g,
       '<span style="background:var(--accent-muted);color:var(--primary);padding:1px 5px;border-radius:4px;font-weight:500">@$2</span>')
     .replace(/([A-Z]{2,6})-(\d+)/g,
-      '<span style="background:var(--surface-container-highest);color:var(--primary);padding:1px 6px;border-radius:4px;font-family:var(--font-mono);font-size:0.75rem">$1-$2</span>');
+      '<a href="/tasks?task=$1-$2" style="background:var(--surface-container-highest);color:var(--primary);padding:1px 6px;border-radius:4px;font-family:var(--font-mono);font-size:0.75rem;text-decoration:none">$1-$2</a>');
   return <span className="message-content" dangerouslySetInnerHTML={{ __html: sanitizeHtml(html) }} />;
 }
 


### PR DESCRIPTION
## What changed
- normalize exact, unambiguous plain-text agent names and slugs into structured chat mentions
- reject ambiguous agent aliases with a clear mention-menu instruction instead of waking an arbitrary employee
- use normalized content consistently for notifications, agent dispatch, and cross-reference jobs
- format MCP `task_create` completion confirmations with the resulting task key and title
- make task keys clickable in thread confirmations as well as main chat

## Why
Autocomplete mentions woke agent employees reliably, while manually typed names such as `@Rita` could be persisted as inert text. MCP-backed approvals also used the `task_create` action name, which the confirmation formatter did not recognize and rendered as the generic `Completed task create.`

## Validation
- `pnpm --filter @deft/api exec tsx --test test/agent-mention-normalization.test.ts test/agent-action-confirmation.test.ts`
- `pnpm --filter @deft/api typecheck`
- `pnpm --filter @deft/web typecheck`
- `pnpm --filter @deft/web build`

The database-backed mention route suite is included for CI. It could not run locally because the local Docker/Postgres runtime is stopped.
