### PR TITLE
Align approval fallback with attention inbox

### DIFF
--- a/apps/api/src/workers/handlers/agent-reply.ts
+++ b/apps/api/src/workers/handlers/agent-reply.ts
@@ -959,7 +959,7 @@ function buildWriteIntentClarification(content: string, replyText: string): stri
 
 export function normalizeApprovalSurfaceCopy(text: string): string {
   const inlineApprovalCopy =
-    'Use the approval card below this message to approve or dismiss it. It is also mirrored in Inbox > Approvals.';
+    'Use the approval card below this message to approve or dismiss it. It is also mirrored in Inbox under Needs you.';
   let normalized = text
     .replace(
       /(?:Please\s+)?(?:check|open|go to)\s+(?:your\s+)?Inbox\s+(?:under|in)\s+the\s+["']?Approvals["']?\s+tab\s+to\s+approve\s+or\s+reject[^.\n]*(?:\.|$)/gi,
@@ -967,7 +967,7 @@ export function normalizeApprovalSurfaceCopy(text: string): string {
     )
     .replace(
       /You can also manage this in your Inbox under the Approvals tab\.?/gi,
-      'It is also mirrored in Inbox > Approvals.',
+      'It is also mirrored in Inbox under Needs you.',
     );
 
   const mentionsInlineCard = /\b(?:approval card|approve\/reject button|approve or dismiss|below this message|here to finalize)\b/i.test(normalized);

--- a/apps/api/test/agent-reply-discussion-command.test.ts
+++ b/apps/api/test/agent-reply-discussion-command.test.ts
@@ -357,6 +357,6 @@ test('approval copy points to the inline card before inbox fallback', () => {
   );
 
   assert.match(normalized, /approval card below this message/i);
-  assert.match(normalized, /Inbox > Approvals/i);
+  assert.match(normalized, /Inbox under Needs you/i);
   assert.doesNotMatch(normalized, /check your Inbox under the Approvals tab/i);
 });


### PR DESCRIPTION
## What changed

- Replaces stale `Inbox > Approvals` guidance with the current `Inbox under Needs you` destination.
- Updates the focused approval-copy regression test.

## Why

The public attention-system dogfood found that Defty correctly mirrored approvals into the new attention inbox, but its confirmation copy still named the retired Approvals tab.

## Validation

- `pnpm --filter @deft/api exec tsx --test test/agent-reply-discussion-command.test.ts`
- 20/20 focused tests passed.