### PR TITLE
docs: reconcile public product truth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,36 @@ env vars. Patch versions (`0.X.Y`) are non-breaking fixes only.
 
 ## [Unreleased]
 
+### Added
+
+- Guided personal MCP connections for Codex, Claude, ChatGPT-compatible clients, and custom streamable HTTP MCP clients.
+- Operational headless MCP tools for unread triage, context packets, people, teams, tasks, messages, notes, wiki, decisions, and calendar workflows.
+- Task Table view, richer Timeline and Calendar interactions, persistent view preferences, and improved bulk operations.
+- Profile, member, team, and linked-resource management with team dashboard summaries.
+- Agent employee bridge supervision, structured-mention wakeup, assignment flows, and completion receipts.
+- Synthetic 60-person workspace certification for isolation, job backlog, notification volume, bulk operations, and recovery exercises.
+
+### Changed
+
+- Reworked Defty planning so natural-language requests resolve through model-generated structured drafts, deterministic validation, approval, execution, and confirmation.
+- Moved supported approval cards into the source conversation with an inbox mirror.
+- Reworked chat knowledge capture into settled-window episode processing with quiet receipts.
+- Simplified Connections, Agent employees, Inbox, Settings, Chat, Tasks, Knowledge, and Calendar interfaces across desktop and mobile.
+- Standardized public positioning on source-available BSL 1.1, the self-hosted v1 integration contract, and current alpha boundaries.
+
+### Fixed
+
+- Scheduled chat-to-knowledge jobs now reach their registered handler.
+- Agent task creation supports structured descriptions, subtasks, dependencies, and richer completion receipts.
+- Personal MCP unread and owner-operator workflows avoid hidden-tool and keyword-search fallbacks.
+- Mobile scrolling, navigation overlays, chat composers, avatar propagation, mentions, approval placement, and task-view interaction defects found during dogfooding.
+- Self-host bootstrap, environment validation, health checks, and production preflight coverage.
+
 ## [0.1.0-alpha] — 2026-05-26
 
-First public alpha. Deft is an open-source AI-native workspace — native chat
+> Historical release snapshot. Some integrations and architecture described below were later retired or narrowed. Use [FEATURES.md](FEATURES.md), [current limitations](docs/current-limitations.md), and the self-hosted v1 contract for the current product boundary.
+
+First public alpha. Deft is a source-available AI-native workspace: native chat
 + tasks + an AI agent (Defty) with direct SQL access to your data, plus a
 Bring-Your-Own-Agent (BYOA) MCP surface for connecting external runtimes
 (Claude Code, Claude Desktop, Codex, Cursor, custom MCP).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,106 +1,124 @@
 # Contributing to Deft
 
-## Development Setup
+Deft welcomes focused bug fixes, tests, documentation, accessibility improvements, and product changes that fit the current self-hosted workspace scope.
 
-### Prerequisites
-- Node.js 20+ (22 recommended)
-- pnpm 9+
-- PostgreSQL 16
-- Redis 7 (optional — needed for real-time features)
+## Before you start
 
-### Setup
+- Search existing issues and pull requests.
+- Open an issue before a large architectural or product change.
+- Keep pull requests narrow enough to review and revert safely.
+- Do not include secrets, customer data, generated reports, local databases, or unrelated formatting churn.
+- Read [current limitations](docs/current-limitations.md) and the [roadmap](ROADMAP.md) before building around a deferred capability.
+
+## Development setup
+
+### Requirements
+
+- Node.js 20 or newer (22 recommended)
+- pnpm 9 or newer
+- PostgreSQL 16 with pgvector
+- Redis 7
 
 ```bash
 git clone https://github.com/Maneek21/Deft.git
-cd deft
+cd Deft
 pnpm install
 cp .env.example .env
-# Edit .env with your database credentials
 
-# Create database and push schema (+ full-text-search extras)
 createdb deft
 pnpm db:push-full
-
-# Seed demo data (6 Testers Tomatoes users + demo org + sample messages/tasks).
-# This wipes the DB — dev only, NEVER run in production.
-pnpm db:seed:demo
-
-# Or, for a prod-safe seed (Defty + bundled skills/templates only):
-#   pnpm db:seed
-
-# Start development servers
+pnpm db:seed
 pnpm dev
 ```
 
-The web app runs at `http://localhost:3000`, API at `http://localhost:3001`.
+The web app runs at `http://localhost:3000`; the API runs at `http://localhost:3001`.
 
-### Test accounts (after seeding)
-| Email | Password | Role |
-|-------|----------|------|
-| diego@testers-tomatoes.com | tomato123 | Owner |
-| marigold@testers-tomatoes.com | tomato123 | Admin |
-| cesar@testers-tomatoes.com | tomato123 | Member |
-| lina@testers-tomatoes.com | tomato123 | Member |
-| sage@testers-tomatoes.com | tomato123 | Member |
-| tomas@testers-tomatoes.com | tomato123 | Member |
+Use `pnpm db:seed` for the production-safe platform bundle. The following development seeds reset the database and must never be used against production data:
 
-## Project Structure
-
+```bash
+pnpm db:seed:demo
+pnpm db:seed:pilot
 ```
