### PR TITLE
feat(settings): simplify connections and navigation

### DIFF
--- a/apps/web/src/app/(app)/settings/agent-employees/page.tsx
+++ b/apps/web/src/app/(app)/settings/agent-employees/page.tsx
@@ -196,12 +196,12 @@ export default function AgentEmployeesPage() {
     <div className="mx-auto w-full max-w-[980px] p-4 md:p-6">
       <div className="mb-5 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div>
-          <h2
+          <h1
             className="text-[20px] font-semibold"
             style={{ color: 'var(--foreground)', fontFamily: 'var(--font-heading)' }}
           >
             Agent Employees
-          </h2>
+          </h1>
           <p className="mt-1 max-w-[620px] text-[13px]" style={{ color: 'var(--muted)' }}>
             See who is working, who needs review, and which runtimes still need setup.
           </p>
@@ -234,6 +234,11 @@ export default function AgentEmployeesPage() {
           </Link>
         )}
       </div>
+
+      <nav className="mb-4 flex gap-1 overflow-x-auto" aria-label="Agent employee settings">
+        <Link href="/settings/agent-employees" className="deft-pill" data-active={true}>Employees</Link>
+        <Link href="/settings/agent" className="deft-pill" style={{ color: 'var(--muted)' }}>Governance & audit</Link>
+      </nav>
 
       {error && (
         <div

--- a/apps/web/src/app/(app)/settings/agent/page.tsx
+++ b/apps/web/src/app/(app)/settings/agent/page.tsx
@@ -297,18 +297,23 @@ export default function AgentSettingsPage() {
 
   return (
     <div className="h-full overflow-y-auto">
-    <div className="p-6 max-w-[900px]">
+    <div className="mx-auto w-full max-w-[900px] p-4 sm:p-6">
       <div className="mb-6">
-        <h2
+        <h1
           className="text-[18px] font-semibold"
           style={{ color: 'var(--foreground)', fontFamily: 'var(--font-heading)' }}
         >
           Agent governance
-        </h2>
+        </h1>
         <p className="text-[12px] mt-1 max-w-[640px]" style={{ color: 'var(--muted)' }}>
           Set global trust rails for Defty and shared agent employees, then review approvals, receipts, and agent health from one place.
         </p>
       </div>
+
+      <nav className="mb-4 flex gap-1 overflow-x-auto" aria-label="Agent employee settings">
+        <Link href="/settings/agent-employees" className="deft-pill" style={{ color: 'var(--muted)' }}>Employees</Link>
+        <Link href="/settings/agent" className="deft-pill" data-active={true}>Governance & audit</Link>
+      </nav>
 
       {/* Approvals moved banner */}
       <div
@@ -316,10 +321,7 @@ export default function AgentSettingsPage() {
         style={{ background: 'var(--surface)', border: '1px solid var(--border)', color: 'var(--foreground)' }}
       >
         Pending approvals moved to{' '}
-        <a href="/approvals" className="underline" style={{ color: 'var(--accent)' }}>
-          Approvals
-        </a>
-        .
+        <Link href="/inbox?tab=approvals" className="underline" style={{ color: 'var(--accent)' }}>Inbox &gt; Approvals</Link>.
       </div>
 
       {/* Trust level — unchanged */}
@@ -330,7 +332,7 @@ export default function AgentSettingsPage() {
         >
           Trust Level
         </h3>
-        <div className="grid grid-cols-3 gap-3">
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
           {TRUST_LEVELS.map((t) => (
             <button
               key={t.value}

--- a/apps/web/src/app/(app)/settings/groups/page.tsx
+++ b/apps/web/src/app/(app)/settings/groups/page.tsx
@@ -1,8 +1,7 @@
 'use client';
 
 import { useEffect, useMemo, useState } from 'react';
-import Link from 'next/link';
-import { AtSign, Check, MessageSquare, Plus, Trash2, Users, X } from 'lucide-react';
+import { AtSign, Check, Plus, Trash2, Users, X } from 'lucide-react';
 import { api } from '@/lib/api';
 
 type GroupMember = {
@@ -164,9 +163,9 @@ export default function GroupsPage() {
       <div className="mx-auto max-w-[860px] p-4 sm:p-6">
         <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <div>
-            <h2 className="text-[1.125rem] font-semibold" style={{ color: 'var(--on-surface)' }}>Groups</h2>
+            <h1 className="text-[1.125rem] font-semibold" style={{ color: 'var(--on-surface)' }}>Mention groups</h1>
             <p className="mt-0.5 text-[0.8125rem]" style={{ color: 'var(--outline)' }}>
-              Lightweight mention lists for chat. Use teams when you need ownership, leads, resources, and operating context.
+              Notify the same coworkers with one reusable @mention. Mention groups never grant access to private spaces.
             </p>
           </div>
           <button
@@ -176,20 +175,6 @@ export default function GroupsPage() {
           >
             <Plus size={14} strokeWidth={2} /> Create
           </button>
-        </div>
-
-        <div className="grid gap-3 md:grid-cols-3 mb-5">
-          <GroupNote icon={AtSign} title="Mention lists" body="Groups exist so people can notify a set of coworkers with one handle." />
-          <GroupNote icon={MessageSquare} title="Chat-first" body="Use @handle in chat; it does not grant private space access by itself." />
-          <Link
-            href="/settings/teams"
-            className="rounded-xl p-4"
-            style={{ background: 'var(--surface-container-low)', border: '1px solid var(--outline-variant)' }}
-          >
-            <Users size={16} strokeWidth={1.75} style={{ color: 'var(--accent)' }} />
-            <p className="text-[13px] font-semibold mt-3" style={{ color: 'var(--on-surface)' }}>Need structure?</p>
-            <p className="text-[12px] leading-relaxed mt-1" style={{ color: 'var(--outline)' }}>Use Teams for leads, membership, linked work, and team dashboards.</p>
-          </Link>
         </div>
 
         <div className="grid grid-cols-2 gap-2 mb-5">
@@ -329,27 +314,6 @@ export default function GroupsPage() {
           )}
         </div>
       </div>
-    </div>
-  );
-}
-
-function GroupNote({
-  icon: Icon,
-  title,
-  body,
-}: {
-  icon: typeof AtSign;
-  title: string;
-  body: string;
-}) {
-  return (
-    <div
-      className="rounded-xl p-4"
-      style={{ background: 'var(--surface-container-low)', border: '1px solid var(--outline-variant)' }}
-    >
-      <Icon size={16} strokeWidth={1.75} style={{ color: 'var(--accent)' }} />
-      <p className="text-[13px] font-semibold mt-3" style={{ color: 'var(--on-surface)' }}>{title}</p>
-      <p className="text-[12px] leading-relaxed mt-1" style={{ color: 'var(--outline)' }}>{body}</p>
     </div>
   );
 }

--- a/apps/web/src/app/(app)/settings/integrations/page.tsx
+++ b/apps/web/src/app/(app)/settings/integrations/page.tsx
@@ -169,11 +169,11 @@ export default function IntegrationsPage() {
   return (
     <div className="h-full overflow-y-auto">
     <div className="p-6 max-w-[640px]">
-      <h2 className="text-[1.125rem] font-semibold mb-1" style={{ color: 'var(--on-surface)' }}>
-        Integrations
-      </h2>
+      <h1 className="text-[1.5rem] font-semibold mb-1" style={{ color: 'var(--on-surface)' }}>
+        Agent tool servers
+      </h1>
       <p className="text-[0.8125rem] mb-6" style={{ color: 'var(--outline)' }}>
-        Connect calendar feeds and MCP-compatible tool servers. Agent employees can bring their own external tools through MCP.
+        Connect MCP-compatible tool servers that extend what agent employees can do. Personal AI apps and calendar feeds are managed in their own settings.
       </p>
 
       <div className="grid gap-3 md:grid-cols-3 mb-6">
@@ -216,7 +216,7 @@ export default function IntegrationsPage() {
       <div className="mt-10">
         <div className="flex items-center justify-between mb-1">
           <h2 className="text-[1.125rem] font-semibold" style={{ color: 'var(--on-surface)' }}>
-            MCP Connections
+            Connected tool servers
           </h2>
           <button
             onClick={() => { setEditingMcp(null); setMcpPrefill(null); setShowMcpForm(true); }}
@@ -224,7 +224,7 @@ export default function IntegrationsPage() {
             style={{ background: 'var(--accent)', color: 'white', fontFamily: 'var(--font-heading)' }}
           >
             <Plug size={13} />
-            Add MCP Server
+            Add tool server
           </button>
         </div>
         <p className="text-[0.8125rem] mb-4" style={{ color: 'var(--outline)' }}>

--- a/apps/web/src/app/(app)/settings/mcp-access/page.tsx
+++ b/apps/web/src/app/(app)/settings/mcp-access/page.tsx
@@ -10,7 +10,6 @@ import {
   ChevronRight,
   Code2,
   Copy,
-  FileText,
   Globe2,
   History,
   KeyRound,
@@ -19,7 +18,6 @@ import {
   Settings2,
   ShieldCheck,
   Sparkles,
-  Terminal,
   Trash2,
   Wrench,
 } from 'lucide-react';
@@ -142,21 +140,6 @@ const PRESETS: Array<{ id: AccessPreset; title: string; detail: string; scopes: 
     title: 'Custom scopes',
     detail: 'Choose exact MCP scopes. Best for self-hosted admins and unusual clients.',
     scopes: READ_SCOPES,
-  },
-];
-
-const CONTEXT_PACKET_CARDS = [
-  {
-    title: 'Company memory',
-    detail: 'Org-wide wiki knowledge the AI app can use across projects and channels.',
-  },
-  {
-    title: 'Channel memory',
-    detail: 'Knowledge created in, cited from, or scoped to the space where the work is happening.',
-  },
-  {
-    title: 'Personal memory',
-    detail: 'Private notes and memories scoped to the connected human user.',
   },
 ];
 
@@ -583,9 +566,9 @@ export default function McpAccessPage() {
   ];
 
   return (
-    <div className="flex flex-col h-full overflow-y-auto">
+    <div className="flex h-full min-w-0 flex-col overflow-x-hidden overflow-y-auto">
       <PageHeader
-        title="AI App Connections"
+        title="Connections"
         description="Connect Codex, Claude, ChatGPT, or any MCP client to your Deft workspace."
         secondary={
           <TabStrip>
@@ -600,7 +583,7 @@ export default function McpAccessPage() {
         compact
       />
 
-      <div className="max-w-5xl w-full mx-auto px-4 md:px-6 pb-8 space-y-4">
+      <div className="mx-auto w-full min-w-0 max-w-5xl space-y-4 px-4 pb-8 md:px-6">
         {error && (
           <div className="rounded-lg px-3 py-2 text-[13px]" style={{ color: 'var(--danger)', border: '1px solid var(--danger)', background: 'color-mix(in srgb, var(--danger) 8%, transparent)' }}>
             {error}
@@ -612,177 +595,175 @@ export default function McpAccessPage() {
           </div>
         )}
 
-        <section className="rounded-lg p-4" style={{ background: 'var(--surface-container-low)', border: '1px solid var(--border-default)' }}>
-          <div className="flex flex-col gap-4">
-            <div className="flex items-start gap-3">
-              <div className="w-8 h-8 rounded-md flex items-center justify-center shrink-0" style={{ background: 'var(--accent-muted)', color: 'var(--accent)' }}>
-                <Sparkles size={16} />
+        {!loading && (tokens.length > 0 || grants.length > 0) && (
+          <section className="flex min-w-0 items-center justify-between gap-3 rounded-lg p-3 sm:p-4" style={{ background: 'var(--surface-container-low)', border: '1px solid var(--border-default)' }}>
+            <div className="min-w-0">
+              <div className="flex items-center gap-2 text-[13px] font-semibold" style={{ color: 'var(--text-primary)' }}>
+                <Check size={14} style={{ color: 'var(--status-green, #10b981)' }} />
+                {tokens.length + grants.length} active connection{tokens.length + grants.length === 1 ? '' : 's'}
               </div>
-              <div>
-                <h2 className="text-[15px] font-semibold" style={{ color: 'var(--text-primary)' }}>What do you want to connect?</h2>
-                <p className="text-[12px] mt-1" style={{ color: 'var(--text-secondary)' }}>
-                  Pick the app first. Deft will show the right connection path instead of making you sort through every MCP detail.
-                </p>
+              <p className="mt-1 hidden truncate text-[11px] sm:block" style={{ color: 'var(--text-secondary)' }}>Review last use, scopes, or revoke access below.</p>
+            </div>
+            <a href="#active-connections" className="deft-pill shrink-0" style={{ color: 'var(--accent)', border: '1px solid var(--border-default)' }}>Manage</a>
+          </section>
+        )}
+
+        <section className="min-w-0 overflow-hidden rounded-lg" style={{ background: 'var(--surface-container-low)', border: '1px solid var(--border-default)' }}>
+          <div className="flex flex-col gap-4 p-4 md:p-5" style={{ borderBottom: '1px solid var(--border-default)' }}>
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <div className="flex items-start gap-3">
+                <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md" style={{ background: 'var(--accent-muted)', color: 'var(--accent)' }}>
+                  <Sparkles size={16} />
+                </div>
+                <div>
+                  <h2 className="text-[15px] font-semibold" style={{ color: 'var(--text-primary)' }}>Connect an AI app</h2>
+                  <p className="mt-1 text-[12px]" style={{ color: 'var(--text-secondary)' }}>Choose an app. Deft will only show the setup it needs.</p>
+                </div>
               </div>
+              <Link href="/settings/agent-employees" className="inline-flex items-center gap-1.5 self-start text-[12px] font-medium" style={{ color: 'var(--accent)' }}>
+                Need a shared agent employee? <ChevronRight size={13} />
+              </Link>
             </div>
 
-            <div className="grid md:grid-cols-2 xl:grid-cols-3 gap-3">
-              {CLIENT_OPTIONS.map((client) => {
+            <div className="-mx-1 flex gap-2 overflow-x-auto px-1 pb-1">
+              {CLIENT_OPTIONS.filter((client) => client.id !== 'agent-employee').map((client) => {
                 const active = client.id === selectedClient;
                 return (
                   <button
                     key={client.id}
                     type="button"
                     onClick={() => chooseClient(client.id)}
-                    className="rounded-md p-3 text-left transition-colors"
+                    className="deft-pill shrink-0 gap-2 transition-colors"
                     style={{
-                      background: active ? 'color-mix(in srgb, var(--accent) 12%, var(--surface-container))' : 'var(--surface-container)',
+                      background: active ? 'var(--accent)' : 'var(--surface-container)',
                       border: active ? '1px solid var(--accent)' : '1px solid var(--border-default)',
+                      color: active ? 'white' : 'var(--text-secondary)',
                     }}
+                    aria-pressed={active}
                   >
-                    <div className="flex items-start justify-between gap-3">
-                      <div className="flex items-center gap-2 min-w-0">
-                        <span className="w-7 h-7 rounded-md flex items-center justify-center shrink-0" style={{ background: active ? 'var(--accent-muted)' : 'var(--surface-container-low)', color: active ? 'var(--accent)' : 'var(--text-secondary)' }}>
-                          {clientIcon(client.id)}
-                        </span>
-                        <span className="text-[13px] font-semibold truncate" style={{ color: 'var(--text-primary)' }}>{client.name}</span>
-                      </div>
-                      <span className="text-[10px] rounded px-1.5 py-0.5 shrink-0" style={{ color: active ? 'var(--accent)' : 'var(--text-tertiary)', border: '1px solid var(--border-default)' }}>{client.fit}</span>
-                    </div>
-                    <p className="text-[11px] mt-3 leading-relaxed" style={{ color: 'var(--text-secondary)' }}>{client.detail}</p>
+                    {clientIcon(client.id)}
+                    {client.name}
                   </button>
                 );
               })}
             </div>
           </div>
-        </section>
 
-        <div className="grid lg:grid-cols-[1.05fr_.95fr] gap-4 items-start">
-          <div className="space-y-4">
-            {tokenSetupClient && (
-              <section className="rounded-lg p-4" style={{ background: 'var(--surface-container-low)', border: '1px solid var(--border-default)' }}>
-                <div className="flex items-start gap-3">
-                  <div className="w-8 h-8 rounded-md flex items-center justify-center shrink-0" style={{ background: 'var(--accent-muted)', color: 'var(--accent)' }}>
-                    <ShieldCheck size={16} />
+          <div className="p-4 md:p-5">
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+              <div className="flex min-w-0 items-start gap-3">
+                <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md" style={{ background: 'var(--accent-muted)', color: 'var(--accent)' }}>
+                  {clientIcon(selectedClient)}
+                </span>
+                <div className="min-w-0">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <h3 className="text-[16px] font-semibold" style={{ color: 'var(--text-primary)' }}>{selectedClientOption.name}</h3>
+                    <span className="rounded-full px-2 py-0.5 text-[10px]" style={{ background: 'var(--surface-container)', color: 'var(--text-tertiary)', border: '1px solid var(--border-default)' }}>{selectedClientOption.fit}</span>
                   </div>
-                  <div className="flex-1 min-w-0">
-                    <h2 className="text-[15px] font-semibold" style={{ color: 'var(--text-primary)' }}>Choose what {selectedClientOption.name} can do</h2>
-                    <p className="text-[12px] mt-1" style={{ color: 'var(--text-secondary)' }}>
-                      Personal MCP tokens act as you. The app can only see what you can see, and every write is recorded under your name.
-                    </p>
-
-                    <div className="grid md:grid-cols-3 gap-3 mt-4">
-                      {PRESETS.map((preset) => {
-                        const active = preset.id === accessPreset;
-                        return (
-                          <button
-                            key={preset.id}
-                            type="button"
-                            onClick={() => setAccessPreset(preset.id)}
-                            className="rounded-md p-3 text-left"
-                            style={{
-                              background: active ? 'color-mix(in srgb, var(--accent) 12%, var(--surface-container))' : 'var(--surface-container)',
-                              border: active ? '1px solid var(--accent)' : '1px solid var(--border-default)',
-                            }}
-                          >
-                            <div className="text-[13px] font-medium" style={{ color: 'var(--text-primary)' }}>{preset.title}</div>
-                            <p className="text-[11px] mt-1 leading-relaxed" style={{ color: 'var(--text-secondary)' }}>{preset.detail}</p>
-                          </button>
-                        );
-                      })}
-                    </div>
-
-                    {accessPreset === 'custom' && (
-                      <div className="grid sm:grid-cols-2 gap-2 mt-3">
-                        {ALL_SCOPES.map((scope) => (
-                          <label key={scope} className="flex items-start gap-2 rounded-md p-2.5 text-[11px]" style={{ background: 'var(--surface-container)', color: 'var(--text-secondary)', border: '1px solid var(--border-default)' }}>
-                            <input
-                              type="checkbox"
-                              checked={customScopes.includes(scope)}
-                              onChange={() => toggleCustomScope(scope)}
-                              className="mt-0.5"
-                            />
-                            <span>
-                              <span className="font-medium" style={{ color: 'var(--text-primary)' }}>{scope}</span>
-                              <span> - {SCOPE_LABELS[scope]}</span>
-                            </span>
-                          </label>
-                        ))}
-                      </div>
-                    )}
-
-                    <div className="flex flex-wrap gap-1.5 mt-3">
-                      {selectedScopes.map((scope) => <ScopePill key={scope} scope={scope} />)}
-                    </div>
-                  </div>
+                  <p className="mt-1 max-w-2xl text-[12px]" style={{ color: 'var(--text-secondary)' }}>{selectedClientOption.detail}</p>
                 </div>
-              </section>
-            )}
+              </div>
+              <div className="flex shrink-0 items-center gap-1 text-[11px]" style={{ color: 'var(--text-tertiary)' }}>
+                <span className="flex h-5 w-5 items-center justify-center rounded-full text-white" style={{ background: 'var(--accent)' }}><Check size={11} /></span>
+                App
+                <span className="mx-1 h-px w-5" style={{ background: 'var(--border-default)' }} />
+                <span className="flex h-5 w-5 items-center justify-center rounded-full" style={{ border: '1px solid var(--border-default)', color: 'var(--text-secondary)' }}>2</span>
+                {tokenSetupClient ? 'Access' : 'Setup'}
+                <span className="mx-1 h-px w-5" style={{ background: 'var(--border-default)' }} />
+                <span className="flex h-5 w-5 items-center justify-center rounded-full" style={{ border: '1px solid var(--border-default)', color: 'var(--text-secondary)' }}>3</span>
+                Connect
+              </div>
+            </div>
 
             {tokenSetupClient && (
-              <section className="rounded-lg p-4" style={{ background: 'var(--surface-container-low)', border: '1px solid var(--border-default)' }}>
-                <div className="flex items-start gap-3">
-                  <div className="w-8 h-8 rounded-md flex items-center justify-center shrink-0" style={{ background: 'var(--accent-muted)', color: 'var(--accent)' }}>
-                    <KeyRound size={16} />
+              <div className="mt-5 grid min-w-0 gap-6 lg:grid-cols-[minmax(0,.85fr)_minmax(0,1.15fr)]">
+                <div className="min-w-0 lg:pr-6" style={{ borderColor: 'var(--border-default)' }}>
+                  <div className="flex items-center gap-2">
+                    <ShieldCheck size={14} style={{ color: 'var(--accent)' }} />
+                    <h4 className="text-[13px] font-semibold" style={{ color: 'var(--text-primary)' }}>2. Choose access</h4>
                   </div>
-                  <div className="flex-1 min-w-0">
-                    <h2 className="text-[15px] font-semibold" style={{ color: 'var(--text-primary)' }}>Create the connection</h2>
-                    <p className="text-[12px] mt-1" style={{ color: 'var(--text-secondary)' }}>
-                      Generate a token, copy the config for {selectedClientOption.name}, then test it from the AI app.
-                    </p>
-                    <div className="grid md:grid-cols-[1fr_auto] gap-3 mt-4">
-                      <input
-                        value={tokenName}
-                        onChange={(e) => setTokenName(e.target.value)}
-                        className="h-10 rounded-md px-3 text-[13px] outline-none"
-                        style={{ background: 'var(--surface-container)', color: 'var(--text-primary)', border: '1px solid var(--border-default)' }}
-                      />
-                      <button
-                        type="button"
-                        disabled={busy || selectedScopes.length === 0}
-                        onClick={createToken}
-                        className="inline-flex items-center justify-center gap-2 rounded-md px-3 py-2 text-[13px] font-medium text-white disabled:opacity-50"
-                        style={{ background: 'var(--accent)' }}
-                      >
+                  <p className="mt-1 text-[11px]" style={{ color: 'var(--text-secondary)' }}>This connection acts as you and can only reach work you can access.</p>
+                  <div className="mt-3 divide-y" style={{ borderColor: 'var(--border-default)' }}>
+                    {PRESETS.map((preset) => {
+                      const active = preset.id === accessPreset;
+                      return (
+                        <button key={preset.id} type="button" onClick={() => setAccessPreset(preset.id)} className="flex w-full items-start gap-3 py-3 text-left">
+                          <span className="mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-full" style={{ border: active ? '4px solid var(--accent)' : '1px solid var(--border-strong, var(--border-default))' }} />
+                          <span>
+                            <span className="block text-[12px] font-medium" style={{ color: 'var(--text-primary)' }}>{preset.title}</span>
+                            <span className="mt-0.5 block text-[11px] leading-relaxed" style={{ color: 'var(--text-secondary)' }}>{preset.detail}</span>
+                          </span>
+                        </button>
+                      );
+                    })}
+                  </div>
+
+                  {accessPreset === 'custom' ? (
+                    <div className="mt-3 grid gap-2 sm:grid-cols-2 lg:grid-cols-1 xl:grid-cols-2">
+                      {ALL_SCOPES.map((scope) => (
+                        <label key={scope} className="flex items-start gap-2 rounded-md p-2.5 text-[11px]" style={{ background: 'var(--surface-container)', color: 'var(--text-secondary)', border: '1px solid var(--border-default)' }}>
+                          <input type="checkbox" checked={customScopes.includes(scope)} onChange={() => toggleCustomScope(scope)} className="mt-0.5" />
+                          <span><span className="font-medium" style={{ color: 'var(--text-primary)' }}>{scope}</span><span> - {SCOPE_LABELS[scope]}</span></span>
+                        </label>
+                      ))}
+                    </div>
+                  ) : (
+                    <button type="button" onClick={() => setAccessPreset('custom')} className="mt-3 text-[11px] font-medium" style={{ color: 'var(--accent)' }}>
+                      Review individual scopes
+                    </button>
+                  )}
+                </div>
+
+                <div className="min-w-0 border-t pt-5 lg:border-l lg:border-t-0 lg:pl-6 lg:pt-0" style={{ borderColor: 'var(--border-default)' }}>
+                  <div className="flex items-center gap-2">
+                    <KeyRound size={14} style={{ color: 'var(--accent)' }} />
+                    <h4 className="text-[13px] font-semibold" style={{ color: 'var(--text-primary)' }}>3. Create connection</h4>
+                  </div>
+                  <p className="mt-1 text-[11px]" style={{ color: 'var(--text-secondary)' }}>Create one token for this app. The config appears after the token is generated.</p>
+                  <label className="mt-4 block">
+                    <span className="mb-1.5 block text-[11px] font-medium" style={{ color: 'var(--text-secondary)' }}>Connection name</span>
+                    <div className="flex flex-col gap-2 sm:flex-row">
+                      <input value={tokenName} onChange={(event) => setTokenName(event.target.value)} className="h-10 min-w-0 flex-1 rounded-md px-3 text-[13px] outline-none" style={{ background: 'var(--surface-container)', color: 'var(--text-primary)', border: '1px solid var(--border-default)' }} />
+                      <button type="button" disabled={busy || selectedScopes.length === 0} onClick={createToken} className="inline-flex h-10 items-center justify-center gap-2 rounded-full px-4 text-[13px] font-medium text-white disabled:opacity-50" style={{ background: 'var(--accent)' }}>
                         {busy ? <Loader2 size={14} className="animate-spin" /> : <Plug size={14} />}
-                        Generate token
+                        {newToken ? 'Create another' : 'Generate token'}
                       </button>
                     </div>
+                  </label>
 
-                    {newToken && (
-                      <div className="mt-4 rounded-md p-3" style={{ background: 'color-mix(in srgb, var(--accent) 8%, var(--surface-container))', border: '1px solid var(--accent)' }}>
+                  {newToken ? (
+                    <div className="mt-4 space-y-3">
+                      <div className="rounded-md p-3" style={{ background: 'color-mix(in srgb, var(--accent) 8%, var(--surface-container))', border: '1px solid var(--accent)' }}>
                         <div className="flex items-center justify-between gap-3">
-                          <div>
-                            <div className="text-[13px] font-semibold" style={{ color: 'var(--text-primary)' }}>New token</div>
-                            <p className="text-[11px]" style={{ color: 'var(--text-secondary)' }}>Copy it now. Deft will not show it again.</p>
-                          </div>
-                          <button type="button" onClick={() => copy('token', newToken)} className="inline-flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-[12px]" style={{ border: '1px solid var(--border-default)', color: 'var(--text-primary)' }}>
-                            <Copy size={13} /> Copy
-                          </button>
+                          <div><div className="text-[12px] font-semibold" style={{ color: 'var(--text-primary)' }}>Token ready</div><p className="text-[11px]" style={{ color: 'var(--text-secondary)' }}>Copy it now. Deft will not show it again.</p></div>
+                          <button type="button" onClick={() => copy('token', newToken)} className="inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-[11px] font-medium" style={{ background: 'var(--accent)', color: 'white' }}><Copy size={12} /> Copy token</button>
                         </div>
-                        <pre className="mt-3 overflow-x-auto rounded-md p-3 text-[11px]" style={{ background: 'var(--surface-container)', color: 'var(--text-primary)' }}>{newToken}</pre>
+                        <pre className="mt-3 max-w-full overflow-x-auto rounded-md p-3 text-[11px]" style={{ background: 'var(--surface-container)', color: 'var(--text-primary)' }}>{newToken}</pre>
                       </div>
-                    )}
-
-                    <div className="mt-4 rounded-md p-3" style={{ background: 'var(--surface-container)', border: '1px solid var(--border-default)' }}>
-                      <div className="flex items-start justify-between gap-3">
-                        <div>
-                          <div className="text-[13px] font-semibold" style={{ color: 'var(--text-primary)' }}>{selectedSnippet.title}</div>
-                          <p className="text-[11px] mt-1" style={{ color: 'var(--text-secondary)' }}>{selectedSnippet.detail}</p>
+                      <div className="rounded-md p-3" style={{ background: 'var(--surface-container)', border: '1px solid var(--border-default)' }}>
+                        <div className="flex items-start justify-between gap-3">
+                          <div><div className="text-[12px] font-semibold" style={{ color: 'var(--text-primary)' }}>{selectedSnippet.title}</div><p className="mt-1 text-[11px]" style={{ color: 'var(--text-secondary)' }}>{selectedSnippet.detail}</p></div>
+                          <button type="button" onClick={() => copy(selectedSnippet.title.toLowerCase(), selectedSnippet.value)} className="shrink-0 rounded-md p-1.5" style={{ color: 'var(--text-secondary)', border: '1px solid var(--border-default)' }} aria-label={`Copy ${selectedSnippet.title}`}><Copy size={13} /></button>
                         </div>
-                        <button type="button" onClick={() => copy(selectedSnippet.title.toLowerCase(), selectedSnippet.value)} className="p-1.5 rounded-md shrink-0" style={{ color: 'var(--text-secondary)', border: '1px solid var(--border-default)' }} aria-label={`Copy ${selectedSnippet.title}`}>
-                          <Copy size={13} />
-                        </button>
+                        <pre className="mt-3 max-h-56 max-w-full overflow-x-auto rounded-md p-3 text-[11px]" style={{ background: 'var(--surface-container-high, var(--surface-container-low))', color: 'var(--text-primary)' }}>{selectedSnippet.value}</pre>
                       </div>
-                      <pre className="mt-3 overflow-x-auto rounded-md p-3 text-[11px] max-h-56" style={{ background: 'var(--surface-container-high, var(--surface-container-low))', color: 'var(--text-primary)' }}>{selectedSnippet.value}</pre>
+                      <div className="flex items-start justify-between gap-3 rounded-md px-3 py-2.5" style={{ background: 'var(--surface-container)' }}>
+                        <div className="min-w-0"><div className="text-[11px] font-medium" style={{ color: 'var(--text-primary)' }}>Test the connection</div><p className="mt-0.5 truncate text-[11px]" style={{ color: 'var(--text-secondary)' }}>{TEST_PROMPTS[0]}</p></div>
+                        <button type="button" onClick={() => copy('test prompt', TEST_PROMPTS[0])} className="shrink-0 rounded-md p-1.5" style={{ color: 'var(--text-secondary)' }} aria-label="Copy test prompt"><Copy size={13} /></button>
+                      </div>
                     </div>
-                  </div>
+                  ) : (
+                    <div className="mt-4 flex items-start gap-3 rounded-md px-3 py-3" style={{ background: 'var(--surface-container)' }}>
+                      <ShieldCheck size={15} className="mt-0.5 shrink-0" style={{ color: 'var(--text-tertiary)' }} />
+                      <p className="text-[11px] leading-relaxed" style={{ color: 'var(--text-secondary)' }}>Your token and ready-to-copy {selectedClientOption.name} config will appear here. Every use is recorded in connection activity below.</p>
+                    </div>
+                  )}
                 </div>
-              </section>
+              </div>
             )}
 
             {selectedClientOption.setupKind === 'oauth' && (
-              <section className="rounded-lg p-4" style={{ background: 'var(--surface-container-low)', border: '1px solid var(--border-default)' }}>
+              <div className="mt-5 border-t pt-5" style={{ borderColor: 'var(--border-default)' }}>
                 <div className="flex items-start gap-3">
                   <div className="w-8 h-8 rounded-md flex items-center justify-center shrink-0" style={{ background: 'var(--accent-muted)', color: 'var(--accent)' }}>
                     <Globe2 size={16} />
@@ -842,31 +823,33 @@ export default function McpAccessPage() {
                         </div>
                       </div>
                     )}
-                    <div className="grid md:grid-cols-2 gap-3 mt-4">
-                      {remoteRows.slice(0, 3).map(([label, value]) => (
-                        <div key={label} className="rounded-md p-3 min-w-0" style={{ background: 'var(--surface-container)', border: '1px solid var(--border-default)' }}>
-                          <div className="text-[11px] font-medium uppercase tracking-wide" style={{ color: 'var(--text-tertiary)' }}>{label}</div>
-                          <div className="mt-1 flex items-center gap-2 min-w-0">
-                            <code className="text-[11px] truncate flex-1" style={{ color: 'var(--text-primary)' }}>{value ?? 'Not loaded'}</code>
-                            {value && (
-                              <button type="button" onClick={() => copy(label.toLowerCase(), value)} className="p-1 rounded-md" style={{ color: 'var(--text-secondary)' }} aria-label={`Copy ${label}`}>
-                                <Copy size={13} />
-                              </button>
-                            )}
+                    {!isClaudeConnector && (
+                      <div className="grid md:grid-cols-2 gap-3 mt-4">
+                        {remoteRows.slice(0, 3).map(([label, value]) => (
+                          <div key={label} className="rounded-md p-3 min-w-0" style={{ background: 'var(--surface-container)', border: '1px solid var(--border-default)' }}>
+                            <div className="text-[11px] font-medium uppercase tracking-wide" style={{ color: 'var(--text-tertiary)' }}>{label}</div>
+                            <div className="mt-1 flex items-center gap-2 min-w-0">
+                              <code className="text-[11px] truncate flex-1" style={{ color: 'var(--text-primary)' }}>{value ?? 'Not loaded'}</code>
+                              {value && (
+                                <button type="button" onClick={() => copy(label.toLowerCase(), value)} className="p-1 rounded-md" style={{ color: 'var(--text-secondary)' }} aria-label={`Copy ${label}`}>
+                                  <Copy size={13} />
+                                </button>
+                              )}
+                            </div>
                           </div>
-                        </div>
-                      ))}
-                    </div>
+                        ))}
+                      </div>
+                    )}
                     <button type="button" onClick={() => setAdvancedOpen(true)} className="mt-3 inline-flex items-center gap-1.5 text-[12px]" style={{ color: 'var(--accent)' }}>
                       <Settings2 size={13} /> Show all OAuth endpoints
                     </button>
                   </div>
                 </div>
-              </section>
+              </div>
             )}
 
             {selectedClientOption.setupKind === 'agent' && (
-              <section className="rounded-lg p-4" style={{ background: 'var(--surface-container-low)', border: '1px solid var(--border-default)' }}>
+              <div className="mt-5 border-t pt-5" style={{ borderColor: 'var(--border-default)' }}>
                 <div className="flex items-start gap-3">
                   <div className="w-8 h-8 rounded-md flex items-center justify-center shrink-0" style={{ background: 'var(--accent-muted)', color: 'var(--accent)' }}>
                     <Bot size={16} />
@@ -881,51 +864,12 @@ export default function McpAccessPage() {
                     </Link>
                   </div>
                 </div>
-              </section>
+              </div>
             )}
           </div>
+        </section>
 
-          <aside className="space-y-4">
-            <section className="rounded-lg p-4" style={{ background: 'var(--surface-container-low)', border: '1px solid var(--border-default)' }}>
-              <div className="flex items-start gap-3">
-                <div className="w-8 h-8 rounded-md flex items-center justify-center shrink-0" style={{ background: 'var(--accent-muted)', color: 'var(--accent)' }}>
-                  <Terminal size={16} />
-                </div>
-                <div className="flex-1 min-w-0">
-                  <h2 className="text-[14px] font-semibold" style={{ color: 'var(--text-primary)' }}>Test it from the app</h2>
-                  <p className="text-[12px] mt-1" style={{ color: 'var(--text-secondary)' }}>
-                    After connecting, run one prompt and check that recent activity updates below.
-                  </p>
-                  <div className="mt-3 space-y-2">
-                    {TEST_PROMPTS.map((prompt) => (
-                      <div key={prompt} className="flex items-start gap-2 rounded-md p-2" style={{ background: 'var(--surface-container)', border: '1px solid var(--border-default)' }}>
-                        <FileText size={13} className="mt-0.5 shrink-0" style={{ color: 'var(--text-tertiary)' }} />
-                        <span className="text-[11px] leading-relaxed" style={{ color: 'var(--text-secondary)' }}>{prompt}</span>
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              </div>
-            </section>
-
-            <section className="rounded-lg p-4" style={{ background: 'var(--surface-container-low)', border: '1px solid var(--border-default)' }}>
-              <h2 className="text-[14px] font-semibold" style={{ color: 'var(--text-primary)' }}>Context packets available</h2>
-              <p className="text-[12px] mt-1" style={{ color: 'var(--text-secondary)' }}>Connected clients can retrieve the right memory packet for the work they are doing.</p>
-              <div className="space-y-2 mt-3">
-                {CONTEXT_PACKET_CARDS.map((card) => (
-                  <div key={card.title} className="rounded-md p-3" style={{ background: 'var(--surface-container)', border: '1px solid var(--border-default)' }}>
-                    <div className="flex items-center gap-2 text-[12px] font-medium" style={{ color: 'var(--text-primary)' }}>
-                      <FileText size={13} /> {card.title}
-                    </div>
-                    <p className="text-[11px] mt-1 leading-relaxed" style={{ color: 'var(--text-secondary)' }}>{card.detail}</p>
-                  </div>
-                ))}
-              </div>
-            </section>
-          </aside>
-        </div>
-
-        <section className="rounded-lg p-4" style={{ background: 'var(--surface-container-low)', border: '1px solid var(--border-default)' }}>
+        <section id="active-connections" className="min-w-0 scroll-mt-4 rounded-lg p-4" style={{ background: 'var(--surface-container-low)', border: '1px solid var(--border-default)' }}>
           <div className="flex items-center gap-2 mb-3">
             <Activity size={15} style={{ color: 'var(--accent)' }} />
             <h2 className="text-[14px] font-semibold" style={{ color: 'var(--text-primary)' }}>Manage active connections</h2>

--- a/apps/web/src/app/(app)/settings/page.tsx
+++ b/apps/web/src/app/(app)/settings/page.tsx
@@ -1,136 +1,118 @@
 'use client';
 
+import { useMemo, useState } from 'react';
 import Link from 'next/link';
 import { useTheme } from '@/components/theme-provider';
 import { useAuth } from '@/lib/auth-context';
-import { settingsNavGroups } from '@/lib/settings-navigation';
-import { Bot, CalendarDays, Code2, Moon, Settings2, Sun, User, Users, Workflow } from 'lucide-react';
+import { getSettingsNavGroups } from '@/lib/settings-navigation';
+import {
+  Bot,
+  CalendarDays,
+  ChevronRight,
+  Moon,
+  Search,
+  Settings2,
+  Sun,
+  UserRound,
+  Users,
+  Workflow,
+} from 'lucide-react';
 
-const groupIcons = {
-  Personal: User,
-  Workspace: Users,
-  'Work System': Workflow,
-  'Agents & AI': Bot,
-  Developer: Code2,
-} as const;
+const overviewCards = [
+  { title: 'Profile', body: 'Identity, status, notifications, and security.', href: '/settings/profile', icon: UserRound, admin: false },
+  { title: 'People & teams', body: 'Membership, access, ownership, and team context.', href: '/settings/members', icon: Users, admin: true },
+  { title: 'Calendar', body: 'Bring external calendar context into Deft or subscribe to Deft events.', href: '/settings/calendar', icon: CalendarDays, admin: false },
+  { title: 'AI connections', body: 'Connect Codex, Claude, ChatGPT, and other MCP clients.', href: '/settings/mcp-access', icon: Workflow, admin: false },
+  { title: 'Agent employees', body: 'Operate shared agents as accountable members of the workspace.', href: '/settings/agent-employees', icon: Bot, admin: true },
+] as const;
 
 export default function SettingsPage() {
   const { theme, toggleTheme } = useTheme();
   const { user, org } = useAuth();
-
-  const currentTheme = theme;
+  const [query, setQuery] = useState('');
+  const isAdmin = user?.role === 'owner' || user?.role === 'admin';
+  const groups = getSettingsNavGroups(user?.role ?? 'member');
+  const availableItems = groups.flatMap((group) => group.items);
+  const results = useMemo(() => {
+    const normalized = query.trim().toLowerCase();
+    if (!normalized) return [];
+    return availableItems.filter((item) => `${item.name} ${item.description}`.toLowerCase().includes(normalized));
+  }, [availableItems, query]);
 
   return (
     <div className="h-full overflow-y-auto">
-      <div className="mx-auto max-w-6xl px-5 py-8 md:px-8 md:py-10">
-        <header className="mb-8 flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
-          <div>
-            <div className="mb-3 inline-flex items-center gap-2 rounded-full px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.06em]" style={{ background: 'var(--surface-container-low)', color: 'var(--text-secondary)' }}>
-              <Settings2 size={13} />
-              Workspace controls
-            </div>
-            <h1 className="text-[30px] font-semibold tracking-tight md:text-[36px]" style={{ color: 'var(--foreground)', fontFamily: 'var(--font-heading)' }}>
-              Settings
-            </h1>
-            <p className="mt-2 max-w-2xl text-[15px] leading-6" style={{ color: 'var(--text-secondary)' }}>
-              Manage your profile, people, teams, agents, calendar feeds, templates, and developer access from one place.
-            </p>
+      <div className="mx-auto max-w-5xl px-5 py-8 md:px-8 md:py-10">
+        <header className="mb-6">
+          <div className="mb-3 inline-flex items-center gap-2 rounded-full px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.06em]" style={{ background: 'var(--surface-container-low)', color: 'var(--text-secondary)' }}>
+            <Settings2 size={13} /> Workspace controls
           </div>
-
-          <div className="deft-soft-card p-4 lg:min-w-[280px]">
-            <div className="flex items-center gap-3">
-              {user?.avatar_url ? (
-                // eslint-disable-next-line @next/next/no-img-element
-                <img src={user.avatar_url} alt="" className="h-11 w-11 rounded-full object-cover" />
-              ) : (
-                <div className="flex h-11 w-11 items-center justify-center rounded-full text-[15px] font-semibold text-white" style={{ background: 'var(--accent)' }}>
-                  {user?.name?.charAt(0).toUpperCase() || '?'}
-                </div>
-              )}
-              <div className="min-w-0">
-                <div className="truncate text-[14px] font-semibold" style={{ color: 'var(--foreground)' }}>{user?.name || 'Unknown user'}</div>
-                <div className="truncate text-[12px]" style={{ color: 'var(--text-tertiary)' }}>{org?.name || user?.email || 'Workspace'}</div>
-              </div>
-            </div>
-            <Link href="/settings/profile" className="deft-pill mt-3" style={{ color: 'var(--accent)' }}>
-              Edit profile
-            </Link>
-          </div>
+          <h1 className="text-[30px] font-semibold tracking-tight md:text-[36px]" style={{ color: 'var(--foreground)', fontFamily: 'var(--font-heading)' }}>Settings</h1>
+          <p className="mt-2 max-w-2xl text-[15px] leading-6" style={{ color: 'var(--text-secondary)' }}>
+            Manage your account and the parts of the workspace you are responsible for.
+          </p>
         </header>
 
-        <section className="mb-8 grid gap-3 md:grid-cols-2">
-          <button
-            type="button"
-            onClick={() => {
-              if (currentTheme !== 'light') toggleTheme();
-            }}
-            className="deft-soft-card flex items-center gap-3 p-4 text-left transition-colors"
-            style={{
-              background: currentTheme === 'light' ? 'var(--accent-subtle)' : 'var(--card-bg)',
-              border: `1px solid ${currentTheme === 'light' ? 'var(--accent)' : 'var(--border)'}`,
-            }}
-          >
-            <Sun size={18} style={{ color: currentTheme === 'light' ? 'var(--accent)' : 'var(--text-secondary)' }} />
-            <div>
-              <div className="text-[13px] font-semibold" style={{ color: 'var(--foreground)' }}>Light mode</div>
-              <div className="text-[12px]" style={{ color: 'var(--text-tertiary)' }}>Use a brighter interface.</div>
+        <div className="relative mb-6">
+          <Search size={16} className="absolute left-3 top-1/2 -translate-y-1/2" style={{ color: 'var(--text-tertiary)' }} />
+          <input
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Find a setting..."
+            className="h-11 w-full rounded-full pl-10 pr-4 text-[13px] outline-none"
+            style={{ background: 'var(--card-bg)', border: '1px solid var(--border)', color: 'var(--foreground)' }}
+          />
+          {query.trim() && (
+            <div className="absolute left-0 right-0 top-full z-20 mt-2 overflow-hidden rounded-lg" style={{ background: 'var(--card-bg)', border: '1px solid var(--border)', boxShadow: 'var(--shadow-lg)' }}>
+              {results.length === 0 ? (
+                <p className="px-4 py-5 text-[13px]" style={{ color: 'var(--text-secondary)' }}>No settings match “{query}”.</p>
+              ) : results.map((item) => (
+                <Link key={item.href} href={item.href} className="flex items-center justify-between gap-4 border-b px-4 py-3 last:border-b-0" style={{ borderColor: 'var(--border-default)' }}>
+                  <span className="min-w-0"><span className="block text-[13px] font-medium" style={{ color: 'var(--foreground)' }}>{item.name}</span><span className="block truncate text-[11px]" style={{ color: 'var(--text-tertiary)' }}>{item.description}</span></span>
+                  <ChevronRight size={15} style={{ color: 'var(--accent)' }} />
+                </Link>
+              ))}
             </div>
-          </button>
-          <button
-            type="button"
-            onClick={() => {
-              if (currentTheme !== 'dark') toggleTheme();
-            }}
-            className="deft-soft-card flex items-center gap-3 p-4 text-left transition-colors"
-            style={{
-              background: currentTheme === 'dark' ? 'var(--accent-subtle)' : 'var(--card-bg)',
-              border: `1px solid ${currentTheme === 'dark' ? 'var(--accent)' : 'var(--border)'}`,
-            }}
-          >
-            <Moon size={18} style={{ color: currentTheme === 'dark' ? 'var(--accent)' : 'var(--text-secondary)' }} />
-            <div>
-              <div className="text-[13px] font-semibold" style={{ color: 'var(--foreground)' }}>Dark mode</div>
-              <div className="text-[12px]" style={{ color: 'var(--text-tertiary)' }}>Use the focused workspace theme.</div>
-            </div>
-          </button>
+          )}
+        </div>
+
+        <section className="mb-6 grid gap-3 md:grid-cols-[minmax(0,1fr)_auto]">
+          <Link href="/settings/profile" className="deft-soft-card flex min-w-0 items-center gap-3 p-4">
+            {user?.avatar_url ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img src={user.avatar_url} alt="" className="h-11 w-11 shrink-0 rounded-full object-cover" />
+            ) : (
+              <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full text-[15px] font-semibold text-white" style={{ background: 'var(--accent)' }}>{user?.name?.charAt(0).toUpperCase() || '?'}</div>
+            )}
+            <div className="min-w-0 flex-1"><div className="truncate text-[14px] font-semibold" style={{ color: 'var(--foreground)' }}>{user?.name || 'Unknown user'}</div><div className="truncate text-[12px]" style={{ color: 'var(--text-tertiary)' }}>{org?.name || user?.email || 'Workspace'}</div></div>
+            <ChevronRight size={16} style={{ color: 'var(--accent)' }} />
+          </Link>
+          <div className="deft-soft-card flex items-center gap-1 p-1.5" aria-label="Theme">
+            <button type="button" onClick={() => theme !== 'light' && toggleTheme()} className="deft-pill" data-active={theme === 'light'} style={{ background: theme === 'light' ? 'var(--accent-subtle)' : 'transparent', color: theme === 'light' ? 'var(--accent)' : 'var(--text-secondary)' }}><Sun size={15} /> Light</button>
+            <button type="button" onClick={() => theme !== 'dark' && toggleTheme()} className="deft-pill" data-active={theme === 'dark'} style={{ background: theme === 'dark' ? 'var(--accent-subtle)' : 'transparent', color: theme === 'dark' ? 'var(--accent)' : 'var(--text-secondary)' }}><Moon size={15} /> Dark</button>
+          </div>
         </section>
 
-        <div className="grid gap-4 lg:grid-cols-2">
-          {settingsNavGroups.map((group) => {
-            const Icon = groupIcons[group.label as keyof typeof groupIcons] || CalendarDays;
-            return (
-              <section key={group.label} className="deft-soft-card p-5">
-                <div className="mb-4 flex items-start gap-3">
-                  <div className="flex h-9 w-9 items-center justify-center rounded-lg" style={{ background: 'var(--surface-container-low)', color: 'var(--accent)' }}>
-                    <Icon size={17} />
-                  </div>
-                  <div>
-                    <h2 className="text-[15px] font-semibold" style={{ color: 'var(--foreground)', fontFamily: 'var(--font-heading)' }}>{group.label}</h2>
-                    <p className="mt-1 text-[12px] leading-5" style={{ color: 'var(--text-secondary)' }}>{group.description}</p>
-                  </div>
-                </div>
-                <div>
-                  {group.items.map((item, index) => (
-                    <Link
-                      key={item.href}
-                      href={item.href}
-                      className="group flex items-center justify-between gap-4 py-3"
-                      style={{ borderTop: index === 0 ? 'none' : '1px solid var(--outline-variant)' }}
-                    >
-                      <div className="min-w-0">
-                        <div className="text-[13px] font-medium" style={{ color: 'var(--foreground)' }}>{item.name}</div>
-                        <div className="mt-0.5 text-[12px] leading-5" style={{ color: 'var(--text-tertiary)' }}>{item.description}</div>
-                      </div>
-                      <span className="text-[12px] transition-transform group-hover:translate-x-0.5" style={{ color: 'var(--accent)' }}>
-                        Open
-                      </span>
-                    </Link>
-                  ))}
-                </div>
-              </section>
-            );
-          })}
-        </div>
+        <section>
+          <h2 className="mb-3 text-[12px] font-semibold uppercase tracking-[0.07em]" style={{ color: 'var(--text-tertiary)' }}>Common settings</h2>
+          <div className="grid gap-3 md:grid-cols-2">
+            {overviewCards.filter((card) => !card.admin || isAdmin).map(({ title, body, href, icon: Icon }) => (
+              <Link key={href} href={href} className="deft-soft-card group flex items-start gap-3 p-4">
+                <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg" style={{ background: 'var(--surface-container-low)', color: 'var(--accent)' }}><Icon size={17} /></div>
+                <div className="min-w-0 flex-1"><h3 className="text-[14px] font-semibold" style={{ color: 'var(--foreground)' }}>{title}</h3><p className="mt-1 text-[12px] leading-5" style={{ color: 'var(--text-secondary)' }}>{body}</p></div>
+                <ChevronRight size={15} className="mt-1 transition-transform group-hover:translate-x-0.5" style={{ color: 'var(--accent)' }} />
+              </Link>
+            ))}
+          </div>
+        </section>
+
+        {isAdmin && (
+          <section className="mt-6 border-t pt-5" style={{ borderColor: 'var(--border-default)' }}>
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <div><h2 className="text-[13px] font-semibold" style={{ color: 'var(--foreground)' }}>Advanced administration</h2><p className="mt-0.5 text-[12px]" style={{ color: 'var(--text-tertiary)' }}>Automation, recovery, providers, governance, and developer access live in the Advanced section of the sidebar.</p></div>
+              <Link href="/settings/library" className="deft-pill" style={{ color: 'var(--accent)', border: '1px solid var(--border)' }}>Open task settings <ChevronRight size={13} /></Link>
+            </div>
+          </section>
+        )}
       </div>
     </div>
   );

--- a/apps/web/src/app/(app)/settings/teams/page.tsx
+++ b/apps/web/src/app/(app)/settings/teams/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import {
   AlertTriangle,
+  ArrowLeft,
   Archive,
   ArchiveRestore,
   Bot,
@@ -264,6 +265,7 @@ function SectionTitle({ icon: Icon, title, eyebrow }: { icon: any; title: string
 export default function TeamsSettingsPage() {
   const { user } = useAuth();
   const [teams, setTeams] = useState<Team[]>([]);
+  const [mobileDetailOpen, setMobileDetailOpen] = useState(false);
   const [members, setMembers] = useState<SimpleMember[]>([]);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [detail, setDetail] = useState<TeamDetail | null>(null);
@@ -569,11 +571,11 @@ export default function TeamsSettingsPage() {
   const leadName = detail?.lead?.name ?? (detail?.team.lead_user_id ? 'Assigned lead' : 'No lead yet');
 
   return (
-    <div className="h-full overflow-y-auto">
-      <div className="mx-auto max-w-[1220px] space-y-4 p-4 sm:p-6">
+    <div className="h-full min-w-0 overflow-x-hidden overflow-y-auto">
+      <div className="mx-auto w-full min-w-0 max-w-[1220px] space-y-4 p-4 sm:p-6">
         <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
           <div className="min-w-0 flex-1">
-            <h2 className="section-title" style={{ fontFamily: 'var(--font-heading)' }}>Teams</h2>
+            <h1 className="section-title" style={{ fontFamily: 'var(--font-heading)' }}>Teams</h1>
             <p className="mt-1 max-w-2xl text-[13px] leading-relaxed" style={{ color: 'var(--muted)' }}>
               Shape work around real operating teams, then give managers one place to see people, linked work, context, and agent activity.
             </p>
@@ -671,7 +673,7 @@ export default function TeamsSettingsPage() {
         )}
 
         <div className="grid gap-4 lg:grid-cols-[360px_minmax(0,1fr)]">
-          <section className="min-w-0 overflow-hidden rounded-lg" style={{ background: 'var(--card-bg)', border: '1px solid var(--border)' }}>
+          <section className={`${mobileDetailOpen ? 'hidden lg:block' : 'block'} min-w-0 overflow-hidden rounded-lg`} style={{ background: 'var(--card-bg)', border: '1px solid var(--border)' }}>
             <div className="border-b p-3" style={{ borderColor: 'var(--border-default)' }}>
               <div className="relative">
                 <Search size={15} className="absolute left-3 top-1/2 -translate-y-1/2" style={{ color: 'var(--muted)' }} />
@@ -699,7 +701,7 @@ export default function TeamsSettingsPage() {
                 return (
                   <button
                     key={team.id}
-                    onClick={() => setSelectedId(team.id)}
+                    onClick={() => { setSelectedId(team.id); setMobileDetailOpen(true); }}
                     className="flex w-full min-w-0 items-start gap-3 border-b px-3 py-3 text-left transition last:border-b-0 hover:bg-[var(--bg-hover)]"
                     style={{ background: selected ? 'var(--hover-tint)' : 'transparent', borderColor: 'var(--border-default)' }}
                   >
@@ -728,7 +730,10 @@ export default function TeamsSettingsPage() {
             </div>
           </section>
 
-          <section className="min-w-0 space-y-4">
+          <section className={`${mobileDetailOpen ? 'block' : 'hidden lg:block'} min-w-0 space-y-4`}>
+            <button type="button" onClick={() => setMobileDetailOpen(false)} className="deft-pill lg:hidden" style={{ color: 'var(--muted)', border: '1px solid var(--border)' }}>
+              <ArrowLeft size={13} /> All teams
+            </button>
             {detailLoading ? (
               <div className="rounded-lg p-8 text-center text-[13px]" style={{ background: 'var(--card-bg)', border: '1px solid var(--border)', color: 'var(--muted)' }}>
                 Loading team dashboard...
@@ -758,7 +763,7 @@ export default function TeamsSettingsPage() {
                         </p>
                       )}
                     </div>
-                    <div className="flex flex-col gap-2 sm:w-[320px]">
+                    <div className="min-w-0 flex flex-col gap-2 sm:w-[320px] sm:max-w-full">
                       {canManageSelectedTeam && (
                         archiveConfirm === (detail.team.is_archived ? 'restore' : 'archive') ? (
                           <div
@@ -1019,7 +1024,7 @@ export default function TeamsSettingsPage() {
                               data-testid="team-resource-select"
                               value={resourceForm.resource_id}
                               onChange={(e) => setResourceForm((prev) => ({ ...prev, resource_id: e.target.value }))}
-                              className="h-8 min-w-0 rounded-md px-2 text-[12px] outline-none"
+                              className="h-8 w-full min-w-0 max-w-full rounded-md px-2 text-[12px] outline-none"
                               style={{ background: 'var(--card-bg)', border: '1px solid var(--border)', color: 'var(--foreground)' }}
                               disabled={availableResources.length === 0}
                             >
@@ -1065,7 +1070,7 @@ export default function TeamsSettingsPage() {
                           return (
                             <span
                               key={resource.id}
-                              className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-medium"
+                              className="inline-flex max-w-full items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-medium"
                               title={restricted ? 'You need to be a member of this private space to see its name and messages.' : undefined}
                               style={{
                                 color: restricted ? 'var(--muted)' : 'white',
@@ -1073,8 +1078,8 @@ export default function TeamsSettingsPage() {
                                 border: restricted ? '1px solid var(--border)' : '1px solid transparent',
                               }}
                             >
-                              {restricted && <Lock size={10} />}
-                              {resourceSingularLabel(resource.resource_type)}: {label}
+                              {restricted && <Lock size={10} className="shrink-0" />}
+                              <span className="truncate">{resourceSingularLabel(resource.resource_type)}: {label}</span>
                               {canManageSelectedTeam && (
                                 <button
                                   data-testid={`team-resource-detach-${resource.resource_type}-${resource.resource_id}`}

--- a/apps/web/src/app/(app)/tasks/page.tsx
+++ b/apps/web/src/app/(app)/tasks/page.tsx
@@ -5,6 +5,7 @@ import { useAuth } from '@/lib/auth-context';
 import { api } from '@/lib/api';
 import { getSocket } from '@/lib/socket';
 import { useSearchParams, useRouter } from 'next/navigation';
+import Link from 'next/link';
 import { TaskBoard } from '@/components/task-board';
 import { TaskTable } from '@/components/task-table';
 import { TaskDetail } from '@/components/task-detail';
@@ -1186,6 +1187,11 @@ export default function TasksPage() {
                             </div>
                           </button>
                         ))}
+                        <div className="mt-1 border-t px-2 pt-1" style={{ borderColor: 'var(--border)' }}>
+                          <Link href="/settings/library" className="block rounded-md px-2 py-2 text-[11px] font-medium hover:bg-[var(--hover-tint)]" style={{ color: 'var(--accent)' }}>Manage task templates</Link>
+                          <Link href="/settings/workflows" className="block rounded-md px-2 py-2 text-[11px] hover:bg-[var(--hover-tint)]" style={{ color: 'var(--muted)' }}>Automations</Link>
+                          <Link href="/settings/projects" className="block rounded-md px-2 py-2 text-[11px] hover:bg-[var(--hover-tint)]" style={{ color: 'var(--muted)' }}>Project recovery</Link>
+                        </div>
                       </div>
                     </>
                   )}

--- a/apps/web/src/components/sidebar.tsx
+++ b/apps/web/src/components/sidebar.tsx
@@ -7,7 +7,7 @@ import { useChatContext } from '@/lib/chat-context';
 import { HUDDLES_ENABLED } from '@/lib/feature-flags';
 import { agentConnectionStatus } from '@/lib/agent-employee-status';
 import { registerOpenCreateSpace } from '@/lib/quick-actions';
-import { isSettingsItemActive, settingsNavGroups } from '@/lib/settings-navigation';
+import { getSettingsNavGroups, isSettingsItemActive } from '@/lib/settings-navigation';
 import { useTheme } from './theme-provider';
 import { Logo } from './brand/logo';
 import { api } from '@/lib/api';
@@ -39,6 +39,7 @@ import {
   BookOpen,
   Smile,
   Inbox,
+  ChevronDown,
 } from 'lucide-react';
 import { CreateSpaceModal } from './create-space-modal';
 import { CreateDmModal } from './create-dm-modal';
@@ -600,6 +601,16 @@ function TasksSidebarContent({ onNav }: { onNav?: () => void }) {
 // ── Settings sidebar content ─────────────────────────────────────────
 function SettingsSidebarContent({ onNav }: { onNav?: () => void }) {
   const pathname = usePathname();
+  const { user } = useAuth();
+  const groups = getSettingsNavGroups(user?.role ?? 'member');
+  const primaryGroups = groups.filter((group) => !group.advanced);
+  const advancedGroup = groups.find((group) => group.advanced);
+  const advancedActive = advancedGroup?.items.some((item) => isSettingsItemActive(pathname, item.href)) ?? false;
+  const [advancedOpen, setAdvancedOpen] = useState(advancedActive);
+
+  useEffect(() => {
+    if (advancedActive) setAdvancedOpen(true);
+  }, [advancedActive]);
 
   return (
     <div className="px-3 pt-5 pb-6 overflow-y-auto">
@@ -612,7 +623,7 @@ function SettingsSidebarContent({ onNav }: { onNav?: () => void }) {
         </span>
       </div>
       <div className="space-y-4">
-        {settingsNavGroups.map((group) => (
+        {primaryGroups.map((group) => (
           <div key={group.label}>
             <div className="px-2 pb-1 text-[0.625rem] font-semibold uppercase tracking-[0.06em]" style={{ color: 'var(--outline)' }}>
               {group.label}
@@ -642,6 +653,47 @@ function SettingsSidebarContent({ onNav }: { onNav?: () => void }) {
             </div>
           </div>
         ))}
+        {advancedGroup && (
+          <div>
+            <button
+              type="button"
+              onClick={() => setAdvancedOpen((open) => !open)}
+              className="flex h-8 w-full items-center justify-between rounded-full px-2 text-left"
+              style={{
+                background: advancedActive ? 'var(--bg-active)' : 'transparent',
+                color: advancedActive ? 'var(--on-surface)' : 'var(--outline)',
+              }}
+              aria-expanded={advancedOpen}
+            >
+              <span className="text-[0.625rem] font-semibold uppercase tracking-[0.06em]">Advanced</span>
+              <ChevronDown size={13} className={`transition-transform ${advancedOpen ? 'rotate-180' : ''}`} />
+            </button>
+            {advancedOpen && (
+              <div className="mt-1 space-y-0.5">
+                {advancedGroup.items.map((section) => {
+                  const active = isSettingsItemActive(pathname, section.href);
+                  return (
+                    <Link
+                      key={section.href}
+                      href={section.href}
+                      onClick={onNav}
+                      className="block flex h-[34px] w-full items-center gap-2 px-2 text-left"
+                      style={{
+                        background: active ? 'var(--bg-active)' : 'transparent',
+                        color: active ? 'var(--on-surface)' : 'var(--on-surface-variant)',
+                        fontWeight: 500,
+                        fontSize: '0.8125rem',
+                        borderRadius: '999px',
+                      }}
+                    >
+                      <span className="truncate">{section.name}</span>
+                    </Link>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/apps/web/src/lib/settings-navigation.test.ts
+++ b/apps/web/src/lib/settings-navigation.test.ts
@@ -1,0 +1,25 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { getSettingsNavGroups, isSettingsItemActive } from './settings-navigation';
+
+test('members see only personal workspace and personal connection settings', () => {
+  const items = getSettingsNavGroups('member').flatMap((group) => group.items);
+  assert.deepEqual(items.map((item) => item.name), ['General', 'Profile', 'Calendar', 'Connections']);
+  assert.equal(items.some((item) => item.href === '/settings/api-access'), false);
+});
+
+test('owners get seven primary destinations and specialist controls under Advanced', () => {
+  const groups = getSettingsNavGroups('owner');
+  const primary = groups.filter((group) => !group.advanced).flatMap((group) => group.items);
+  const advanced = groups.find((group) => group.advanced);
+
+  assert.equal(primary.length, 7);
+  assert.ok(advanced);
+  assert.ok(advanced.items.some((item) => item.name === 'Mention groups'));
+  assert.ok(advanced.items.some((item) => item.name === 'API access'));
+});
+
+test('nested settings routes keep their parent navigation item active', () => {
+  assert.equal(isSettingsItemActive('/settings/agent-employees/create', '/settings/agent-employees'), true);
+  assert.equal(isSettingsItemActive('/settings/profile', '/settings'), false);
+});

--- a/apps/web/src/lib/settings-navigation.ts
+++ b/apps/web/src/lib/settings-navigation.ts
@@ -1,63 +1,73 @@
+export type SettingsRole = 'owner' | 'admin' | 'member' | 'guest';
+
 export type SettingsNavItem = {
   name: string;
   href: string;
   description: string;
+  roles?: SettingsRole[];
 };
 
 export type SettingsNavGroup = {
   label: string;
   description: string;
+  advanced?: boolean;
   items: SettingsNavItem[];
 };
 
+const ADMIN_ROLES: SettingsRole[] = ['owner', 'admin'];
+
 export const settingsNavGroups: SettingsNavGroup[] = [
   {
-    label: 'Personal',
-    description: 'Your profile, identity, availability, and display preferences.',
+    label: 'Account',
+    description: 'Your workspace preferences and identity.',
     items: [
-      { name: 'General', href: '/settings', description: 'Theme and top-level settings overview.' },
-      { name: 'Profile', href: '/settings/profile', description: 'Work identity, avatar, status, notifications, and password.' },
+      { name: 'General', href: '/settings', description: 'Theme and settings overview.' },
+      { name: 'Profile', href: '/settings/profile', description: 'Identity, status, notifications, and security.' },
     ],
   },
   {
     label: 'Workspace',
-    description: 'People, teams, mention groups, and shared workspace context.',
+    description: 'People, teams, and shared time.',
     items: [
-      { name: 'Members', href: '/settings/members', description: 'Invite people, recover accounts, and manage access.' },
-      { name: 'Teams', href: '/settings/teams', description: 'Organize people around operating teams and linked work.' },
-      { name: 'Groups', href: '/settings/groups', description: 'Lightweight mention lists for chat coordination.' },
+      { name: 'People', href: '/settings/members', description: 'Invite people and manage workspace access.', roles: ADMIN_ROLES },
+      { name: 'Teams', href: '/settings/teams', description: 'Organize people around ownership and linked work.', roles: ADMIN_ROLES },
       { name: 'Calendar', href: '/settings/calendar', description: 'Connect calendars with self-hostable ICS feeds.' },
-      { name: 'Tags', href: '/settings/tags', description: 'Review workspace labels and usage counts.' },
     ],
   },
   {
-    label: 'Work System',
-    description: 'Reusable work patterns, archived projects, and workflow automation.',
+    label: 'AI & Connections',
+    description: 'Shared agents and personal AI apps.',
     items: [
-      { name: 'Deleted projects', href: '/settings/projects', description: 'Restore recently deleted projects during the recovery window.' },
-      { name: 'Workflows', href: '/settings/workflows', description: 'Automate simple task status-change rules.' },
-      { name: 'Templates', href: '/settings/library', description: 'Reusable task templates and work packs.' },
-      { name: 'Integrations', href: '/settings/integrations', description: 'Connect tool servers and supported workspace feeds.' },
+      { name: 'Agent employees', href: '/settings/agent-employees', description: 'Manage agents that work alongside the team.', roles: ADMIN_ROLES },
+      { name: 'Connections', href: '/settings/mcp-access', description: 'Connect Codex, Claude, ChatGPT, or another MCP client.' },
     ],
   },
   {
-    label: 'Agents & AI',
-    description: 'AI providers, shared agent employees, and personal AI app access.',
+    label: 'Advanced',
+    description: 'Specialist workspace, automation, AI, and developer controls.',
+    advanced: true,
     items: [
-      { name: 'AI Providers', href: '/settings/ai', description: 'Bring your own model providers or local endpoints.' },
-      { name: 'Agent Employees', href: '/settings/agent-employees', description: 'Manage shared agents that act as workspace employees.' },
-      { name: 'MCP Access', href: '/settings/mcp-access', description: 'Connect Codex, Claude, ChatGPT, or any MCP client as you.' },
-      { name: 'Agent governance', href: '/settings/agent', description: 'Review agent trust level, activity, and pending action history.' },
-    ],
-  },
-  {
-    label: 'Developer',
-    description: 'Programmatic access for custom tools and internal systems.',
-    items: [
-      { name: 'API Access', href: '/settings/api-access', description: 'Create API keys for external services and scripts.' },
+      { name: 'Mention groups', href: '/settings/groups', description: 'Reusable @mention lists for chat.', roles: ADMIN_ROLES },
+      { name: 'Tags', href: '/settings/tags', description: 'Review workspace labels and usage counts.', roles: ADMIN_ROLES },
+      { name: 'Task templates', href: '/settings/library', description: 'Reusable task templates and work packs.', roles: ADMIN_ROLES },
+      { name: 'Automations', href: '/settings/workflows', description: 'Task status-change rules.', roles: ADMIN_ROLES },
+      { name: 'Project recovery', href: '/settings/projects', description: 'Restore recently deleted projects.', roles: ADMIN_ROLES },
+      { name: 'Agent tool servers', href: '/settings/integrations', description: 'External MCP tools available to agents.', roles: ADMIN_ROLES },
+      { name: 'AI providers', href: '/settings/ai', description: 'Model providers and local endpoints.', roles: ADMIN_ROLES },
+      { name: 'Agent governance', href: '/settings/agent', description: 'Workspace trust defaults, activity, and audit.', roles: ADMIN_ROLES },
+      { name: 'API access', href: '/settings/api-access', description: 'Service keys for scripts and runtimes.', roles: ADMIN_ROLES },
     ],
   },
 ];
+
+export function getSettingsNavGroups(role?: SettingsRole | null): SettingsNavGroup[] {
+  return settingsNavGroups
+    .map((group) => ({
+      ...group,
+      items: group.items.filter((item) => !item.roles || !role || item.roles.includes(role)),
+    }))
+    .filter((group) => group.items.length > 0);
+}
 
 export const settingsNavItems = settingsNavGroups.flatMap((group) => group.items);
 


### PR DESCRIPTION
## Summary\n- replace the settings buffet with role-aware primary groups and a single Advanced section\n- redesign MCP Access into a guided App -> Access -> Connect flow\n- provide exact Claude four-field OAuth setup while retaining Codex, Claude Code, ChatGPT, custom client, audit, revoke, and history capabilities\n- tighten copy and cross-links across teams, groups, integrations, agent employees, and task setup\n\n## Validation\n- pnpm --filter @deft/web typecheck\n- pnpm --filter @deft/web lint\n- pnpm exec tsx --test apps/web/src/lib/settings-navigation.test.ts\n- pnpm --filter @deft/web build (40 routes)\n- local browser: all client pickers render; Claude shows the required four fields; no console errors\n- mobile browser: 390px client/scroll width parity (no horizontal overflow)\n\n## Dependency\nBuilt and tested on top of #164 operational headless MCP parity and #165 shared-office hardening.