### PR TITLE
feat(mcp): add operational headless workspace parity

### DIFF
--- a/apps/api/src/lib/mcp-tools/human.ts
+++ b/apps/api/src/lib/mcp-tools/human.ts
@@ -3,8 +3,13 @@ import { and, desc, eq, or, sql } from 'drizzle-orm';
 import { db } from '../db.js';
 import {
   connectedAccounts,
+  agentActions,
+  agentEmployees,
   events,
   messages,
+  notes,
+  noteVersions,
+  notifications,
   oauthAuditEvents,
   orgMembers,
   orgs,
@@ -30,6 +35,8 @@ import { getTeamContext, getTeamProfile, listTeamSummaries } from './team-contex
 import { createTaskBundle, type TaskBundleSubtaskInput } from '../task-bundle.js';
 import { bulkUpdateTasks, BulkTaskUpdateError, bulkTaskUpdateSchema } from '../task-bulk-update.js';
 import { queryCompactTasks, type CompactTaskQuery } from '../task-compact-query.js';
+import { visibleNoteCondition } from '../note-visibility.js';
+import { approveAction, rejectAction } from '../agent-approval-resolver.js';
 
 export type HumanToolContext = {
   org_id: string;
@@ -182,6 +189,19 @@ export const HUMAN_READ_TOOLS = new Set([
   'team_list',
   'team_get',
   'team_context',
+  'workspace_capabilities',
+  'note_list',
+  'note_get',
+  'calendar_list',
+  'calendar_get',
+  'calendar_availability',
+  'inbox_list',
+  'inbox_get',
+  'approval_list',
+  'approval_get',
+  'task_saved_view_list',
+  'agent_employee_list',
+  'agent_employee_get',
 ]);
 
 export const HUMAN_WRITE_TOOLS = new Set([
@@ -194,6 +214,21 @@ export const HUMAN_WRITE_TOOLS = new Set([
   'comment_on_task',
   'message_post',
   'send_message',
+  'note_create',
+  'note_update',
+  'note_archive',
+  'calendar_event_create',
+  'calendar_event_update',
+  'calendar_event_cancel',
+  'inbox_mark_read',
+  'inbox_mark_all_read',
+  'approval_approve',
+  'approval_reject',
+  'project_create',
+  'project_update',
+  'project_archive',
+  'task_saved_view_create',
+  'agent_employee_update_state',
 ]);
 
 export const HUMAN_TOOLS: Record<string, HumanToolHandler> = {
@@ -237,6 +272,34 @@ export const HUMAN_TOOLS: Record<string, HumanToolHandler> = {
   events_query: humanEventsQuery,
   wiki_upsert: humanWikiUpsert,
   send_message: humanSendMessage,
+  workspace_capabilities: humanWorkspaceCapabilities,
+  note_list: humanNoteList,
+  note_get: humanNoteGet,
+  note_create: humanNoteCreate,
+  note_update: humanNoteUpdate,
+  note_archive: humanNoteArchive,
+  calendar_list: humanCalendarList,
+  calendar_get: humanCalendarGet,
+  calendar_availability: humanCalendarAvailability,
+  calendar_event_create: humanCalendarEventCreate,
+  calendar_event_update: humanCalendarEventUpdate,
+  calendar_event_cancel: humanCalendarEventCancel,
+  inbox_list: humanInboxList,
+  inbox_get: humanInboxGet,
+  inbox_mark_read: humanInboxMarkRead,
+  inbox_mark_all_read: humanInboxMarkAllRead,
+  approval_list: humanApprovalList,
+  approval_get: humanApprovalGet,
+  approval_approve: humanApprovalApprove,
+  approval_reject: humanApprovalReject,
+  project_create: humanProjectCreate,
+  project_update: humanProjectUpdate,
+  project_archive: humanProjectArchive,
+  task_saved_view_list: humanTaskSavedViewList,
+  task_saved_view_create: humanTaskSavedViewCreate,
+  agent_employee_list: humanAgentEmployeeList,
+  agent_employee_get: humanAgentEmployeeGet,
+  agent_employee_update_state: humanAgentEmployeeUpdateState,
 };
 
 function hasAnyScope(ctx: HumanToolContext, scopes: string[]): boolean {
@@ -315,6 +378,35 @@ function fallbackDedupeInput(toolName: string, args: Record<string, unknown>): R
       return { space_id: args.space_id ?? null, parent_id: args.parent_id ?? null, content: normalizedText(args.content) };
     case 'send_message':
       return { target: args.target ?? null, space_id: args.space_id ?? null, space_name: normalizedText(args.space_name), thread_id: args.thread_id ?? null, user_id: args.user_id ?? null, email: normalizedText(args.email), person_name: normalizedText(args.person_name), content: normalizedText(args.content) };
+    case 'note_create':
+      return { title: normalizedText(args.title), content: normalizedText(args.content), visibility: args.visibility ?? 'private', visibility_space_id: args.visibility_space_id ?? null };
+    case 'note_update':
+      return { note_id: args.note_id ?? null, fields: args };
+    case 'note_archive':
+      return { note_id: args.note_id ?? null };
+    case 'calendar_event_create':
+      return { title: normalizedText(args.title), start: args.start ?? null, end: args.end ?? null, all_day: args.all_day ?? false };
+    case 'calendar_event_update':
+      return { event_id: args.event_id ?? null, fields: args };
+    case 'calendar_event_cancel':
+      return { event_id: args.event_id ?? null };
+    case 'inbox_mark_read':
+      return { notification_id: args.notification_id ?? null };
+    case 'inbox_mark_all_read':
+      return { all: true };
+    case 'approval_approve':
+    case 'approval_reject':
+      return { action_id: args.action_id ?? null, reason: normalizedText(args.reason) };
+    case 'project_create':
+      return { name: normalizedText(args.name), prefix: normalizedText(args.prefix) };
+    case 'project_update':
+      return { project_id: args.project_id ?? null, fields: args };
+    case 'project_archive':
+      return { project_id: args.project_id ?? null, archived: args.archived ?? true };
+    case 'task_saved_view_create':
+      return { name: normalizedText(args.name), project_id: args.project_id ?? null, config: args.config ?? null, is_shared: args.is_shared ?? false };
+    case 'agent_employee_update_state':
+      return { employee_id: args.employee_id ?? null, state: args.state ?? null };
     default:
       return null;
   }
@@ -2746,6 +2838,445 @@ export async function humanEventsQuery(args: { limit?: number }, ctx: HumanToolC
   return textResult((rows as any).rows ?? []);
 }
 
+function operationalBoundary() {
+  return {
+    operationally_headless: true,
+    ui_only: [
+      'initial workspace authentication and connector authorization',
+      'billing and provider secrets',
+      'ownership transfer, member role changes, and member removal',
+      'agent credential reveal, rotation, and deletion',
+      'irreversible project deletion',
+    ],
+  };
+}
+
+export async function humanWorkspaceCapabilities(_args: Record<string, never>, ctx: HumanToolContext): Promise<ToolResult> {
+  const scopeError = requireScope(ctx, 'read:workspace');
+  if (scopeError) return scopeError;
+  const available = [...HUMAN_READ_TOOLS, ...HUMAN_WRITE_TOOLS].filter((name) => {
+    const required = HUMAN_TOOL_SCOPES[name];
+    if (required && !ctx.scopes.includes(required)) return false;
+    if (name === 'agent_employee_update_state' && !canManageWorkspace(ctx)) return false;
+    return true;
+  });
+  return textResult({
+    ...operationalBoundary(),
+    role: ctx.role,
+    granted_scopes: ctx.scopes,
+    available_tools: available.sort(),
+    guidance: 'Use attention_digest for triage, resolve_targets before fuzzy writes, and reuse idempotency_key when retrying the same write.',
+  });
+}
+
+export async function humanNoteList(args: { query?: string; limit?: number }, ctx: HumanToolContext): Promise<ToolResult> {
+  const scopeError = requireScope(ctx, 'read:workspace');
+  if (scopeError) return scopeError;
+  const limit = Math.min(Math.max(1, args.limit ?? 50), 100);
+  const query = args.query?.trim();
+  const rows = await db.select({
+    id: notes.id, title: notes.title, content: notes.content, icon: notes.icon,
+    is_pinned: notes.is_pinned, visibility: notes.visibility,
+    visibility_space_id: notes.visibility_space_id, user_id: notes.user_id,
+    version: notes.version, created_at: notes.created_at, updated_at: notes.updated_at,
+  }).from(notes).where(and(
+    eq(notes.org_id, ctx.org_id), eq(notes.is_deleted, false), eq(notes.is_template, false),
+    visibleNoteCondition(ctx.user_id), query ? sql`(${notes.title} ILIKE ${`%${query}%`} OR ${notes.content} ILIKE ${`%${query}%`})` : sql`true`,
+  )).orderBy(desc(notes.is_pinned), desc(notes.updated_at)).limit(limit);
+  return textResult(rows.map((row) => ({ ...row, url: `/notes?note=${row.id}` })));
+}
+
+export async function humanNoteGet(args: { note_id?: string }, ctx: HumanToolContext): Promise<ToolResult> {
+  const scopeError = requireScope(ctx, 'read:workspace');
+  if (scopeError) return scopeError;
+  if (!args.note_id) return errorResult('note_id is required');
+  const [row] = await db.select().from(notes).where(and(
+    eq(notes.id, args.note_id), eq(notes.org_id, ctx.org_id), eq(notes.is_deleted, false), visibleNoteCondition(ctx.user_id),
+  )).limit(1);
+  return row ? textResult({ ...row, url: `/notes?note=${row.id}` }) : errorResult('Note not found or not visible');
+}
+
+function validNoteVisibility(value: unknown): value is 'private' | 'org' | 'space' {
+  return typeof value === 'string' && ['private', 'org', 'space'].includes(value);
+}
+
+async function validateNoteSpace(ctx: HumanToolContext, visibility: string, spaceId?: string | null): Promise<ToolResult | null> {
+  if (visibility !== 'space') return null;
+  if (!spaceId) return errorResult('visibility_space_id is required for a space-visible note');
+  return await userIsSpaceMember(ctx, spaceId) ? null : errorResult('You are not a member of that space');
+}
+
+export async function humanNoteCreate(args: Record<string, unknown>, ctx: HumanToolContext): Promise<ToolResult> {
+  const scopeError = requireScope(ctx, 'write:workspace');
+  if (scopeError) return scopeError;
+  return withIdempotency('note_create', args, ctx, async () => {
+    const visibility = validNoteVisibility(args.visibility) ? args.visibility : 'private';
+    const spaceId = typeof args.visibility_space_id === 'string' ? args.visibility_space_id : null;
+    const spaceError = await validateNoteSpace(ctx, visibility, spaceId);
+    if (spaceError) return spaceError;
+    const [created] = await db.insert(notes).values({
+      org_id: ctx.org_id, user_id: ctx.user_id,
+      title: typeof args.title === 'string' ? args.title.trim() : '',
+      content: typeof args.content === 'string' ? args.content : '',
+      icon: typeof args.icon === 'string' ? args.icon : null,
+      is_pinned: args.is_pinned === true,
+      visibility, visibility_space_id: visibility === 'space' ? spaceId : null,
+    }).returning();
+    return textResult({ created: true, note: created, url: `/notes?note=${created!.id}` });
+  });
+}
+
+export async function humanNoteUpdate(args: Record<string, unknown>, ctx: HumanToolContext): Promise<ToolResult> {
+  const scopeError = requireScope(ctx, 'write:workspace');
+  if (scopeError) return scopeError;
+  if (typeof args.note_id !== 'string') return errorResult('note_id is required');
+  return withIdempotency('note_update', args, ctx, async () => {
+    const [current] = await db.select().from(notes).where(and(
+      eq(notes.id, args.note_id as string), eq(notes.org_id, ctx.org_id), eq(notes.user_id, ctx.user_id), eq(notes.is_deleted, false),
+    )).limit(1);
+    if (!current) return errorResult('Note not found or not owned by the connected user');
+    const visibility = validNoteVisibility(args.visibility) ? args.visibility : current.visibility;
+    const spaceId = args.visibility_space_id === null ? null : typeof args.visibility_space_id === 'string' ? args.visibility_space_id : current.visibility_space_id;
+    const spaceError = await validateNoteSpace(ctx, visibility, spaceId);
+    if (spaceError) return spaceError;
+    const updates: Record<string, unknown> = {};
+    for (const field of ['title', 'content', 'icon', 'is_pinned'] as const) if (args[field] !== undefined) updates[field] = args[field];
+    if (args.visibility !== undefined) updates.visibility = visibility;
+    if (args.visibility !== undefined || args.visibility_space_id !== undefined) updates.visibility_space_id = visibility === 'space' ? spaceId : null;
+    if (args.content !== undefined && args.content !== current.content) {
+      await db.insert(noteVersions).values({ note_id: current.id, version: current.version, title: current.title, content: current.content, edited_by: ctx.user_id }).onConflictDoNothing();
+      updates.version = current.version + 1;
+    }
+    if (Object.keys(updates).length === 0) return textResult({ updated: false, note: current, url: `/notes?note=${current.id}` });
+    const [updated] = await db.update(notes).set(updates).where(and(eq(notes.id, current.id), eq(notes.version, current.version))).returning();
+    return updated ? textResult({ updated: true, note: updated, url: `/notes?note=${updated.id}` }) : errorResult('Note changed in another session; read it again before retrying');
+  });
+}
+
+export async function humanNoteArchive(args: Record<string, unknown>, ctx: HumanToolContext): Promise<ToolResult> {
+  const scopeError = requireScope(ctx, 'write:workspace');
+  if (scopeError) return scopeError;
+  if (typeof args.note_id !== 'string') return errorResult('note_id is required');
+  return withIdempotency('note_archive', args, ctx, async () => {
+    const [updated] = await db.update(notes).set({ is_deleted: true }).where(and(
+      eq(notes.id, args.note_id as string), eq(notes.org_id, ctx.org_id), eq(notes.user_id, ctx.user_id), eq(notes.is_deleted, false),
+    )).returning({ id: notes.id, title: notes.title });
+    return updated ? textResult({ archived: true, note: updated }) : errorResult('Note not found or not owned by the connected user');
+  });
+}
+
+function parseRequiredDate(value: unknown, field: string): Date | ToolResult {
+  if (typeof value !== 'string') return errorResult(`${field} is required as an ISO timestamp`);
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? errorResult(`${field} must be a valid ISO timestamp`) : parsed;
+}
+
+export async function humanCalendarList(args: { from?: string; until?: string; limit?: number }, ctx: HumanToolContext): Promise<ToolResult> {
+  const scopeError = requireScope(ctx, 'read:calendar');
+  if (scopeError) return scopeError;
+  const from = args.from ? new Date(args.from) : new Date(Date.now() - 2 * 60 * 60 * 1000);
+  const until = args.until ? new Date(args.until) : new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
+  if (Number.isNaN(from.getTime()) || Number.isNaN(until.getTime()) || until <= from) return errorResult('from/until must be a valid increasing ISO range');
+  const rows = await db.execute(sql`
+    SELECT e.* FROM events e LEFT JOIN connected_accounts ca ON ca.id = e.connected_account_id
+    WHERE e.org_id = ${ctx.org_id} AND (e.user_id = ${ctx.user_id} OR ca.user_id = ${ctx.user_id})
+      AND e.event_type = 'calendar_event' AND e.timestamp >= ${from} AND e.timestamp <= ${until}
+    ORDER BY e.timestamp ASC LIMIT ${Math.min(Math.max(1, args.limit ?? 100), 200)}
+  `);
+  return textResult((rows as any).rows ?? []);
+}
+
+export async function humanCalendarGet(args: { event_id?: string }, ctx: HumanToolContext): Promise<ToolResult> {
+  const scopeError = requireScope(ctx, 'read:calendar');
+  if (scopeError) return scopeError;
+  if (!args.event_id || !(await userCanSeeEvent(ctx, args.event_id))) return errorResult('Event not found or not visible');
+  const [row] = await db.select().from(events).where(eq(events.id, args.event_id)).limit(1);
+  return textResult(row);
+}
+
+export async function humanCalendarAvailability(args: { from?: string; until?: string }, ctx: HumanToolContext): Promise<ToolResult> {
+  const result = await humanCalendarList({ from: args.from, until: args.until, limit: 200 }, ctx);
+  if (result.isError) return result;
+  const rows = JSON.parse(result.content[0]?.text ?? '[]') as Array<any>;
+  return textResult({ from: args.from ?? null, until: args.until ?? null, busy: rows.map((row) => ({ event_id: row.id, title: row.title, start: row.metadata?.start ?? row.timestamp, end: row.metadata?.end ?? row.timestamp, source: row.source })) });
+}
+
+export async function humanCalendarEventCreate(args: Record<string, unknown>, ctx: HumanToolContext): Promise<ToolResult> {
+  const scopeError = requireScope(ctx, 'write:calendar');
+  if (scopeError) return scopeError;
+  return withIdempotency('calendar_event_create', args, ctx, async () => {
+    if (typeof args.title !== 'string' || !args.title.trim()) return errorResult('title is required');
+    const start = parseRequiredDate(args.start, 'start'); if (!(start instanceof Date)) return start;
+    const end = parseRequiredDate(args.end, 'end'); if (!(end instanceof Date)) return end;
+    if (end <= start) return errorResult('end must be after start');
+    const [user] = await db.select({ email: users.email }).from(users).where(eq(users.id, ctx.user_id)).limit(1);
+    const [created] = await db.insert(events).values({ org_id: ctx.org_id, source: 'native', event_type: 'calendar_event', title: args.title.trim(), body: typeof args.description === 'string' ? args.description : null, actor: user?.email ?? null, timestamp: start, metadata: { start: start.toISOString(), end: end.toISOString(), location: typeof args.location === 'string' ? args.location : null, attendees: [], status: 'confirmed', allDay: args.all_day === true }, user_id: ctx.user_id }).returning();
+    return textResult({ created: true, event: created, url: `/calendar?event=${created!.id}` });
+  });
+}
+
+export async function humanCalendarEventUpdate(args: Record<string, unknown>, ctx: HumanToolContext): Promise<ToolResult> {
+  const scopeError = requireScope(ctx, 'write:calendar');
+  if (scopeError) return scopeError;
+  if (typeof args.event_id !== 'string') return errorResult('event_id is required');
+  return withIdempotency('calendar_event_update', args, ctx, async () => {
+    const [current] = await db.select().from(events).where(and(eq(events.id, args.event_id as string), eq(events.org_id, ctx.org_id), eq(events.user_id, ctx.user_id), eq(events.source, 'native'))).limit(1);
+    if (!current) return errorResult('Native event not found or not editable');
+    const metadata = { ...(current.metadata as Record<string, unknown>) };
+    const updates: Record<string, unknown> = {};
+    if (typeof args.title === 'string' && args.title.trim()) updates.title = args.title.trim();
+    if (args.description !== undefined) updates.body = typeof args.description === 'string' ? args.description : null;
+    if (args.start !== undefined) { const start = parseRequiredDate(args.start, 'start'); if (!(start instanceof Date)) return start; updates.timestamp = start; metadata.start = start.toISOString(); }
+    if (args.end !== undefined) { const end = parseRequiredDate(args.end, 'end'); if (!(end instanceof Date)) return end; metadata.end = end.toISOString(); }
+    if (args.location !== undefined) metadata.location = typeof args.location === 'string' ? args.location : null;
+    const startValue = new Date(String(metadata.start ?? current.timestamp)); const endValue = new Date(String(metadata.end ?? current.timestamp));
+    if (!Number.isNaN(endValue.getTime()) && endValue <= startValue) return errorResult('end must be after start');
+    updates.metadata = metadata;
+    const [updated] = await db.update(events).set(updates).where(eq(events.id, current.id)).returning();
+    return textResult({ updated: true, event: updated, url: `/calendar?event=${updated!.id}` });
+  });
+}
+
+export async function humanCalendarEventCancel(args: Record<string, unknown>, ctx: HumanToolContext): Promise<ToolResult> {
+  const scopeError = requireScope(ctx, 'write:calendar');
+  if (scopeError) return scopeError;
+  if (typeof args.event_id !== 'string') return errorResult('event_id is required');
+  return withIdempotency('calendar_event_cancel', args, ctx, async () => {
+    const [deleted] = await db.delete(events).where(and(eq(events.id, args.event_id as string), eq(events.org_id, ctx.org_id), eq(events.user_id, ctx.user_id), eq(events.source, 'native'))).returning({ id: events.id, title: events.title });
+    return deleted ? textResult({ cancelled: true, event: deleted }) : errorResult('Native event not found or not cancellable');
+  });
+}
+
+export async function humanInboxList(args: { unread_only?: boolean; type?: string; limit?: number }, ctx: HumanToolContext): Promise<ToolResult> {
+  const scopeError = requireScope(ctx, 'read:workspace');
+  if (scopeError) return scopeError;
+  const rows = await db.select().from(notifications).where(and(
+    eq(notifications.org_id, ctx.org_id), eq(notifications.user_id, ctx.user_id),
+    args.unread_only === false ? sql`true` : eq(notifications.is_read, false),
+    args.type ? eq(notifications.type, args.type as any) : sql`true`,
+  )).orderBy(desc(notifications.created_at)).limit(Math.min(Math.max(1, args.limit ?? 50), 100));
+  return textResult(rows);
+}
+
+export async function humanInboxGet(args: { notification_id?: string }, ctx: HumanToolContext): Promise<ToolResult> {
+  const scopeError = requireScope(ctx, 'read:workspace'); if (scopeError) return scopeError;
+  if (!args.notification_id) return errorResult('notification_id is required');
+  const [row] = await db.select().from(notifications).where(and(eq(notifications.id, args.notification_id), eq(notifications.org_id, ctx.org_id), eq(notifications.user_id, ctx.user_id))).limit(1);
+  return row ? textResult(row) : errorResult('Notification not found');
+}
+
+export async function humanInboxMarkRead(args: Record<string, unknown>, ctx: HumanToolContext): Promise<ToolResult> {
+  const scopeError = requireScope(ctx, 'write:workspace'); if (scopeError) return scopeError;
+  if (typeof args.notification_id !== 'string') return errorResult('notification_id is required');
+  return withIdempotency('inbox_mark_read', args, ctx, async () => {
+    const [row] = await db.update(notifications).set({ is_read: true }).where(and(eq(notifications.id, args.notification_id as string), eq(notifications.org_id, ctx.org_id), eq(notifications.user_id, ctx.user_id))).returning();
+    return row ? textResult({ marked_read: true, notification: row }) : errorResult('Notification not found');
+  });
+}
+
+export async function humanInboxMarkAllRead(args: Record<string, unknown>, ctx: HumanToolContext): Promise<ToolResult> {
+  const scopeError = requireScope(ctx, 'write:workspace'); if (scopeError) return scopeError;
+  return withIdempotency('inbox_mark_all_read', args, ctx, async () => {
+    const rows = await db.update(notifications).set({ is_read: true }).where(and(eq(notifications.org_id, ctx.org_id), eq(notifications.user_id, ctx.user_id), eq(notifications.is_read, false))).returning({ id: notifications.id });
+    return textResult({ marked_read: rows.length });
+  });
+}
+
+async function ownApproval(ctx: HumanToolContext, actionId: string) {
+  const [row] = await db.select().from(agentActions).where(and(eq(agentActions.id, actionId), eq(agentActions.org_id, ctx.org_id), eq(agentActions.user_id, ctx.user_id))).limit(1);
+  return row ?? null;
+}
+
+export async function humanApprovalList(args: { status?: string; limit?: number }, ctx: HumanToolContext): Promise<ToolResult> {
+  const scopeError = requireScope(ctx, 'read:workspace'); if (scopeError) return scopeError;
+  const status = args.status ?? 'pending';
+  if (!['pending', 'approved', 'rejected', 'expired', 'all'].includes(status)) return errorResult('status must be pending, approved, rejected, expired, or all');
+  const rows = await db.select().from(agentActions).where(and(eq(agentActions.org_id, ctx.org_id), eq(agentActions.user_id, ctx.user_id), status === 'all' ? sql`true` : eq(agentActions.approval_status, status as any))).orderBy(desc(agentActions.created_at)).limit(Math.min(Math.max(1, args.limit ?? 50), 100));
+  return textResult(rows.map((row) => ({ ...row, url: '/inbox?tab=approvals' })));
+}
+
+export async function humanApprovalGet(args: { action_id?: string }, ctx: HumanToolContext): Promise<ToolResult> {
+  const scopeError = requireScope(ctx, 'read:workspace'); if (scopeError) return scopeError;
+  if (!args.action_id) return errorResult('action_id is required');
+  const row = await ownApproval(ctx, args.action_id);
+  return row ? textResult({ ...row, url: '/inbox?tab=approvals' }) : errorResult('Approval not found');
+}
+
+export async function humanApprovalApprove(args: Record<string, unknown>, ctx: HumanToolContext): Promise<ToolResult> {
+  const scopeError = requireScope(ctx, 'write:workspace'); if (scopeError) return scopeError;
+  if (typeof args.action_id !== 'string') return errorResult('action_id is required');
+  return withIdempotency('approval_approve', args, ctx, async () => {
+    if (!(await ownApproval(ctx, args.action_id as string))) return errorResult('Approval not found');
+    const result = await approveAction(args.action_id as string, ctx.user_id);
+    return result.status === 'error' ? errorResult(`${result.code}: ${result.message}`) : textResult(result);
+  });
+}
+
+export async function humanApprovalReject(args: Record<string, unknown>, ctx: HumanToolContext): Promise<ToolResult> {
+  const scopeError = requireScope(ctx, 'write:workspace'); if (scopeError) return scopeError;
+  if (typeof args.action_id !== 'string') return errorResult('action_id is required');
+  return withIdempotency('approval_reject', args, ctx, async () => {
+    if (!(await ownApproval(ctx, args.action_id as string))) return errorResult('Approval not found');
+    const result = await rejectAction(args.action_id as string, ctx.user_id, typeof args.reason === 'string' ? args.reason : undefined);
+    return result.status === 'error' ? errorResult(`${result.code}: ${result.message}`) : textResult(result);
+  });
+}
+
+function canManageWorkspace(ctx: HumanToolContext) { return ctx.role === 'owner' || ctx.role === 'admin'; }
+
+export async function humanProjectCreate(args: Record<string, unknown>, ctx: HumanToolContext): Promise<ToolResult> {
+  const scopeError = requireScope(ctx, 'write:workspace'); if (scopeError) return scopeError;
+  return withIdempotency('project_create', args, ctx, async () => {
+    const name = typeof args.name === 'string' ? args.name.trim() : '';
+    const prefix = typeof args.prefix === 'string' ? args.prefix.trim().toUpperCase() : '';
+    if (!name || !/^[A-Z0-9]{2,6}$/.test(prefix)) return errorResult('name and a unique 2-6 character alphanumeric prefix are required');
+    const leadResult = await resolveActiveMember(ctx, { user_id: args.lead_id, label: 'project_create lead' });
+    if (leadResult.error) return leadResult.error;
+    const [duplicate] = await db.select({ id: projects.id }).from(projects).where(and(eq(projects.org_id, ctx.org_id), eq(projects.prefix, prefix))).limit(1);
+    if (duplicate) return errorResult(`Project prefix ${prefix} is already in use`);
+    const [created] = await db.insert(projects).values({ org_id: ctx.org_id, name, prefix, description: typeof args.description === 'string' ? args.description : null, color: typeof args.color === 'string' ? args.color : null, icon: typeof args.icon === 'string' ? args.icon : null, lead_id: leadResult.user?.id ?? null }).returning();
+    return textResult({ created: true, project: created, url: `/tasks?project=${created!.id}` });
+  });
+}
+
+export async function humanProjectUpdate(args: Record<string, unknown>, ctx: HumanToolContext): Promise<ToolResult> {
+  const scopeError = requireScope(ctx, 'write:workspace'); if (scopeError) return scopeError;
+  if (typeof args.project_id !== 'string') return errorResult('project_id is required');
+  return withIdempotency('project_update', args, ctx, async () => {
+    if (!(await userCanSeeProject(ctx, args.project_id as string))) return errorResult('Project not found');
+    const updates: Record<string, unknown> = {};
+    for (const field of ['name', 'description', 'color', 'icon'] as const) if (args[field] !== undefined) updates[field] = args[field];
+    if (args.lead_id === null) updates.lead_id = null;
+    else if (args.lead_id !== undefined) {
+      const leadResult = await resolveActiveMember(ctx, { user_id: args.lead_id, label: 'project_update lead' });
+      if (leadResult.error) return leadResult.error;
+      updates.lead_id = leadResult.user?.id ?? null;
+    }
+    if (Object.keys(updates).length === 0) return errorResult('At least one editable project field is required');
+    const [updated] = await db.update(projects).set(updates).where(and(eq(projects.id, args.project_id as string), eq(projects.org_id, ctx.org_id))).returning();
+    return textResult({ updated: true, project: updated, url: `/tasks?project=${updated!.id}` });
+  });
+}
+
+export async function humanProjectArchive(args: Record<string, unknown>, ctx: HumanToolContext): Promise<ToolResult> {
+  const scopeError = requireScope(ctx, 'write:workspace'); if (scopeError) return scopeError;
+  if (typeof args.project_id !== 'string') return errorResult('project_id is required');
+  return withIdempotency('project_archive', args, ctx, async () => {
+    const [updated] = await db.update(projects).set({ is_archived: args.archived !== false }).where(and(eq(projects.id, args.project_id as string), eq(projects.org_id, ctx.org_id), eq(projects.is_deleted, false))).returning();
+    return updated ? textResult({ archived: updated.is_archived, project: updated, url: `/tasks?project=${updated.id}` }) : errorResult('Project not found');
+  });
+}
+
+export async function humanTaskSavedViewList(args: { project_id?: string; limit?: number }, ctx: HumanToolContext): Promise<ToolResult> {
+  const scopeError = requireScope(ctx, 'read:tasks'); if (scopeError) return scopeError;
+  const rows = await db.select().from(savedViews).where(and(eq(savedViews.org_id, ctx.org_id), or(eq(savedViews.user_id, ctx.user_id), eq(savedViews.is_shared, true)), args.project_id ? eq(savedViews.project_id, args.project_id) : sql`true`)).orderBy(desc(savedViews.updated_at)).limit(Math.min(Math.max(1, args.limit ?? 50), 100));
+  return textResult(rows);
+}
+
+export async function humanTaskSavedViewCreate(args: Record<string, unknown>, ctx: HumanToolContext): Promise<ToolResult> {
+  const scopeError = requireScope(ctx, 'write:tasks'); if (scopeError) return scopeError;
+  return withIdempotency('task_saved_view_create', args, ctx, async () => {
+    if (typeof args.name !== 'string' || !args.name.trim() || !args.config || typeof args.config !== 'object') return errorResult('name and config are required');
+    if (typeof args.project_id === 'string' && !(await userCanSeeProject(ctx, args.project_id))) return errorResult('Project not found');
+    const [created] = await db.insert(savedViews).values({ org_id: ctx.org_id, user_id: ctx.user_id, project_id: typeof args.project_id === 'string' ? args.project_id : null, name: args.name.trim(), config: args.config, is_shared: args.is_shared === true && canManageWorkspace(ctx) }).returning();
+    return textResult({ created: true, saved_view: created });
+  });
+}
+
+export async function humanAgentEmployeeList(args: { include_paused?: boolean; limit?: number }, ctx: HumanToolContext): Promise<ToolResult> {
+  const scopeError = requireScope(ctx, 'read:workspace'); if (scopeError) return scopeError;
+  const rows = await db.select({ id: agentEmployees.id, name: agentEmployees.name, slug: agentEmployees.slug, role: agentEmployees.role, job_title: agentEmployees.job_title, runtime_kind: agentEmployees.runtime_kind, is_active: agentEmployees.is_active, unhealthy: agentEmployees.unhealthy, unhealthy_reason: agentEmployees.unhealthy_reason, certification_status: agentEmployees.certification_status, last_mcp_call_at: agentEmployees.last_mcp_call_at, last_work_outcome_at: agentEmployees.last_work_outcome_at }).from(agentEmployees).where(and(eq(agentEmployees.org_id, ctx.org_id), eq(agentEmployees.is_deleted, false), args.include_paused ? sql`true` : eq(agentEmployees.is_active, true))).orderBy(agentEmployees.name).limit(Math.min(Math.max(1, args.limit ?? 50), 100));
+  return textResult(rows.map((row) => ({ ...row, url: `/settings/agent-employees/${row.id}` })));
+}
+
+export async function humanAgentEmployeeGet(args: { employee_id?: string }, ctx: HumanToolContext): Promise<ToolResult> {
+  const scopeError = requireScope(ctx, 'read:workspace'); if (scopeError) return scopeError;
+  if (!args.employee_id) return errorResult('employee_id is required');
+  const [row] = await db.select({ id: agentEmployees.id, name: agentEmployees.name, slug: agentEmployees.slug, role: agentEmployees.role, job_title: agentEmployees.job_title, expertise_description: agentEmployees.expertise_description, runtime_kind: agentEmployees.runtime_kind, trust_level: agentEmployees.trust_level, max_daily_actions: agentEmployees.max_daily_actions, daily_action_count: agentEmployees.daily_action_count, is_active: agentEmployees.is_active, unhealthy: agentEmployees.unhealthy, unhealthy_reason: agentEmployees.unhealthy_reason, certification_status: agentEmployees.certification_status, last_verified_at: agentEmployees.last_verified_at, last_mcp_call_at: agentEmployees.last_mcp_call_at, last_work_outcome_at: agentEmployees.last_work_outcome_at }).from(agentEmployees).where(and(eq(agentEmployees.id, args.employee_id), eq(agentEmployees.org_id, ctx.org_id), eq(agentEmployees.is_deleted, false))).limit(1);
+  return row ? textResult({ ...row, url: `/settings/agent-employees/${row.id}` }) : errorResult('Agent employee not found');
+}
+
+export async function humanAgentEmployeeUpdateState(args: Record<string, unknown>, ctx: HumanToolContext): Promise<ToolResult> {
+  const scopeError = requireScope(ctx, 'write:workspace'); if (scopeError) return scopeError;
+  if (!canManageWorkspace(ctx)) return errorResult('Only workspace owners and admins can pause, resume, or mark an agent healthy');
+  if (typeof args.employee_id !== 'string') return errorResult('employee_id is required');
+  return withIdempotency('agent_employee_update_state', args, ctx, async () => {
+    const updates: Record<string, unknown> = {};
+    if (args.state === 'paused') updates.is_active = false;
+    else if (args.state === 'active') updates.is_active = true;
+    else if (args.state === 'healthy') { updates.unhealthy = false; updates.unhealthy_reason = null; }
+    else return errorResult('state must be active, paused, or healthy');
+    const [updated] = await db.update(agentEmployees).set(updates).where(and(eq(agentEmployees.id, args.employee_id as string), eq(agentEmployees.org_id, ctx.org_id), eq(agentEmployees.is_deleted, false))).returning({ id: agentEmployees.id, name: agentEmployees.name, is_active: agentEmployees.is_active, unhealthy: agentEmployees.unhealthy });
+    return updated ? textResult({ updated: true, employee: updated, url: `/settings/agent-employees/${updated.id}` }) : errorResult('Agent employee not found');
+  });
+}
+
+export const HUMAN_TOOL_SCOPES: Record<string, string> = {
+  search: 'read:workspace', fetch: 'read:workspace', platform_context: 'read:workspace', attention_digest: 'read:workspace',
+  member_list: 'read:workspace', resolve_member: 'read:workspace', resolve_targets: 'read:workspace', member_get: 'read:workspace', activity_query: 'read:workspace',
+  events_query: 'read:calendar', memory_recall: 'read:wiki', wiki_search: 'read:wiki', memory_list: 'read:wiki',
+  list_my_tasks: 'read:tasks', task_get: 'read:tasks', task_query: 'read:tasks', task_saved_view_get: 'read:tasks',
+  project_list: 'read:workspace', resolve_project: 'read:workspace', project_get: 'read:workspace',
+  space_list: 'read:messages', resolve_space: 'read:messages', space_get: 'read:messages', thread_fetch: 'read:messages', messages_recent: 'read:messages', messages_search: 'read:messages',
+  project_progress: 'read:tasks', team_workload: 'read:tasks', team_list: 'read:workspace', team_get: 'read:workspace', team_context: 'read:workspace',
+  memory_write: 'write:wiki', wiki_upsert: 'write:wiki', task_create: 'write:tasks', task_update: 'write:tasks', task_bulk_update: 'write:tasks', task_transition: 'write:tasks', comment_on_task: 'write:tasks',
+  message_post: 'write:messages', send_message: 'write:messages',
+  workspace_capabilities: 'read:workspace', note_list: 'read:workspace', note_get: 'read:workspace',
+  note_create: 'write:workspace', note_update: 'write:workspace', note_archive: 'write:workspace',
+  calendar_list: 'read:calendar', calendar_get: 'read:calendar', calendar_availability: 'read:calendar',
+  calendar_event_create: 'write:calendar', calendar_event_update: 'write:calendar', calendar_event_cancel: 'write:calendar',
+  inbox_list: 'read:workspace', inbox_get: 'read:workspace', inbox_mark_read: 'write:workspace', inbox_mark_all_read: 'write:workspace',
+  approval_list: 'read:workspace', approval_get: 'read:workspace', approval_approve: 'write:workspace', approval_reject: 'write:workspace',
+  project_create: 'write:workspace', project_update: 'write:workspace', project_archive: 'write:workspace',
+  task_saved_view_list: 'read:tasks', task_saved_view_create: 'write:tasks',
+  agent_employee_list: 'read:workspace', agent_employee_get: 'read:workspace', agent_employee_update_state: 'write:workspace',
+};
+
+function operationalHumanSchemas(): Array<Record<string, unknown>> {
+  const read = (name: string, title: string, description: string, properties: Record<string, unknown> = {}, required?: string[]) => ({
+    name, title, description, annotations: { readOnlyHint: true },
+    inputSchema: { type: 'object', properties, ...(required ? { required } : {}) },
+  });
+  const write = (name: string, title: string, description: string, properties: Record<string, unknown> = {}, required?: string[]) => ({
+    name, title, description: `${description} Reuse idempotency_key when retrying the same intent.`,
+    annotations: { readOnlyHint: false, destructiveHint: false },
+    inputSchema: { type: 'object', properties: { ...properties, idempotency_key: { type: 'string', description: 'Stable retry key.' } }, ...(required ? { required } : {}) },
+  });
+  const id = (description: string) => ({ type: 'string', description });
+  const limit = { type: 'integer', minimum: 1, maximum: 100 };
+  const iso = (description: string) => ({ type: 'string', description });
+  return [
+    read('workspace_capabilities', 'Inspect Deft MCP Capabilities', 'Return granted scopes, available operational tools, usage guidance, and the intentionally UI-only boundary.'),
+    read('note_list', 'List Deft Notes', 'List private notes owned by the connected user plus org/space notes they can see.', { query: { type: 'string' }, limit }),
+    read('note_get', 'Get Deft Note', 'Read one visible note including its full TipTap HTML content.', { note_id: id('Note id') }, ['note_id']),
+    write('note_create', 'Create Deft Note', 'Create a private, org, or space-visible note as the connected user.', { title: { type: 'string' }, content: { type: 'string' }, icon: { type: 'string' }, is_pinned: { type: 'boolean' }, visibility: { type: 'string', enum: ['private', 'org', 'space'] }, visibility_space_id: id('Required for space visibility') }),
+    write('note_update', 'Update Deft Note', 'Update a note owned by the connected user with optimistic version protection.', { note_id: id('Note id'), title: { type: 'string' }, content: { type: 'string' }, icon: { type: ['string', 'null'] }, is_pinned: { type: 'boolean' }, visibility: { type: 'string', enum: ['private', 'org', 'space'] }, visibility_space_id: { type: ['string', 'null'] } }, ['note_id']),
+    write('note_archive', 'Archive Deft Note', 'Soft-delete a note owned by the connected user.', { note_id: id('Note id') }, ['note_id']),
+    read('calendar_list', 'List Deft Calendar Events', "List the connected user's native and imported calendar events in a time range.", { from: iso('ISO range start'), until: iso('ISO range end'), limit }),
+    read('calendar_get', 'Get Deft Calendar Event', 'Read one visible native or imported calendar event.', { event_id: id('Event id') }, ['event_id']),
+    read('calendar_availability', 'Check Deft Calendar Availability', 'Return busy windows from native and imported calendar context.', { from: iso('ISO range start'), until: iso('ISO range end') }),
+    write('calendar_event_create', 'Create Deft Calendar Event', 'Create a native Deft calendar event owned by the connected user.', { title: { type: 'string' }, start: iso('ISO start'), end: iso('ISO end'), description: { type: 'string' }, location: { type: 'string' }, all_day: { type: 'boolean' } }, ['title', 'start', 'end']),
+    write('calendar_event_update', 'Update Deft Calendar Event', 'Update a native event owned by the connected user. Imported ICS events remain read-only.', { event_id: id('Event id'), title: { type: 'string' }, start: iso('ISO start'), end: iso('ISO end'), description: { type: ['string', 'null'] }, location: { type: ['string', 'null'] } }, ['event_id']),
+    { ...write('calendar_event_cancel', 'Cancel Deft Calendar Event', 'Remove a native event owned by the connected user. Imported events cannot be changed.', { event_id: id('Event id') }, ['event_id']), annotations: { readOnlyHint: false, destructiveHint: true } },
+    read('inbox_list', 'List Deft Inbox', 'List notifications for the connected user.', { unread_only: { type: 'boolean' }, type: { type: 'string' }, limit }),
+    read('inbox_get', 'Get Deft Inbox Item', 'Read one notification owned by the connected user.', { notification_id: id('Notification id') }, ['notification_id']),
+    write('inbox_mark_read', 'Mark Deft Inbox Item Read', 'Mark one owned notification read.', { notification_id: id('Notification id') }, ['notification_id']),
+    write('inbox_mark_all_read', 'Mark Deft Inbox Read', 'Mark all unread notifications for the connected user read.'),
+    read('approval_list', 'List Deft Approvals', 'List pending or historical approval actions assigned to the connected user.', { status: { type: 'string', enum: ['pending', 'approved', 'rejected', 'expired', 'all'] }, limit }),
+    read('approval_get', 'Get Deft Approval', 'Read one approval assigned to the connected user, including exact action parameters.', { action_id: id('Approval action id') }, ['action_id']),
+    write('approval_approve', 'Approve Deft Action', 'Approve and execute one pending action assigned to the connected user through the canonical approval resolver.', { action_id: id('Approval action id') }, ['action_id']),
+    write('approval_reject', 'Reject Deft Action', 'Reject one pending action assigned to the connected user.', { action_id: id('Approval action id'), reason: { type: 'string' } }, ['action_id']),
+    write('project_create', 'Create Deft Project', 'Create a project with fixed Deft workflow defaults.', { name: { type: 'string' }, prefix: { type: 'string', minLength: 2, maxLength: 6 }, description: { type: 'string' }, color: { type: 'string' }, icon: { type: 'string' }, lead_id: id('Optional member user id') }, ['name', 'prefix']),
+    write('project_update', 'Update Deft Project', 'Update editable fields on an active project. Prefixes remain immutable.', { project_id: id('Project id'), name: { type: 'string' }, description: { type: ['string', 'null'] }, color: { type: ['string', 'null'] }, icon: { type: ['string', 'null'] }, lead_id: { type: ['string', 'null'] } }, ['project_id']),
+    write('project_archive', 'Archive Or Restore Deft Project', 'Archive or unarchive a project without deleting its task history.', { project_id: id('Project id'), archived: { type: 'boolean', description: 'Defaults to true.' } }, ['project_id']),
+    read('task_saved_view_list', 'List Deft Task Saved Views', 'List personal and shared task views available to the connected user.', { project_id: id('Optional project id'), limit }),
+    write('task_saved_view_create', 'Create Deft Task Saved View', 'Save task filters, sorting, grouping, and columns as a personal view. Admins may share it.', { name: { type: 'string' }, project_id: id('Optional project id'), config: { type: 'object', additionalProperties: true }, is_shared: { type: 'boolean' } }, ['name', 'config']),
+    read('agent_employee_list', 'List Deft Agent Employees', 'List agent employees and their operational health without exposing credentials.', { include_paused: { type: 'boolean' }, limit }),
+    read('agent_employee_get', 'Get Deft Agent Employee', "Read one agent employee's health, certification, limits, and recent contact state without exposing credentials.", { employee_id: id('Agent employee id') }, ['employee_id']),
+    write('agent_employee_update_state', 'Update Deft Agent State', 'Owner/admin-only control to pause, resume, or clear an unhealthy circuit breaker. Credential operations remain UI-only.', { employee_id: id('Agent employee id'), state: { type: 'string', enum: ['active', 'paused', 'healthy'] } }, ['employee_id', 'state']),
+  ];
+}
+
 function withoutCallerSlug(schema: Record<string, unknown>): Record<string, unknown> {
   const clone = JSON.parse(JSON.stringify(schema));
   if (clone?.inputSchema?.properties) delete clone.inputSchema.properties.caller_employee_slug;
@@ -2757,6 +3288,7 @@ function withoutCallerSlug(schema: Record<string, unknown>): Record<string, unkn
 
 export function buildHumanToolSchemas(agentSchemas: Array<Record<string, unknown>>): Array<Record<string, unknown>> {
   const compatibilitySchemas = [
+    ...operationalHumanSchemas(),
     {
       name: 'search',
       title: 'Search Deft',
@@ -3149,7 +3681,7 @@ export function buildHumanToolSchemas(agentSchemas: Array<Record<string, unknown
     });
   const existingNames = new Set(existing.map((schema) => String(schema.name ?? '')));
   return [
-    ...compatibilitySchemas.filter((schema) => !existingNames.has(schema.name)),
+    ...compatibilitySchemas.filter((schema) => !existingNames.has(String(schema.name ?? ''))),
     ...existing,
   ];
 }

--- a/apps/api/src/lib/oauth-mcp.ts
+++ b/apps/api/src/lib/oauth-mcp.ts
@@ -24,6 +24,8 @@ export const REMOTE_MCP_WRITE_SCOPES = [
   'write:tasks',
   'write:messages',
   'write:wiki',
+  'write:calendar',
+  'write:workspace',
 ] as const;
 
 export const REMOTE_MCP_SCOPES = [
@@ -74,7 +76,9 @@ export function normalizeScopes(value: string | string[] | undefined | null): st
 }
 
 export function profileForScopes(scopes: string[]): ConnectorProfile {
-  return scopes.includes('write:tasks') || scopes.includes('write:messages') ? 'task-helper' : 'knowledge';
+  return scopes.some((scope) => REMOTE_MCP_WRITE_SCOPES.includes(scope as typeof REMOTE_MCP_WRITE_SCOPES[number]))
+    ? 'task-helper'
+    : 'knowledge';
 }
 
 export function pkceS256(verifier: string): string {

--- a/apps/api/src/routes/mcp-access.ts
+++ b/apps/api/src/routes/mcp-access.ts
@@ -17,6 +17,8 @@ const ALLOWED_SCOPES = [
   'write:tasks',
   'write:messages',
   'write:wiki',
+  'write:calendar',
+  'write:workspace',
 ] as const;
 
 const createTokenSchema = z.object({

--- a/apps/api/src/routes/mcp-server-v1.ts
+++ b/apps/api/src/routes/mcp-server-v1.ts
@@ -44,6 +44,7 @@ import {
 import type { ToolContext, ToolResult } from '../lib/mcp-tools/types.js';
 import {
   HUMAN_TOOLS,
+  HUMAN_TOOL_SCOPES,
   buildHumanToolSchemas,
   type HumanToolContext,
 } from '../lib/mcp-tools/human.js';
@@ -198,53 +199,11 @@ async function dispatchTool(
   }
 }
 
-const HUMAN_TOOL_SCOPE: Record<string, string> = {
-  search: 'read:workspace',
-  fetch: 'read:workspace',
-  platform_context: 'read:workspace',
-  member_list: 'read:workspace',
-  resolve_member: 'read:workspace',
-  resolve_targets: 'read:workspace',
-  member_get: 'read:workspace',
-  activity_query: 'read:workspace',
-  events_query: 'read:calendar',
-  memory_recall: 'read:wiki',
-  wiki_search: 'read:wiki',
-  memory_list: 'read:wiki',
-  list_my_tasks: 'read:tasks',
-  task_get: 'read:tasks',
-  task_query: 'read:tasks',
-  task_saved_view_get: 'read:tasks',
-  project_list: 'read:workspace',
-  resolve_project: 'read:workspace',
-  project_get: 'read:workspace',
-  space_list: 'read:messages',
-  resolve_space: 'read:messages',
-  space_get: 'read:messages',
-  project_progress: 'read:tasks',
-  team_workload: 'read:tasks',
-  team_list: 'read:workspace',
-  team_get: 'read:workspace',
-  team_context: 'read:workspace',
-  thread_fetch: 'read:messages',
-  messages_recent: 'read:messages',
-  messages_search: 'read:messages',
-  memory_write: 'write:wiki',
-  wiki_upsert: 'write:wiki',
-  task_create: 'write:tasks',
-  task_update: 'write:tasks',
-  task_bulk_update: 'write:tasks',
-  task_transition: 'write:tasks',
-  comment_on_task: 'write:tasks',
-  message_post: 'write:messages',
-  send_message: 'write:messages',
-};
-
 function humanCatalog(scopes: string[]) {
   return buildHumanToolSchemas(toolSchemas as unknown as Array<Record<string, unknown>>)
     .filter((schema) => {
       const name = String(schema.name ?? '');
-      const required = HUMAN_TOOL_SCOPE[name];
+      const required = HUMAN_TOOL_SCOPES[name];
       return !required || scopes.includes(required);
     });
 }
@@ -259,7 +218,7 @@ async function dispatchHumanTool(
   if (!handler) {
     return { isError: true, content: [{ type: 'text', text: `Unknown or unavailable personal MCP tool: ${toolName}` }] };
   }
-  const requiredScope = HUMAN_TOOL_SCOPE[canonicalToolName];
+  const requiredScope = HUMAN_TOOL_SCOPES[canonicalToolName];
   if (requiredScope && !ctx.scopes.includes(requiredScope)) {
     return { isError: true, content: [{ type: 'text', text: `Missing MCP scope: ${requiredScope}` }] };
   }

--- a/apps/api/test/mcp-operational-headless-contract.test.ts
+++ b/apps/api/test/mcp-operational-headless-contract.test.ts
@@ -1,0 +1,100 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { REMOTE_MCP_SCOPES, normalizeScopes } from '../src/lib/oauth-mcp.js';
+import {
+  HUMAN_READ_TOOLS,
+  HUMAN_TOOL_SCOPES,
+  HUMAN_TOOLS,
+  HUMAN_WRITE_TOOLS,
+  buildHumanToolSchemas,
+} from '../src/lib/mcp-tools/human.js';
+import { toolSchemas } from '../src/lib/mcp-tools/index.js';
+
+const READ_TOOLS = [
+  'workspace_capabilities',
+  'note_list',
+  'note_get',
+  'calendar_list',
+  'calendar_get',
+  'calendar_availability',
+  'inbox_list',
+  'inbox_get',
+  'approval_list',
+  'approval_get',
+  'task_saved_view_list',
+  'agent_employee_list',
+  'agent_employee_get',
+];
+
+const WRITE_TOOLS = [
+  'note_create',
+  'note_update',
+  'note_archive',
+  'calendar_event_create',
+  'calendar_event_update',
+  'calendar_event_cancel',
+  'inbox_mark_read',
+  'inbox_mark_all_read',
+  'approval_approve',
+  'approval_reject',
+  'project_create',
+  'project_update',
+  'project_archive',
+  'task_saved_view_create',
+  'agent_employee_update_state',
+];
+
+test('operational headless scopes are accepted without weakening default read grants', () => {
+  assert.ok(REMOTE_MCP_SCOPES.includes('write:calendar'));
+  assert.ok(REMOTE_MCP_SCOPES.includes('write:workspace'));
+  assert.deepEqual(normalizeScopes(undefined), [
+    'read:workspace',
+    'read:wiki',
+    'read:tasks',
+    'read:messages',
+    'read:calendar',
+  ]);
+  assert.deepEqual(normalizeScopes('write:calendar write:workspace unknown:scope'), [
+    'write:calendar',
+    'write:workspace',
+  ]);
+});
+
+test('every operational tool is registered, classified, and advertised once', () => {
+  const schemas = buildHumanToolSchemas(toolSchemas as unknown as Array<Record<string, unknown>>);
+  const schemaByName = new Map(schemas.map((schema) => [String(schema.name), schema]));
+  assert.equal(new Set(schemas.map((schema) => String(schema.name))).size, schemas.length);
+  for (const name of [...HUMAN_READ_TOOLS, ...HUMAN_WRITE_TOOLS]) {
+    assert.ok(HUMAN_TOOL_SCOPES[name], `${name} must have an explicit scope contract`);
+  }
+
+  for (const name of READ_TOOLS) {
+    assert.ok(HUMAN_READ_TOOLS.has(name), `${name} must be a read tool`);
+    assert.equal(typeof HUMAN_TOOLS[name], 'function', `${name} must have a handler`);
+    assert.equal((schemaByName.get(name)?.annotations as any)?.readOnlyHint, true);
+  }
+  for (const name of WRITE_TOOLS) {
+    assert.ok(HUMAN_WRITE_TOOLS.has(name), `${name} must be a write tool`);
+    assert.equal(typeof HUMAN_TOOLS[name], 'function', `${name} must have a handler`);
+    const schema = schemaByName.get(name)!;
+    assert.equal((schema.annotations as any)?.readOnlyHint, false);
+    assert.ok((schema.inputSchema as any)?.properties?.idempotency_key, `${name} must advertise retry safety`);
+  }
+  assert.equal((schemaByName.get('calendar_event_cancel')?.annotations as any)?.destructiveHint, true);
+});
+
+test('capability catalog keeps dangerous administration out of MCP', () => {
+  const names = new Set(buildHumanToolSchemas(toolSchemas as unknown as Array<Record<string, unknown>>).map((schema) => String(schema.name)));
+  for (const forbidden of [
+    'member_remove',
+    'member_change_role',
+    'transfer_ownership',
+    'billing_update',
+    'provider_secret_set',
+    'agent_employee_reveal_token',
+    'agent_employee_delete',
+    'project_delete',
+  ]) {
+    assert.equal(names.has(forbidden), false, `${forbidden} must remain UI-only`);
+  }
+});

--- a/apps/api/test/oauth-mcp.test.ts
+++ b/apps/api/test/oauth-mcp.test.ts
@@ -52,6 +52,10 @@ const PRIVATE_MESSAGE_ID = `oauth-mcp-private-message-${TEST_ID}`;
 const PRIVATE_PROOF = `PRIVATE-OAUTH-MCP-PROOF-${TEST_ID}`;
 const TEAM_ID = `oauth-mcp-team-${TEST_ID}`;
 const TEAM_HANDLE = `oauth-mcp-salsa-ops-${TEST_ID.slice(0, 8)}`;
+const NOTE_ID = `oauth-mcp-note-${TEST_ID}`;
+const EVENT_ID = `oauth-mcp-event-${TEST_ID}`;
+const NOTIFICATION_ID = `oauth-mcp-notification-${TEST_ID}`;
+const APPROVAL_ID = `oauth-mcp-approval-${TEST_ID}`;
 
 let testApp: Hono;
 let helpers: typeof import('../src/lib/oauth-mcp.js');
@@ -79,6 +83,9 @@ async function cleanup() {
     await client.query(`DELETE FROM oauth_audit_events WHERE user_id = $1 OR org_id = $2`, [USER_ID, ORG_ID]);
     await client.query(`DELETE FROM oauth_clients WHERE client_name LIKE 'OAuth MCP Test%'`);
     await client.query(`DELETE FROM events WHERE org_id = $1`, [ORG_ID]);
+    await client.query(`DELETE FROM notifications WHERE org_id = $1`, [ORG_ID]);
+    await client.query(`DELETE FROM action_receipts WHERE org_id = $1`, [ORG_ID]);
+    await client.query(`DELETE FROM agent_actions WHERE org_id = $1`, [ORG_ID]);
     await client.query(`DELETE FROM team_dashboard_snapshots WHERE org_id = $1`, [ORG_ID]);
     await client.query(`DELETE FROM team_resources WHERE org_id = $1`, [ORG_ID]);
     await client.query(`DELETE FROM team_members WHERE org_id = $1`, [ORG_ID]);
@@ -96,6 +103,8 @@ async function cleanup() {
     await client.query(`DELETE FROM wiki_ops_log WHERE org_id = $1`, [ORG_ID]);
     await client.query(`DELETE FROM wiki_page_versions WHERE page_id IN (SELECT id FROM wiki_pages WHERE org_id = $1)`, [ORG_ID]);
     await client.query(`DELETE FROM wiki_pages WHERE org_id = $1`, [ORG_ID]);
+    await client.query(`DELETE FROM note_versions WHERE note_id IN (SELECT id FROM notes WHERE org_id = $1)`, [ORG_ID]);
+    await client.query(`DELETE FROM notes WHERE org_id = $1`, [ORG_ID]);
     await client.query(`DELETE FROM agent_employees WHERE org_id = $1`, [ORG_ID]);
     await client.query(`DELETE FROM org_members WHERE org_id = $1`, [ORG_ID]);
     await client.query(`DELETE FROM users WHERE id IN ($1, $2)`, [USER_ID, OTHER_USER_ID]);
@@ -302,6 +311,27 @@ async function seedWorkspace() {
       `INSERT INTO messages (id, org_id, space_id, user_id, content)
        VALUES ($1, $2, $3, $4, $5)`,
       [PRIVATE_MESSAGE_ID, ORG_ID, PRIVATE_SPACE_ID, OTHER_USER_ID, `${PRIVATE_PROOF} private space message`],
+    );
+    await client.query(
+      `INSERT INTO notes (id, org_id, user_id, title, content, visibility)
+       VALUES ($1, $2, $3, 'OAuth MCP operator note', '<p>Headless operating note</p>', 'private')`,
+      [NOTE_ID, ORG_ID, USER_ID],
+    );
+    await client.query(
+      `INSERT INTO events (id, org_id, source, event_type, title, body, actor, timestamp, metadata, user_id)
+       VALUES ($1, $2, 'native', 'calendar_event', 'OAuth MCP operating review', 'Review headless parity', 'OAuth MCP User', now() + interval '2 days',
+         jsonb_build_object('start', (now() + interval '2 days')::text, 'end', (now() + interval '2 days 1 hour')::text, 'status', 'confirmed'), $3)`,
+      [EVENT_ID, ORG_ID, USER_ID],
+    );
+    await client.query(
+      `INSERT INTO notifications (id, org_id, user_id, type, title, body, link)
+       VALUES ($1, $2, $3, 'system', 'OAuth MCP attention item', 'Inspect this through MCP', '/inbox')`,
+      [NOTIFICATION_ID, ORG_ID, USER_ID],
+    );
+    await client.query(
+      `INSERT INTO agent_actions (id, org_id, user_id, agent_employee_id, action, params, approval_tier, approval_status)
+       VALUES ($1, $2, $3, $4, 'post_message', jsonb_build_object('space_id', $5::text, 'content', 'Approval contract fixture'), 'quick', 'pending')`,
+      [APPROVAL_ID, ORG_ID, USER_ID, ATTRIBUTED_AGENT_EMPLOYEE_ID, SPACE_ID],
     );
   });
 }
@@ -1183,6 +1213,19 @@ test('OAuth tools/list read catalog only advertises callable tools', async () =>
     messages_search: { query: 'salsa', limit: 5 },
     project_progress: { project_id: PROJECT_ID },
     team_workload: { days: 7 },
+    workspace_capabilities: {},
+    note_list: { limit: 5 },
+    note_get: { note_id: NOTE_ID },
+    calendar_list: { limit: 5 },
+    calendar_get: { event_id: EVENT_ID },
+    calendar_availability: {},
+    inbox_list: { limit: 5 },
+    inbox_get: { notification_id: NOTIFICATION_ID },
+    approval_list: { limit: 5 },
+    approval_get: { action_id: APPROVAL_ID },
+    task_saved_view_list: { limit: 5 },
+    agent_employee_list: { limit: 5 },
+    agent_employee_get: { employee_id: ATTRIBUTED_AGENT_EMPLOYEE_ID },
   };
 
   for (const tool of tools) {
@@ -1198,6 +1241,70 @@ test('OAuth tools/list read catalog only advertises callable tools', async () =>
     const body = (await res.json()) as any;
     assert.equal(body.result?.isError, false, `${tool.name} should be callable, got ${JSON.stringify(body)}`);
   }
+});
+
+test('OAuth operational profile can run reversible owner workflows with receipts and dedupe', async () => {
+  const client = await registerClient();
+  const token = await issueOAuthToken(client.client_id, [
+    'read:workspace', 'read:wiki', 'read:tasks', 'read:messages', 'read:calendar',
+    'write:workspace', 'write:calendar', 'write:tasks', 'write:messages', 'write:wiki',
+  ]);
+  let requestId = 2000;
+  const call = async (name: string, args: Record<string, unknown>) => {
+    const res = await jsonPost('/api/mcp/v1', {
+      jsonrpc: '2.0', id: requestId++, method: 'tools/call', params: { name, arguments: args },
+    }, token.access_token);
+    assert.equal(res.status, 200, `${name} returns HTTP 200`);
+    const body = (await res.json()) as any;
+    assert.equal(body.result?.isError, false, `${name} should succeed: ${JSON.stringify(body)}`);
+    return JSON.parse(body.result.content[0].text);
+  };
+
+  const capabilities = await call('workspace_capabilities', {});
+  assert.equal(capabilities.operationally_headless, true);
+  assert.ok(capabilities.available_tools.includes('note_create'));
+  assert.ok(capabilities.available_tools.includes('calendar_event_create'));
+  assert.ok(capabilities.ui_only.includes('initial workspace authentication and connector authorization'));
+
+  const noteArgs = { title: 'MCP weekly operator note', content: '<p>One operating record</p>', visibility: 'private' };
+  const firstNote = await call('note_create', noteArgs);
+  const replayedNote = await call('note_create', noteArgs);
+  assert.equal(replayedNote.note.id, firstNote.note.id, 'fallback dedupe replays an identical create intent');
+  assert.match(firstNote.url, /^\/notes\?note=/);
+  const updatedNote = await call('note_update', { note_id: firstNote.note.id, content: '<p>Updated operating record</p>', idempotency_key: `note-update-${TEST_ID}` });
+  assert.equal(updatedNote.note.version, 2);
+
+  const start = new Date(Date.now() + 5 * 24 * 60 * 60 * 1000);
+  const end = new Date(start.getTime() + 45 * 60 * 1000);
+  const calendar = await call('calendar_event_create', { title: 'Headless owner review', start: start.toISOString(), end: end.toISOString(), idempotency_key: `event-create-${TEST_ID}` });
+  assert.match(calendar.url, /^\/calendar\?event=/);
+  const calendarUpdate = await call('calendar_event_update', { event_id: calendar.event.id, title: 'Headless owner review updated', idempotency_key: `event-update-${TEST_ID}` });
+  assert.equal(calendarUpdate.event.title, 'Headless owner review updated');
+  const cancelled = await call('calendar_event_cancel', { event_id: calendar.event.id, idempotency_key: `event-cancel-${TEST_ID}` });
+  assert.equal(cancelled.cancelled, true);
+
+  const inbox = await call('inbox_mark_read', { notification_id: NOTIFICATION_ID, idempotency_key: `inbox-${TEST_ID}` });
+  assert.equal(inbox.notification.is_read, true);
+  const rejected = await call('approval_reject', { action_id: APPROVAL_ID, reason: 'Contract verification', idempotency_key: `approval-${TEST_ID}` });
+  assert.ok(['rejected', 'ok'].includes(rejected.status) || rejected.approval_status === 'rejected');
+
+  const prefix = `H${TEST_ID.replace(/-/g, '').slice(0, 4)}`.toUpperCase();
+  const createdProject = await call('project_create', { name: 'Headless MCP Operations', prefix, idempotency_key: `project-create-${TEST_ID}` });
+  assert.match(createdProject.url, /^\/tasks\?project=/);
+  const updatedProject = await call('project_update', { project_id: createdProject.project.id, description: 'Managed through one MCP connection', idempotency_key: `project-update-${TEST_ID}` });
+  assert.equal(updatedProject.project.description, 'Managed through one MCP connection');
+  const archivedProject = await call('project_archive', { project_id: createdProject.project.id, archived: true, idempotency_key: `project-archive-${TEST_ID}` });
+  assert.equal(archivedProject.archived, true);
+
+  const savedView = await call('task_saved_view_create', { name: 'Owner attention', project_id: PROJECT_ID, config: { filters: { priorities: ['p1'] }, columns: ['title', 'priority'] }, idempotency_key: `view-${TEST_ID}` });
+  assert.equal(savedView.created, true);
+  const paused = await call('agent_employee_update_state', { employee_id: ATTRIBUTED_AGENT_EMPLOYEE_ID, state: 'paused', idempotency_key: `agent-pause-${TEST_ID}` });
+  assert.equal(paused.employee.is_active, false);
+  const resumed = await call('agent_employee_update_state', { employee_id: ATTRIBUTED_AGENT_EMPLOYEE_ID, state: 'active', idempotency_key: `agent-resume-${TEST_ID}` });
+  assert.equal(resumed.employee.is_active, true);
+
+  const archivedNote = await call('note_archive', { note_id: firstNote.note.id, idempotency_key: `note-archive-${TEST_ID}` });
+  assert.equal(archivedNote.archived, true);
 });
 
 test('OAuth refresh tokens rotate and reject replay', async () => {

--- a/apps/web/src/app/(app)/settings/mcp-access/page.tsx
+++ b/apps/web/src/app/(app)/settings/mcp-access/page.tsx
@@ -38,7 +38,7 @@ type McpToken = {
 };
 
 const READ_SCOPES = ['read:workspace', 'read:wiki', 'read:tasks', 'read:messages', 'read:calendar'];
-const WRITE_SCOPES = ['write:tasks', 'write:messages', 'write:wiki'];
+const WRITE_SCOPES = ['write:tasks', 'write:messages', 'write:wiki', 'write:calendar', 'write:workspace'];
 const ALL_SCOPES = [...READ_SCOPES, ...WRITE_SCOPES];
 
 const SCOPE_LABELS: Record<string, string> = {
@@ -50,6 +50,8 @@ const SCOPE_LABELS: Record<string, string> = {
   'write:tasks': 'Create, update, transition, and comment on tasks',
   'write:messages': 'Post messages into spaces and DMs you can access',
   'write:wiki': 'Save or update wiki knowledge as you',
+  'write:calendar': 'Create, update, and cancel your native Deft calendar events',
+  'write:workspace': 'Manage your notes, inbox, approvals, projects, and agent operations',
 };
 
 type ClientId = 'codex' | 'claude-code' | 'claude-desktop' | 'remote-web' | 'custom' | 'agent-employee';

--- a/apps/web/src/app/oauth/authorize/page.tsx
+++ b/apps/web/src/app/oauth/authorize/page.tsx
@@ -107,7 +107,9 @@ function OAuthAuthorizeContent() {
   const canWriteTasks = preview?.scopes.includes('write:tasks') ?? false;
   const canWriteMessages = preview?.scopes.includes('write:messages') ?? false;
   const canWriteWiki = preview?.scopes.includes('write:wiki') ?? false;
-  const hasWriteAccess = canWriteTasks || canWriteMessages || canWriteWiki;
+  const canWriteCalendar = preview?.scopes.includes('write:calendar') ?? false;
+  const canWriteWorkspace = preview?.scopes.includes('write:workspace') ?? false;
+  const hasWriteAccess = canWriteTasks || canWriteMessages || canWriteWiki || canWriteCalendar || canWriteWorkspace;
   const accessLabel = hasWriteAccess ? 'Workspace helper access' : 'Knowledge access';
 
   return (
@@ -180,6 +182,12 @@ function OAuthAuthorizeContent() {
                       <li className="flex gap-2"><Check size={16} style={{ color: 'var(--accent)' }} /> Create and update wiki knowledge pages</li>
                     ) : (
                       <li className="flex gap-2"><X size={16} style={{ color: 'var(--danger)' }} /> Edit wiki pages</li>
+                    )}
+                    {canWriteCalendar && (
+                      <li className="flex gap-2"><Check size={16} style={{ color: 'var(--accent)' }} /> Manage your native Deft calendar events</li>
+                    )}
+                    {canWriteWorkspace && (
+                      <li className="flex gap-2"><Check size={16} style={{ color: 'var(--accent)' }} /> Manage notes, inbox, approvals, projects, and agent operations</li>
                     )}
                   </>
                 ) : (

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -256,7 +256,12 @@ Create a personal token, choose read-only or write-enabled scopes, and paste the
 generated streamable HTTP MCP config into Claude Desktop, Claude Code, ChatGPT
 MCP clients, or any compatible MCP runtime. Personal tokens act as the user who
 created them. Writes create tasks, messages, and wiki pages under that user's
-identity.
+identity. With the corresponding scopes, personal clients can also manage the
+user's notes, native calendar events, inbox state, assigned approvals, projects,
+saved task views, and bounded agent-employee state. Initial authentication,
+connector authorization, member administration, credentials, billing, and
+irreversible deletion remain UI-only. In that sense Deft is operationally
+headless after setup, not a UI-free product.
 
 ### AI client compatibility
 
@@ -288,7 +293,10 @@ token in Settings -> MCP Access and use it as a bearer token.
 Start pilots with read-only scopes (`read:workspace`, `read:wiki`,
 `read:tasks`, `read:messages`, `read:calendar`). Add write scopes only when the
 user expects that AI client to create or update Deft records under their own
-identity.
+identity. The write scopes are `write:tasks`, `write:messages`, `write:wiki`,
+`write:calendar`, and `write:workspace`. The broad workspace scope covers notes,
+inbox state, approvals, projects, saved views, and owner/admin-only agent state;
+it does not expose secrets or member administration.
 
 Bring-your-own-agent employees connect through MCP:
 


### PR DESCRIPTION
## Summary

Expands personal OAuth/bearer MCP from task/wiki/message assistance into an operational workspace surface after initial setup. Adds governed notes, native calendar, inbox, approvals, project, saved-view, and bounded agent-state tools with explicit scopes, tenant/role checks, idempotent writes, and direct UI links.

The supported claim is **operationally headless after setup**. Initial authentication/authorization, member administration, secrets, billing, and irreversible deletion remain UI-only.

## Type

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [x] Docs only
- [ ] CI / tooling

## Contract

- Adds OAuth scopes `write:calendar` and `write:workspace`.
- Adds 28 operational tools: 13 read and 15 write.
- Keeps personal-token identity, org isolation, space visibility, resource ownership, and admin-only agent controls enforced.
- Routes approvals through the canonical resolver.
- Applies explicit idempotency keys plus bounded fallback dedupe to every new write.
- Excludes credentials, member administration, billing, ownership transfer, and irreversible deletion.
- No schema migration.

## Test plan

- [x] `pnpm -r --parallel typecheck`
- [x] API production build
- [x] Web production build
- [x] Full serial API suite: 776 passed, 0 failed
- [x] Operational MCP contract suite
- [x] OAuth/MCP Postgres workflow coverage
- [x] Existing MCP write regression coverage
- [x] Production Docker image build and binary smoke
- [x] `git diff --check`

## Checklist

- [x] `pnpm -r typecheck` passes
- [x] Relevant API tests pass
- [x] No schema change
- [x] Approvals use the existing governed approval flow
- [x] No secrets, keys, or `.env` content committed

## Notes

The repository's local `pnpm lint` path currently has a pre-existing ESLint 10 / eslint-plugin-react compatibility failure. Lint is not a configured required CI job; this PR does not mix that tooling repair into the MCP contract change.