+
+Demo users use the password `tomato123`. Start with `diego@testers-tomatoes.com`.
+
+## Repository structure
+
+```text
 deft/
-├── apps/web/src/
-│   ├── app/(app)/         # Authenticated pages (dashboard, chat, tasks, agent, settings)
-│   ├── app/login/         # Auth pages
-│   ├── components/        # Shared React components
-│   └── lib/               # Client utilities (api, auth, socket, context)
-├── apps/api/src/
-│   ├── routes/            # Hono API route handlers
-│   ├── lib/               # Server utilities (db, env, agent tools)
-│   ├── middleware/         # Auth middleware
-│   └── socket.ts          # Socket.io setup
-├── packages/db/
-│   ├── src/schema.ts      # Drizzle ORM schema (all 30 tables)
-│   ├── seed.ts            # Database seed script
-│   └── drizzle.config.ts  # Migration config
-└── packages/shared/       # Shared types and constants
+|-- apps/
+|   |-- web/               Next.js App Router application
+|   `-- api/               Hono API, WebSocket, jobs, agents, and MCP
+|-- packages/
+|   |-- db/                Drizzle schema, migrations, and seeds
+|   `-- shared/            Shared schemas, types, and constants
+|-- scripts/               Bootstrap, smoke, pilot, and certification tools
+|-- docs/                  User docs and engineering records
+|-- docker-compose.yml
+`-- pnpm-workspace.yaml
 ```
 
-## Code Standards
+## Code standards
 
-- **TypeScript strict mode** everywhere — no `any` unless absolutely necessary
-- **Zod** for all request validation on API routes
-- **Drizzle ORM** — no raw SQL except in agent queries
-- **Functional React** — no class components, prefer server components where possible
-- **Tailwind CSS** — no CSS modules, no styled-components
-- **File naming**: kebab-case for files, PascalCase for components
+- TypeScript strict mode
+- Zod validation at request and external-data boundaries
+- Drizzle ORM for application data access
+- `org_id` and permission checks on every workspace query
+- Functional React components and existing local component patterns
+- Tailwind CSS and shared tokens from `apps/web/src/app/globals.css`
+- Kebab-case files and PascalCase React components
+- Error responses shaped as `{ error: string, code: string }`
+- Succinct comments only where the implementation is not self-explanatory
 
-## Adding a New API Endpoint
+## Tests and gates
 
-1. Create or edit a route file in `apps/api/src/routes/`
-2. Use Hono: `export const myRoutes = new Hono();`
-3. Add Zod validation for request body
-4. Use `c.get('user')` for authenticated user context
-5. Always filter by `org_id` for multi-tenant isolation
-6. Return errors as `{ error: string, code: string }`
-7. Register in `apps/api/src/index.ts`
+Choose tests based on the change. CI runs the required repository gates, but local focused tests should pass before a pull request is opened.
 
-## Adding a New Agent Tool
+| Change | Minimum local validation |
+|---|---|
+| Documentation only | `git diff --check` and local-link review |
+| Web UI | `pnpm --filter @deft/web lint`, `pnpm --filter @deft/web typecheck`, and browser verification at relevant desktop/mobile breakpoints |
+| API or agent behavior | Focused API test files plus `pnpm --filter @deft/api typecheck` |
+| Database schema | Fresh `pnpm db:push-full`, seed, focused API tests, and an explicit upgrade/rollback note |
+| Self-host or Docker | `pnpm selfhost:doctor`, `pnpm selfhost:smoke`, and the affected Compose flow |
+| MCP | Focused protocol tests and one real client-style workflow when behavior changes |
 
-1. Define the tool schema in `apps/api/src/lib/agent-tools.ts`
-2. Implement the handler in `apps/api/src/lib/agent-context.ts` (read-only) or `agent-actions.ts` (write)
-3. Write actions must go through approval flow
+Before requesting review:
 
-## Branch & PR Convention
+```bash
+pnpm typecheck
+pnpm --filter @deft/web lint
+pnpm --filter @deft/api test
+pnpm build
+```
 
-- Branch names: `feat/short-description`, `fix/short-description`, `chore/short-description`
-- Commit messages: conventional commits (`feat:`, `fix:`, `chore:`, `docs:`)
-- PRs: describe changes, link related issue, include screenshots for UI changes
-- All PRs must pass TypeScript type-check
+If a broad command cannot run in your environment, say so in the pull request and include the focused evidence you did collect.
 
-## Design System
+## API and database changes
 
-Key rules:
-- No borders for layout — use tonal layering
-- Inter for text, JetBrains Mono for technical data
-- All colors via CSS variables in `apps/web/src/app/globals.css`
-- Brand assets live in `apps/web/public/brand/`; use the `<Logo />` component (`apps/web/src/components/brand/logo.tsx`) rather than inlining SVGs.
+1. Validate requests and responses with Zod.
+2. Resolve the authenticated user and org before querying workspace data.
+3. Enforce space, role, and entity ownership explicitly.
+4. Add or update focused tests for success, permission denial, cross-org denial, and malformed input.
+5. Register new routes in the existing router structure.
+6. Document migrations, fresh-install behavior, and upgrade behavior.
+
+## Agent and MCP changes
+
+- Treat model output as an untrusted proposal.
+- Keep resolver and executor validation authoritative.
+- Route risky writes through the established approval tiers.
+- Preserve actor identity and produce an audit receipt.
+- Add idempotency for externally retried writes.
+- Test ambiguous references, revoked credentials, stale state, private resources, duplicate commands, and partial failure.
+
+## Pull requests
+
+- Use a short descriptive branch name.
+- Use conventional commit prefixes such as `feat:`, `fix:`, `docs:`, `test:`, or `chore:`.
+- Explain the user-visible behavior, implementation boundary, validation, and residual risk.
+- Include before/after screenshots for UI work.
+- Link an issue when one exists.
+- Keep generated certification artifacts out of the repository unless maintainers explicitly request them.
+
+By contributing, you agree that your contribution is licensed under the repository's [Business Source License 1.1](LICENSE) terms and retains the required project attribution.

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1,638 +1,218 @@
-# Deft — Complete Feature Inventory
+# Deft capability reference
+
+> Last verified against the repository on July 16, 2026.
+>
+> Deft is an alpha. This file describes the current product surface, not a compatibility guarantee. See [current limitations](docs/current-limitations.md) and the [roadmap](ROADMAP.md) before planning a production deployment.
+
+## Product model
 
-> Last updated: April 16, 2026 (Phases 0-6 of the task-management overhaul shipped; Phase 8 is the next milestone)
-> Verified against codebase: 66+ database tables, 35+ route files, 40+ agent tools, 17+ background workers, 23 pages, 50+ components
+Deft is a self-hostable work record shared by human employees and AI agents.
+
+- **Chat is the conversation surface.** Messages, threads, mentions, files, and decisions remain attached to the people and spaces where work happened.
+- **Tasks are the action surface.** Projects turn intent into assigned, trackable work.
+- **Knowledge is the memory surface.** Durable facts, decisions, procedures, and references can be organized at org, space, or personal scope.
+- **Approvals are the governance surface.** Agent writes can be drafted, reviewed, approved, dismissed, and audited.
+- **MCP is the headless access surface.** Personal AI apps and agent employees can use permission-aware workspace tools.
+
+## Workspace surfaces
+
+### Chat
 
----
+- Public and private spaces, direct messages, and group DMs
+- Threads with independent read state
+- Rich text, links, code, lists, block quotes, files, and inline media
+- Structured mentions, message and task references, emoji reactions, pins, and saved messages
+- Typing state, online/idle presence, custom status, and do-not-disturb
+- Scheduled messages, message history, and quiet chat-to-knowledge capture
+- Huddles and asynchronous audio/video clips, subject to browser and deployment support
+- Defty and agent employees participate in the same chat surfaces as people
+
+### Tasks
+
+- Projects with human-readable task keys
+- Fixed status model: backlog, to do, in progress, in review, done, cancelled
+- P0 through P3 priority, assignees, reporters, labels, start dates, due dates, estimates, and recurrence
+- Board, Table, Timeline, Calendar, Pipeline, and personal task views
+- Inline Table editing, sorting, column controls, and persistent per-user view preferences
+- Drag and resize scheduling in Timeline, calendar placement, and board drag-and-drop
+- Subtasks, dependencies, task relationships, comments, reactions, watchers, and activity diffs
+- Bulk selection and bulk status, priority, assignment, move, and delete operations
+- Task creation from chat and agent-drafted task plans with approval
+- Project archive and soft delete with recovery support
+
+### Notes
 
-## Architecture Overview
+- Personal and workspace note scopes
+- Rich text editing, pinning, search, and optimistic concurrency protection
+- Agent note search, read, create, and note-to-wiki tools
+
+### Knowledge
+
+- Wiki types: concept, entity, decision, resource, procedure, preference, and fact
+- Org, space, and personal scopes
+- Full-text and semantic retrieval with source citations
+- Links, backlinks, graph views, confidence indicators, and operations history
+- Channel memory and org-wide company memory views
+- Scheduled knowledge lint and maintenance jobs
+- Context packets for agents that combine relevant messages, tasks, wiki pages, decisions, people, and calendar context
+
+### Calendar
+
+- Native workspace events
+- Read-only ICS subscriptions and polling sync
+- Month, week, and day views
+- Workspace calendar context available to Defty and scoped MCP clients
+- Calendar connection health, last sync, and error state in settings
+
+### Dashboard and inbox
 
-```
-Frontend:  Next.js 14 (App Router) + React + Tailwind CSS
-API:       Hono on Node.js (TypeScript)
-Database:  PostgreSQL + pgvector (66 tables, Drizzle ORM)
-Real-time: Socket.io with room-based presence
-AI:        Multi-LLM (Anthropic Claude, OpenAI, OpenRouter, Ollama)
-Auth:      email/password (JWT + refresh tokens)
-Jobs:      Postgres-based job queue (17 background workers)
-Storage:   Local filesystem (./uploads), Cloudflare R2-ready
-Monorepo:  pnpm workspaces
-```
+- Personal work summary, overdue and in-progress work, calendar context, and workspace attention
+- Customizable dashboard widgets
+- Unified inbox tabs for messages, mentions, task notifications, captures, and approvals
+- Inline approval actions in the inbox and on supported chat messages
+- Real-time notification delivery plus durable notification state
+
+## People and teams
+
+- Profiles with uploaded or preset avatars, role, title, timezone, status, and notification preferences
+- Workspace roles: owner, admin, member, and guest where enabled by the surface
+- Member invitation, activation, deactivation, role management, and search
+- Teams with leads, members, linked spaces, projects, wiki pages, notes, and calendars
+- User groups for reusable group mentions
+- Permission-aware private space membership and org-scoped data access
+- Team dashboard summaries and agent activity visibility
+
+## Defty
+
+Defty is the built-in workspace agent. It can read native Deft context and propose or execute supported workspace actions.
+
+Current capabilities include:
+
+- Answer questions about visible messages, tasks, notes, wiki pages, decisions, people, teams, and calendars
+- Resolve natural-language references against the current conversation and workspace
+- Draft and create tasks, including structured descriptions, subtasks, dependencies, and assignments
+- Update task fields and transition task status
+- Draft and post messages or thread replies
+- Create or update wiki pages and notes
+- Read and write space canvases
+- Link decisions to tasks and mark decisions implemented
+- Produce approval cards in chat and mirror pending approvals in the inbox
+- Post completion confirmations with result details for supported actions
+
+Defty is not a deterministic rules engine. Output quality depends on the configured provider, model, available context, permissions, and request clarity. Validation, approval policy, and executor contracts remain authoritative even when the model proposes an invalid action.
 
----
+## Agent employees
 
-## 1. Communication
+Agent employees are separate workspace identities backed by a customer-controlled runtime.
 
-### Real-time Chat
-Full-featured messaging system with spaces (public, private, DM, group DM). Cursor-based pagination (50/page), room-per-space architecture via Socket.io. Message grouping for consecutive messages from same user within 5 minutes. Day separators between message groups.
+- Onboard from Settings -> Agent employees
+- Receive a scoped employee token for `/api/mcp/v1`
+- Participate in DMs and group spaces
+- Wake from structured mentions and assigned work
+- Read unread work, claim tasks, post progress, and complete supported actions
+- Operate under trust level, scope, health, action-cap, audit, and approval rules
+- Expose supervision state, recent contact, failures, and bridge health to admins
 
-### Threads
-Reply to any message opens a side panel with parent message + replies. Thread replies don't appear in main feed. "X replies" indicator on parent with latest reply time. Per-user thread read tracking (`threadReads` table).
+Deft does not require a specific agent framework. A compatible runtime can be built with Hermes, Codex, Claude, or another streamable HTTP MCP client. The external runtime is operated separately from the Deft application stack.
 
-### Emoji Reactions
-124 standard emojis across categories. Click to toggle reaction on any message. Reaction pills below message showing emoji + count + users who reacted.
+## Personal AI app connections
 
-### Custom Emoji
-Org-specific custom emoji uploads (256KB max, alphanumeric names). Served with correct MIME type. Appear alongside standard emojis.
+Human employees can connect their own AI client from Settings -> Connections.
 
-### Pinned Messages
-Pin important messages per space. Pinned messages bar/sidebar panel with preview. Unique constraint: one pin per message per space.
+- Streamable HTTP MCP endpoint at `/api/mcp/v1`
+- OAuth authorization for compatible remote connector clients
+- Personal bearer tokens for clients that accept HTTP headers
+- Guided setup for Codex, Claude Code, Claude and Claude Desktop, ChatGPT-compatible web apps, and custom clients
+- Read-only and work-capable scope bundles
+- Tokens act as the user who created them and inherit that user's workspace access
+- Connection history, last use, recent actions, scopes, and revocation
+- Idempotency support on write tools to reduce duplicate agent actions
 
-### Saved / Bookmarked Messages
-Personal saved messages collection. Save any message by ID + space. List all saved with author, space, timestamp. Remove saves. Sorted by most recent.
+Representative MCP tools cover:
 
-### Scheduled Messages
-Schedule messages for future delivery. Status tracking: pending → sent → cancelled. Background job polls and sends when time arrives. Scheduled panel in chat UI.
+- Workspace, project, space, member, team, task, message, note, wiki, decision, and calendar reads
+- Unread triage and owner-operator workspace summaries
+- Task create, update, transition, comment, and bulk workflows
+- Message and thread posting
+- Wiki and note writes
+- Context-packet retrieval and memory recall
 
-### File Uploads & Attachments
-50MB per file max. Drag-and-drop zone overlay, clipboard paste (Ctrl+V) for images, paperclip button. Images render inline (max 400x300) with lightbox modal on click. Other files as download cards with icon + name + size. Multiple files per message. Storage in ./uploads with UUID-prefixed filenames (R2-ready).
+Client availability and connector UI vary by vendor and account tier. Deft cannot guarantee that every AI product enables custom MCP connections for every user.
 
-### Audio/Video Clips
-Async voice/video clip recording and upload (50MB WebM). Two modes: async (standalone recording) and live (huddle recording). Auto-transcription via configurable provider (local Whisper, OpenAI Whisper API, or Deepgram Nova-2 with speaker diarization). Timestamped transcript segments with speaker info. AI-powered summarization: TLDR, decisions, action items, blockers extracted. Status pipeline: uploading → transcribing → summarizing → ready. Inline clip card in messages with playback.
+## Governance and audit
 
-### Huddles — Live Audio/Video Calls
-WebRTC audio/video rooms within spaces. Socket.io-based signaling (offer/answer/ICE candidates). Create/join huddles per space. Participant list with mute status. Ring notifications sent to non-muted space members. 30-second grace period before room destruction when empty. Compact + expanded overlay UI with duration timer, mute toggle, participant avatars. Speaking detection visualization. In-memory room state management.
+- Approval tiers: automatic, quick approval, and full review
+- Org trust levels: Conservative, Standard, and Autonomous
+- User and agent identity preserved on native actions
+- Pending approval cards in the source conversation where supported
+- Inbox mirror for centralized approval review
+- Execution receipts, recent agent actions, and audit history
+- Token scopes, revocation, daily action limits, cost accounting, and circuit breakers
+- Space membership checks on REST and WebSocket access
+- Org ownership checks on task, wiki, workflow, message, and agent operations
 
-### Rich Text Editor
-TipTap-based editor with bold, italic, strikethrough, inline code, code blocks, bullet lists, numbered lists, blockquotes, links, headings. Formatting toolbar in composer.
+## AI providers
 
-### @Mentions
-Type `@` → autocomplete dropdown with org members. `@here` and `@all` support. User group mentions (@engineering, @design). Task mentions (#DEFT-1 → styled chip with autocomplete). Creates notifications on mention.
+Deft supports provider-neutral AI configuration:
 
-### Slash Commands
-Slash command autocomplete (e.g., `/remind`, `/task`, `/gif`). Integrated in rich composer.
+- OpenAI
+- Anthropic
+- OpenRouter
+- OpenAI-compatible endpoints
+- Local Ollama-style endpoints
 
-### Link Preview Unfurling
-URLs auto-unfurl with Open Graph metadata (title, description, image, favicon). Async fetch with 5-second timeout, follows redirects. Socket broadcast of preview data.
+Provider keys are optional. Core workspace functionality remains available without AI.
 
-### Typing Indicators
-"X is typing..." with 2-second debounce. Socket.io `typing:start` / `typing:stop` events per space.
+## Self-hosting and operations
 
-### User Presence
-Green dot = online, yellow = idle (5min+ inactivity), no dot = offline. Server tracks per-socket with multi-tab support (only offline when ALL sockets disconnect). Idle detection triggers `presence:idle`, activity resumption triggers `presence:active`.
+- Docker Compose stack for web, API, PostgreSQL, Redis, initialization, doctor, and smoke checks
+- Environment validation and one-command bootstrap helpers
+- Health endpoints for application and dependency checks
+- Backup and reset scripts with explicit safety gates
+- PostgreSQL 16, pgvector, Drizzle ORM, Redis, BullMQ, and Socket.io
+- Local file storage with R2-compatible configuration paths
+- Production guidance for VPS, domain, HTTPS, and reverse proxy setup
+- Synthetic 60-person certification tooling for isolation, bulk operations, job backlog, notification volume, and recovery exercises
 
-### Custom User Status
-Set status emoji + text with optional expiry time. Visible on user profile cards and member lists. Clear status manually or auto-expire.
+Fresh installs currently use `pnpm db:push-full`. A supported versioned upgrade workflow is still deferred; see [current limitations](docs/current-limitations.md).
 
-### Do Not Disturb
-DND mode toggle. Suppresses notifications when active.
+## Security posture
 
-### Canvas — Collaborative Whiteboard
-Per-space collaborative canvas using TipTap JSON document storage. Real-time updates via Socket.io (`canvas:updated` event). Track last editor + edit timestamp. Auto-create canvas when first opened in a space.
+- Org scoping on workspace data
+- Private-space membership enforcement
+- XSS sanitization on rich rendered content
+- Ownership checks on destructive routes
+- Upload path and content-disposition hardening
+- HMAC validation for agent webhooks
+- Encrypted provider and connection secrets
+- Optimistic locking on daily notes
+- Private vulnerability reporting through GitHub Security Advisories
 
-### Space Recaps
-AI-summarized recap of unread or recent messages in a space. Uses the configured workspace AI provider when available; falls back to a simple non-AI summary when no provider is configured.
+Deft has not completed an independent security audit and does not claim SOC 2, HIPAA, ISO 27001, or an uptime SLA.
 
-### Space Management
-Create spaces: public, private, DM, group DM. Space member panel (list, add, remove). Mute spaces. Archive/unarchive. Default space (#general) created on org signup. Private spaces with invite-only access.
+## Current integration contract
 
-### DMs & Group DMs
-All org members listed under "Direct Messages" in sidebar. Click → creates DM or opens existing (deduplication). DM header shows other person's name. Group DM support for multi-party direct conversations.
+The supported self-hosted v1 integration paths are:
 
----
+- Native Deft workspace tools
+- Native Deft calendar events
+- Read-only ICS calendar subscriptions
+- Personal MCP connections
+- MCP-backed agent employees
+- Customer-owned external tools exposed through that customer's agent runtime
 
-## 2. Task Management
+Native Slack, Gmail, GitHub, Google Calendar OAuth, Linear, Notion, and similar managed connectors are not current buyer-facing promises. Legacy source or enum values may remain for compatibility.
 
-### Projects & Task IDs
-Project collections with customizable prefix (e.g., DEFT). Auto-incrementing task numbers per project (DEFT-1, DEFT-2). Project lead, color, archive status.
+## Deliberate non-goals for the current alpha
 
-### Kanban Board
-6 columns: Backlog, To Do, In Progress, In Review, Done, Cancelled. Drag-and-drop between and within columns (@dnd-kit). Column headers with count badge. "+" add task at bottom of each column.
+- Hosted multi-customer SaaS operation under the current BSL license
+- Native iOS, Android, Electron, or Tauri apps
+- Offline-first operation
+- Enterprise compliance certification or uptime SLA
+- Full portfolio planning, OKRs, sprint analytics, or custom report builder
+- Managed third-party OAuth catalog
+- Guaranteed autonomous execution without model, permission, and approval constraints
 
-### List / Table View
-Tabular view with columns: ID, Title, Status, Priority, Assignee, Due Date, Updated. Sortable column headers. Inline status edit (click to change). Click row → detail panel.
+## Source and license
 
-### Task Detail Panel
-450px side panel sliding from right. Editable title (debounced auto-save). Field grid: Status, Priority, Assignee, Reporter, Due Date, Labels — all dropdown pickers. TipTap rich text description editor (auto-save). Tabs: Comments (with add form) | Activity (formatted log). Source message link if created from chat. Subtask display (parent/child).
-
-### Task Comments & Activity Log
-Threaded comments on tasks. Full activity log of every field change (status, assignment, priority, etc.). Formatted display: "In Progress" not "in_progress", "P1 (High)" not "p1". Assignee name resolution in activity.
-
-### Task Relationships
-Three relationship types: blocks, relates_to, duplicates. Bidirectional tracking. Displayed on task detail panel.
-
-### Labels
-Org-wide reusable labels with colors. Apply/remove labels on tasks. Filter tasks by label. Manage labels in settings.
-
-### Saved Views
-Saved filter/sort configurations per user per project. Reusable view presets.
-
-### Quick Create & Bulk Operations
-Press `C` key → quick-create modal with title + fields (defaults to Backlog). Bulk delete and reassign operations.
-
-### Task Filters
-Filter by: status (multi-select), assignee, priority (multi-select), project, labels, due date (overdue/today/this week). My Tasks toggle. URL-driven filtering.
-
-### Cross-References
-Link messages to tasks and tasks to other tasks with context notes. Display on task detail panel. Searchable index. Background worker auto-detects references.
-
-### Duplicate Task Detection
-Background worker identifies similar/duplicate tasks. Prevents redundant work.
-
-### Blocked Task Detection & Alerts
-Keyword detection in messages ("blocked", "stuck", "waiting on"). Background worker generates alerts. Notifies relevant team members.
-
-### Chat ↔ Tasks Bridge
-Create task from message (hover menu → "Create task" → pre-filled modal). Task mentions in chat (#DEFT-1 autocomplete → styled chip). Status changes auto-post system messages in linked spaces.
-
-### Inline Agent Task-Suggestion Cards
-When the message classifier flags a chat message as actionable, an inline suggestion card appears under the message offering one-click task creation (pre-filled with extracted title, assignee, due date). Dismissable; creates a real `taskActivity` entry on accept (Task 3.12).
-
-### Recurrence
-Recurring tasks with `daily | weekly | biweekly | monthly` patterns. `recurrence_source_id` links generated copies back to the original, so the board shows a family rather than orphans. Clone-gap bug fixed (Task 4.12).
-
-### Task Reactions
-Emoji reactions on tasks (same palette as chat). Unique `(task, user, emoji)` constraint. Visible on task cards + detail panel. Real-time via Socket.io (Task 6.3).
-
-### @Mentions on Tasks
-Type `@` in task description or comments → autocomplete dropdown with org members. Mentioned user receives a notification and the activity log records the mention event (Task 6.4).
-
-### Activity Diff View
-Task activity log renders field changes inline as `old → new` diffs (status, priority, assignee, labels, due date, title) instead of flat strings. Bulk changes grouped (Task 6.2).
-
-### Live Agent Progress on Tasks
-When an agent is executing a plan that touches a task, the detail panel streams each step (tool call + result) live. Completed plans leave a condensed receipt on the task (Task 3.10).
-
-### Proactive Agent Comments
-The nudge-check worker posts agent-authored comments on stalled or overdue tasks and on auto-accepted task extractions — deduped to one proactive comment per task per 7 days (Task 3.11).
-
-### Project Archive + Soft-Delete
-Per-project settings modal exposes Archive (hide from lists, keep tasks active) and Delete (soft-delete with a 7-day recovery window). Deleted projects are restorable from Settings → Recently deleted until the window closes (Task 5.8).
-
-### External tool automation
-Self-hosted v1 does not promise native GitHub, Slack, Gmail, or Google Calendar OAuth. Teams that need external tool automation should connect those tools through their own MCP servers or BYOA agent runtimes, then onboard the agent as a Deft employee. Legacy GitHub event/source code may remain for compatibility but is not a buyer-facing self-hosted v1 feature.
-
----
-
-## 3. MCP Access
-
-Deft exposes workspace context and safe native actions through `/api/mcp/v1`. This is the current self-hosted v1 path for both human employees and agent employees.
-
-### Human employees
-- Users create personal MCP tokens from Settings -> MCP Access.
-- Personal tokens act as that user: reads follow their org access, and writes create tasks, messages, and wiki pages under their user identity.
-- Read-only tokens expose context tools only. Write-enabled tokens add task, message, and wiki writes.
-- Intended clients include Claude Desktop, Claude Code, ChatGPT MCP clients, and any streamable HTTP MCP client.
-
-### AI client compatibility
-| Client | Current stance |
-|---|---|
-| Claude Code | Remote HTTP MCP connection verified. Model-side tool use still depends on the user's Claude Code subscription/API access. |
-| Codex CLI / IDE | Codex supports streamable HTTP MCP with bearer-token and OAuth flows; Deft exposes the matching endpoint and OAuth metadata. |
-| ChatGPT main app | Requires an eligible account/workspace with Developer Mode or custom MCP app support enabled. |
-| Claude Desktop / Claude web | Depends on the user's current MCP connector surface. Use OAuth when available, or personal bearer-token MCP when the client supports HTTP headers. |
-| Generic MCP runtimes | Supported when they can speak streamable HTTP MCP and send OAuth or bearer-token credentials. |
-
-Pilot guidance: start human AI clients with read-only scopes. Enable write scopes only when the user explicitly wants that AI client to create tasks, post messages, or write wiki entries as that user.
-
-### Agent employees
-- Admins create agent employees from Settings -> Agent Employees.
-- Agent employee tokens act as that employee and keep the existing trust, approval, health, and audit model.
-- Customers can connect already-running OpenClaw, Hermes, Codex-style, or custom MCP/BYOA runtimes instead of asking Deft to host every external tool.
-
-### Internal capability registry
-Deft still has an internal `skills` table for first-party agent/tool bundles and future ecosystem work. It is not the pilot-facing integration surface. Project-level customization through `project_skills` / `project_config` was retired; projects now use fixed engineering defaults.
-
-### Current self-hosted v1 stance
-- Deft Workspace, task tools, knowledge/wiki, calendar feed read context, personal MCP access, and MCP/BYOA agent employees are the supported path.
-- External SaaS tools such as GitHub, Slack, Gmail, Linear, and Notion should be connected inside the user's own agent runtime or MCP server.
-- Legacy slugs or enum values may remain for old data, but they should not be shown as native self-hosted v1 promises.
-
----
-
-## 4. Knowledge & Documentation
-
-### Wiki Pages
-Structured knowledge base with 7 page types: concept, entity, decision, resource, procedure, preference, fact. 3 scopes: org-wide, space-scoped, user-private. Auto-generated slugs with collision avoidance. Full-text search and type/scope filtering. Pagination (50 items/page).
-
-### Semantic Page Linking & Backlinks
-Directed link graph between wiki pages. Each link carries optional context (reason/label). Backlinks view showing all pages that reference a given page. Link count aggregation on list view.
-
-### Confidence Scoring & Automated Decay
-Each page has a confidence score (0–1). Visual confidence bars: green (>70%), yellow (50–70%), red (<50%). Daily wiki lint worker decays pages with confidence below 0.3 (soft delete). Automated stale content detection.
-
-### Citations & Source Tracking
-Link wiki pages to their source messages, tasks, or events. Citation excerpts showing what was referenced. Displayed on page detail view.
-
-### Wiki Ops Log
-Full audit trail of wiki operations: create, update, delete, merge, lint. Tracks actor (performed_by) and details (JSONB).
-
-### Wiki Lint — Daily Health Check
-Automated daily worker per org. Detects orphaned pages (no links in or out), stale content, low confidence. Logs all issues to ops log. Auto-decays very low confidence pages.
-
-### Space Knowledge — Quick Capture
-Lightweight knowledge capture sidebar in chat. 4 types: decision, resource, action_item, note. Link to source message. Real-time Socket.io events (`knowledge:created/updated/deleted`). Searchable across org via `/api/knowledge`.
-
-### Decisions Tracking
-Record decisions with text, context, and tags. Link to source message. Track who decided (decided_by). Reversibility flag (is_reversed). Search/filter by query or space.
-
-### Daily Notes
-Personal rich text notes with emoji icons. TipTap HTML content. Pin/unpin notes (pinned show first). Search by title. Sorted by pinned status + update time.
-
-### Tags System
-Org-wide colored tags. Apply tags to multiple entity types: messages, tasks, clips, daily notes. Tag search/filter. Browse tagged entities. Tag management in settings.
-
----
-
-## 5. AI Agent
-
-### Conversational Interface
-Dedicated AI chat page with streaming SSE responses. Multi-turn conversations with history. Auto-titled from first message. Thinking indicator (bouncing dots). Auto-scroll with manual scroll-up respect. Empty state with 5 suggestion cards. Markdown rendering for responses.
-
-### 32+ Agent Tools
-Organized in 5 categories:
-
-**Read-only tools (auto-execute):**
-- `search_messages` — full-text search across chat with space/author filters
-- `search_tasks` — query by title, status, priority, assignee, project, overdue flag
-- `get_task_detail` — full task with comments and activity
-- `get_workspace_stats` — aggregate metrics (tasks, messages, active users)
-- `get_team_workload` — task distribution by assignee and status
-- `get_project_progress` — completion %, overdue counts, recent activity
-- `get_user_activity` — person's recent task changes, messages, assignments
-- `get_task_dependencies` — blocking/blocked-by relationships
-- `search_blockers` — find mentions of blocked/stuck work
-- `search_decisions` — retrieve past team decisions
-- `search_knowledge` — find documented knowledge entries
-- `wiki_search` — search wiki pages
-- `wiki_read` — read full wiki page with backlinks
-- `remember` — store facts (conversation/user/org scopes)
-- `recall` — retrieve stored memories
-
-**Calendar tools (auto-execute):**
-- `check_calendar` — view native Deft calendar events and imported ICS feed events
-
-
-**Write tools (require approval):**
-- `create_task` — new tasks in projects
-- `update_task_status` — move tasks between statuses
-- `assign_task` — assign to team members
-- `post_message` — post in spaces
-- `add_knowledge` — add knowledge entries
-- `wiki_write` — create/update wiki pages
-
-**Manager tools (require manager role):**
-- `get_team_health` — health status per member (green/yellow/red)
-- `get_team_performance` — velocity metrics per week
-- `get_workload_balance` — identify over/underloaded members
-- `prep_oneone` — generate 1:1 meeting prep for a person
-- `find_expert` — find who has expertise on a topic
-- `get_team_dynamics` — collaboration clusters, mentoring pairs, tensions
-- `analyze_skills_gap` — missing skills in team
-- `get_burnout_risks` — members showing strain signals (manager-only, privacy-conscious)
-
-### Three-Tier Approval System
-- **Auto-execute**: read-only tools, memory operations, native/calendar-feed reads
-- **Quick-approve**: task creation, status updates, assignments (one-click approval card)
-- **Full-review**: multi-step plans, message posting, external writes (preview + edit)
-
-### Trust Levels
-Per-org setting: Conservative (all writes need approval) → Standard (some auto-execute) → Autonomous (most auto-execute). Configurable in settings.
-
-### Agent Memory System
-Store and retrieve facts at three scopes: conversation, user, org. Upsert semantics (update if exists). Used by `remember` and `recall` tools. Persistent across conversations.
-
-### Agent Actions with Undo
-Write actions create pending records. User sees approval card with Approve/Reject buttons. Approved actions can be undone within 5 minutes. Full action log in settings.
-
-### Citations with Confidence
-Task and message sources shown below response (max 5, expandable). Confidence indicator: green (3+ sources), amber (1-2), red (0 sources).
-
-### @agent / @deft Mentions in Chat
-Mention `@agent` or `@deft` in any space message. Background worker picks up mention, runs agent reasoning with thread context, posts reply in thread. Auto-creates agent system user. Up to 8 reasoning iterations.
-
-### Follow-up Suggestions
-Agent provides follow-up question suggestions after responses.
-
-### Message Classification Pipeline
-Every chat message classified by Haiku for: intent (task_create, question, discussion, actionable, none), entity extraction (assignee, project, due_date), agent mention detection, task reference detection, blocked indicators, memorable facts, team decisions.
-
----
-
-## 6. Dashboard & Analytics
-
-### Bento Grid Home View
-Responsive card-based dashboard (1 col mobile, 2 col tablet, 3 col desktop). Cards: Today (tasks due, span 2), Quick Stats (4-stat grid: overdue/due today/in progress/completed), Unread (space notifications), Projects (progress rings), Activity (recent feed), Calendar (mini widget with day bucketing), My Work (kanban-lite: todo/in_progress/in_review columns), Team (manager-only health cards), My Insights (personal metrics).
-
-### AI Standup Generation
-Daily AI-generated standup using the configured AI provider. Gathers: status changes, new tasks, messages by space, active users, completed count, overdue count. Falls back to template-based summary if no API key. Auto-posts to default space as system message.
-
-### Personal Insights
-Activity metrics: messages sent, tasks completed, active spaces. Expertise areas with scores. Top collaborators with interaction counts. Work patterns (behavioral analysis). Weekly pace/velocity (4-week trend).
-
-### Team Health Monitoring
-Per-member health cards with green/yellow/red status dots. Action items extraction. Wins identification. Uses patterns, messages, and task data for insights. Manager-only view.
-
-### Burnout Detection
-Detects: working hours shift, sentiment decline, velocity drop, isolation patterns. Privacy-conscious (analyzes public message patterns only, never content). Configurable thresholds. Generates alerts with confidence scores. Manager + affected user visibility only.
-
-### 1:1 Meeting Prep
-Auto-generated preparation documents for manager-report 1:1 meetings. Includes: summary, wins, focus areas, concerns, talking points. Uses team member activity data. Status tracking: generated → discussed → archived.
-
-### Expertise Tracking
-Per-user expertise scored by topic. Factors: message count on topic, questions answered, help mentions received, tasks completed in area. Expertise score aggregation. Used by `find_expert` agent tool.
-
-### Collaboration Graph
-Tracks interactions between all org members. Metrics: interaction count, recency-weighted score, DM count, shared space count, mention count, thread co-participation. Powers "top collaborators" in personal insights.
-
-### People Influence Mapping
-Maps influence types per person: decision_maker, blocker_resolver, reviewer, connector, mentor. Evidence-based scoring. Used by `get_team_dynamics` agent tool.
-
-### People Relationships
-Maps relationship types with direction: close_collaborator, mentor_mentee, tension, delegation_chain, cross_team_bridge. Powers team dynamics analysis.
-
-### Velocity Calculator
-4-week velocity trend (tasks completed per week). Trend detection: increasing, stable, declining. Per-person and team-wide breakdowns.
-
-### Workload Analyzer
-Identifies over/underloaded team members. Priority-weighted task distribution. Used by `get_workload_balance` agent tool.
-
-### Bottleneck Detector
-Identifies stuck reviews, stalled tasks, review bottlenecks. Surfaces blockers in team analytics.
-
-### Skills Gap Analyzer
-Maps expertise coverage across team. Identifies single points of failure (only one person knows X). Highlights well-covered vs. gap areas.
-
-### Space Recap
-AI-summarized recap of unread or recent messages per space. On-demand generation via API. Uses the configured AI provider for intelligent summarization.
-
-### Weekly Digest
-Weekly org-wide summary for managers. Aggregates: velocity, task completion, decisions made, risks, wins. Delivered via background worker.
-
----
-
-## 7. Calendar & Scheduling
-
-### Multi-View Calendar
-Three views: month (day buckets with event dots), week (7-day horizontal), day (hourly timeline). Event creation/edit modals. Day detail panel showing all events. Navigation between dates.
-
-### Native Calendar Events
-Create, update, delete events within Deft. Stored in unified events table.
-
-### ICS Calendar Sync
-Self-hostable ICS subscriptions. Users can export Deft tasks/events as a personal feed and import external calendar feeds into Deft. Read-only external calendar context is available to the agent through `check_calendar`; external writes are expected to come from BYOA/MCP tools rather than managed provider OAuth.
-
-### Meeting Briefs
-AI-generated pre-meeting summaries. Links to calendar event. Prep content stored as JSON. Background worker checks every 15 minutes for upcoming meetings.
-
----
-
-## 8. Automation & Background Intelligence
-
-### Workflow Rules
-User-created automation rules. Trigger types: keyword_in_message, new_member_joins, reaction_added, `task.status_changed`. Action types: create_task, send_message, notify_user. Flexible JSON config for triggers and actions. Enable/disable rules. Run history with results log.
-
-### Workflow Executor (basic)
-First production workflow runner (Task 5.7). Listens for `task.status_changed` transitions and executes any matching workflow_rule with four supported actions: `add_comment`, `assign_to`, `add_label`, `notify`. Action results are logged back to the rule's run history. Broader trigger coverage + skill-defined triggers land in Phase 8.
-
-### 17 Background Workers
-All powered by Postgres-based job queue (no external Redis required). Atomic job claiming with `SELECT FOR UPDATE SKIP LOCKED`. Exponential backoff on retry.
-
-| Worker | Schedule | Purpose |
-|--------|----------|---------|
-| standup-generate | Daily at 9am local time per org (standup-generate cron) | Generate daily team standup summaries |
-| standup-check | Hourly | Validate/process standup entries |
-| nudge-check | Hourly | Smart reminders for stalled/overdue/unassigned tasks |
-| meeting-prep-check | Every 15 min | Generate meeting briefs for upcoming meetings |
-| people-graph | Daily | Update interaction, expertise, and pattern data |
-| manager-pulse | Daily | Generate team health snapshots |
-| burnout-detect | Daily | Detect burnout risk signals |
-| weekly-digest | Weekly | Generate org-wide weekly summary |
-| wiki-lint | Daily | Validate wiki health, detect orphans, decay stale pages |
-| agent-reply | On demand | Process @agent/@deft mentions in chat |
-| task-extract | On demand | Extract tasks from natural language in messages |
-| memory-extract | On demand | Extract memorable facts from conversations |
-| cross-reference | On demand | Auto-detect and link task/message references |
-| clip-process | On demand | Transcribe and summarize audio/video clips |
-| duplicate-detect | On demand | Identify duplicate/similar tasks |
-| blocked-alert | On demand | Alert on blocked task mentions |
-| embed-content | On demand | Semantic search via pgvector + OpenAI text-embedding-3-small (1536 dims). Populated on wiki ingest by the embed-content worker. Requires `OPENAI_API_KEY` env var. Implemented 2026-04-16. |
-
-### Cron Scheduling
-Postgres-based cron with idempotent job creation. Re-enqueue pattern (complete job → re-enqueue with delay). Stale job cleanup for crashed workers (5 min timeout).
-
-### Agent Nudges
-Smart reminders for: stalled tasks (no update in X days), overdue tasks, unassigned tasks. Dismissable by user. Background worker generates nudges hourly.
-
----
-
-## 9. Search & Navigation
-
-### Global Search (Cmd+K)
-Unified search across spaces, tasks, people, messages, notes, tags. Glassmorphism overlay with backdrop blur. Results grouped by type. Task search supports title or PREFIX-NUMBER (e.g., "DEFT-1"). 200ms debounced.
-
-### Command Mode
-Type `>` in search bar for actions: Create task, New space, Toggle dark mode, Open settings, Ask Deft.
-
-### Keyboard Shortcuts
-| Shortcut | Action |
-|----------|--------|
-| Cmd+K / Ctrl+K | Command palette |
-| ? | Keyboard shortcuts help |
-| G → D | Dashboard |
-| G → C | Chat |
-| G → T | Tasks |
-| G → A | Agent |
-| G → S | Settings |
-| G → N | Notes |
-| G → L | Calendar |
-| G → K | Knowledge |
-| G → R | Reminders |
-| C (on tasks page) | Quick-create task |
-| Shift+Esc | Mark all notifications read |
-| Ctrl+Shift+M | Mark current space read |
-| Enter | Send message |
-| Shift+Enter | New line in composer |
-| Esc | Close panels/modals |
-
----
-
-## 10. Integrations
-
-### Calendar Feeds — Working
-ICS feed export/import. Polling sync worker syncs subscribed feeds to the local events table. Agent can read native and ICS events with `check_calendar`. Connection status, errors, and last sync time are shown in settings.
-
-
-### Unified Events Table
-External data normalized into single `events` table. Current self-hostable sources: native and ics. Legacy sources such as google_calendar, github, and linear remain in the enum for old rows and compatibility. Event types include calendar_event and legacy activity events. External ID deduplication. User mapping. Agent queries across native + events data together.
-
----
-
-## 11. Platform & Infrastructure
-
-### Multi-Tenant Architecture
-`org_id` on every table (66 tables). All queries filter by org_id. Row-level isolation. No cross-org data leakage.
-
-### Self-Hosting
-Docker Compose deployment with health checks. Multi-stage Dockerfile (deps → build → production). Persistent volumes for data and uploads. `.env.example` with documented variables.
-
-### Open Source (BSL 1.1)
-Business Source License 1.1 — use for any purpose except hosting as a service for third parties. Converts to Apache 2.0 after 4 years. Mandatory attribution in forks.
-
-### Authentication
-Email/password auth with JWT access tokens (15min) + refresh tokens (30d, HttpOnly). Automatic token refresh on 401. bcrypt password hashing (12 rounds). First signup bootstraps the self-hosted workspace; later users join by invite.
-
-### Roles & Permissions
-4 roles: owner, admin, member, guest. Role-based UI (admin-only member management, manager-only analytics). Org membership tracking.
-
-### Invite System
-Email invites with unique tokens. Link-based invites. Invite expiry tracking. Accept tracking (who accepted, when). Role assignment on invite.
-
-### Onboarding
-5-step setup wizard: workspace name → invite team → create spaces (general, engineering, design, random templates) → create project → meet Deft AI. Completion flags tracked per user.
-
-### Theming
-Light/dark/system preference. Obsidian dark theme: 8-level tonal surface scale, muted violet accent, glassmorphism floating elements. CSS custom properties. 150ms transitions.
-
-### Audit Log
-Complete audit trail of all user and agent actions. Tracks: actor (user or agent), action, entity type/ID, before/after state snapshots (JSON), metadata. Queryable by actor, entity, or action type.
-
-### Encryption
-AES-256-GCM for sensitive OAuth tokens. Key derived via scrypt from env variable. IV + tag + ciphertext format.
-
-### Multi-LLM Support
-Unified LLM router supporting 4 providers: Anthropic, OpenAI, OpenRouter, and Ollama. Per-org API key overrides. Token usage tracking.
-
-### Real-Time (Socket.io)
-Room-based broadcasting: org rooms, space rooms, user rooms, huddle rooms. JWT-authenticated WebSocket connections. 15+ event types for messages, typing, presence, notifications, reactions, threads, tasks, spaces, huddles, knowledge, canvas.
-
-### Notifications System
-In-app notifications for: mentions, task assignments, task updates, agent suggestions, huddle started, system events. Real-time delivery via Socket.io. Mark single or all as read. Unread count badge in header.
-
-### Reminders
-Schedule reminders for messages or custom alerts. Remind_at time with in-process scheduling. Fires as notification + socket event. Upcoming/past views. Source message linking.
-
-### User Groups
-Named groups (e.g., @engineering, @design) with handle/slug. Add/remove members. Bulk mentioning in chat. Handle uniqueness per org.
-
-### Message Edit History
-`messageVersions` table tracks all message edits. Previous content preserved for audit.
-
----
-
-## 12. Security & Hardening
-
-### XSS Prevention
-- DOMPurify sanitization on all `dangerouslySetInnerHTML` call sites (space-chat, thread-panel, task-detail comments, notes version history, dashboard standup)
-- HTML entity escaping in `inlineFormat()` markdown renderer before regex processing
-- Centralized `sanitizeHtml()` utility at `apps/web/src/lib/sanitize.ts` with explicit tag/attribute allowlists
-
-### Access Control — IDOR Fixes
-- Workflow run deletion: ownership verified before cascade delete
-- Agent conversation deletion: user ownership verified before message purge
-- Wiki citation deletion: task org_id + scoped citation delete (source_id match)
-
-### Space Membership Enforcement
-- All space endpoints (GET members, POST members) require space membership
-- Message listing (GET /:spaceId) requires space membership
-- Message forwarding checks both source and target space membership
-- Pin/unpin operations require space membership
-- WebSocket `space:join` validates membership before joining room
-- Shared `requireSpaceMembership()` utility at `apps/api/src/lib/space-membership.ts`
-
-### Upload Safety
-- Filename sanitized with `path.basename()` + special character stripping on upload
-- Content-Disposition header uses `attachment` (not `inline`) + URI-encoded filename
-
-### Data Integrity
-- Daily notes PATCH uses optimistic locking (CAS version check) — returns 409 Conflict on concurrent edits
-
----
-
-## Next Milestone — Phase 8 (OpenClaw autonomy)
-
-Flagged as explicitly NOT shipped yet:
-
-- OpenClaw autonomous heartbeat lifecycle (long-running employees with scheduled self-wake).
-- Skill-defined trigger dispatcher (arbitrary triggers from skill manifests beyond the current `cron:standup`).
-- Heartbeat cost guardrails (per-turn + per-day caps, circuit-breakers).
-
----
-
-## What Does NOT Exist
-
-- Mobile app (iOS / Android) — web-only
-- Desktop app (Electron / Tauri)
-- Offline support
-- Screen sharing in huddles
-- SFU / media server for huddles (peer-to-peer only, limits group call size)
-- SOC 2, HIPAA, or other compliance certifications
-- Uptime SLA
-- Public REST/GraphQL API for third-party developers
-- Zapier / Make integration
-- Data export (CSV, JSON)
-- Burndown / sprint velocity charts (traditional PM analytics)
-- Goal / OKR tracking
-- Portfolio management
-- Custom report builder
-- Timeline / Gantt view
-- Sprints / cycles
-- Roadmap view
-- Guest access (external collaborators outside org)
-- Page-level or channel-level permissions (org-level roles only)
-- IP allowlisting
-- DLP / eDiscovery
-- Domain verification
-- Billing / subscription management (schema exists, no routes)
-- Rich blocks in wiki (wiki content is text-based, not block-based like Notion)
-- Embeds (Figma, Loom, YouTube) in wiki/docs
-- Drag-and-drop page hierarchy in wiki (link-based, not tree-based)
-
----
-
-## Tested & Verified (Playwright E2E — 2026-04-16)
-
-The following surfaces were tested end-to-end via Playwright automation on April 16, 2026. All items below passed unless noted.
-
-### Confirmed Working
-- Dashboard with all 10+ bento-grid widgets rendering correctly
-- Task board with 6 columns (Backlog, To Do, In Progress, In Review, Done, Cancelled collapsed)
-- Task list view with sortable columns and inline status editing
-- Calendar view with tasks placed on due dates
-- Pipeline view (renders correctly after copy fix)
-- Task detail panel: Description, Subtasks, Dependencies, Comments, Activity tabs
-- Task reactions bar (emoji toggle on task detail)
-- Recurrence dropdown (None / Daily / Weekly / Biweekly / Monthly)
-- Priority mapping (p1 displays as "High", etc.)
-- Status labels standardized ("To Do" not "Todo")
-- Filter bar: Assignee, Priority, Status, Labels, Project, Due date, Views
-- Skills library page: 3 tabs (Bundled 9 / Marketplace 0 / Your org 0)
-- Skills cards: View / Install / Attach / Fork actions, context-bloat indicator
-- Agent Employees list with seeded Alex PM employee
-- Create Agent wizard: 5 steps with Skills picker showing all 9 bundled skills
-- Project selector dropdown across views
-
-### Bugs Found & Fixed During Testing
-1. `/api/agent-employees` 500 — schema/DB mismatch from 20 unapplied migrations (0025-0044). Fixed by applying all migrations + seeding 9 bundled skills.
-2. Skills wizard "No skills available" — 3 frontend callers expected `{skills:[...]}` wrapper but endpoint returns raw array. Fixed in `fd2cb3f`.
-3. Pipeline view "No deals" copy — sales-specific empty text leaked to Engineering projects. Fixed in `73946cf`.
-4. Skills page breadcrumb said "Dashboard" instead of "Skills". Fixed in `73946cf`.
-5. Skills wizard fetch — added error swallow on fetch failure. Fixed in `73946cf`.
-
-### Known Limitations (not yet fixed)
-- **Postgres status enum constraint** — `tasks.status` column uses a Postgres enum with 6 Engineering values (`backlog`, `todo`, `in_progress`, `in_review`, `done`, `cancelled`). Marketing/Sales statuses will fail at the DB layer until the column is changed from enum to text.
-- **`tasks.completed_at` column missing** — people-graph worker uses `updated_at` as fallback for task completion time.
-- **Chat task-reference pills** don't respect `hide_prefix_ids` skill config (would need per-message task lookup to suppress prefix display).
-- **Notification panel rows** cannot render `variant="notification"` TaskCard because list endpoints don't embed the full Task payload.
-- **Board-card reactions** only visible when task data is pre-hydrated (list endpoints don't hydrate reaction counts).
-- **Drizzle `_journal.json`** stale since migration 0017 — production deploy must apply migrations 0025-0044 manually via `drizzle-kit push` or direct SQL.
-- **Sidebar wiring** for archived projects not implemented (backend archive/restore is ready, no UI entry point in sidebar).
-
----
-
-## Stats Summary
-
-| Metric | Count |
-|--------|-------|
-| Database tables | 66+ |
-| API route files | 35+ |
-| API endpoints | 110+ |
-| React components | 50+ |
-| Pages | 23 |
-| Socket.io event types | 15+ |
-| Agent tools | 40+ |
-| Background workers | 17+ |
-| Cron jobs | 7 (hourly to weekly) |
-| LLM providers supported | 4 |
-| Keyboard shortcuts | 18 |
-| Day-one bundled skills | 9 (6 capability-pack + 3 project-workflow) |
+Deft is source-available under the [Business Source License 1.1](LICENSE). It is not OSI open source today. The license permits use, modification, distribution, and self-hosting, but prohibits offering Deft as a hosted or managed service to third parties during the BSL term. Each release converts to Apache License 2.0 four years after its release date.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,44 @@
+# Deft roadmap
+
+This roadmap communicates direction, not delivery dates. Deft is an alpha and priorities may change as pilots expose better evidence.
+
+## Now: make the alpha dependable
+
+- Keep the human workspace surfaces coherent across desktop and mobile
+- Harden Defty approval, execution, confirmation, and recovery behavior
+- Certify personal MCP and agent employee workflows with real clients
+- Improve self-host bootstrap, diagnostics, backups, and operator documentation
+- Replace stale repository claims with current product proof
+- Keep permission, org isolation, and private-space tests mandatory
+
+## Next preview: make upgrades and releases repeatable
+
+- Support versioned database upgrades from the previous preview
+- Publish signed or checksummed release artifacts and a GHCR image
+- Add release notes that distinguish fresh installs from upgrades
+- Add browser smoke, dependency review, CodeQL, container scanning, and SBOM generation to release gates
+- Certify backup, upgrade, rollback, and restore on the supported Docker Compose path
+- Expand import/export and operator recovery guidance
+
+## Before stable v1
+
+- Define a stable API, migration, and configuration compatibility policy
+- Publish a supported release and security maintenance policy
+- Complete independent security review of the highest-risk auth, permission, MCP, agent, upload, and WebSocket paths
+- Establish measurable performance envelopes for small and medium team deployments
+- Close accessibility and cross-browser gaps on core workspace workflows
+- Make observability and failure recovery understandable without source-code access
+
+## Later, evidence permitting
+
+- Finer workspace and knowledge permissions
+- Broader data import/export
+- Additional calendar and external-tool pathways through customer-owned MCP runtimes
+- Richer team analytics and administrative audit controls
+- Ecosystem work around reusable agent skills and templates
+
+## Explicit non-commitments
+
+The roadmap does not currently promise native Slack, Gmail, GitHub, Google Calendar OAuth, Linear, or Notion connectors. It also does not promise a hosted multi-customer Deft service under the current BSL license. External tools should be connected through customer-owned agent or MCP runtimes unless the product contract changes.
+
+See [current limitations](docs/current-limitations.md) for boundaries that apply today.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,45 +1,57 @@
-# Security Policy
+# Security policy
 
-## Supported Versions
+## Supported versions
 
-Deft is in alpha. Security fixes land on the latest commit of the `master` branch. We don't yet publish tagged releases — versioned release support will begin when we cut `v0.1.0`.
+Deft is an alpha. Security fixes land on the latest commit of `master` and are included in the next preview release. The project does not maintain long-lived security branches yet.
 
-| Version | Supported |
-| ------- | --------- |
-| `master` (latest commit) | ✅ |
-| Older commits / forks | ❌ |
+| Version | Support |
+|---|---|
+| `master` | Actively maintained |
+| Latest GitHub preview release | Best effort until the next preview is published |
+| Older commits, releases, and forks | Not maintained by the Deft project |
 
-## Reporting a Vulnerability
+Production operators should pin a commit, review release notes before updating, and maintain tested backups. See [current limitations](docs/current-limitations.md).
 
-If you've found a security issue, please report it **privately** rather than opening a public GitHub issue.
+## Report a vulnerability privately
 
-**Preferred:** [GitHub Security Advisories](https://github.com/Maneek21/Deft/security/advisories/new) (private to maintainers).
+Do not open a public GitHub issue for a suspected vulnerability.
 
-**Or email:** security@deft.ing
+Preferred channel: [GitHub Security Advisories](https://github.com/Maneek21/Deft/security/advisories/new).
 
-Please include:
-- A description of the issue and its impact
-- Steps to reproduce
-- Affected version / commit SHA
-- Any proof-of-concept code
+Alternative: email `security@deft.ing`.
 
-We aim to acknowledge within **3 business days** and provide a triage update within **7 business days**.
+Include, when possible:
 
-## Disclosure Timeline
+- A clear description of the issue and its impact
+- Affected commit SHA, release, and deployment shape
+- Reproduction steps or proof-of-concept code
+- Whether the issue can cross an org, user, space, or agent boundary
+- Any suggested mitigation
 
-We follow a **90-day disclosure window** from initial report. If we can't fix in 90 days we'll coordinate publication with you. Severe issues affecting production self-hosters may move faster.
+We aim to acknowledge reports within three business days and provide an initial triage update within seven business days. These are targets, not a contractual SLA.
 
-## Scope
+## Disclosure
 
-In scope:
-- The Deft API (`apps/api`), web app (`apps/web`), database schema (`packages/db`)
-- The docker-compose self-host stack
-- Authentication, authorization, multi-tenant isolation (`org_id` enforcement)
-- The agent action surface and approval flow
+We generally coordinate around a 90-day disclosure window. Critical issues affecting active self-hosters may be handled faster. Please allow maintainers time to ship a fix and notify operators before publishing technical details.
 
-Out of scope:
-- Third-party MCP servers connecting BYOA agents — report those to the MCP server's maintainer
-- Vulnerabilities in dependencies (report to upstream, then ping us so we can bump)
-- Issues only reproducible against modified forks
+## In scope
 
-Thanks for helping keep Deft secure.
+- Authentication, authorization, session, invitation, and role handling
+- Multi-tenant and `org_id` isolation
+- Private space and direct-message access
+- Agent, approval, MCP, OAuth, webhook, and token boundaries
+- Task, message, wiki, note, calendar, people, and team APIs
+- WebSocket room authorization and event delivery
+- Upload, file path, rich-content, and rendering security
+- Docker Compose, bootstrap, backup, and self-host configuration supplied by this repository
+- Supply-chain issues in project-owned build and release automation
+
+## Out of scope
+
+- Vulnerabilities in third-party MCP servers, AI clients, model providers, or customer-owned agent runtimes
+- Unsupported forks or local modifications
+- Social engineering, credential reuse, or exposed secrets not caused by Deft
+- Dependency vulnerabilities without a demonstrated impact on Deft; report those upstream and notify us if Deft needs a coordinated upgrade
+- Availability testing that could disrupt a public demo or another operator's deployment
+
+Thank you for helping keep Deft and its self-hosters safe.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,32 @@
+# Support
+
+Deft is an alpha, source-available self-hosted project. Community support is best effort and does not include an uptime or response-time SLA.
+
+## Where to ask
+
+- **Bug:** open a GitHub issue with reproduction steps.
+- **Feature or product proposal:** start a GitHub Discussion before a large implementation.
+- **Installation or usage question:** use GitHub Discussions.
+- **Security issue:** follow [SECURITY.md](SECURITY.md) and report privately.
+- **Contribution:** read [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## A useful support request includes
+
+- Deft commit SHA or release
+- Deployment shape: Docker Compose, local development, or another container host
+- Operating system and architecture
+- Redacted environment details relevant to the failure
+- Exact command or user workflow
+- Expected and actual behavior
+- Browser console, API, worker, Postgres, or Redis errors where relevant
+- Whether the issue reproduces on a fresh workspace
+
+Never post API keys, passwords, MCP tokens, OAuth credentials, database dumps, or private workspace content in an issue.
+
+## Operator responsibility
+
+Self-hosters are responsible for infrastructure, HTTPS, DNS, backups, restore drills, provider credentials, email delivery, storage, monitoring, and upgrades. Review [docs/self-hosting.md](docs/self-hosting.md) and [current limitations](docs/current-limitations.md) before piloting with important data.
+
+## What maintainers may close
+
+Maintainers may close requests that cannot be reproduced, omit required context after follow-up, depend on unsupported forks, request prohibited hosted-service use, disclose secrets, or fall outside the current product contract.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,23 @@
+# Deft documentation
+
+## Start here
+
+- [Self-hosting](self-hosting.md)
+- [VPS, domain, and HTTPS](self-hosting-vps-domain-https.md)
+- [Self-hosted v1 contract](self-hosted-v1-contract.md)
+- [Current limitations](current-limitations.md)
+- [Roadmap](../ROADMAP.md)
+- [Support](../SUPPORT.md)
+- [Security](../SECURITY.md)
+- [Contributing](../CONTRIBUTING.md)
+
+## Operator and integration guides
+
+- [Hermes agent channel service](hermes-agent-channel-service.md)
+- Public product capabilities: [FEATURES.md](../FEATURES.md)
+
+## Engineering records
+
+`docs/superpowers/` contains dated specifications, plans, audits, and implementation records. These files are useful development history, but they are not the current product contract. When a dated record conflicts with the README, current limitations, self-hosted v1 contract, or current source code, prefer the current public documentation and code.
+
+`docs/deprecated/` contains retired designs and compatibility history. Do not treat those files as supported setup instructions.

--- a/docs/current-limitations.md
+++ b/docs/current-limitations.md
@@ -1,0 +1,60 @@
+# Current limitations
+
+Last reviewed July 16, 2026.
+
+Deft is an alpha. It is suitable for technical evaluation, internal use, and controlled pilots where an operator can tolerate breaking changes and investigate failures.
+
+## Installation and upgrades
+
+- Fresh installs use `pnpm db:push-full` to apply the Drizzle schema plus supplemental search and index SQL.
+- `pnpm db:migrate` is not a supported upgrade path yet.
+- The repository does not currently certify upgrading every historical alpha database to the latest commit.
+- Operators should pin a commit, back up Postgres and uploads, and rehearse restore before updating.
+
+## Deployment contract
+
+- One workspace per self-hosted deployment is the supported v1 contract.
+- Docker Compose is the primary documented deployment path.
+- The API requires a long-running container host with WebSocket support; it is not suited to a request-only serverless runtime.
+- Self-hosters operate DNS, HTTPS, reverse proxy, backups, storage, monitoring, and incident response.
+- No uptime SLA or managed support contract is included with the repository.
+
+## AI and agents
+
+- Core workspace features run without an AI provider; agent features do not.
+- Model output is probabilistic. Deft validates structured drafts and applies permission and approval rules, but cannot guarantee perfect interpretation.
+- Agent employees require a separately operated compatible runtime. Deft does not host every external runtime or tool.
+- A healthy token or connection does not guarantee that an external runtime is online, subscribed, or able to finish assigned work.
+- Autonomous behavior remains bounded by scopes, trust, approvals, action caps, provider availability, and customer configuration.
+
+## MCP and external tools
+
+- Deft supports streamable HTTP MCP with OAuth or personal bearer-token access, depending on the client.
+- Client support varies by vendor, application, account tier, and connector policy.
+- Native Slack, Gmail, GitHub, Google Calendar OAuth, Linear, and Notion connectors are not part of the current self-hosted v1 promise.
+- External tools should be connected through a customer-owned agent runtime or MCP server.
+- Calendar subscriptions through ICS are read-only; native Deft calendar events are writable inside Deft.
+
+## Scale and performance
+
+- The project includes synthetic 60-person certification and substantial local/public-demo dogfooding.
+- That evidence is not a production benchmark, capacity guarantee, or substitute for load testing on the operator's hardware.
+- Sustained concurrency, large file volume, long retention, WebSocket fanout, notification bursts, and job backlog should be tested for each deployment.
+
+## Security and compliance
+
+- Deft has ongoing auth, org-isolation, space-membership, MCP, upload, and rich-content security tests.
+- Deft has not completed an independent security audit.
+- Deft does not claim SOC 2, ISO 27001, HIPAA, GDPR certification, DLP, eDiscovery, or an uptime SLA.
+- Operators remain responsible for regional privacy, retention, backup, access, and compliance obligations.
+
+## Product boundaries
+
+- Web application only; no native desktop or mobile app.
+- No offline-first mode.
+- Huddles are browser-based and are not a substitute for a dedicated large-group meeting platform.
+- Knowledge is link- and graph-oriented, not a full Notion-style block database system.
+- Task management does not currently target portfolio planning, sprint analytics, OKRs, billing, or a custom report builder.
+- Some lower-frequency settings and administrative flows have less dogfood depth than chat, tasks, knowledge, MCP, and agent workflows.
+
+These limitations should shrink over time. Track direction in [ROADMAP.md](../ROADMAP.md) and release-specific changes in [CHANGELOG.md](../CHANGELOG.md).

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -383,20 +383,28 @@ gunzip -c backups/deft-backup-20260101T120000Z.sql.gz | docker compose exec -T p
 
 ## Upgrading
 
-Deft is alpha and does not yet publish stable tagged releases. To roll forward:
+Deft publishes alpha preview releases but does not yet provide a supported versioned database migration path. Do not run an unreviewed `git pull` against important data.
+
+For a controlled alpha update:
+
+1. Pin the target commit or preview tag.
+2. Read its release notes and schema changes.
+3. Take a SQL backup and preserve uploads.
+4. Rehearse the update and restore on a copy of the deployment.
+5. Only then rebuild and run the alpha initializer:
 
 ```bash
