### PR TITLE
build: publish portable preview releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,123 @@
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing v-prefixed tag to package
+        required: true
+        type: string
+      prerelease:
+        description: Mark the GitHub release as a prerelease
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: write
+  packages: write
+  id-token: write
+  attestations: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: maneek21/deft
+
+jobs:
+  publish:
+    name: Publish release image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+          fetch-depth: 0
+
+      - name: Resolve release tag
+        id: release
+        shell: bash
+        run: |
+          tag="${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}"
+          [[ "$tag" == v* ]] || { echo "Release tag must start with v" >&2; exit 1; }
+          git rev-parse "$tag^{commit}" >/dev/null
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
+          echo "sha=$(git rev-parse "$tag^{commit}")" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-buildx-action@v4
+
+      - uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate image metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=${{ steps.release.outputs.version }}
+            type=raw,value=sha-${{ steps.release.outputs.sha }}
+
+      - name: Build and publish amd64 image
+        id: image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          provenance: mode=max
+          sbom: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Attest image provenance
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.image.outputs.digest }}
+          push-to-registry: true
+
+      - name: Generate release manifest
+        shell: bash
+        run: |
+          mkdir -p dist
+          cp docker-compose.yml compose.prod.yml compose.release.yml .env.example dist/
+          cat > dist/release-manifest.json <<JSON
+          {
+            "schema": "deft.release.v1",
+            "tag": "${{ steps.release.outputs.tag }}",
+            "commit": "${{ steps.release.outputs.sha }}",
+            "image": "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.release.outputs.version }}",
+            "digest": "${{ steps.image.outputs.digest }}",
+            "platforms": ["linux/amd64"],
+            "upgrade_support": "fresh-install-only"
+          }
+          JSON
+
+      - name: Generate SPDX SBOM
+        uses: anchore/sbom-action@v0.20.5
+        with:
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.image.outputs.digest }}
+          format: spdx-json
+          output-file: dist/deft-${{ steps.release.outputs.version }}.spdx.json
+
+      - name: Generate checksums
+        shell: bash
+        run: (cd dist && sha256sum * > SHA256SUMS)
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PRERELEASE: ${{ github.event_name == 'workflow_dispatch' && inputs.prerelease || contains(steps.release.outputs.version, '-') }}
+        shell: bash
+        run: |
+          args=(--repo "$GITHUB_REPOSITORY" --title "Deft ${{ steps.release.outputs.tag }}" --generate-notes --verify-tag)
+          [[ "$PRERELEASE" == "true" ]] && args+=(--prerelease)
+          gh release create "${{ steps.release.outputs.tag }}" dist/* "${args[@]}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ env vars. Patch versions (`0.X.Y`) are non-breaking fixes only.
 
 ### Added
 
+- Tagged preview release workflow with a GHCR image, provenance attestation,
+  SPDX SBOM, checksums, and a machine-readable release manifest.
+- Runtime public-URL injection for portable prebuilt images.
 - Guided personal MCP connections for Codex, Claude, ChatGPT-compatible clients, and custom streamable HTTP MCP clients.
 - Operational headless MCP tools for unread triage, context packets, people, teams, tasks, messages, notes, wiki, decisions, and calendar workflows.
 - Task Table view, richer Timeline and Calendar interactions, persistent view preferences, and improved bulk operations.

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,9 +23,9 @@ WORKDIR /app
 # docker-compose passes these as build args; declare and export them before
 # `next build` so self-hosted installs on custom domains/ports do not silently
 # fall back to localhost:3001.
-ARG NEXT_PUBLIC_APP_URL=http://localhost:3000
-ARG NEXT_PUBLIC_API_URL=http://localhost:3001
-ARG NEXT_PUBLIC_WS_URL=http://localhost:3001
+ARG NEXT_PUBLIC_APP_URL=__DEFT_APP_URL__
+ARG NEXT_PUBLIC_API_URL=__DEFT_API_URL__
+ARG NEXT_PUBLIC_WS_URL=__DEFT_WS_URL__
 ENV NEXT_PUBLIC_APP_URL=$NEXT_PUBLIC_APP_URL
 ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
 ENV NEXT_PUBLIC_WS_URL=$NEXT_PUBLIC_WS_URL
@@ -72,4 +72,4 @@ EXPOSE 3000 3001
 # Start both web and API. Use the locally-installed next binary (pnpm exec),
 # not `npx next start` — npx downloads a fresh next install to ~/.npm/_npx/
 # that lacks the Turbopack runtime files our build produced.
-CMD sh -c "cd /app/apps/api && node --import tsx src/server.ts & cd /app/apps/web && pnpm exec next start -p 3000"
+CMD ["sh", "/app/scripts/docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -118,6 +118,25 @@ Open [http://localhost:3000](http://localhost:3000). The first account creates a
 
 See [docs/self-hosting.md](docs/self-hosting.md) for environment variables, HTTPS, backups, health checks, AI providers, and production operations.
 
+### Run a named preview image
+
+Preview releases also publish an amd64 image to GHCR. Download the release
+assets, copy `.env.example` to `.env`, set the required secrets and public
+URLs, then run:
+
+```bash
+export DEFT_IMAGE=ghcr.io/maneek21/deft:0.2.0-preview.1
+docker compose -f docker-compose.yml -f compose.prod.yml -f compose.release.yml pull
+docker compose -f docker-compose.yml -f compose.prod.yml -f compose.release.yml up -d postgres redis
+docker compose -f docker-compose.yml -f compose.prod.yml -f compose.release.yml run --rm init
+docker compose -f docker-compose.yml -f compose.prod.yml -f compose.release.yml up -d deft
+docker compose -f docker-compose.yml -f compose.prod.yml -f compose.release.yml run --rm doctor
+```
+
+The current preview channel is for fresh installs. Read the self-hosting guide
+and [current limitations](docs/current-limitations.md) before putting durable
+data into an alpha deployment.
+
 > Fresh installs currently use `pnpm db:push-full`. Versioned `pnpm db:migrate` upgrades are not supported yet. Read [Project status and limitations](#project-status-and-limitations) before deploying important data.
 
 ## Local development

--- a/compose.release.yml
+++ b/compose.release.yml
@@ -1,0 +1,20 @@
+# Use this overlay with docker-compose.yml to run a named GHCR release without
+# compiling the monorepo locally. Keep compose.prod.yml in the stack for public
+# deployments so Postgres and Redis are not published to the host.
+x-deft-release-image: &deft-release-image
+  image: ${DEFT_IMAGE:-ghcr.io/maneek21/deft:0.2.0-preview.1}
+  pull_policy: always
+  build: !reset null
+
+services:
+  deft:
+    <<: *deft-release-image
+
+  init:
+    <<: *deft-release-image
+
+  doctor:
+    <<: *deft-release-image
+
+  smoke:
+    <<: *deft-release-image

--- a/docs/current-limitations.md
+++ b/docs/current-limitations.md
@@ -8,6 +8,7 @@ Deft is an alpha. It is suitable for technical evaluation, internal use, and con
 
 - Fresh installs use `pnpm db:push-full` to apply the Drizzle schema plus supplemental search and index SQL.
 - `pnpm db:migrate` is not a supported upgrade path yet.
+- Named GHCR preview images are amd64-only and fresh-install-only.
 - The repository does not currently certify upgrading every historical alpha database to the latest commit.
 - Operators should pin a commit, back up Postgres and uploads, and rehearse restore before updating.
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -28,6 +28,38 @@ The stack runs comfortably on 2 vCPU / 4 GB RAM for small pilots.
 
 ## First Boot
 
+### Choose source build or named release
+
+The source-build path below is the most flexible option for contributors.
+Tagged preview releases also publish an amd64 image to
+`ghcr.io/maneek21/deft`. The release image injects `NEXT_PUBLIC_APP_URL`,
+`NEXT_PUBLIC_API_URL`, and `NEXT_PUBLIC_WS_URL` when the container starts, so
+the same image works on localhost or a custom domain.
+
+For a named release, download `docker-compose.yml`, `compose.prod.yml`,
+`compose.release.yml`, and `.env.example` from the GitHub release into one
+directory. Then set:
+
+```bash
+DEFT_IMAGE=ghcr.io/maneek21/deft:<release-version>
+```
+
+Use the release overlay in every application/tool command:
+
+```bash
+docker compose -f docker-compose.yml -f compose.prod.yml -f compose.release.yml pull
+docker compose -f docker-compose.yml -f compose.prod.yml -f compose.release.yml up -d postgres redis
+docker compose -f docker-compose.yml -f compose.prod.yml -f compose.release.yml run --rm init
+docker compose -f docker-compose.yml -f compose.prod.yml -f compose.release.yml up -d deft
+docker compose -f docker-compose.yml -f compose.prod.yml -f compose.release.yml run --rm doctor
+docker compose -f docker-compose.yml -f compose.prod.yml -f compose.release.yml run --rm smoke
+```
+
+Release assets include `SHA256SUMS`, an SPDX SBOM, and a manifest containing
+the exact commit and image digest. Preview images are currently
+**fresh-install-only**; do not run `init` against data from another tagged
+version until that upgrade hop is explicitly documented as supported.
+
 ### Fast path: one-command bootstrap
 
 If you are working from a cloned repo with Node.js and pnpm available on the

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "selfhost:preflight": "tsx scripts/selfhost-doctor.ts",
     "selfhost:reset": "tsx scripts/selfhost-reset.ts",
     "selfhost:smoke": "tsx scripts/selfhost-smoke.ts",
+    "test:public-env": "node --test scripts/inject-public-env.test.mjs",
     "typecheck": "pnpm -r --parallel typecheck"
   },
   "engines": {

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -eu
+
+node /app/scripts/inject-public-env.mjs
+
+(cd /app/apps/api && node --import tsx src/server.ts) &
+
+cd /app/apps/web
+exec pnpm exec next start -p 3000

--- a/scripts/inject-public-env.mjs
+++ b/scripts/inject-public-env.mjs
@@ -1,0 +1,62 @@
+import { readFile, readdir, writeFile } from 'node:fs/promises';
+import { extname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export const PUBLIC_ENV_PLACEHOLDERS = {
+  __DEFT_APP_URL__: 'NEXT_PUBLIC_APP_URL',
+  __DEFT_API_URL__: 'NEXT_PUBLIC_API_URL',
+  __DEFT_WS_URL__: 'NEXT_PUBLIC_WS_URL',
+};
+
+const TEXT_EXTENSIONS = new Set(['.html', '.js', '.json', '.map', '.txt']);
+
+export async function injectPublicEnv(root, env = process.env) {
+  const replacements = Object.entries(PUBLIC_ENV_PLACEHOLDERS).map(([placeholder, key]) => {
+    const value = env[key];
+    if (!value) throw new Error(`${key} is required when using the prebuilt Deft image`);
+    return [placeholder, value.replace(/\/$/, '')];
+  });
+
+  let filesChanged = 0;
+  let replacementsMade = 0;
+
+  async function visit(directory) {
+    for (const entry of await readdir(directory, { withFileTypes: true })) {
+      const path = join(directory, entry.name);
+      if (entry.isDirectory()) {
+        await visit(path);
+        continue;
+      }
+      if (!TEXT_EXTENSIONS.has(extname(entry.name))) continue;
+
+      const original = await readFile(path, 'utf8');
+      let next = original;
+      for (const [placeholder, value] of replacements) {
+        const occurrences = next.split(placeholder).length - 1;
+        if (!occurrences) continue;
+        replacementsMade += occurrences;
+        next = next.replaceAll(placeholder, value);
+      }
+      if (next !== original) {
+        await writeFile(path, next);
+        filesChanged += 1;
+      }
+    }
+  }
+
+  await visit(root);
+  return { filesChanged, replacementsMade };
+}
+
+async function main() {
+  const root = process.argv[2] || '/app/apps/web/.next';
+  const result = await injectPublicEnv(root);
+  console.log(`[public-env] injected ${result.replacementsMade} values across ${result.filesChanged} files`);
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main().catch((error) => {
+    console.error(`[public-env] ${error instanceof Error ? error.message : String(error)}`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/inject-public-env.test.mjs
+++ b/scripts/inject-public-env.test.mjs
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import { injectPublicEnv } from './inject-public-env.mjs';
+
+test('injects public URLs into nested Next.js output', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'deft-public-env-'));
+  try {
+    await mkdir(join(root, 'static', 'chunks'), { recursive: true });
+    const chunk = join(root, 'static', 'chunks', 'app.js');
+    await writeFile(chunk, '"__DEFT_APP_URL__"+"__DEFT_API_URL__"+"__DEFT_WS_URL__"');
+
+    const result = await injectPublicEnv(root, {
+      NEXT_PUBLIC_APP_URL: 'https://deft.example/',
+      NEXT_PUBLIC_API_URL: 'https://deft.example/',
+      NEXT_PUBLIC_WS_URL: 'https://deft.example/',
+    });
+
+    assert.deepEqual(result, { filesChanged: 1, replacementsMade: 3 });
+    assert.equal(
+      await readFile(chunk, 'utf8'),
+      '"https://deft.example"+"https://deft.example"+"https://deft.example"',
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('fails clearly when a required runtime URL is absent', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'deft-public-env-'));
+  try {
+    await assert.rejects(
+      injectPublicEnv(root, {
+        NEXT_PUBLIC_APP_URL: 'https://deft.example',
+        NEXT_PUBLIC_API_URL: 'https://deft.example',
+      }),
+      /NEXT_PUBLIC_WS_URL is required/,
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- publish tagged amd64 preview images to GHCR with provenance, OCI SBOM, downloadable SPDX SBOM, checksums, and a release manifest
- add a release Compose overlay so users can install a named image without compiling the monorepo
- inject public app/API/WebSocket URLs into the compiled bundle at container startup so one image works on arbitrary domains
- document the fresh-install-only preview boundary

## Verification
- node --test scripts/inject-public-env.test.mjs
- pnpm --filter @deft/web typecheck
- docker compose release-overlay config validation
- production Docker build with placeholder URLs
- runtime injection check: 29 replacements across 21 compiled files, zero placeholders left
- isolated fresh Compose install from the candidate image
- selfhost doctor: all checks passed
- selfhost smoke: OAuth metadata, DCR, MCP initialize, and protected tools challenge passed

## Release boundary
This PR deliberately publishes linux/amd64 only and labels the preview fresh-install-only. Versioned upgrades remain separate work.