### PR TITLE
Fix ChatGPT OAuth scope negotiation

### DIFF
--- a/apps/api/src/lib/oauth-mcp.ts
+++ b/apps/api/src/lib/oauth-mcp.ts
@@ -43,6 +43,7 @@ export const REMOTE_MCP_AUTHORIZATION_SCOPES = [
 export type RemoteMcpScope = typeof REMOTE_MCP_SCOPES[number];
 type RemoteMcpAuthorizationScope = typeof REMOTE_MCP_AUTHORIZATION_SCOPES[number];
 export type ConnectorProfile = 'knowledge' | 'task-helper' | 'workspace-operator';
+export type AuthorizationScopeSelectionMode = 'client-requested' | 'deft-choice';
 
 export type OAuthAccessPrincipal = {
   kind: 'oauth';
@@ -83,6 +84,29 @@ export function normalizeScopes(value: string | string[] | undefined | null): st
     ? requested.filter((s) => allowed.has(s as RemoteMcpAuthorizationScope))
     : [...REMOTE_MCP_READ_SCOPES];
   return scopes.length > 0 ? Array.from(new Set(scopes)) : [...REMOTE_MCP_READ_SCOPES];
+}
+
+export function authorizationScopeSelection(
+  requestedScope: string | string[] | undefined | null,
+  clientMetadata: Record<string, unknown> | null | undefined,
+) {
+  const registeredScope = typeof clientMetadata?.scope === 'string' && clientMetadata.scope.trim()
+    ? clientMetadata.scope
+    : null;
+  const clientOmittedScope = registeredScope === null;
+  const requestedScopes = normalizeScopes(requestedScope ?? registeredScope);
+  const registeredScopes = registeredScope ? normalizeScopes(registeredScope) : null;
+  const scopes = registeredScopes
+    ? requestedScopes.filter((scope) => registeredScopes.includes(scope))
+    : requestedScopes;
+
+  return {
+    scopes,
+    availableScopes: clientOmittedScope
+      ? [...REMOTE_MCP_AUTHORIZATION_SCOPES]
+      : scopes,
+    mode: (clientOmittedScope ? 'deft-choice' : 'client-requested') as AuthorizationScopeSelectionMode,
+  };
 }
 
 export function profileForScopes(scopes: string[]): ConnectorProfile {

--- a/apps/api/src/routes/oauth-mcp.ts
+++ b/apps/api/src/routes/oauth-mcp.ts
@@ -7,6 +7,7 @@ import {
   OAuthMcpError,
   REMOTE_MCP_AUTHORIZATION_SCOPES,
   REMOTE_MCP_SCOPES,
+  authorizationScopeSelection,
   auditOAuth,
   createAuthorizationCode,
   exchangeAuthorizationCode,
@@ -132,7 +133,9 @@ oauthPublicRoutes.post('/register', async (c) => {
       grant_types: grantTypes,
       response_types: responseTypes,
       token_endpoint_auth_method: authMethod,
-      scope: normalizeScopes(parsed.data.scope).join(' '),
+      ...(parsed.data.scope?.trim()
+        ? { scope: normalizeScopes(parsed.data.scope).join(' ') }
+        : {}),
     }, 201);
   } catch (err) {
     return oauthError(c, err);
@@ -214,7 +217,10 @@ oauthProtectedRoutes.get('/authorize/preview', async (c) => {
       codeChallengeMethod: parsed.data.code_challenge_method,
       resource: parsed.data.resource,
     });
-    const scopes = normalizeScopes(parsed.data.scope);
+    const selection = authorizationScopeSelection(
+      parsed.data.scope,
+      client.metadata as Record<string, unknown>,
+    );
     return c.json({
       client: {
         client_id: client.client_id,
@@ -223,8 +229,10 @@ oauthProtectedRoutes.get('/authorize/preview', async (c) => {
         logo_uri: client.logo_uri,
       },
       resource,
-      scopes,
-      profile: profileForScopes(scopes),
+      scopes: selection.scopes,
+      available_scopes: selection.availableScopes,
+      scope_selection_mode: selection.mode,
+      profile: profileForScopes(selection.scopes),
     });
   } catch (err) {
     return oauthError(c, err);
@@ -247,7 +255,15 @@ oauthProtectedRoutes.post('/authorize', async (c) => {
       codeChallengeMethod: parsed.data.code_challenge_method,
       resource: parsed.data.resource,
     });
-    const scopes = normalizeScopes(parsed.data.scope);
+    const requestedScopes = normalizeScopes(parsed.data.scope);
+    const selection = authorizationScopeSelection(
+      parsed.data.scope,
+      client.metadata as Record<string, unknown>,
+    );
+    if (requestedScopes.some((scope) => !selection.scopes.includes(scope))) {
+      throw new OAuthMcpError(400, 'invalid_scope', 'Requested scope exceeds this client registration');
+    }
+    const scopes = selection.scopes;
     const { code } = await createAuthorizationCode({
       orgId: user.org_id,
       userId: user.id,

--- a/apps/api/test/mcp-operational-headless-contract.test.ts
+++ b/apps/api/test/mcp-operational-headless-contract.test.ts
@@ -1,6 +1,13 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { REMOTE_MCP_SCOPES, normalizeScopes, profileForScopes } from '../src/lib/oauth-mcp.js';
+import {
+  REMOTE_MCP_AUTHORIZATION_SCOPES,
+  REMOTE_MCP_READ_SCOPES,
+  REMOTE_MCP_SCOPES,
+  authorizationScopeSelection,
+  normalizeScopes,
+  profileForScopes,
+} from '../src/lib/oauth-mcp.js';
 import { isHttpsPublicUrl } from '../src/lib/public-url.js';
 import {
   HUMAN_READ_TOOLS,
@@ -63,6 +70,36 @@ test('operational headless scopes are accepted without weakening default read gr
   assert.equal(profileForScopes(['read:workspace', 'write:tasks']), 'task-helper');
   assert.equal(profileForScopes(['read:workspace', 'write:calendar']), 'workspace-operator');
   assert.equal(profileForScopes(['read:workspace', 'write:workspace']), 'workspace-operator');
+});
+
+test('scope-less OAuth clients get a read-safe default with explicit access choices', () => {
+  const omitted = authorizationScopeSelection(undefined, {});
+  assert.deepEqual(omitted.scopes, [...REMOTE_MCP_READ_SCOPES]);
+  assert.deepEqual(omitted.availableScopes, [...REMOTE_MCP_AUTHORIZATION_SCOPES]);
+  assert.equal(omitted.mode, 'deft-choice');
+
+  const legacyChatGpt = authorizationScopeSelection(
+    'read:workspace read:wiki read:tasks read:messages read:calendar',
+    { client_name: 'ChatGPT' },
+  );
+  assert.deepEqual(legacyChatGpt.scopes, [...REMOTE_MCP_READ_SCOPES]);
+  assert.deepEqual(legacyChatGpt.availableScopes, [...REMOTE_MCP_AUTHORIZATION_SCOPES]);
+  assert.equal(legacyChatGpt.mode, 'deft-choice');
+
+  const explicitReadOnly = authorizationScopeSelection(
+    'read:workspace read:wiki',
+    { scope: 'read:workspace read:wiki' },
+  );
+  assert.deepEqual(explicitReadOnly.scopes, ['read:workspace', 'read:wiki']);
+  assert.deepEqual(explicitReadOnly.availableScopes, ['read:workspace', 'read:wiki']);
+  assert.equal(explicitReadOnly.mode, 'client-requested');
+
+  const blockedEscalation = authorizationScopeSelection(
+    'read:workspace write:tasks',
+    { scope: 'read:workspace' },
+  );
+  assert.deepEqual(blockedEscalation.scopes, ['read:workspace']);
+  assert.deepEqual(blockedEscalation.availableScopes, ['read:workspace']);
 });
 
 test('hosted connector readiness requires a real HTTPS public URL', () => {

--- a/apps/api/test/oauth-mcp.test.ts
+++ b/apps/api/test/oauth-mcp.test.ts
@@ -448,6 +448,15 @@ test('OAuth metadata and dynamic client registration describe the remote MCP con
   assert.equal(refreshClientRes.status, 201);
   const refreshClient = (await refreshClientRes.json()) as { scope: string };
   assert.equal(refreshClient.scope, 'read:workspace offline_access');
+
+  const scopeLessClientRes = await jsonPost('/oauth/register', {
+    client_name: `OAuth MCP Test Scope-less ${TEST_ID}`,
+    redirect_uris: ['http://localhost:3999/callback'],
+  });
+  assert.equal(scopeLessClientRes.status, 201);
+  const scopeLessClient = (await scopeLessClientRes.json()) as Record<string, unknown>;
+  assert.ok(String(scopeLessClient.client_id).startsWith('deft_dcr_'));
+  assert.equal(Object.hasOwn(scopeLessClient, 'scope'), false);
 });
 
 test('OAuth PKCE token exchange resolves to a scoped human MCP principal', async () => {

--- a/apps/web/src/app/(app)/settings/mcp-access/page.tsx
+++ b/apps/web/src/app/(app)/settings/mcp-access/page.tsx
@@ -99,8 +99,8 @@ const CLIENT_OPTIONS: ClientOption[] = [
   {
     id: 'remote-web',
     name: 'ChatGPT / hosted AI apps',
-    fit: 'Remote OAuth app',
-    detail: 'Create a custom app in ChatGPT or another hosted client using Deft\'s public MCP URL and OAuth discovery.',
+    fit: 'Plan-dependent access',
+    detail: 'ChatGPT Pro currently supports read/fetch. Full read/write MCP requires an eligible Business or Enterprise/Edu workspace using Developer Mode.',
     setupKind: 'oauth',
     defaultPreset: 'read',
     tokenName: 'Remote AI app',
@@ -585,8 +585,8 @@ export default function McpAccessPage() {
     : [
         'In ChatGPT web, enable developer mode for an eligible account, then open Settings -> Apps -> Create.',
         'Use the Connector URL below and choose OAuth authentication. Deft publishes the discovery metadata automatically.',
-        'Click Scan Tools, complete the Deft authorization screen, and choose the exact read and write permissions.',
-        'Create the draft app, enable it in a new chat, and confirm a read before trying a write action.',
+        'Click Scan Tools and complete the Deft authorization screen. Deft starts scope-less connections read-only; add write permissions only when your ChatGPT plan supports full MCP.',
+        'Create the draft app, enable it in a new chat, and confirm a read. On Business or Enterprise/Edu, test a write action and approve ChatGPT\'s confirmation prompt.',
       ];
   const claudeConnectorFields = [
     {

--- a/apps/web/src/app/oauth/authorize/page.tsx
+++ b/apps/web/src/app/oauth/authorize/page.tsx
@@ -16,6 +16,8 @@ type Preview = {
   };
   resource: string;
   scopes: string[];
+  available_scopes: string[];
+  scope_selection_mode: 'client-requested' | 'deft-choice';
   profile: string;
 };
 
@@ -130,9 +132,10 @@ function OAuthAuthorizeContent() {
       : [...current, scope]);
   }
 
-  const requestedReadScopes = preview?.scopes.filter((scope) => scope.startsWith('read:')) ?? [];
-  const requestedWriteScopes = preview?.scopes.filter((scope) => scope.startsWith('write:')) ?? [];
-  const requestedSessionScopes = preview?.scopes.filter((scope) => scope === 'offline_access') ?? [];
+  const availableScopes = preview?.available_scopes ?? preview?.scopes ?? [];
+  const availableReadScopes = availableScopes.filter((scope) => scope.startsWith('read:'));
+  const availableWriteScopes = availableScopes.filter((scope) => scope.startsWith('write:'));
+  const availableSessionScopes = availableScopes.filter((scope) => scope === 'offline_access');
   const canWriteTasks = selectedScopes.includes('write:tasks');
   const canWriteMessages = selectedScopes.includes('write:messages');
   const canWriteWiki = selectedScopes.includes('write:wiki');
@@ -184,15 +187,23 @@ function OAuthAuthorizeContent() {
                   <p className="mt-1 text-[12px]" style={{ color: 'var(--text-secondary)' }}>Turn off anything this connection does not need. You can revoke it later from Settings → Connections.</p>
                 </div>
                 <div className="flex gap-2">
-                  <button type="button" onClick={() => setSelectedScopes([...requestedReadScopes, ...requestedSessionScopes])} className="rounded-full px-3 py-1.5 text-[11px] font-medium" style={{ color: 'var(--text-secondary)', border: '1px solid var(--border-default)' }}>Read only</button>
-                  <button type="button" onClick={() => setSelectedScopes(preview.scopes)} className="rounded-full px-3 py-1.5 text-[11px] font-medium" style={{ color: 'white', background: 'var(--accent)' }}>Requested access</button>
+                  <button type="button" onClick={() => setSelectedScopes([...availableReadScopes, ...availableSessionScopes])} className="rounded-full px-3 py-1.5 text-[11px] font-medium" style={{ color: 'var(--text-secondary)', border: '1px solid var(--border-default)' }}>Read only</button>
+                  <button type="button" onClick={() => setSelectedScopes(availableScopes)} className="rounded-full px-3 py-1.5 text-[11px] font-medium" style={{ color: 'white', background: 'var(--accent)' }}>
+                    {preview.scope_selection_mode === 'deft-choice' ? 'Full workspace' : 'Requested access'}
+                  </button>
                 </div>
               </div>
+              {preview.scope_selection_mode === 'deft-choice' && (
+                <div className="mt-4 rounded-md p-3 text-[11px] leading-relaxed" style={{ color: 'var(--text-secondary)', background: 'color-mix(in srgb, var(--accent) 7%, var(--surface-container-low))', border: '1px solid var(--border-default)' }}>
+                  <strong style={{ color: 'var(--text-primary)' }}>{preview.client.client_name} did not specify OAuth permissions.</strong>{' '}
+                  Deft started this connection in read-only mode. You can explicitly add write access below, but the AI app may still limit write actions based on its plan, workspace controls, or connection mode.
+                </div>
+              )}
               <div className="mt-4 grid gap-4 sm:grid-cols-2">
                 <div>
                   <div className="text-[11px] font-semibold uppercase tracking-wide" style={{ color: 'var(--text-tertiary)' }}>Read</div>
                   <div className="mt-2 space-y-2">
-                    {requestedReadScopes.map((scope) => (
+                    {availableReadScopes.map((scope) => (
                       <label key={scope} className="flex cursor-pointer items-start gap-2 rounded-md p-2.5" style={{ background: 'var(--surface-container-low)', border: '1px solid var(--border-default)' }}>
                         <input type="checkbox" checked={selectedScopes.includes(scope)} onChange={() => toggleScope(scope)} className="mt-0.5" />
                         <span className="text-[11px] leading-relaxed" style={{ color: 'var(--text-secondary)' }}><strong style={{ color: 'var(--text-primary)' }}>{scope}</strong><br />{SCOPE_LABELS[scope] ?? scope}</span>
@@ -202,9 +213,9 @@ function OAuthAuthorizeContent() {
                 </div>
                 <div>
                   <div className="text-[11px] font-semibold uppercase tracking-wide" style={{ color: 'var(--text-tertiary)' }}>Write</div>
-                  {requestedWriteScopes.length > 0 ? (
+                  {availableWriteScopes.length > 0 ? (
                     <div className="mt-2 space-y-2">
-                      {requestedWriteScopes.map((scope) => (
+                      {availableWriteScopes.map((scope) => (
                         <label key={scope} className="flex cursor-pointer items-start gap-2 rounded-md p-2.5" style={{ background: 'var(--surface-container-low)', border: '1px solid var(--border-default)' }}>
                           <input type="checkbox" checked={selectedScopes.includes(scope)} onChange={() => toggleScope(scope)} className="mt-0.5" />
                           <span className="text-[11px] leading-relaxed" style={{ color: 'var(--text-secondary)' }}><strong style={{ color: 'var(--text-primary)' }}>{scope}</strong><br />{SCOPE_LABELS[scope] ?? scope}</span>
@@ -216,7 +227,7 @@ function OAuthAuthorizeContent() {
                   )}
                 </div>
               </div>
-              {requestedSessionScopes.map((scope) => (
+              {availableSessionScopes.map((scope) => (
                 <label key={scope} className="mt-4 flex cursor-pointer items-start gap-2 rounded-md p-2.5" style={{ background: 'var(--surface-container-low)', border: '1px solid var(--border-default)' }}>
                   <input type="checkbox" checked={selectedScopes.includes(scope)} onChange={() => toggleScope(scope)} className="mt-0.5" />
                   <span className="text-[11px] leading-relaxed" style={{ color: 'var(--text-secondary)' }}><strong style={{ color: 'var(--text-primary)' }}>Stay connected</strong><br />{SCOPE_LABELS[scope]}</span>


### PR DESCRIPTION
## Summary
- preserve scope-less OAuth dynamic registrations instead of silently pinning them to read-only
- let Deft's consent screen offer the complete read/write scope set while defaulting safely to reads
- enforce registered-client scope ceilings server-side and reject escalation with `invalid_scope`
- clarify ChatGPT plan-dependent write support on MCP Access

## Why
ChatGPT may dynamically register without a `scope` value. Deft previously converted that omission into a permanent read-only registration, so the client could never request writes later. Scope-less registrations now remain flexible while explicit read-only registrations remain constrained.

## Verification
- `pnpm --filter @deft/api exec tsx --test test/mcp-operational-headless-contract.test.ts`
- `pnpm --filter @deft/api exec tsx --test --test-concurrency=1 --test-force-exit test/oauth-mcp.test.ts`
- `pnpm --filter @deft/api typecheck`
- `pnpm --filter @deft/web typecheck`
- targeted ESLint for the OAuth consent and MCP Access pages
- browser dogfood of scope-less consent defaults and Full workspace selection