### PR TITLE
Harden guided MCP connection flows

### DIFF
--- a/apps/api/src/lib/oauth-mcp.ts
+++ b/apps/api/src/lib/oauth-mcp.ts
@@ -33,8 +33,16 @@ export const REMOTE_MCP_SCOPES = [
   ...REMOTE_MCP_WRITE_SCOPES,
 ] as const;
 
+// Authorization-only scope. It is advertised by the OAuth server, but not by
+// the MCP protected resource because it does not grant access to workspace data.
+export const REMOTE_MCP_AUTHORIZATION_SCOPES = [
+  ...REMOTE_MCP_SCOPES,
+  'offline_access',
+] as const;
+
 export type RemoteMcpScope = typeof REMOTE_MCP_SCOPES[number];
-export type ConnectorProfile = 'knowledge' | 'task-helper';
+type RemoteMcpAuthorizationScope = typeof REMOTE_MCP_AUTHORIZATION_SCOPES[number];
+export type ConnectorProfile = 'knowledge' | 'task-helper' | 'workspace-operator';
 
 export type OAuthAccessPrincipal = {
   kind: 'oauth';
@@ -70,12 +78,17 @@ export function randomToken(prefix: string): string {
 export function normalizeScopes(value: string | string[] | undefined | null): string[] {
   const raw = Array.isArray(value) ? value.join(' ') : value ?? '';
   const requested = raw.split(/\s+/).map((s) => s.trim()).filter(Boolean);
-  const allowed = new Set(REMOTE_MCP_SCOPES);
-  const scopes = requested.length > 0 ? requested.filter((s) => allowed.has(s as RemoteMcpScope)) : [...REMOTE_MCP_READ_SCOPES];
+  const allowed = new Set(REMOTE_MCP_AUTHORIZATION_SCOPES);
+  const scopes = requested.length > 0
+    ? requested.filter((s) => allowed.has(s as RemoteMcpAuthorizationScope))
+    : [...REMOTE_MCP_READ_SCOPES];
   return scopes.length > 0 ? Array.from(new Set(scopes)) : [...REMOTE_MCP_READ_SCOPES];
 }
 
 export function profileForScopes(scopes: string[]): ConnectorProfile {
+  if (scopes.includes('write:workspace') || scopes.includes('write:calendar')) {
+    return 'workspace-operator';
+  }
   return scopes.some((scope) => REMOTE_MCP_WRITE_SCOPES.includes(scope as typeof REMOTE_MCP_WRITE_SCOPES[number]))
     ? 'task-helper'
     : 'knowledge';

--- a/apps/api/src/lib/public-url.ts
+++ b/apps/api/src/lib/public-url.ts
@@ -20,7 +20,6 @@ export function oauthIssuerUrl(): string {
   return apiPublicUrl();
 }
 
-export function isHttpsPublicUrl(): boolean {
-  const url = apiPublicUrl();
-  return url.startsWith('https://') || url.startsWith('http://localhost') || url.startsWith('http://127.0.0.1');
+export function isHttpsPublicUrl(url = apiPublicUrl()): boolean {
+  return url.startsWith('https://');
 }

--- a/apps/api/src/routes/oauth-mcp.ts
+++ b/apps/api/src/routes/oauth-mcp.ts
@@ -5,6 +5,7 @@ import { db } from '../lib/db.js';
 import { oauthClients, oauthGrants, oauthAccessTokens, oauthRefreshTokens, oauthAuditEvents } from '@deft/db/schema';
 import {
   OAuthMcpError,
+  REMOTE_MCP_AUTHORIZATION_SCOPES,
   REMOTE_MCP_SCOPES,
   auditOAuth,
   createAuthorizationCode,
@@ -87,7 +88,7 @@ oauthWellKnownRoutes.get('/oauth-authorization-server', (c) => {
     grant_types_supported: ['authorization_code', 'refresh_token'],
     code_challenge_methods_supported: ['S256'],
     token_endpoint_auth_methods_supported: ['none'],
-    scopes_supported: REMOTE_MCP_SCOPES,
+    scopes_supported: REMOTE_MCP_AUTHORIZATION_SCOPES,
   });
 });
 
@@ -194,7 +195,7 @@ oauthProtectedRoutes.get('/readiness', async (c) => {
     authorization_server_metadata: urls.authorizationServerMetadata,
     https_ready: isHttpsPublicUrl(),
     scopes: REMOTE_MCP_SCOPES,
-    profiles: ['knowledge', 'task-helper'],
+    profiles: ['knowledge', 'task-helper', 'workspace-operator'],
   });
 });
 

--- a/apps/api/test/mcp-operational-headless-contract.test.ts
+++ b/apps/api/test/mcp-operational-headless-contract.test.ts
@@ -1,6 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { REMOTE_MCP_SCOPES, normalizeScopes } from '../src/lib/oauth-mcp.js';
+import { REMOTE_MCP_SCOPES, normalizeScopes, profileForScopes } from '../src/lib/oauth-mcp.js';
+import { isHttpsPublicUrl } from '../src/lib/public-url.js';
 import {
   HUMAN_READ_TOOLS,
   HUMAN_TOOL_SCOPES,
@@ -58,6 +59,16 @@ test('operational headless scopes are accepted without weakening default read gr
     'write:calendar',
     'write:workspace',
   ]);
+  assert.equal(profileForScopes(['read:workspace']), 'knowledge');
+  assert.equal(profileForScopes(['read:workspace', 'write:tasks']), 'task-helper');
+  assert.equal(profileForScopes(['read:workspace', 'write:calendar']), 'workspace-operator');
+  assert.equal(profileForScopes(['read:workspace', 'write:workspace']), 'workspace-operator');
+});
+
+test('hosted connector readiness requires a real HTTPS public URL', () => {
+  assert.equal(isHttpsPublicUrl('http://localhost:3301'), false);
+  assert.equal(isHttpsPublicUrl('http://127.0.0.1:3301'), false);
+  assert.equal(isHttpsPublicUrl('https://deft.example.com'), true);
 });
 
 test('every operational tool is registered, classified, and advertised once', () => {

--- a/apps/api/test/oauth-mcp.test.ts
+++ b/apps/api/test/oauth-mcp.test.ts
@@ -97,6 +97,7 @@ async function cleanup() {
     await client.query(`DELETE FROM task_comments WHERE org_id = $1`, [ORG_ID]);
     await client.query(`DELETE FROM task_activity WHERE org_id = $1`, [ORG_ID]);
     await client.query(`DELETE FROM saved_views WHERE org_id = $1`, [ORG_ID]);
+    await client.query(`DELETE FROM agent_nudges WHERE task_id IN (SELECT id FROM tasks WHERE org_id = $1)`, [ORG_ID]);
     await client.query(`DELETE FROM tasks WHERE org_id = $1`, [ORG_ID]);
     await client.query(`DELETE FROM projects WHERE org_id = $1`, [ORG_ID]);
     await client.query(`DELETE FROM wiki_citations WHERE org_id = $1`, [ORG_ID]);
@@ -415,6 +416,7 @@ test('OAuth metadata and dynamic client registration describe the remote MCP con
   assert.equal(protectedBody.resource, 'http://localhost:3301/api/mcp/v1');
   assert.ok(protectedBody.authorization_servers.includes('http://localhost:3301'));
   assert.ok(protectedBody.scopes_supported.includes('write:wiki'));
+  assert.equal(protectedBody.scopes_supported.includes('offline_access'), false);
 
   const authServer = await testApp.request('/.well-known/oauth-authorization-server');
   assert.equal(authServer.status, 200);
@@ -422,6 +424,7 @@ test('OAuth metadata and dynamic client registration describe the remote MCP con
   assert.equal(authBody.registration_endpoint, 'http://localhost:3301/oauth/register');
   assert.equal(authBody.authorization_endpoint, 'http://localhost:3012/oauth/authorize');
   assert.ok(authBody.scopes_supported.includes('write:wiki'));
+  assert.ok(authBody.scopes_supported.includes('offline_access'));
 
   const client = await registerClient();
   assert.ok(client.client_id.startsWith('deft_dcr_'));
@@ -436,6 +439,15 @@ test('OAuth metadata and dynamic client registration describe the remote MCP con
   const wikiClient = (await wikiClientRes.json()) as { client_id: string; scope: string };
   assert.ok(wikiClient.client_id.startsWith('deft_dcr_'));
   assert.equal(wikiClient.scope, 'read:workspace read:wiki write:wiki');
+
+  const refreshClientRes = await jsonPost('/oauth/register', {
+    client_name: `OAuth MCP Refresh Client ${TEST_ID}`,
+    redirect_uris: ['http://localhost:3999/callback'],
+    scope: 'read:workspace offline_access',
+  });
+  assert.equal(refreshClientRes.status, 201);
+  const refreshClient = (await refreshClientRes.json()) as { scope: string };
+  assert.equal(refreshClient.scope, 'read:workspace offline_access');
 });
 
 test('OAuth PKCE token exchange resolves to a scoped human MCP principal', async () => {

--- a/apps/web/src/app/(app)/settings/mcp-access/page.tsx
+++ b/apps/web/src/app/(app)/settings/mcp-access/page.tsx
@@ -10,6 +10,7 @@ import {
   ChevronRight,
   Code2,
   Copy,
+  FileText,
   Globe2,
   History,
   KeyRound,
@@ -18,6 +19,7 @@ import {
   Settings2,
   ShieldCheck,
   Sparkles,
+  Terminal,
   Trash2,
   Wrench,
 } from 'lucide-react';
@@ -37,6 +39,7 @@ type McpToken = {
 
 const READ_SCOPES = ['read:workspace', 'read:wiki', 'read:tasks', 'read:messages', 'read:calendar'];
 const WRITE_SCOPES = ['write:tasks', 'write:messages', 'write:wiki', 'write:calendar', 'write:workspace'];
+const COLLABORATE_SCOPES = [...READ_SCOPES, 'write:tasks', 'write:messages', 'write:wiki'];
 const ALL_SCOPES = [...READ_SCOPES, ...WRITE_SCOPES];
 
 const SCOPE_LABELS: Record<string, string> = {
@@ -52,8 +55,8 @@ const SCOPE_LABELS: Record<string, string> = {
   'write:workspace': 'Manage your notes, inbox, approvals, projects, and agent operations',
 };
 
-type ClientId = 'codex' | 'claude-code' | 'claude-desktop' | 'remote-web' | 'custom' | 'agent-employee';
-type AccessPreset = 'read' | 'work' | 'custom';
+type ClientId = 'codex' | 'claude-code' | 'claude-desktop' | 'remote-web' | 'headless' | 'custom' | 'agent-employee';
+type AccessPreset = 'read' | 'work' | 'operate' | 'custom';
 
 type ClientOption = {
   id: ClientId;
@@ -95,12 +98,21 @@ const CLIENT_OPTIONS: ClientOption[] = [
   },
   {
     id: 'remote-web',
-    name: 'ChatGPT / other web apps',
-    fit: 'Remote connector path',
-    detail: 'Use this when a hosted AI app asks for a public MCP URL, OAuth metadata, or a custom connector.',
+    name: 'ChatGPT / hosted AI apps',
+    fit: 'Remote OAuth app',
+    detail: 'Create a custom app in ChatGPT or another hosted client using Deft\'s public MCP URL and OAuth discovery.',
     setupKind: 'oauth',
     defaultPreset: 'read',
     tokenName: 'Remote AI app',
+  },
+  {
+    id: 'headless',
+    name: 'Headless / automation',
+    fit: 'Full workspace operation',
+    detail: 'For scripts and AI clients that operate notes, inbox, approvals, projects, calendar, and agent state without opening Deft.',
+    setupKind: 'token',
+    defaultPreset: 'operate',
+    tokenName: 'Headless operator',
   },
   {
     id: 'custom',
@@ -125,29 +137,60 @@ const CLIENT_OPTIONS: ClientOption[] = [
 const PRESETS: Array<{ id: AccessPreset; title: string; detail: string; scopes: string[] }> = [
   {
     id: 'read',
-    title: 'Read-only assistant',
+    title: 'Read and answer',
     detail: 'Can answer questions using visible workspace, task, chat, calendar, and wiki context.',
     scopes: READ_SCOPES,
   },
   {
     id: 'work',
-    title: 'Work-capable assistant',
-    detail: 'Can read context and do work as you: create tasks, post messages, and update wiki knowledge.',
+    title: 'Collaborate in work',
+    detail: 'Can create and update tasks, post messages, and maintain wiki knowledge as you.',
+    scopes: COLLABORATE_SCOPES,
+  },
+  {
+    id: 'operate',
+    title: 'Operate the workspace',
+    detail: 'Adds calendar writes plus notes, inbox, approvals, projects, and agent operations for headless use.',
     scopes: ALL_SCOPES,
   },
   {
     id: 'custom',
-    title: 'Custom scopes',
-    detail: 'Choose exact MCP scopes. Best for self-hosted admins and unusual clients.',
+    title: 'Choose individually',
+    detail: 'Turn each read and write permission on or off yourself.',
     scopes: READ_SCOPES,
   },
 ];
 
-const TEST_PROMPTS = [
+const CONTEXT_PACKET_CARDS = [
+  {
+    title: 'Company memory',
+    detail: 'Org-wide wiki knowledge the AI app can use across projects and channels.',
+  },
+  {
+    title: 'Channel memory',
+    detail: 'Knowledge created in, cited from, or scoped to the space where the work is happening.',
+  },
+  {
+    title: 'Personal memory',
+    detail: 'Private notes and memories scoped to the connected human user.',
+  },
+];
+
+const READ_TEST_PROMPTS = [
   'Check my unread messages and tell me what needs my attention.',
   'List my open tasks, find blockers, and suggest the next action.',
   'Search wiki for launch blockers, then summarize what changed recently.',
+  'Show me which Deft capabilities and tools this connection can use.',
+];
+
+const COLLABORATE_TEST_PROMPTS = [
   'Create a follow-up task from this discussion, post an update, and show me the receipt.',
+  'Update the relevant wiki page with this decision without creating a duplicate.',
+];
+
+const OPERATE_TEST_PROMPTS = [
+  'Review my inbox, approvals, tasks, and calendar, then give me one prioritized operating brief.',
+  'Create a calendar event for the agreed review, add a note with the agenda, and show me the receipts.',
 ];
 
 type RemoteReadiness = {
@@ -301,7 +344,7 @@ function clientById(id: ClientId) {
 function clientIcon(id: ClientId) {
   if (id === 'codex' || id === 'claude-code') return <Code2 size={16} />;
   if (id === 'claude-desktop' || id === 'remote-web') return <Globe2 size={16} />;
-  if (id === 'custom') return <Wrench size={16} />;
+  if (id === 'headless' || id === 'custom') return <Wrench size={16} />;
   return <Bot size={16} />;
 }
 
@@ -364,9 +407,20 @@ export default function McpAccessPage() {
   const selectedClientOption = clientById(selectedClient);
   const selectedScopes = useMemo(() => {
     if (accessPreset === 'read') return READ_SCOPES;
-    if (accessPreset === 'work') return ALL_SCOPES;
+    if (accessPreset === 'work') return COLLABORATE_SCOPES;
+    if (accessPreset === 'operate') return ALL_SCOPES;
     return customScopes;
   }, [accessPreset, customScopes]);
+  const testPrompts = useMemo(() => {
+    const prompts = [...READ_TEST_PROMPTS];
+    if (selectedScopes.some((scope) => ['write:tasks', 'write:messages', 'write:wiki'].includes(scope))) {
+      prompts.push(...COLLABORATE_TEST_PROMPTS);
+    }
+    if (selectedScopes.includes('write:workspace') || selectedScopes.includes('write:calendar')) {
+      prompts.push(...OPERATE_TEST_PROMPTS);
+    }
+    return prompts;
+  }, [selectedScopes]);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -494,17 +548,9 @@ export default function McpAccessPage() {
     }
     if (selectedClient === 'claude-code') {
       return {
-        title: 'Claude Code MCP JSON',
-        detail: 'Use this with Claude Code config or add-json. Do not paste bearer tokens into a Claude chat.',
-        value: JSON.stringify({
-          mcpServers: {
-            deft: {
-              type: 'http',
-              url: endpointForConfig,
-              headers: { Authorization: `Bearer ${tokenForConfig}` },
-            },
-          },
-        }, null, 2),
+        title: 'Claude Code CLI',
+        detail: 'Run this in a terminal. Then use /mcp in Claude Code to verify the connection. Do not paste the token into a Claude chat.',
+        value: `claude mcp add --transport http --scope user deft "${endpointForConfig}" --header "Authorization: Bearer ${tokenForConfig}"`,
       };
     }
     return {
@@ -528,17 +574,19 @@ export default function McpAccessPage() {
     ['Registration endpoint', remote?.registration_endpoint],
   ];
   const isClaudeConnector = selectedClient === 'claude-desktop';
+  const isChatGptConnector = selectedClient === 'remote-web';
   const remoteSteps = isClaudeConnector
     ? [
         'In Claude, open Settings or Customize -> Connectors. Do not paste MCP JSON or tokens into a chat.',
         'Add a custom connector and use the Connector URL below.',
-        'Click Connect in Claude. Deft will handle OAuth and scope approval.',
+        'Click Connect in Claude. On the Deft approval screen, choose the exact read and write permissions before allowing access.',
         'Enable the connector for the chat where Claude should use Deft tools.',
       ]
     : [
-        'Open the AI app settings area for custom or remote MCP connectors.',
-        'Add the Connector URL below, then follow the app\'s OAuth sign-in flow.',
-        'Use the metadata links only if the app asks for discovery or OAuth details.',
+        'In ChatGPT web, enable developer mode for an eligible account, then open Settings -> Apps -> Create.',
+        'Use the Connector URL below and choose OAuth authentication. Deft publishes the discovery metadata automatically.',
+        'Click Scan Tools, complete the Deft authorization screen, and choose the exact read and write permissions.',
+        'Create the draft app, enable it in a new chat, and confirm a read before trying a write action.',
       ];
   const claudeConnectorFields = [
     {
@@ -568,7 +616,7 @@ export default function McpAccessPage() {
   return (
     <div className="flex h-full min-w-0 flex-col overflow-x-hidden overflow-y-auto">
       <PageHeader
-        title="Connections"
+        title="AI App Connections"
         description="Connect Codex, Claude, ChatGPT, or any MCP client to your Deft workspace."
         secondary={
           <TabStrip>
@@ -595,175 +643,177 @@ export default function McpAccessPage() {
           </div>
         )}
 
-        {!loading && (tokens.length > 0 || grants.length > 0) && (
-          <section className="flex min-w-0 items-center justify-between gap-3 rounded-lg p-3 sm:p-4" style={{ background: 'var(--surface-container-low)', border: '1px solid var(--border-default)' }}>
-            <div className="min-w-0">
-              <div className="flex items-center gap-2 text-[13px] font-semibold" style={{ color: 'var(--text-primary)' }}>
-                <Check size={14} style={{ color: 'var(--status-green, #10b981)' }} />
-                {tokens.length + grants.length} active connection{tokens.length + grants.length === 1 ? '' : 's'}
+        <section className="rounded-lg p-4" style={{ background: 'var(--surface-container-low)', border: '1px solid var(--border-default)' }}>
+          <div className="flex flex-col gap-4">
+            <div className="flex items-start gap-3">
+              <div className="w-8 h-8 rounded-md flex items-center justify-center shrink-0" style={{ background: 'var(--accent-muted)', color: 'var(--accent)' }}>
+                <Sparkles size={16} />
               </div>
-              <p className="mt-1 hidden truncate text-[11px] sm:block" style={{ color: 'var(--text-secondary)' }}>Review last use, scopes, or revoke access below.</p>
-            </div>
-            <a href="#active-connections" className="deft-pill shrink-0" style={{ color: 'var(--accent)', border: '1px solid var(--border-default)' }}>Manage</a>
-          </section>
-        )}
-
-        <section className="min-w-0 overflow-hidden rounded-lg" style={{ background: 'var(--surface-container-low)', border: '1px solid var(--border-default)' }}>
-          <div className="flex flex-col gap-4 p-4 md:p-5" style={{ borderBottom: '1px solid var(--border-default)' }}>
-            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-              <div className="flex items-start gap-3">
-                <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md" style={{ background: 'var(--accent-muted)', color: 'var(--accent)' }}>
-                  <Sparkles size={16} />
-                </div>
-                <div>
-                  <h2 className="text-[15px] font-semibold" style={{ color: 'var(--text-primary)' }}>Connect an AI app</h2>
-                  <p className="mt-1 text-[12px]" style={{ color: 'var(--text-secondary)' }}>Choose an app. Deft will only show the setup it needs.</p>
-                </div>
+              <div>
+                <h2 className="text-[15px] font-semibold" style={{ color: 'var(--text-primary)' }}>What do you want to connect?</h2>
+                <p className="text-[12px] mt-1" style={{ color: 'var(--text-secondary)' }}>
+                  Pick the app first. Deft will show the right connection path instead of making you sort through every MCP detail.
+                </p>
               </div>
-              <Link href="/settings/agent-employees" className="inline-flex items-center gap-1.5 self-start text-[12px] font-medium" style={{ color: 'var(--accent)' }}>
-                Need a shared agent employee? <ChevronRight size={13} />
-              </Link>
             </div>
 
-            <div className="-mx-1 flex gap-2 overflow-x-auto px-1 pb-1">
-              {CLIENT_OPTIONS.filter((client) => client.id !== 'agent-employee').map((client) => {
+            <div className="grid md:grid-cols-2 xl:grid-cols-3 gap-3">
+              {CLIENT_OPTIONS.map((client) => {
                 const active = client.id === selectedClient;
                 return (
                   <button
                     key={client.id}
                     type="button"
                     onClick={() => chooseClient(client.id)}
-                    className="deft-pill shrink-0 gap-2 transition-colors"
+                    className="rounded-md p-3 text-left transition-colors"
                     style={{
-                      background: active ? 'var(--accent)' : 'var(--surface-container)',
+                      background: active ? 'color-mix(in srgb, var(--accent) 12%, var(--surface-container))' : 'var(--surface-container)',
                       border: active ? '1px solid var(--accent)' : '1px solid var(--border-default)',
-                      color: active ? 'white' : 'var(--text-secondary)',
                     }}
-                    aria-pressed={active}
                   >
-                    {clientIcon(client.id)}
-                    {client.name}
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="flex items-center gap-2 min-w-0">
+                        <span className="w-7 h-7 rounded-md flex items-center justify-center shrink-0" style={{ background: active ? 'var(--accent-muted)' : 'var(--surface-container-low)', color: active ? 'var(--accent)' : 'var(--text-secondary)' }}>
+                          {clientIcon(client.id)}
+                        </span>
+                        <span className="text-[13px] font-semibold truncate" style={{ color: 'var(--text-primary)' }}>{client.name}</span>
+                      </div>
+                      <span className="text-[10px] rounded px-1.5 py-0.5 shrink-0" style={{ color: active ? 'var(--accent)' : 'var(--text-tertiary)', border: '1px solid var(--border-default)' }}>{client.fit}</span>
+                    </div>
+                    <p className="text-[11px] mt-3 leading-relaxed" style={{ color: 'var(--text-secondary)' }}>{client.detail}</p>
                   </button>
                 );
               })}
             </div>
           </div>
+        </section>
 
-          <div className="p-4 md:p-5">
-            <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-              <div className="flex min-w-0 items-start gap-3">
-                <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md" style={{ background: 'var(--accent-muted)', color: 'var(--accent)' }}>
-                  {clientIcon(selectedClient)}
-                </span>
-                <div className="min-w-0">
-                  <div className="flex flex-wrap items-center gap-2">
-                    <h3 className="text-[16px] font-semibold" style={{ color: 'var(--text-primary)' }}>{selectedClientOption.name}</h3>
-                    <span className="rounded-full px-2 py-0.5 text-[10px]" style={{ background: 'var(--surface-container)', color: 'var(--text-tertiary)', border: '1px solid var(--border-default)' }}>{selectedClientOption.fit}</span>
+        <div className="grid lg:grid-cols-[1.05fr_.95fr] gap-4 items-start">
+          <div className="space-y-4">
+            {tokenSetupClient && (
+              <section className="rounded-lg p-4" style={{ background: 'var(--surface-container-low)', border: '1px solid var(--border-default)' }}>
+                <div className="flex items-start gap-3">
+                  <div className="w-8 h-8 rounded-md flex items-center justify-center shrink-0" style={{ background: 'var(--accent-muted)', color: 'var(--accent)' }}>
+                    <ShieldCheck size={16} />
                   </div>
-                  <p className="mt-1 max-w-2xl text-[12px]" style={{ color: 'var(--text-secondary)' }}>{selectedClientOption.detail}</p>
+                  <div className="flex-1 min-w-0">
+                    <h2 className="text-[15px] font-semibold" style={{ color: 'var(--text-primary)' }}>Choose what {selectedClientOption.name} can do</h2>
+                    <p className="text-[12px] mt-1" style={{ color: 'var(--text-secondary)' }}>
+                      Personal MCP tokens act as you. The app can only see what you can see, and every write is recorded under your name.
+                    </p>
+
+                    <div className="grid sm:grid-cols-2 gap-3 mt-4">
+                      {PRESETS.map((preset) => {
+                        const active = preset.id === accessPreset;
+                        return (
+                          <button
+                            key={preset.id}
+                            type="button"
+                            onClick={() => setAccessPreset(preset.id)}
+                            className="rounded-md p-3 text-left"
+                            style={{
+                              background: active ? 'color-mix(in srgb, var(--accent) 12%, var(--surface-container))' : 'var(--surface-container)',
+                              border: active ? '1px solid var(--accent)' : '1px solid var(--border-default)',
+                            }}
+                          >
+                            <div className="text-[13px] font-medium" style={{ color: 'var(--text-primary)' }}>{preset.title}</div>
+                            <p className="text-[11px] mt-1 leading-relaxed" style={{ color: 'var(--text-secondary)' }}>{preset.detail}</p>
+                          </button>
+                        );
+                      })}
+                    </div>
+
+                    {accessPreset === 'custom' && (
+                      <div className="grid sm:grid-cols-2 gap-2 mt-3">
+                        {ALL_SCOPES.map((scope) => (
+                          <label key={scope} className="flex items-start gap-2 rounded-md p-2.5 text-[11px]" style={{ background: 'var(--surface-container)', color: 'var(--text-secondary)', border: '1px solid var(--border-default)' }}>
+                            <input
+                              type="checkbox"
+                              checked={customScopes.includes(scope)}
+                              onChange={() => toggleCustomScope(scope)}
+                              className="mt-0.5"
+                            />
+                            <span>
+                              <span className="font-medium" style={{ color: 'var(--text-primary)' }}>{scope}</span>
+                              <span> - {SCOPE_LABELS[scope]}</span>
+                            </span>
+                          </label>
+                        ))}
+                      </div>
+                    )}
+
+                    <div className="flex flex-wrap gap-1.5 mt-3">
+                      {selectedScopes.map((scope) => <ScopePill key={scope} scope={scope} />)}
+                    </div>
+                  </div>
                 </div>
-              </div>
-              <div className="flex shrink-0 items-center gap-1 text-[11px]" style={{ color: 'var(--text-tertiary)' }}>
-                <span className="flex h-5 w-5 items-center justify-center rounded-full text-white" style={{ background: 'var(--accent)' }}><Check size={11} /></span>
-                App
-                <span className="mx-1 h-px w-5" style={{ background: 'var(--border-default)' }} />
-                <span className="flex h-5 w-5 items-center justify-center rounded-full" style={{ border: '1px solid var(--border-default)', color: 'var(--text-secondary)' }}>2</span>
-                {tokenSetupClient ? 'Access' : 'Setup'}
-                <span className="mx-1 h-px w-5" style={{ background: 'var(--border-default)' }} />
-                <span className="flex h-5 w-5 items-center justify-center rounded-full" style={{ border: '1px solid var(--border-default)', color: 'var(--text-secondary)' }}>3</span>
-                Connect
-              </div>
-            </div>
+              </section>
+            )}
 
             {tokenSetupClient && (
-              <div className="mt-5 grid min-w-0 gap-6 lg:grid-cols-[minmax(0,.85fr)_minmax(0,1.15fr)]">
-                <div className="min-w-0 lg:pr-6" style={{ borderColor: 'var(--border-default)' }}>
-                  <div className="flex items-center gap-2">
-                    <ShieldCheck size={14} style={{ color: 'var(--accent)' }} />
-                    <h4 className="text-[13px] font-semibold" style={{ color: 'var(--text-primary)' }}>2. Choose access</h4>
+              <section className="rounded-lg p-4" style={{ background: 'var(--surface-container-low)', border: '1px solid var(--border-default)' }}>
+                <div className="flex items-start gap-3">
+                  <div className="w-8 h-8 rounded-md flex items-center justify-center shrink-0" style={{ background: 'var(--accent-muted)', color: 'var(--accent)' }}>
+                    <KeyRound size={16} />
                   </div>
-                  <p className="mt-1 text-[11px]" style={{ color: 'var(--text-secondary)' }}>This connection acts as you and can only reach work you can access.</p>
-                  <div className="mt-3 divide-y" style={{ borderColor: 'var(--border-default)' }}>
-                    {PRESETS.map((preset) => {
-                      const active = preset.id === accessPreset;
-                      return (
-                        <button key={preset.id} type="button" onClick={() => setAccessPreset(preset.id)} className="flex w-full items-start gap-3 py-3 text-left">
-                          <span className="mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-full" style={{ border: active ? '4px solid var(--accent)' : '1px solid var(--border-strong, var(--border-default))' }} />
-                          <span>
-                            <span className="block text-[12px] font-medium" style={{ color: 'var(--text-primary)' }}>{preset.title}</span>
-                            <span className="mt-0.5 block text-[11px] leading-relaxed" style={{ color: 'var(--text-secondary)' }}>{preset.detail}</span>
-                          </span>
-                        </button>
-                      );
-                    })}
-                  </div>
-
-                  {accessPreset === 'custom' ? (
-                    <div className="mt-3 grid gap-2 sm:grid-cols-2 lg:grid-cols-1 xl:grid-cols-2">
-                      {ALL_SCOPES.map((scope) => (
-                        <label key={scope} className="flex items-start gap-2 rounded-md p-2.5 text-[11px]" style={{ background: 'var(--surface-container)', color: 'var(--text-secondary)', border: '1px solid var(--border-default)' }}>
-                          <input type="checkbox" checked={customScopes.includes(scope)} onChange={() => toggleCustomScope(scope)} className="mt-0.5" />
-                          <span><span className="font-medium" style={{ color: 'var(--text-primary)' }}>{scope}</span><span> - {SCOPE_LABELS[scope]}</span></span>
-                        </label>
-                      ))}
-                    </div>
-                  ) : (
-                    <button type="button" onClick={() => setAccessPreset('custom')} className="mt-3 text-[11px] font-medium" style={{ color: 'var(--accent)' }}>
-                      Review individual scopes
-                    </button>
-                  )}
-                </div>
-
-                <div className="min-w-0 border-t pt-5 lg:border-l lg:border-t-0 lg:pl-6 lg:pt-0" style={{ borderColor: 'var(--border-default)' }}>
-                  <div className="flex items-center gap-2">
-                    <KeyRound size={14} style={{ color: 'var(--accent)' }} />
-                    <h4 className="text-[13px] font-semibold" style={{ color: 'var(--text-primary)' }}>3. Create connection</h4>
-                  </div>
-                  <p className="mt-1 text-[11px]" style={{ color: 'var(--text-secondary)' }}>Create one token for this app. The config appears after the token is generated.</p>
-                  <label className="mt-4 block">
-                    <span className="mb-1.5 block text-[11px] font-medium" style={{ color: 'var(--text-secondary)' }}>Connection name</span>
-                    <div className="flex flex-col gap-2 sm:flex-row">
-                      <input value={tokenName} onChange={(event) => setTokenName(event.target.value)} className="h-10 min-w-0 flex-1 rounded-md px-3 text-[13px] outline-none" style={{ background: 'var(--surface-container)', color: 'var(--text-primary)', border: '1px solid var(--border-default)' }} />
-                      <button type="button" disabled={busy || selectedScopes.length === 0} onClick={createToken} className="inline-flex h-10 items-center justify-center gap-2 rounded-full px-4 text-[13px] font-medium text-white disabled:opacity-50" style={{ background: 'var(--accent)' }}>
+                  <div className="flex-1 min-w-0">
+                    <h2 className="text-[15px] font-semibold" style={{ color: 'var(--text-primary)' }}>Create the connection</h2>
+                    <p className="text-[12px] mt-1" style={{ color: 'var(--text-secondary)' }}>
+                      Generate a token, copy the config for {selectedClientOption.name}, then test it from the AI app.
+                    </p>
+                    <div className="grid md:grid-cols-[1fr_auto] gap-3 mt-4">
+                      <input
+                        value={tokenName}
+                        onChange={(e) => setTokenName(e.target.value)}
+                        className="h-10 rounded-md px-3 text-[13px] outline-none"
+                        style={{ background: 'var(--surface-container)', color: 'var(--text-primary)', border: '1px solid var(--border-default)' }}
+                      />
+                      <button
+                        type="button"
+                        disabled={busy || selectedScopes.length === 0}
+                        onClick={createToken}
+                        className="inline-flex items-center justify-center gap-2 rounded-md px-3 py-2 text-[13px] font-medium text-white disabled:opacity-50"
+                        style={{ background: 'var(--accent)' }}
+                      >
                         {busy ? <Loader2 size={14} className="animate-spin" /> : <Plug size={14} />}
-                        {newToken ? 'Create another' : 'Generate token'}
+                        Generate token
                       </button>
                     </div>
-                  </label>
 
-                  {newToken ? (
-                    <div className="mt-4 space-y-3">
-                      <div className="rounded-md p-3" style={{ background: 'color-mix(in srgb, var(--accent) 8%, var(--surface-container))', border: '1px solid var(--accent)' }}>
+                    {newToken && (
+                      <div className="mt-4 rounded-md p-3" style={{ background: 'color-mix(in srgb, var(--accent) 8%, var(--surface-container))', border: '1px solid var(--accent)' }}>
                         <div className="flex items-center justify-between gap-3">
-                          <div><div className="text-[12px] font-semibold" style={{ color: 'var(--text-primary)' }}>Token ready</div><p className="text-[11px]" style={{ color: 'var(--text-secondary)' }}>Copy it now. Deft will not show it again.</p></div>
-                          <button type="button" onClick={() => copy('token', newToken)} className="inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-[11px] font-medium" style={{ background: 'var(--accent)', color: 'white' }}><Copy size={12} /> Copy token</button>
+                          <div>
+                            <div className="text-[13px] font-semibold" style={{ color: 'var(--text-primary)' }}>New token</div>
+                            <p className="text-[11px]" style={{ color: 'var(--text-secondary)' }}>Copy it now. Deft will not show it again.</p>
+                          </div>
+                          <button type="button" onClick={() => copy('token', newToken)} className="inline-flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-[12px]" style={{ border: '1px solid var(--border-default)', color: 'var(--text-primary)' }}>
+                            <Copy size={13} /> Copy
+                          </button>
                         </div>
-                        <pre className="mt-3 max-w-full overflow-x-auto rounded-md p-3 text-[11px]" style={{ background: 'var(--surface-container)', color: 'var(--text-primary)' }}>{newToken}</pre>
+                        <pre className="mt-3 overflow-x-auto rounded-md p-3 text-[11px]" style={{ background: 'var(--surface-container)', color: 'var(--text-primary)' }}>{newToken}</pre>
                       </div>
-                      <div className="rounded-md p-3" style={{ background: 'var(--surface-container)', border: '1px solid var(--border-default)' }}>
-                        <div className="flex items-start justify-between gap-3">
-                          <div><div className="text-[12px] font-semibold" style={{ color: 'var(--text-primary)' }}>{selectedSnippet.title}</div><p className="mt-1 text-[11px]" style={{ color: 'var(--text-secondary)' }}>{selectedSnippet.detail}</p></div>
-                          <button type="button" onClick={() => copy(selectedSnippet.title.toLowerCase(), selectedSnippet.value)} className="shrink-0 rounded-md p-1.5" style={{ color: 'var(--text-secondary)', border: '1px solid var(--border-default)' }} aria-label={`Copy ${selectedSnippet.title}`}><Copy size={13} /></button>
+                    )}
+
+                    <div className="mt-4 rounded-md p-3" style={{ background: 'var(--surface-container)', border: '1px solid var(--border-default)' }}>
+                      <div className="flex items-start justify-between gap-3">
+                        <div>
+                          <div className="text-[13px] font-semibold" style={{ color: 'var(--text-primary)' }}>{selectedSnippet.title}</div>
+                          <p className="text-[11px] mt-1" style={{ color: 'var(--text-secondary)' }}>{selectedSnippet.detail}</p>
                         </div>
-                        <pre className="mt-3 max-h-56 max-w-full overflow-x-auto rounded-md p-3 text-[11px]" style={{ background: 'var(--surface-container-high, var(--surface-container-low))', color: 'var(--text-primary)' }}>{selectedSnippet.value}</pre>
+                        <button type="button" onClick={() => copy(selectedSnippet.title.toLowerCase(), selectedSnippet.value)} className="p-1.5 rounded-md shrink-0" style={{ color: 'var(--text-secondary)', border: '1px solid var(--border-default)' }} aria-label={`Copy ${selectedSnippet.title}`}>
+                          <Copy size={13} />
+                        </button>
                       </div>
-                      <div className="flex items-start justify-between gap-3 rounded-md px-3 py-2.5" style={{ background: 'var(--surface-container)' }}>
-                        <div className="min-w-0"><div className="text-[11px] font-medium" style={{ color: 'var(--text-primary)' }}>Test the connection</div><p className="mt-0.5 truncate text-[11px]" style={{ color: 'var(--text-secondary)' }}>{TEST_PROMPTS[0]}</p></div>
-                        <button type="button" onClick={() => copy('test prompt', TEST_PROMPTS[0])} className="shrink-0 rounded-md p-1.5" style={{ color: 'var(--text-secondary)' }} aria-label="Copy test prompt"><Copy size={13} /></button>
-                      </div>
+                      <pre className="mt-3 overflow-x-auto rounded-md p-3 text-[11px] max-h-56" style={{ background: 'var(--surface-container-high, var(--surface-container-low))', color: 'var(--text-primary)' }}>{selectedSnippet.value}</pre>
                     </div>
-                  ) : (
-                    <div className="mt-4 flex items-start gap-3 rounded-md px-3 py-3" style={{ background: 'var(--surface-container)' }}>
-                      <ShieldCheck size={15} className="mt-0.5 shrink-0" style={{ color: 'var(--text-tertiary)' }} />
-                      <p className="text-[11px] leading-relaxed" style={{ color: 'var(--text-secondary)' }}>Your token and ready-to-copy {selectedClientOption.name} config will appear here. Every use is recorded in connection activity below.</p>
-                    </div>
-                  )}
+                  </div>
                 </div>
-              </div>
+              </section>
             )}
 
             {selectedClientOption.setupKind === 'oauth' && (
-              <div className="mt-5 border-t pt-5" style={{ borderColor: 'var(--border-default)' }}>
+              <section className="rounded-lg p-4" style={{ background: 'var(--surface-container-low)', border: '1px solid var(--border-default)' }}>
                 <div className="flex items-start gap-3">
                   <div className="w-8 h-8 rounded-md flex items-center justify-center shrink-0" style={{ background: 'var(--accent-muted)', color: 'var(--accent)' }}>
                     <Globe2 size={16} />
@@ -772,12 +822,12 @@ export default function McpAccessPage() {
                     <div className="flex items-start justify-between gap-3">
                       <div>
                         <h2 className="text-[15px] font-semibold" style={{ color: 'var(--text-primary)' }}>
-                          {isClaudeConnector ? 'Claude connector setup' : 'Remote connector setup'}
+                          {isClaudeConnector ? 'Claude connector setup' : 'ChatGPT custom app setup'}
                         </h2>
                         <p className="text-[12px] mt-1" style={{ color: 'var(--text-secondary)' }}>
                           {isClaudeConnector
                             ? 'Claude connectors are added from Claude settings at the account level. The URL/token cannot be pasted into an active chat and expected to work.'
-                            : 'Use this path only when the hosted AI app asks for a remote MCP connector or OAuth metadata. For Codex and Claude Code, token setup is more direct.'}
+                            : 'ChatGPT connects from OpenAI cloud, so Deft must be publicly reachable over HTTPS. The app uses Deft OAuth; do not paste a personal token into ChatGPT.'}
                         </p>
                       </div>
                       <span className="text-[11px] rounded-md px-2 py-1 shrink-0" style={{ background: remote?.https_ready ? 'var(--accent-muted)' : 'var(--surface-container)', color: remote?.https_ready ? 'var(--accent)' : 'var(--text-tertiary)', border: '1px solid var(--border-default)' }}>
@@ -800,6 +850,11 @@ export default function McpAccessPage() {
                     <div className="mt-3 rounded-md p-3 text-[11px] leading-relaxed" style={{ background: 'var(--surface-container)', color: 'var(--text-secondary)', border: '1px solid var(--border-default)' }}>
                       <strong style={{ color: 'var(--text-primary)' }}>Security note:</strong> never paste a live bearer token into Claude, ChatGPT, or any AI chat. If you already did, revoke that personal token below and generate a fresh one. Remote Claude connectors should authenticate through Deft OAuth.
                     </div>
+                    {isChatGptConnector && (
+                      <div className="mt-3 rounded-md p-3 text-[11px] leading-relaxed" style={{ background: 'var(--surface-container)', color: 'var(--text-secondary)', border: '1px solid var(--border-default)' }}>
+                        <strong style={{ color: 'var(--text-primary)' }}>ChatGPT availability:</strong> full read/write custom MCP apps currently require Business or Enterprise/Edu on ChatGPT web. Pro developer mode is limited to read/fetch access. Workspace admin or developer-mode controls may also apply.
+                      </div>
+                    )}
                     {isClaudeConnector && (
                       <div className="mt-4 rounded-md p-3" style={{ background: 'var(--surface-container)', border: '1px solid var(--border-default)' }}>
                         <div className="text-[12px] font-semibold" style={{ color: 'var(--text-primary)' }}>Fill Claude's four fields like this</div>
@@ -823,33 +878,31 @@ export default function McpAccessPage() {
                         </div>
                       </div>
                     )}
-                    {!isClaudeConnector && (
-                      <div className="grid md:grid-cols-2 gap-3 mt-4">
-                        {remoteRows.slice(0, 3).map(([label, value]) => (
-                          <div key={label} className="rounded-md p-3 min-w-0" style={{ background: 'var(--surface-container)', border: '1px solid var(--border-default)' }}>
-                            <div className="text-[11px] font-medium uppercase tracking-wide" style={{ color: 'var(--text-tertiary)' }}>{label}</div>
-                            <div className="mt-1 flex items-center gap-2 min-w-0">
-                              <code className="text-[11px] truncate flex-1" style={{ color: 'var(--text-primary)' }}>{value ?? 'Not loaded'}</code>
-                              {value && (
-                                <button type="button" onClick={() => copy(label.toLowerCase(), value)} className="p-1 rounded-md" style={{ color: 'var(--text-secondary)' }} aria-label={`Copy ${label}`}>
-                                  <Copy size={13} />
-                                </button>
-                              )}
-                            </div>
+                    <div className="grid md:grid-cols-2 gap-3 mt-4">
+                      {remoteRows.slice(0, 3).map(([label, value]) => (
+                        <div key={label} className="rounded-md p-3 min-w-0" style={{ background: 'var(--surface-container)', border: '1px solid var(--border-default)' }}>
+                          <div className="text-[11px] font-medium uppercase tracking-wide" style={{ color: 'var(--text-tertiary)' }}>{label}</div>
+                          <div className="mt-1 flex items-center gap-2 min-w-0">
+                            <code className="text-[11px] truncate flex-1" style={{ color: 'var(--text-primary)' }}>{value ?? 'Not loaded'}</code>
+                            {value && (
+                              <button type="button" onClick={() => copy(label.toLowerCase(), value)} className="p-1 rounded-md" style={{ color: 'var(--text-secondary)' }} aria-label={`Copy ${label}`}>
+                                <Copy size={13} />
+                              </button>
+                            )}
                           </div>
-                        ))}
-                      </div>
-                    )}
+                        </div>
+                      ))}
+                    </div>
                     <button type="button" onClick={() => setAdvancedOpen(true)} className="mt-3 inline-flex items-center gap-1.5 text-[12px]" style={{ color: 'var(--accent)' }}>
                       <Settings2 size={13} /> Show all OAuth endpoints
                     </button>
                   </div>
                 </div>
-              </div>
+              </section>
             )}
 
             {selectedClientOption.setupKind === 'agent' && (
-              <div className="mt-5 border-t pt-5" style={{ borderColor: 'var(--border-default)' }}>
+              <section className="rounded-lg p-4" style={{ background: 'var(--surface-container-low)', border: '1px solid var(--border-default)' }}>
                 <div className="flex items-start gap-3">
                   <div className="w-8 h-8 rounded-md flex items-center justify-center shrink-0" style={{ background: 'var(--accent-muted)', color: 'var(--accent)' }}>
                     <Bot size={16} />
@@ -864,12 +917,51 @@ export default function McpAccessPage() {
                     </Link>
                   </div>
                 </div>
-              </div>
+              </section>
             )}
           </div>
-        </section>
 
-        <section id="active-connections" className="min-w-0 scroll-mt-4 rounded-lg p-4" style={{ background: 'var(--surface-container-low)', border: '1px solid var(--border-default)' }}>
+          <aside className="space-y-4">
+            <section className="rounded-lg p-4" style={{ background: 'var(--surface-container-low)', border: '1px solid var(--border-default)' }}>
+              <div className="flex items-start gap-3">
+                <div className="w-8 h-8 rounded-md flex items-center justify-center shrink-0" style={{ background: 'var(--accent-muted)', color: 'var(--accent)' }}>
+                  <Terminal size={16} />
+                </div>
+                <div className="flex-1 min-w-0">
+                  <h2 className="text-[14px] font-semibold" style={{ color: 'var(--text-primary)' }}>Test it from the app</h2>
+                  <p className="text-[12px] mt-1" style={{ color: 'var(--text-secondary)' }}>
+                    After connecting, run one prompt and check that recent activity updates below.
+                  </p>
+                  <div className="mt-3 space-y-2">
+                    {testPrompts.map((prompt) => (
+                      <div key={prompt} className="flex items-start gap-2 rounded-md p-2" style={{ background: 'var(--surface-container)', border: '1px solid var(--border-default)' }}>
+                        <FileText size={13} className="mt-0.5 shrink-0" style={{ color: 'var(--text-tertiary)' }} />
+                        <span className="text-[11px] leading-relaxed" style={{ color: 'var(--text-secondary)' }}>{prompt}</span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            </section>
+
+            <section className="rounded-lg p-4" style={{ background: 'var(--surface-container-low)', border: '1px solid var(--border-default)' }}>
+              <h2 className="text-[14px] font-semibold" style={{ color: 'var(--text-primary)' }}>Context packets available</h2>
+              <p className="text-[12px] mt-1" style={{ color: 'var(--text-secondary)' }}>Connected clients can retrieve the right memory packet for the work they are doing.</p>
+              <div className="space-y-2 mt-3">
+                {CONTEXT_PACKET_CARDS.map((card) => (
+                  <div key={card.title} className="rounded-md p-3" style={{ background: 'var(--surface-container)', border: '1px solid var(--border-default)' }}>
+                    <div className="flex items-center gap-2 text-[12px] font-medium" style={{ color: 'var(--text-primary)' }}>
+                      <FileText size={13} /> {card.title}
+                    </div>
+                    <p className="text-[11px] mt-1 leading-relaxed" style={{ color: 'var(--text-secondary)' }}>{card.detail}</p>
+                  </div>
+                ))}
+              </div>
+            </section>
+          </aside>
+        </div>
+
+        <section className="rounded-lg p-4" style={{ background: 'var(--surface-container-low)', border: '1px solid var(--border-default)' }}>
           <div className="flex items-center gap-2 mb-3">
             <Activity size={15} style={{ color: 'var(--accent)' }} />
             <h2 className="text-[14px] font-semibold" style={{ color: 'var(--text-primary)' }}>Manage active connections</h2>

--- a/apps/web/src/app/oauth/authorize/page.tsx
+++ b/apps/web/src/app/oauth/authorize/page.tsx
@@ -19,6 +19,20 @@ type Preview = {
   profile: string;
 };
 
+const SCOPE_LABELS: Record<string, string> = {
+  'read:workspace': 'Workspace map, people, projects, receipts, and activity',
+  'read:wiki': 'Company, channel, and personal knowledge',
+  'read:tasks': 'Tasks, comments, progress, and workload',
+  'read:messages': 'Visible spaces, threads, unread work, and search',
+  'read:calendar': 'Native and subscribed calendar context',
+  'write:tasks': 'Create, update, transition, and comment on tasks',
+  'write:messages': 'Post messages into spaces and DMs you can access',
+  'write:wiki': 'Create and update wiki knowledge',
+  'write:calendar': 'Create, update, and cancel native calendar events',
+  'write:workspace': 'Manage notes, inbox, approvals, projects, and agent operations',
+  offline_access: 'Keep this connector signed in by allowing secure refresh-token rotation',
+};
+
 export default function OAuthAuthorizePage() {
   return (
     <Suspense>
@@ -32,6 +46,7 @@ function OAuthAuthorizeContent() {
   const searchParams = useSearchParams();
   const { user, loading } = useAuth();
   const [preview, setPreview] = useState<Preview | null>(null);
+  const [selectedScopes, setSelectedScopes] = useState<string[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
 
@@ -65,7 +80,9 @@ function OAuthAuthorizeContent() {
         setError(body.error_description ?? body.error ?? `Authorization preview failed: ${res.status}`);
         return;
       }
-      setPreview(await res.json());
+      const nextPreview = await res.json() as Preview;
+      setPreview(nextPreview);
+      setSelectedScopes(nextPreview.scopes);
     })().catch((err) => {
       if (!cancelled) setError((err as Error).message);
     });
@@ -76,7 +93,10 @@ function OAuthAuthorizeContent() {
     setBusy(true);
     setError(null);
     try {
-      const res = await api.post('/api/oauth/authorize', authorizeParams);
+      const res = await api.post('/api/oauth/authorize', {
+        ...authorizeParams,
+        scope: selectedScopes.join(' '),
+      });
       if (!res.ok) {
         const body = await res.json().catch(() => ({}));
         throw new Error(body.error_description ?? body.error ?? `Authorization failed: ${res.status}`);
@@ -104,11 +124,21 @@ function OAuthAuthorizeContent() {
     window.location.href = url.toString();
   }
 
-  const canWriteTasks = preview?.scopes.includes('write:tasks') ?? false;
-  const canWriteMessages = preview?.scopes.includes('write:messages') ?? false;
-  const canWriteWiki = preview?.scopes.includes('write:wiki') ?? false;
-  const canWriteCalendar = preview?.scopes.includes('write:calendar') ?? false;
-  const canWriteWorkspace = preview?.scopes.includes('write:workspace') ?? false;
+  function toggleScope(scope: string) {
+    setSelectedScopes((current) => current.includes(scope)
+      ? current.filter((item) => item !== scope)
+      : [...current, scope]);
+  }
+
+  const requestedReadScopes = preview?.scopes.filter((scope) => scope.startsWith('read:')) ?? [];
+  const requestedWriteScopes = preview?.scopes.filter((scope) => scope.startsWith('write:')) ?? [];
+  const requestedSessionScopes = preview?.scopes.filter((scope) => scope === 'offline_access') ?? [];
+  const canWriteTasks = selectedScopes.includes('write:tasks');
+  const canWriteMessages = selectedScopes.includes('write:messages');
+  const canWriteWiki = selectedScopes.includes('write:wiki');
+  const canWriteCalendar = selectedScopes.includes('write:calendar');
+  const canWriteWorkspace = selectedScopes.includes('write:workspace');
+  const hasResourceScope = selectedScopes.some((scope) => scope !== 'offline_access');
   const hasWriteAccess = canWriteTasks || canWriteMessages || canWriteWiki || canWriteCalendar || canWriteWorkspace;
   const accessLabel = hasWriteAccess ? 'Workspace helper access' : 'Knowledge access';
 
@@ -148,13 +178,50 @@ function OAuthAuthorizeContent() {
         {preview && (
           <>
             <section className="mt-6 rounded-lg p-4" style={{ background: 'var(--surface-container)', border: '1px solid var(--border-default)' }}>
-              <h2 className="text-[13px] font-semibold uppercase tracking-wide" style={{ color: 'var(--text-tertiary)' }}>This app can read</h2>
-              <ul className="mt-3 space-y-2 text-[14px]" style={{ color: 'var(--text-primary)' }}>
-                <li className="flex gap-2"><Check size={16} style={{ color: 'var(--accent)' }} /> Company wiki and memory</li>
-                <li className="flex gap-2"><Check size={16} style={{ color: 'var(--accent)' }} /> Tasks and project context you can access</li>
-                <li className="flex gap-2"><Check size={16} style={{ color: 'var(--accent)' }} /> Messages in spaces you can access</li>
-                <li className="flex gap-2"><Check size={16} style={{ color: 'var(--accent)' }} /> Calendar context available to your workspace</li>
-              </ul>
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div>
+                  <h2 className="text-[13px] font-semibold uppercase tracking-wide" style={{ color: 'var(--text-tertiary)' }}>Choose access</h2>
+                  <p className="mt-1 text-[12px]" style={{ color: 'var(--text-secondary)' }}>Turn off anything this connection does not need. You can revoke it later from Settings → Connections.</p>
+                </div>
+                <div className="flex gap-2">
+                  <button type="button" onClick={() => setSelectedScopes([...requestedReadScopes, ...requestedSessionScopes])} className="rounded-full px-3 py-1.5 text-[11px] font-medium" style={{ color: 'var(--text-secondary)', border: '1px solid var(--border-default)' }}>Read only</button>
+                  <button type="button" onClick={() => setSelectedScopes(preview.scopes)} className="rounded-full px-3 py-1.5 text-[11px] font-medium" style={{ color: 'white', background: 'var(--accent)' }}>Requested access</button>
+                </div>
+              </div>
+              <div className="mt-4 grid gap-4 sm:grid-cols-2">
+                <div>
+                  <div className="text-[11px] font-semibold uppercase tracking-wide" style={{ color: 'var(--text-tertiary)' }}>Read</div>
+                  <div className="mt-2 space-y-2">
+                    {requestedReadScopes.map((scope) => (
+                      <label key={scope} className="flex cursor-pointer items-start gap-2 rounded-md p-2.5" style={{ background: 'var(--surface-container-low)', border: '1px solid var(--border-default)' }}>
+                        <input type="checkbox" checked={selectedScopes.includes(scope)} onChange={() => toggleScope(scope)} className="mt-0.5" />
+                        <span className="text-[11px] leading-relaxed" style={{ color: 'var(--text-secondary)' }}><strong style={{ color: 'var(--text-primary)' }}>{scope}</strong><br />{SCOPE_LABELS[scope] ?? scope}</span>
+                      </label>
+                    ))}
+                  </div>
+                </div>
+                <div>
+                  <div className="text-[11px] font-semibold uppercase tracking-wide" style={{ color: 'var(--text-tertiary)' }}>Write</div>
+                  {requestedWriteScopes.length > 0 ? (
+                    <div className="mt-2 space-y-2">
+                      {requestedWriteScopes.map((scope) => (
+                        <label key={scope} className="flex cursor-pointer items-start gap-2 rounded-md p-2.5" style={{ background: 'var(--surface-container-low)', border: '1px solid var(--border-default)' }}>
+                          <input type="checkbox" checked={selectedScopes.includes(scope)} onChange={() => toggleScope(scope)} className="mt-0.5" />
+                          <span className="text-[11px] leading-relaxed" style={{ color: 'var(--text-secondary)' }}><strong style={{ color: 'var(--text-primary)' }}>{scope}</strong><br />{SCOPE_LABELS[scope] ?? scope}</span>
+                        </label>
+                      ))}
+                    </div>
+                  ) : (
+                    <p className="mt-2 rounded-md p-3 text-[11px]" style={{ color: 'var(--text-secondary)', background: 'var(--surface-container-low)', border: '1px solid var(--border-default)' }}>This app requested read-only access. No write permission will be granted.</p>
+                  )}
+                </div>
+              </div>
+              {requestedSessionScopes.map((scope) => (
+                <label key={scope} className="mt-4 flex cursor-pointer items-start gap-2 rounded-md p-2.5" style={{ background: 'var(--surface-container-low)', border: '1px solid var(--border-default)' }}>
+                  <input type="checkbox" checked={selectedScopes.includes(scope)} onChange={() => toggleScope(scope)} className="mt-0.5" />
+                  <span className="text-[11px] leading-relaxed" style={{ color: 'var(--text-secondary)' }}><strong style={{ color: 'var(--text-primary)' }}>Stay connected</strong><br />{SCOPE_LABELS[scope]}</span>
+                </label>
+              ))}
             </section>
 
             <section className="mt-3 rounded-lg p-4" style={{ background: 'var(--surface-container)', border: '1px solid var(--border-default)' }}>
@@ -202,7 +269,7 @@ function OAuthAuthorizeContent() {
             </section>
 
             <div className="mt-4 flex flex-wrap gap-1.5">
-              {preview.scopes.map((scope) => (
+              {selectedScopes.map((scope) => (
                 <span key={scope} className="rounded-md px-2 py-1 text-[11px]" style={{ background: 'var(--surface-container)', border: '1px solid var(--border-default)', color: 'var(--text-secondary)' }}>
                   {scope}
                 </span>
@@ -213,7 +280,7 @@ function OAuthAuthorizeContent() {
               <button type="button" onClick={deny} className="h-11 rounded-md text-[14px] font-medium" style={{ border: '1px solid var(--border-default)', color: 'var(--text-primary)' }}>
                 Cancel
               </button>
-              <button type="button" disabled={busy} onClick={approve} className="h-11 rounded-md text-[14px] font-medium text-white disabled:opacity-60 inline-flex items-center justify-center gap-2" style={{ background: 'var(--accent)' }}>
+              <button type="button" disabled={busy || !hasResourceScope} onClick={approve} className="h-11 rounded-md text-[14px] font-medium text-white disabled:opacity-60 inline-flex items-center justify-center gap-2" style={{ background: 'var(--accent)' }}>
                 {busy && <Loader2 size={16} className="animate-spin" />}
                 Allow access
               </button>

--- a/scripts/product-browser-smoke.mjs
+++ b/scripts/product-browser-smoke.mjs
@@ -84,7 +84,7 @@ async function main() {
     for (const [path, heading] of [
       ['/settings', 'Settings'],
       ['/settings/profile', 'Profile'],
-      ['/settings/mcp-access', 'Connect an AI app'],
+      ['/settings/mcp-access', 'Connect Deft to an AI app'],
     ]) {
       await settle(page, path);
       await page.getByRole('heading', { name: heading }).first().waitFor({ timeout: 10_000 });

--- a/scripts/product-browser-smoke.mjs
+++ b/scripts/product-browser-smoke.mjs
@@ -84,7 +84,7 @@ async function main() {
     for (const [path, heading] of [
       ['/settings', 'Settings'],
       ['/settings/profile', 'Profile'],
-      ['/settings/mcp-access', 'Connect Deft to an AI app'],
+      ['/settings/mcp-access', 'What do you want to connect?'],
     ]) {
       await settle(page, path);
       await page.getByRole('heading', { name: heading }).first().waitFor({ timeout: 10_000 });


### PR DESCRIPTION
## What changed

- restores an app-first MCP setup flow for Codex, Claude Code, Claude hosted connectors, ChatGPT custom apps, custom clients, and agent runtimes
- adds explicit read-only, task helper, and full workspace-operator permission presets plus per-scope customization
- adds selectable OAuth consent scopes and standards-correct `offline_access` refresh authorization
- distinguishes authorization-server scopes from MCP protected-resource scopes
- requires real public HTTPS for hosted-connector readiness and exposes the workspace-operator readiness profile
- documents exact client-specific configuration steps, limitations, and test prompts in-product

## Why

The simplified MCP Access page hid read/write controls and no longer matched how major MCP clients actually connect. Hosted OAuth clients also needed refresh authorization and a clearer least-privilege consent flow.

## Validation

- `pnpm --filter @deft/api exec tsx --test test/oauth-mcp.test.ts test/mcp-operational-headless-contract.test.ts test/mcp-access-history.test.ts` (16/16)
- `pnpm --filter @deft/api typecheck`
- `pnpm --filter @deft/web typecheck`
- `pnpm --filter @deft/web lint`
- local real-SDK token flows: full workspace operator, read-only denial, receipts, revoke
- local OAuth PKCE flow: DCR, consent, exchange, refresh rotation, replay rejection, revoke
- manual browser QA across every client setup card and custom-scope control