-git pull
+git checkout <reviewed-commit-or-preview-tag>
 docker compose build deft init doctor smoke
 docker compose up -d
 docker compose run --rm init
 docker compose run --rm doctor
+docker compose run --rm smoke
 ```
 
-`docker compose run --rm init` is the supported schema/update path during the
-alpha. Versioned `pnpm db:migrate` is not supported yet.
+`docker compose run --rm init` applies the current schema shape. It is the available alpha update mechanism, not a compatibility guarantee for every historical database. Versioned `pnpm db:migrate` upgrades are not supported yet.
 
-Before upgrading production, snapshot the Postgres volume or take a SQL backup.
+See [current limitations](current-limitations.md) before upgrading production.
 
 ## What's Not In Self-Hosted v1
 


### PR DESCRIPTION
## Summary

- replace the stale feature inventory with a current capability reference
- add public roadmap, support, limitations, and documentation index
- update security and contribution guidance for the current alpha
- record the major post-alpha changes in the changelog
- correct self-host upgrade language and separate current contract from dated engineering history

## Validation

- all local Markdown links resolve
- GitHub rendered the capability reference and roadmap successfully
- representative code evidence checked for tasks, context packets, notes, teams, MCP, and ICS
- stale public claims scan is clean
- git diff --check passes

## Scope

Documentation only. No runtime behavior changes.