### PR TITLE
Harden attention fanout under 60-person load

### DIFF
--- a/apps/api/src/lib/attention.ts
+++ b/apps/api/src/lib/attention.ts
@@ -15,7 +15,7 @@ import {
 } from '@deft/db/schema';
 import { db } from './db.js';
 import { getIO } from '../socket.js';
-import { scheduleAttentionDelivery } from './web-push.js';
+import { scheduleAttentionDeliveries, scheduleAttentionDelivery } from './web-push.js';
 
 export type AttentionLane = 'needs_you' | 'updates';
 export type AttentionPriority = 'critical' | 'high' | 'normal' | 'low';
@@ -413,6 +413,122 @@ export async function syncNotificationToAttention(
     }
   }
   return upsertAttentionItem(draft, options);
+}
+
+function draftIdentity(draft: AttentionDraft) {
+  return `${draft.orgId}\u0000${draft.userId}\u0000${draft.dedupeKey}`;
+}
+
+/**
+ * Project freshly inserted notifications into attention with a bounded number
+ * of queries. The single-item path remains the fallback for callers that need
+ * legacy link resolution or isolated retries.
+ */
+export async function syncNotificationsToAttention(
+  sourceNotifications: LegacyNotification[],
+  options: { deliver?: boolean } = {},
+) {
+  if (sourceNotifications.length === 0) return [];
+  const drafts = sourceNotifications.map(notificationToAttentionDraft);
+  const sourceEventIds = drafts.map((draft) => draft.sourceEventId);
+
+  const items = await db.transaction(async (tx) => {
+    const existingEvents = await tx
+      .select({ source_event_id: attentionEvents.source_event_id })
+      .from(attentionEvents)
+      .where(and(
+        inArray(attentionEvents.source_event_id, sourceEventIds),
+        eq(attentionEvents.event_type, 'source_event'),
+      ));
+    const alreadyProjected = new Set(existingEvents.map((event) => event.source_event_id));
+    const pendingDrafts = drafts.filter((draft) => !alreadyProjected.has(draft.sourceEventId));
+    if (pendingDrafts.length === 0) return [];
+
+    const grouped = new Map<string, { draft: AttentionDraft; eventCount: number }>();
+    for (const draft of pendingDrafts) {
+      const key = draftIdentity(draft);
+      const existing = grouped.get(key);
+      grouped.set(key, { draft, eventCount: (existing?.eventCount ?? 0) + 1 });
+    }
+
+    const projected = await tx
+      .insert(attentionItems)
+      .values(Array.from(grouped.values()).map(({ draft, eventCount }) => ({
+        org_id: draft.orgId,
+        user_id: draft.userId,
+        kind: draft.kind,
+        lane: draft.lane,
+        priority: draft.priority,
+        state: 'open_unseen',
+        dedupe_key: draft.dedupeKey,
+        source_type: draft.sourceType,
+        source_id: draft.sourceId,
+        source_event_id: draft.sourceEventId,
+        title: draft.title,
+        body: draft.body ?? null,
+        link: draft.link ?? null,
+        metadata: draft.metadata ?? {},
+        due_at: draft.dueAt ?? null,
+        urgent_at: draft.urgentAt ?? null,
+        last_event_at: draft.occurredAt ?? new Date(),
+        event_count: eventCount,
+      })))
+      .onConflictDoUpdate({
+        target: [attentionItems.org_id, attentionItems.user_id, attentionItems.dedupe_key],
+        set: {
+          kind: sql`excluded.kind`,
+          lane: sql`excluded.lane`,
+          priority: sql`excluded.priority`,
+          state: 'open_unseen',
+          source_type: sql`excluded.source_type`,
+          source_id: sql`excluded.source_id`,
+          source_event_id: sql`excluded.source_event_id`,
+          title: sql`excluded.title`,
+          body: sql`excluded.body`,
+          link: sql`excluded.link`,
+          metadata: sql`excluded.metadata`,
+          due_at: sql`excluded.due_at`,
+          urgent_at: sql`excluded.urgent_at`,
+          last_event_at: sql`excluded.last_event_at`,
+          event_count: sql`${attentionItems.event_count} + excluded.event_count`,
+          version: sql`${attentionItems.version} + 1`,
+          seen_at: null,
+          acknowledged_at: null,
+          snoozed_until: null,
+          resolved_at: null,
+          resolution: null,
+          updated_at: new Date(),
+        },
+      })
+      .returning();
+    const itemByIdentity = new Map(projected.map((item) => [
+      `${item.org_id}\u0000${item.user_id}\u0000${item.dedupe_key}`,
+      item,
+    ]));
+
+    await tx
+      .insert(attentionEvents)
+      .values(pendingDrafts.map((draft) => ({
+        org_id: draft.orgId,
+        attention_item_id: itemByIdentity.get(draftIdentity(draft))!.id,
+        user_id: draft.userId,
+        event_type: 'source_event',
+        source_event_id: draft.sourceEventId,
+        payload: { source_type: draft.sourceType, source_id: draft.sourceId },
+      })))
+      .onConflictDoNothing();
+
+    return projected;
+  });
+
+  for (const item of items) emitAttention(item.event_count > 1 ? 'attention:updated' : 'attention:new', item);
+  if (options.deliver !== false) {
+    await scheduleAttentionDeliveries(items).catch((error) => {
+      console.warn('[attention] push scheduling failed:', error instanceof Error ? error.message : error);
+      return [];
+    });
+  }
+  return items;
 }
 
 export async function filterVisibleAttentionItems<T extends typeof attentionItems.$inferSelect>(

--- a/apps/api/src/lib/notification-policy.ts
+++ b/apps/api/src/lib/notification-policy.ts
@@ -7,7 +7,8 @@ import {
   type UserNotificationPreferences,
 } from '@deft/db/schema';
 import { db } from './db.js';
-import { syncNotificationToAttention } from './attention.js';
+import { syncNotificationToAttention, syncNotificationsToAttention } from './attention.js';
+import { enqueue, QUEUE_NAMES } from './queues.js';
 
 type NotificationChannel = keyof UserNotificationPreferences['channels'];
 type NotificationInsert = typeof notifications.$inferInsert;
@@ -207,6 +208,8 @@ export async function createNotificationsIfAllowed(
   options: NotificationPolicyOptions = {},
 ): Promise<Array<typeof notifications.$inferSelect>> {
   if (values.length === 0) return [];
+  const traceEnabled = process.env.DEFT_CAPACITY_TRACE === '1';
+  const startedAt = performance.now();
   const first = values[0]!;
 
   const inferredChannel = options.channel === undefined
@@ -229,6 +232,7 @@ export async function createNotificationsIfAllowed(
         : eq(spaceMembers.user_id, sqlNeverMatches()),
     )
     .where(inArray(users.id, userIds));
+  const policyReadAt = performance.now();
   const recipientById = new Map(recipients.map((recipient) => [recipient.id, recipient]));
   const evaluatedAt = new Date().toISOString();
 
@@ -257,16 +261,58 @@ export async function createNotificationsIfAllowed(
     }];
   });
 
-  if (allowed.length === 0) return [];
+  if (allowed.length === 0) {
+    if (traceEnabled) {
+      console.info(`[capacity-profile] ${JSON.stringify({
+        event: 'notification_fanout',
+        requested: values.length,
+        allowed: 0,
+        policy_read_ms: Math.round((policyReadAt - startedAt) * 10) / 10,
+        notification_insert_ms: 0,
+        attention_sync_ms: 0,
+        total_ms: Math.round((performance.now() - startedAt) * 10) / 10,
+      })}`);
+    }
+    return [];
+  }
   const inserted = await db.insert(notifications).values(allowed).returning();
-  await Promise.all(inserted.map((notification) =>
-    syncNotificationToAttention(notification).catch((error) => {
-      console.warn('[notification-policy] Attention dual-write failed', {
-        notificationId: notification.id,
+  const insertedAt = performance.now();
+  const byOrg = new Map<string, Array<typeof notifications.$inferSelect>>();
+  for (const notification of inserted) {
+    const group = byOrg.get(notification.org_id) ?? [];
+    group.push(notification);
+    byOrg.set(notification.org_id, group);
+  }
+  let attentionMode = 'queued';
+  for (const [orgId, orgNotifications] of byOrg) {
+    try {
+      await enqueue(QUEUE_NAMES.SCHEDULED_JOBS, 'notification-attention-sync', {
+        orgId,
+        notificationIds: orgNotifications.map((notification) => notification.id),
+        enqueuedAt: new Date().toISOString(),
+      }, { maxAttempts: 5 });
+    } catch (error) {
+      attentionMode = 'synchronous_fallback';
+      console.warn('[notification-policy] Attention queue insert failed; projecting synchronously', {
+        notificationCount: orgNotifications.length,
         error: error instanceof Error ? error.message : String(error),
       });
-    })
-  ));
+      await syncNotificationsToAttention(orgNotifications);
+    }
+  }
+  const attentionQueuedAt = performance.now();
+  if (traceEnabled) {
+    console.info(`[capacity-profile] ${JSON.stringify({
+      event: 'notification_fanout',
+      requested: values.length,
+      allowed: inserted.length,
+      policy_read_ms: Math.round((policyReadAt - startedAt) * 10) / 10,
+      notification_insert_ms: Math.round((insertedAt - policyReadAt) * 10) / 10,
+      attention_enqueue_ms: Math.round((attentionQueuedAt - insertedAt) * 10) / 10,
+      attention_mode: attentionMode,
+      total_ms: Math.round((attentionQueuedAt - startedAt) * 10) / 10,
+    })}`);
+  }
   return inserted;
 }
 

--- a/apps/api/src/lib/web-push.ts
+++ b/apps/api/src/lib/web-push.ts
@@ -1,5 +1,5 @@
 import webpush from 'web-push';
-import { and, desc, eq, gte, sql } from 'drizzle-orm';
+import { and, desc, eq, gte, inArray, sql } from 'drizzle-orm';
 import {
   attentionDeliveries,
   attentionItems,
@@ -166,6 +166,76 @@ export async function scheduleAttentionDelivery(item: AttentionItem) {
     { delay, maxAttempts: PUSH_MAX_ATTEMPTS },
   );
   return delivery;
+}
+
+export async function scheduleAttentionDeliveries(items: AttentionItem[]) {
+  if (!webPushConfigured()) return [];
+  const candidates = items.filter((item) => item.state === 'open_unseen' && item.priority !== 'low');
+  if (candidates.length === 0) return [];
+
+  const userIds = Array.from(new Set(candidates.map((item) => item.user_id)));
+  const userRows = await db
+    .select({ id: users.id, preferences: users.notification_preferences, timezone: users.timezone })
+    .from(users)
+    .where(inArray(users.id, userIds));
+  const userById = new Map(userRows.map((user) => [user.id, user]));
+  const preferenceByUser = new Map(userRows.map((user) => [user.id, normalizedPreferences(user.preferences)]));
+  const preferenceAllowed = candidates.filter((item) => {
+    const preferences = preferenceByUser.get(item.user_id);
+    return preferences ? preferenceAllows(item, preferences) : false;
+  });
+  if (preferenceAllowed.length === 0) return [];
+
+  const orgIds = Array.from(new Set(preferenceAllowed.map((item) => item.org_id)));
+  const subscribedRows = await db
+    .select({ org_id: webPushSubscriptions.org_id, user_id: webPushSubscriptions.user_id })
+    .from(webPushSubscriptions)
+    .where(and(
+      inArray(webPushSubscriptions.org_id, orgIds),
+      inArray(webPushSubscriptions.user_id, Array.from(new Set(preferenceAllowed.map((item) => item.user_id)))),
+      eq(webPushSubscriptions.is_active, true),
+    ));
+  const subscribed = new Set(subscribedRows.map((row) => `${row.org_id}\u0000${row.user_id}`));
+  const now = new Date();
+  const deliveryValues = preferenceAllowed.flatMap((item) => {
+    if (!subscribed.has(`${item.org_id}\u0000${item.user_id}`)) return [];
+    const user = userById.get(item.user_id);
+    const preferences = preferenceByUser.get(item.user_id)!;
+    const quietDelay = preferences.push.quiet_hours.enabled && item.priority !== 'critical'
+      ? quietHoursDelay(
+          now,
+          user?.timezone ?? 'UTC',
+          preferences.push.quiet_hours.start,
+          preferences.push.quiet_hours.end,
+        )
+      : 0;
+    const delay = Math.max(baseDelay(item), quietDelay);
+    return [{
+      org_id: item.org_id,
+      attention_item_id: item.id,
+      user_id: item.user_id,
+      channel: 'web_push',
+      status: 'queued',
+      delivery_version: item.version,
+      next_attempt_at: new Date(now.getTime() + delay),
+      delay,
+    }];
+  });
+  if (deliveryValues.length === 0) return [];
+
+  const deliveries = await db
+    .insert(attentionDeliveries)
+    .values(deliveryValues.map(({ delay: _delay, ...value }) => value))
+    .onConflictDoNothing()
+    .returning();
+  const delayByItem = new Map(deliveryValues.map((value) => [value.attention_item_id, value.delay]));
+  await Promise.all(deliveries.map((delivery) => enqueue(
+    QUEUE_NAMES.SCHEDULED_JOBS,
+    'attention-delivery',
+    { delivery_id: delivery.id },
+    { delay: delayByItem.get(delivery.attention_item_id) ?? 0, maxAttempts: PUSH_MAX_ATTEMPTS },
+  )));
+  return deliveries;
 }
 
 function safePayload(item: AttentionItem) {

--- a/apps/api/src/routes/messages.ts
+++ b/apps/api/src/routes/messages.ts
@@ -591,7 +591,7 @@ messageRoutes.post('/:spaceId', async (c) => {
         const title = isDm
           ? `${userData?.name ?? 'Someone'} sent you a message`
           : `${userData?.name ?? 'Someone'} in #${space.name}`;
-        const link = isDm ? `/chat` : `/chat?space=${spaceId}`;
+        const link = `/chat?space=${spaceId}&message=${message!.id}`;
         const recipientNotifications = await createNotificationsIfAllowed(
           members
             .filter((member) => !mentionedUserIds.includes(member.user_id))
@@ -602,6 +602,11 @@ messageRoutes.post('/:spaceId', async (c) => {
             title,
             body: plainContent,
             link,
+            metadata: {
+              message_id: message!.id,
+              space_id: spaceId,
+              is_direct_message: isDm,
+            },
           })),
           { channel: 'chat', spaceId, isMention: false, respectDnd: true },
         );

--- a/apps/api/src/workers/handlers/notification-attention-sync.ts
+++ b/apps/api/src/workers/handlers/notification-attention-sync.ts
@@ -1,0 +1,44 @@
+import { and, eq, inArray } from 'drizzle-orm';
+import { notifications } from '@deft/db/schema';
+import { db } from '../../lib/db.js';
+import { syncNotificationsToAttention } from '../../lib/attention.js';
+import type { JobData } from '../types.js';
+
+export async function handleNotificationAttentionSync(job: JobData): Promise<void> {
+  const orgId = typeof job.data.orgId === 'string' ? job.data.orgId : '';
+  const notificationIds = Array.isArray(job.data.notificationIds)
+    ? Array.from(new Set(job.data.notificationIds.filter((id): id is string => typeof id === 'string' && id.length > 0)))
+    : [];
+  if (!orgId || notificationIds.length === 0) {
+    throw new Error('notification-attention-sync requires orgId and notificationIds');
+  }
+
+  const rows = await db
+    .select()
+    .from(notifications)
+    .where(and(
+      eq(notifications.org_id, orgId),
+      inArray(notifications.id, notificationIds),
+    ));
+  if (rows.length !== notificationIds.length) {
+    throw new Error(`notification-attention-sync found ${rows.length}/${notificationIds.length} notifications`);
+  }
+
+  const startedAt = performance.now();
+  const enqueuedAt = typeof job.data.enqueuedAt === 'string'
+    ? Date.parse(job.data.enqueuedAt)
+    : Number.NaN;
+  const queueDelayMs = Number.isFinite(enqueuedAt) ? Math.max(0, Date.now() - enqueuedAt) : null;
+  const projected = await syncNotificationsToAttention(rows);
+  const projectionMs = performance.now() - startedAt;
+  if (process.env.DEFT_CAPACITY_TRACE === '1') {
+    console.info(`[capacity-profile] ${JSON.stringify({
+      event: 'attention_projection',
+      notifications: rows.length,
+      projected_items: projected.length,
+      queue_delay_ms: queueDelayMs === null ? null : Math.round(queueDelayMs * 10) / 10,
+      projection_ms: Math.round(projectionMs * 10) / 10,
+      end_to_end_ms: queueDelayMs === null ? null : Math.round((queueDelayMs + projectionMs) * 10) / 10,
+    })}`);
+  }
+}

--- a/apps/api/src/workers/index.ts
+++ b/apps/api/src/workers/index.ts
@@ -53,6 +53,12 @@ const CRON_KEYS: Record<string, string> = {
 const JOB_TIMEOUT_MS = Number.parseInt(process.env.DEFT_JOB_TIMEOUT_MS ?? '120000', 10);
 const WORKER_POLL_INTERVAL_MS = Number.parseInt(process.env.DEFT_WORKER_POLL_INTERVAL_MS ?? '1000', 10);
 const WORKER_BATCH_SIZE = Math.max(1, Number.parseInt(process.env.DEFT_WORKER_BATCH_SIZE ?? '5', 10));
+const ATTENTION_PROJECTION_BATCH_SIZE = Math.max(
+  WORKER_BATCH_SIZE,
+  Number.parseInt(process.env.DEFT_ATTENTION_PROJECTION_BATCH_SIZE ?? '25', 10),
+);
+
+type DequeuedJob = { id: string; name: string; data: any; attempts: number };
 
 function runWithTimeout<T>(promise: Promise<T>, label: string): Promise<T> {
   if (!Number.isFinite(JOB_TIMEOUT_MS) || JOB_TIMEOUT_MS <= 0) return promise;
@@ -231,6 +237,10 @@ async function getScheduledJobHandler(jobName: string): Promise<JobHandler | nul
       const mod = await import('./handlers/attention-delivery.js');
       return mod.handleAttentionDelivery;
     }
+    case 'notification-attention-sync': {
+      const mod = await import('./handlers/notification-attention-sync.js');
+      return mod.handleNotificationAttentionSync;
+    }
     default:
       return null;
   }
@@ -248,7 +258,7 @@ async function getHandler(queueName: string, jobName: string): Promise<JobHandle
 
 async function processDequeuedJob(
   queueName: string,
-  job: { id: string; name: string; data: any; attempts: number },
+  job: DequeuedJob,
 ): Promise<void> {
   const handler = await getHandler(queueName, job.name);
   if (!handler) {
@@ -281,20 +291,75 @@ async function processDequeuedJob(
   }
 }
 
+async function processAttentionProjectionGroup(queueName: string, jobs: DequeuedJob[]): Promise<void> {
+  const notificationIds = Array.from(new Set(jobs.flatMap((job) =>
+    Array.isArray(job.data?.notificationIds) ? job.data.notificationIds : [],
+  )));
+  const timestamps = jobs
+    .map((job) => typeof job.data?.enqueuedAt === 'string' ? Date.parse(job.data.enqueuedAt) : Number.NaN)
+    .filter(Number.isFinite);
+  const merged: DequeuedJob = {
+    id: jobs[0]!.id,
+    name: 'notification-attention-sync',
+    attempts: Math.max(...jobs.map((job) => job.attempts)),
+    data: {
+      orgId: jobs[0]!.data?.orgId,
+      notificationIds,
+      enqueuedAt: timestamps.length > 0 ? new Date(Math.min(...timestamps)).toISOString() : undefined,
+    },
+  };
+  const handler = await getHandler(queueName, merged.name);
+  if (!handler) {
+    await Promise.all(jobs.map((job) => completeJob(job.id)));
+    return;
+  }
+
+  try {
+    await runWithTimeout(
+      handler(merged),
+      `Job group ${merged.name} (${jobs.length} jobs)`,
+    );
+    await Promise.all(jobs.map((job) => completeJob(job.id)));
+    console.log(`[worker] Job group ${merged.name} (${jobs.length} jobs) completed`);
+  } catch (err) {
+    const message = (err as Error).message;
+    await Promise.all(jobs.map((job) => failJob(job.id, message)));
+    console.error(`[worker] Job group ${merged.name} failed:`, message);
+  }
+}
+
 async function pollQueueBatch(queueName: string): Promise<void> {
-  const jobs: Array<{ id: string; name: string; data: any; attempts: number }> = [];
-  for (let i = 0; i < WORKER_BATCH_SIZE; i += 1) {
+  const jobs: DequeuedJob[] = [];
+  const batchSize = queueName === QUEUE_NAMES.SCHEDULED_JOBS
+    ? ATTENTION_PROJECTION_BATCH_SIZE
+    : WORKER_BATCH_SIZE;
+  for (let i = 0; i < batchSize; i += 1) {
     const job = await dequeueJob(queueName as any);
     if (!job) break;
     jobs.push(job);
   }
   if (jobs.length === 0) return;
-  await Promise.all(jobs.map((job) => processDequeuedJob(queueName, job)));
+  const projectionGroups = new Map<string, DequeuedJob[]>();
+  const ordinaryJobs: DequeuedJob[] = [];
+  for (const job of jobs) {
+    if (job.name !== 'notification-attention-sync') {
+      ordinaryJobs.push(job);
+      continue;
+    }
+    const orgId = typeof job.data?.orgId === 'string' ? job.data.orgId : `invalid:${job.id}`;
+    const group = projectionGroups.get(orgId) ?? [];
+    group.push(job);
+    projectionGroups.set(orgId, group);
+  }
+  await Promise.all([
+    ...ordinaryJobs.map((job) => processDequeuedJob(queueName, job)),
+    ...Array.from(projectionGroups.values()).map((group) => processAttentionProjectionGroup(queueName, group)),
+  ]);
 }
 
 // ─── Public API ───
 let pollingInterval: ReturnType<typeof setInterval> | null = null;
-let pollInFlight = false;
+const pollInFlight = new Set<string>();
 
 export function startWorkers(): void {
   if (pollingInterval) return;
@@ -318,16 +383,14 @@ export function startWorkers(): void {
   }, 60000);
 
   pollingInterval = setInterval(async () => {
-    if (pollInFlight) return;
-    pollInFlight = true;
-    try {
-      await Promise.all(
-        Object.values(QUEUE_NAMES).map((queueName) => pollQueueBatch(queueName)),
-      );
-    } catch {
-      // Don't crash the poller on individual errors.
-    } finally {
-      pollInFlight = false;
+    for (const queueName of Object.values(QUEUE_NAMES)) {
+      if (pollInFlight.has(queueName)) continue;
+      pollInFlight.add(queueName);
+      void pollQueueBatch(queueName)
+        .catch(() => {
+          // Don't crash the poller on individual errors.
+        })
+        .finally(() => pollInFlight.delete(queueName));
     }
   }, WORKER_POLL_INTERVAL_MS);
 
@@ -341,4 +404,5 @@ export function stopWorkers(): void {
     clearInterval(pollingInterval);
     pollingInterval = null;
   }
+  pollInFlight.clear();
 }

--- a/apps/api/test/attention-system.test.ts
+++ b/apps/api/test/attention-system.test.ts
@@ -7,6 +7,7 @@ import {
   attentionEvents,
   attentionItems,
   messages,
+  notifications,
   orgMembers,
   orgs,
   spaceMembers,
@@ -24,6 +25,7 @@ import {
   upsertAttentionItem,
   visibleAttentionCondition,
 } from '../src/lib/attention.js';
+import { handleNotificationAttentionSync } from '../src/workers/handlers/notification-attention-sync.js';
 
 let orgId: string;
 let authorId: string;
@@ -67,6 +69,7 @@ before(async () => {
 
 after(async () => {
   await db.delete(attentionItems).where(eq(attentionItems.org_id, orgId));
+  await db.delete(notifications).where(eq(notifications.org_id, orgId));
   await db.delete(agentActions).where(eq(agentActions.org_id, orgId));
   await db.delete(messages).where(eq(messages.org_id, orgId));
   await db.delete(spaceMembers).where(eq(spaceMembers.space_id, privateSpaceId));
@@ -155,6 +158,73 @@ test('attention dedupes source retries and appends distinct events', async () =>
   assert.equal(changed?.event_count, 2);
   const events = await db.select().from(attentionEvents).where(eq(attentionEvents.attention_item_id, first!.id));
   assert.equal(events.filter((event) => event.event_type === 'source_event').length, 2);
+});
+
+test('bulk notification projection is isolated, folded, and idempotent', async () => {
+  const inserted = await db.insert(notifications).values([
+    {
+      org_id: orgId,
+      user_id: recipientId,
+      type: 'message',
+      title: 'First update',
+      body: 'One durable source event',
+      link: `/chat?space=${privateSpaceId}&message=${privateMessageId}`,
+      metadata: { message_id: privateMessageId, space_id: privateSpaceId },
+    },
+    {
+      org_id: orgId,
+      user_id: recipientId,
+      type: 'message',
+      title: 'Updated summary',
+      body: 'A second event folded into the same item',
+      link: `/chat?space=${privateSpaceId}&message=${privateMessageId}`,
+      metadata: { message_id: privateMessageId, space_id: privateSpaceId },
+    },
+    {
+      org_id: orgId,
+      user_id: authorId,
+      type: 'message',
+      title: 'Separate recipient',
+      body: 'The same source remains user-isolated',
+      link: `/chat?space=${privateSpaceId}&message=${privateMessageId}`,
+      metadata: { message_id: privateMessageId, space_id: privateSpaceId },
+    },
+  ]).returning();
+
+  await handleNotificationAttentionSync({
+    id: 'attention-worker-test',
+    name: 'notification-attention-sync',
+    attempts: 1,
+    data: { orgId, notificationIds: inserted.map((notification) => notification.id) },
+  });
+  const projected = await db.select().from(attentionItems).where(and(
+    eq(attentionItems.org_id, orgId),
+    eq(attentionItems.dedupe_key, `message:${privateMessageId}`),
+    inArray(attentionItems.user_id, [recipientId, authorId]),
+  ));
+  assert.equal(projected.length, 2);
+  const recipientItem = projected.find((item) => item.user_id === recipientId);
+  const authorItem = projected.find((item) => item.user_id === authorId);
+  assert.equal(recipientItem?.event_count, 2);
+  assert.equal(authorItem?.event_count, 1);
+  assert.equal(recipientItem?.source_id, privateMessageId);
+  assert.equal(authorItem?.source_id, privateMessageId);
+  assert.equal((await filterVisibleAttentionItems(recipientId, [recipientItem!])).length, 1);
+
+  const eventRows = await db.select().from(attentionEvents).where(inArray(
+    attentionEvents.source_event_id,
+    inserted.map((notification) => `notification:${notification.id}`),
+  ));
+  assert.equal(eventRows.length, 3);
+  await handleNotificationAttentionSync({
+    id: 'attention-worker-replay-test',
+    name: 'notification-attention-sync',
+    attempts: 2,
+    data: { orgId, notificationIds: inserted.map((notification) => notification.id) },
+  });
+
+  const [unchanged] = await db.select().from(attentionItems).where(eq(attentionItems.id, recipientItem!.id));
+  assert.equal(unchanged?.event_count, 2);
 });
 
 test('seen, acknowledged, snoozed, reopened, and resolved are distinct states', async () => {

--- a/apps/api/test/worker-scheduled-routing.test.ts
+++ b/apps/api/test/worker-scheduled-routing.test.ts
@@ -7,3 +7,10 @@ test('scheduled chat-knowledge-batch resolves to a real handler', async () => {
 
   assert.equal(typeof handler, 'function');
 });
+
+test('scheduled notification-attention-sync resolves to a real handler', async () => {
+  const workers = await import('../src/workers/index.js');
+  const handler = await workers._getScheduledJobHandlerForTest('notification-attention-sync');
+
+  assert.equal(typeof handler, 'function');
+});

--- a/scripts/certify-60-person.mjs
+++ b/scripts/certify-60-person.mjs
@@ -18,15 +18,35 @@ const SUSTAINED_MESSAGES = Number(process.env.CERT_SUSTAINED_MESSAGES || USERS *
 const SUSTAINED_STAGGER_MS = Number(process.env.CERT_SUSTAINED_STAGGER_MS || 250);
 const QUEUE_JOBS = Number(process.env.CERT_QUEUE_JOBS || 120);
 const PORT = Number(process.env.CERT_API_PORT || 3391);
+const MAX_WRITE_P95_MS = Number(process.env.CERT_MAX_WRITE_P95_MS || 5000);
+const MAX_INBOX_READ_P95_MS = Number(process.env.CERT_MAX_INBOX_READ_P95_MS || 3000);
+const MAX_QUEUE_DRAIN_SECONDS = Number(process.env.CERT_MAX_QUEUE_DRAIN_SECONDS || 90);
+const MAX_RECOVERY_SECONDS = Number(process.env.CERT_MAX_RECOVERY_SECONDS || 45);
+const MAX_ATTENTION_PROJECTION_SECONDS = Number(process.env.CERT_MAX_ATTENTION_PROJECTION_SECONDS || 30);
+const MAX_ATTENTION_PROJECTION_P95_MS = Number(process.env.CERT_MAX_ATTENTION_PROJECTION_P95_MS || 5000);
 const BASE_URL = `http://127.0.0.1:${PORT}`;
 const PASSWORD = 'Certification-only-Password-42!';
-const runId = new Date().toISOString().replace(/[-:.TZ]/g, '').slice(0, 14);
+const runId = new Date().toISOString().replace(/[-:.TZ]/g, '');
 const databaseName = `deft_cert_${runId}_${process.pid}`.toLowerCase();
 const startedAt = Date.now();
 const results = {
   run_id: runId,
   started_at: new Date().toISOString(),
-  configuration: { users: USERS, burst_messages: BURST_MESSAGES, sustained_messages: SUSTAINED_MESSAGES, sustained_duration_seconds: Math.round(SUSTAINED_MESSAGES * SUSTAINED_STAGGER_MS / 1000), queue_jobs: QUEUE_JOBS },
+  configuration: {
+    users: USERS,
+    burst_messages: BURST_MESSAGES,
+    sustained_messages: SUSTAINED_MESSAGES,
+    sustained_duration_seconds: Math.round(SUSTAINED_MESSAGES * SUSTAINED_STAGGER_MS / 1000),
+    queue_jobs: QUEUE_JOBS,
+    budgets: {
+      message_write_p95_ms: MAX_WRITE_P95_MS,
+      inbox_read_p95_ms: MAX_INBOX_READ_P95_MS,
+      queue_drain_seconds: MAX_QUEUE_DRAIN_SECONDS,
+      recovery_seconds: MAX_RECOVERY_SECONDS,
+      attention_projection_seconds: MAX_ATTENTION_PROJECTION_SECONDS,
+      attention_projection_p95_ms: MAX_ATTENTION_PROJECTION_P95_MS,
+    },
+  },
   phases: {},
   findings: [],
   boundaries: [
@@ -35,6 +55,10 @@ const results = {
     'Browser rendering is outside this backend/realtime load run; product UI has separate dogfood coverage.',
   ],
 };
+
+if (!Number.isInteger(USERS) || USERS < 12) {
+  throw new Error('CERT_USERS must be an integer of at least 12 so policy and concurrency probes are valid');
+}
 
 function parseEnv(source) {
   const out = {};
@@ -59,6 +83,43 @@ function percentile(values, p) {
 
 function latencySummary(values) {
   return { count: values.length, min_ms: percentile(values, 0), p50_ms: percentile(values, 50), p95_ms: percentile(values, 95), p99_ms: percentile(values, 99), max_ms: percentile(values, 100) };
+}
+
+function parseCapacityProfiles(log) {
+  const allRows = log.split(/\r?\n/).flatMap((line) => {
+    const marker = line.indexOf('[capacity-profile] ');
+    if (marker < 0) return [];
+    try {
+      return [JSON.parse(line.slice(marker + '[capacity-profile] '.length))];
+    } catch {
+      return [];
+    }
+  });
+  const rows = allRows.filter((row) => row.event === 'notification_fanout');
+  const projectionRows = allRows.filter((row) => row.event === 'attention_projection');
+  const metric = (key) => latencySummary(rows.map((row) => Number(row[key]) || 0));
+  return {
+    samples: rows.length,
+    requested_notifications: rows.reduce((sum, row) => sum + Number(row.requested || 0), 0),
+    allowed_notifications: rows.reduce((sum, row) => sum + Number(row.allowed || 0), 0),
+    policy_read: metric('policy_read_ms'),
+    notification_insert: metric('notification_insert_ms'),
+    attention_enqueue: metric('attention_enqueue_ms'),
+    total: metric('total_ms'),
+    attention_projection: {
+      jobs: projectionRows.length,
+      notifications: projectionRows.reduce((sum, row) => sum + Number(row.notifications || 0), 0),
+      projected_items: projectionRows.reduce((sum, row) => sum + Number(row.projected_items || 0), 0),
+      queue_delay: latencySummary(projectionRows.flatMap((row) => row.queue_delay_ms === null ? [] : [Number(row.queue_delay_ms) || 0])),
+      projection: latencySummary(projectionRows.map((row) => Number(row.projection_ms) || 0)),
+      end_to_end: latencySummary(projectionRows.flatMap((row) => row.end_to_end_ms === null ? [] : [Number(row.end_to_end_ms) || 0])),
+    },
+  };
+}
+
+function addGateFinding(condition, title, detail) {
+  if (!condition) return;
+  results.findings.push({ severity: 'high', title, detail });
 }
 
 function sleep(ms) { return new Promise((resolve) => setTimeout(resolve, ms)); }
@@ -109,6 +170,52 @@ async function stopApi() {
   apiProcess = null;
 }
 
+async function waitForApiReady(timeoutMs = 60000) {
+  const deadline = Date.now() + timeoutMs;
+  let lastHealth = null;
+  while (Date.now() < deadline) {
+    if (apiProcess?.exitCode !== null && apiProcess?.exitCode !== undefined) {
+      throw new Error(`API exited before readiness with code ${apiProcess.exitCode}.\n${apiLog.slice(-4000)}`);
+    }
+    lastHealth = await timedFetch(`${BASE_URL}/health`);
+    if (lastHealth.ok) return;
+    await sleep(400);
+  }
+  throw new Error(`API readiness timed out after ${timeoutMs}ms. Last health=${JSON.stringify(lastHealth)}\n${apiLog.slice(-4000)}`);
+}
+
+async function assertCertificationSchema(connection) {
+  const requiredTables = [
+    'orgs',
+    'users',
+    'org_members',
+    'spaces',
+    'space_members',
+    'messages',
+    'notifications',
+    'attention_items',
+    'attention_events',
+    'attention_deliveries',
+    'job_queue',
+  ];
+  const tableRows = await connection.query(
+    "SELECT table_name FROM information_schema.tables WHERE table_schema='public' AND table_name=ANY($1)",
+    [requiredTables],
+  );
+  const present = new Set(tableRows.rows.map((row) => row.table_name));
+  const missingTables = requiredTables.filter((table) => !present.has(table));
+  const columnRows = await connection.query(
+    "SELECT column_name FROM information_schema.columns WHERE table_schema='public' AND table_name='users' AND column_name=ANY($1)",
+    [['profile_summary', 'notification_preferences']],
+  );
+  const columns = new Set(columnRows.rows.map((row) => row.column_name));
+  const missingColumns = ['profile_summary', 'notification_preferences'].filter((column) => !columns.has(column));
+  if (missingTables.length || missingColumns.length) {
+    throw new Error(`Certification schema is stale. Missing tables: ${missingTables.join(', ') || 'none'}; missing users columns: ${missingColumns.join(', ') || 'none'}`);
+  }
+  return { required_tables: requiredTables.length, required_user_columns: 2 };
+}
+
 async function timedFetch(url, init = {}) {
   const start = performance.now();
   try {
@@ -128,11 +235,16 @@ function authHeaders(token) {
 
 async function connectSockets(tokens, spaceId) {
   const counters = tokens.map(() => ({ messages: 0, notifications: 0, presence: 0 }));
+  const marker = `[CERT:${runId}:`;
   const sockets = await Promise.all(tokens.map((token, index) => new Promise((resolve, reject) => {
     const socket = io(BASE_URL, { auth: { token }, transports: ['websocket'], reconnection: false, timeout: 10000 });
     const timer = setTimeout(() => { socket.close(); reject(new Error(`socket ${index} timeout`)); }, 12000);
-    socket.on('message:new', () => { counters[index].messages += 1; });
-    socket.on('notification:new', () => { counters[index].notifications += 1; });
+    socket.on('message:new', (message) => {
+      if (String(message?.content ?? '').includes(marker)) counters[index].messages += 1;
+    });
+    socket.on('notification:new', (notification) => {
+      if (String(notification?.body ?? '').includes(marker)) counters[index].notifications += 1;
+    });
     socket.on('presence:update', () => { counters[index].presence += 1; });
     socket.on('connect_error', (error) => { clearTimeout(timer); reject(error); });
     socket.on('connect', () => {
@@ -173,8 +285,8 @@ function renderReport(report) {
   const phaseRows = Object.entries(report.phases).map(([name, value]) => `<tr><th>${htmlEscape(name.replaceAll('_', ' '))}</th><td><pre>${htmlEscape(JSON.stringify(value, null, 2))}</pre></td></tr>`).join('');
   const findingRows = report.findings.map((item) => `<li class="${item.severity}"><strong>${htmlEscape(item.severity.toUpperCase())}: ${htmlEscape(item.title)}</strong><p>${htmlEscape(item.detail)}</p></li>`).join('');
   const passed = report.verdict === 'PASS';
-  return `<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Deft 60-person certification</title><style>
-  :root{color-scheme:dark}*{box-sizing:border-box}body{margin:0;background:#111114;color:#ececf1;font:15px/1.55 Inter,system-ui,sans-serif}main{max-width:1060px;margin:auto;padding:48px 28px 80px}header{border-bottom:1px solid #303038;padding-bottom:28px;margin-bottom:28px}.eyebrow{color:#9b8cff;text-transform:uppercase;font-size:12px;font-weight:750;letter-spacing:.08em}h1{font-size:44px;line-height:1.06;margin:10px 0 14px;letter-spacing:0}h2{margin-top:38px}.verdict{display:inline-flex;padding:7px 13px;border-radius:999px;background:${passed ? '#123b2b' : '#442225'};color:${passed ? '#64e7a4' : '#ff8f98'};font-weight:800}.grid{display:grid;grid-template-columns:repeat(4,1fr);gap:10px}.metric{background:#1b1b20;border:1px solid #303038;border-radius:8px;padding:16px}.metric b{font-size:24px;display:block}.metric span{color:#a6a6b1;font-size:12px}table{border-collapse:collapse;width:100%;background:#17171b;border:1px solid #303038}th,td{text-align:left;vertical-align:top;border-bottom:1px solid #303038;padding:14px}th{width:210px;text-transform:capitalize}pre{white-space:pre-wrap;margin:0;color:#cfcfd8;font:12px/1.45 ui-monospace,monospace}.high strong{color:#ff8f98}.medium strong{color:#ffd36c}.low strong{color:#87d7ff}li{margin-bottom:16px}p{color:#b9b9c3}.boundary{border-left:3px solid #7b68ee;padding-left:14px}</style></head><body><main><header><div class="eyebrow">Deft capacity evidence</div><h1>30-60 person certification</h1><p>One disposable workspace, ${report.configuration.users} people, real HTTP + Socket.IO traffic, notification volume, queue pressure, forced restart, and recovery.</p><span class="verdict">${htmlEscape(report.verdict)}</span></header><section class="grid"><div class="metric"><b>${report.configuration.users}</b><span>connected people</span></div><div class="metric"><b>${report.summary?.messages_succeeded ?? 0}</b><span>messages accepted</span></div><div class="metric"><b>${report.summary?.socket_fanout_ratio ?? 0}%</b><span>message fanout</span></div><div class="metric"><b>${report.summary?.recovery_seconds ?? 'n/a'}s</b><span>service recovery</span></div></section><h2>Findings</h2><ul>${findingRows || '<li>No findings.</li>'}</ul><h2>Evidence</h2><table>${phaseRows}</table><h2>Proven boundary</h2>${report.boundaries.map((item) => `<p class="boundary">${htmlEscape(item)}</p>`).join('')}<p>Generated ${htmlEscape(report.completed_at)} in ${htmlEscape(report.duration_seconds)} seconds. Temporary database: removed.</p></main></body></html>`;
+  return `<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Deft ${report.configuration.users}-person certification</title><style>
+  :root{color-scheme:dark}*{box-sizing:border-box}body{margin:0;background:#111114;color:#ececf1;font:15px/1.55 Inter,system-ui,sans-serif}main{max-width:1060px;margin:auto;padding:48px 28px 80px}header{border-bottom:1px solid #303038;padding-bottom:28px;margin-bottom:28px}.eyebrow{color:#9b8cff;text-transform:uppercase;font-size:12px;font-weight:750;letter-spacing:.08em}h1{font-size:44px;line-height:1.06;margin:10px 0 14px;letter-spacing:0}h2{margin-top:38px}.verdict{display:inline-flex;padding:7px 13px;border-radius:999px;background:${passed ? '#123b2b' : '#442225'};color:${passed ? '#64e7a4' : '#ff8f98'};font-weight:800}.grid{display:grid;grid-template-columns:repeat(4,1fr);gap:10px}.metric{background:#1b1b20;border:1px solid #303038;border-radius:8px;padding:16px}.metric b{font-size:24px;display:block}.metric span{color:#a6a6b1;font-size:12px}table{border-collapse:collapse;width:100%;background:#17171b;border:1px solid #303038}th,td{text-align:left;vertical-align:top;border-bottom:1px solid #303038;padding:14px}th{width:210px;text-transform:capitalize}pre{white-space:pre-wrap;margin:0;color:#cfcfd8;font:12px/1.45 ui-monospace,monospace}.high strong{color:#ff8f98}.medium strong{color:#ffd36c}.low strong{color:#87d7ff}li{margin-bottom:16px}p{color:#b9b9c3}.boundary{border-left:3px solid #7b68ee;padding-left:14px}</style></head><body><main><header><div class="eyebrow">Deft capacity evidence</div><h1>${report.configuration.users}-person certification</h1><p>One disposable workspace, ${report.configuration.users} people, real HTTP + Socket.IO traffic, notification volume, queue pressure, forced restart, and recovery.</p><span class="verdict">${htmlEscape(report.verdict)}</span></header><section class="grid"><div class="metric"><b>${report.configuration.users}</b><span>connected people</span></div><div class="metric"><b>${report.summary?.messages_succeeded ?? 0}</b><span>messages accepted</span></div><div class="metric"><b>${report.summary?.socket_fanout_ratio ?? 0}%</b><span>message fanout</span></div><div class="metric"><b>${report.summary?.recovery_seconds ?? 'n/a'}s</b><span>service recovery</span></div></section><h2>Findings</h2><ul>${findingRows || '<li>No findings.</li>'}</ul><h2>Evidence</h2><table>${phaseRows}</table><h2>Proven boundary</h2>${report.boundaries.map((item) => `<p class="boundary">${htmlEscape(item)}</p>`).join('')}<p>Generated ${htmlEscape(report.completed_at)} in ${htmlEscape(report.duration_seconds)} seconds. Temporary database removed: ${htmlEscape(report.cleanup?.database_removed ?? false)}.</p></main></body></html>`;
 }
 
 let admin = null;
@@ -182,6 +294,7 @@ let adminConnected = false;
 let pool = null;
 let sockets = [];
 let tempDbUrl = '';
+let databaseRemoved = false;
 try {
   const envFile = parseEnv(await readFile(path.join(root, '.env'), 'utf8'));
   const baseDbUrl = process.env.DATABASE_URL || envFile.DATABASE_URL;
@@ -208,6 +321,7 @@ try {
     DEFT_AUTH_RATE_LIMIT_PER_MINUTE: process.env.DEFT_AUTH_RATE_LIMIT_PER_MINUTE || '10',
     DEFT_LOGIN_IP_RATE_LIMIT_PER_MINUTE: process.env.DEFT_LOGIN_IP_RATE_LIMIT_PER_MINUTE || '120',
     DEFT_DEFAULT_RATE_LIMIT_PER_MINUTE: '5000', DEFT_WORKER_BATCH_SIZE: '10', DEFT_WORKER_POLL_INTERVAL_MS: '250',
+    DEFT_CAPACITY_TRACE: '1',
   };
   pool = new Pool({ connectionString: tempDbUrl, max: 20 });
   const schemaStart = performance.now();
@@ -215,23 +329,15 @@ try {
     const tableRows = await pool.query("SELECT tablename FROM pg_tables WHERE schemaname='public'");
     const tableNames = tableRows.rows.map((row) => `"${String(row.tablename).replaceAll('"', '""')}"`);
     if (tableNames.length) await pool.query(`TRUNCATE TABLE ${tableNames.join(', ')} RESTART IDENTITY CASCADE`);
-    // Some older local developer databases predate the users-table journal
-    // repair. Keep the disposable clone usable without mutating that source.
-    await pool.query(`CREATE TABLE IF NOT EXISTS users (
-      id text PRIMARY KEY, email text UNIQUE, name text NOT NULL,
-      kind user_kind NOT NULL DEFAULT 'human', is_agent boolean NOT NULL DEFAULT false,
-      agent_employee_id text, avatar_url text, title text, profile_summary text,
-      expertise_tags text[], timezone text DEFAULT 'UTC', status_emoji text,
-      status_text text, status_expires_at timestamp, password_hash text,
-      email_verified boolean NOT NULL DEFAULT false, last_seen_at timestamp,
-      notification_keywords text[], notification_preferences jsonb NOT NULL DEFAULT '{"keywords":[],"channels":{"chat":true,"tasks":true,"approvals":true,"calendar":true,"agents":true}}'::jsonb,
-      show_read_receipts boolean NOT NULL DEFAULT true, ics_publish_token text,
-      created_at timestamp NOT NULL DEFAULT now(), updated_at timestamp NOT NULL DEFAULT now()
-    )`);
   } else {
     await run('pnpm', ['db:push-full'], { env: certEnv });
   }
-  results.phases.database_bootstrap = { seconds: Math.round((performance.now() - schemaStart) / 100) / 10, method: templateDatabase ? `schema clone of ${templateDatabase}, all data truncated` : 'db:push-full' };
+  const schemaProof = await assertCertificationSchema(pool);
+  results.phases.database_bootstrap = {
+    seconds: Math.round((performance.now() - schemaStart) / 100) / 10,
+    method: templateDatabase ? `schema clone of ${templateDatabase}, all data truncated` : 'db:push-full',
+    schema_proof: schemaProof,
+  };
 
   const orgId = randomUUID();
   const spaceId = randomUUID();
@@ -239,7 +345,7 @@ try {
   const users = Array.from({ length: USERS }, (_, i) => ({ id: randomUUID(), name: `Cert User ${String(i + 1).padStart(2, '0')}`, email: `cert-${runId}-${i + 1}@deft.invalid` }));
   await pool.query('BEGIN');
   try {
-    await pool.query('INSERT INTO orgs (id,name,slug,agent_enabled,ai_config) VALUES ($1,$2,$3,false,$4)', [orgId, '60 Person Certification', `cert-${runId}`, {}]);
+    await pool.query('INSERT INTO orgs (id,name,slug,agent_enabled,ai_config) VALUES ($1,$2,$3,false,$4)', [orgId, `${USERS} Person Certification`, `cert-${runId}`, {}]);
     for (let i = 0; i < users.length; i += 1) {
       const user = users[i];
       await pool.query('INSERT INTO users (id,email,name,password_hash,email_verified,kind) VALUES ($1,$2,$3,$4,true,\'human\')', [user.id, user.email, user.name, passwordHash]);
@@ -254,7 +360,7 @@ try {
   process.stdout.write('[cert] Starting API and workers\n');
   startApi(certEnv);
   const bootStarted = performance.now();
-  await waitFor(async () => (await timedFetch(`${BASE_URL}/health`)).ok, 45000, 400);
+  await waitForApiReady();
   results.phases.initial_boot = { seconds: Math.round((performance.now() - bootStarted) / 100) / 10 };
 
   process.stdout.write('[cert] Measuring production login burst\n');
@@ -292,9 +398,46 @@ try {
     socket_message_deliveries: { expected: expectedMessageDeliveries, actual: actualMessageDeliveries, ratio: expectedMessageDeliveries ? Math.round(actualMessageDeliveries / expectedMessageDeliveries * 10000) / 100 : 0 },
     socket_notification_deliveries: { expected: expectedNotificationDeliveries, actual: actualNotificationDeliveries, ratio: expectedNotificationDeliveries ? Math.round(actualNotificationDeliveries / expectedNotificationDeliveries * 10000) / 100 : 0 },
   };
+  results.phases.notification_fanout_profile = parseCapacityProfiles(apiLog);
   if (burst.failed.length || sustained.failed.length) results.findings.push({ severity: 'high', title: 'Message writes failed under load', detail: `${burst.failed.length + sustained.failed.length} message writes failed.` });
-  if (actualMessageDeliveries < expectedMessageDeliveries) results.findings.push({ severity: 'high', title: 'Socket message fanout was incomplete', detail: `${actualMessageDeliveries}/${expectedMessageDeliveries} expected room deliveries arrived.` });
-  if (actualNotificationDeliveries < expectedNotificationDeliveries) results.findings.push({ severity: 'high', title: 'Realtime notification fanout was incomplete', detail: `${actualNotificationDeliveries}/${expectedNotificationDeliveries} expected user-room deliveries arrived.` });
+  if (actualMessageDeliveries !== expectedMessageDeliveries) results.findings.push({ severity: 'high', title: 'Socket message fanout was not exactly once', detail: `${actualMessageDeliveries}/${expectedMessageDeliveries} expected room deliveries arrived.` });
+  if (actualNotificationDeliveries !== expectedNotificationDeliveries) results.findings.push({ severity: 'high', title: 'Realtime notification fanout was not exactly once', detail: `${actualNotificationDeliveries}/${expectedNotificationDeliveries} expected user-room deliveries arrived.` });
+
+  process.stdout.write('[cert] Waiting for durable notification-to-attention projection\n');
+  const attentionProjectionStarted = performance.now();
+  await waitFor(async () => {
+    const { rows } = await pool.query(`
+      SELECT count(*)::int projected
+      FROM attention_events ae
+      INNER JOIN notifications n ON ae.source_event_id = 'notification:' || n.id
+      WHERE ae.event_type = 'source_event'
+        AND n.org_id = $1
+        AND n.body LIKE $2
+    `, [orgId, `[CERT:${runId}:%`]);
+    return rows[0].projected === expectedNotificationDeliveries ? rows[0].projected : false;
+  }, Math.max(5000, MAX_ATTENTION_PROJECTION_SECONDS * 1000), 250);
+  const attentionProjectionSeconds = Math.round((performance.now() - attentionProjectionStarted) / 100) / 10;
+  results.phases.notification_fanout_profile = parseCapacityProfiles(apiLog);
+  const attentionProjectionProof = await pool.query(`
+    SELECT count(*)::int projected
+    FROM attention_events ae
+    INNER JOIN notifications n ON ae.source_event_id = 'notification:' || n.id
+    WHERE ae.event_type = 'source_event'
+      AND n.org_id = $1
+      AND n.body LIKE $2
+  `, [orgId, `[CERT:${runId}:%`]);
+  results.phases.attention_projection = {
+    expected: expectedNotificationDeliveries,
+    actual: attentionProjectionProof.rows[0].projected,
+    post_load_drain_seconds: attentionProjectionSeconds,
+    end_to_end_p95_ms: results.phases.notification_fanout_profile.attention_projection.end_to_end.p95_ms,
+  };
+  addGateFinding(attentionProjectionSeconds > MAX_ATTENTION_PROJECTION_SECONDS, 'Attention projection exceeded the release budget', `Projection took ${attentionProjectionSeconds}s; the configured budget is ${MAX_ATTENTION_PROJECTION_SECONDS}s.`);
+  addGateFinding(
+    (results.phases.attention_projection.end_to_end_p95_ms ?? Number.POSITIVE_INFINITY) > MAX_ATTENTION_PROJECTION_P95_MS,
+    'Attention projection p95 exceeded the release budget',
+    `End-to-end p95 was ${results.phases.attention_projection.end_to_end_p95_ms ?? 'unavailable'}ms; the configured budget is ${MAX_ATTENTION_PROJECTION_P95_MS}ms.`,
+  );
 
   process.stdout.write('[cert] Verifying notification preference policy under the bulk path\n');
   const policyUsers = users.slice(0, 4);
@@ -326,7 +469,7 @@ try {
   await pool.query('UPDATE space_members SET is_muted=false WHERE space_id=$1 AND user_id=$2', [spaceId, policyUsers[2].id]);
   await pool.query("UPDATE space_members SET notification_level='all' WHERE space_id=$1 AND user_id=$2", [spaceId, policyUsers[3].id]);
 
-  process.stdout.write('[cert] Reading 60 inboxes concurrently\n');
+  process.stdout.write(`[cert] Reading ${USERS} inboxes concurrently\n`);
   const inboxReads = await Promise.all(tokens.map((token) => timedFetch(`${BASE_URL}/api/notifications`, { headers: authHeaders(token) })));
   results.phases.notification_inbox_reads = {
     succeeded: inboxReads.filter((row) => row.ok).length,
@@ -352,7 +495,7 @@ try {
   const restartStarted = performance.now();
   apiLog = '';
   startApi(certEnv);
-  await waitFor(async () => (await timedFetch(`${BASE_URL}/health`)).ok, 45000, 400);
+  await waitForApiReady();
   const healthRecoverySeconds = Math.round((performance.now() - restartStarted) / 100) / 10;
   const drainStarted = performance.now();
   await waitFor(async () => {
@@ -382,7 +525,11 @@ try {
   if (recoveryDeliveries !== USERS) results.findings.push({ severity: 'high', title: 'Post-restart socket proof was incomplete', detail: `${recoveryDeliveries}/${USERS} clients received the recovery message.` });
 
   const p95Write = Math.max(burst.latency.p95_ms || 0, sustained.latency.p95_ms || 0);
-  if (p95Write > 5000) results.findings.push({ severity: 'medium', title: 'Message write latency lacks comfortable headroom', detail: `Worst phase p95 was ${p95Write}ms. The target for a comfortable 60-person pilot is below 5000ms under this artificial all-hands fanout.` });
+  const inboxP95 = results.phases.notification_inbox_reads.latency.p95_ms || 0;
+  addGateFinding(p95Write > MAX_WRITE_P95_MS, 'Message write latency exceeded the release budget', `Worst phase p95 was ${p95Write}ms; the configured budget is ${MAX_WRITE_P95_MS}ms.`);
+  addGateFinding(inboxP95 > MAX_INBOX_READ_P95_MS, 'Inbox read latency exceeded the release budget', `Concurrent inbox-read p95 was ${inboxP95}ms; the configured budget is ${MAX_INBOX_READ_P95_MS}ms.`);
+  addGateFinding(queueDrainSeconds > MAX_QUEUE_DRAIN_SECONDS, 'Queue drain exceeded the release budget', `Queue drain took ${queueDrainSeconds}s; the configured budget is ${MAX_QUEUE_DRAIN_SECONDS}s.`);
+  addGateFinding(healthRecoverySeconds > MAX_RECOVERY_SECONDS, 'Service recovery exceeded the release budget', `Health recovery took ${healthRecoverySeconds}s; the configured budget is ${MAX_RECOVERY_SECONDS}s.`);
   results.summary = {
     messages_succeeded: totalSucceeded + proof.succeeded,
     socket_fanout_ratio: results.phases.message_and_notification_load.socket_message_deliveries.ratio,
@@ -391,6 +538,8 @@ try {
     notification_read_p95_ms: results.phases.notification_inbox_reads.latency.p95_ms,
     queue_drain_seconds: queueDrainSeconds,
     recovery_seconds: healthRecoverySeconds,
+    attention_projection_seconds: attentionProjectionSeconds,
+    attention_projection_p95_ms: results.phases.attention_projection.end_to_end_p95_ms,
   };
   const hardFailures = results.findings.filter((item) => item.severity === 'high').length;
   results.verdict = hardFailures === 0 ? 'PASS' : 'FAIL';
@@ -405,15 +554,23 @@ try {
   if (pool) await pool.end().catch(() => {});
   if (adminConnected && admin && databaseName) {
     await admin.query('SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname=$1', [databaseName]).catch(() => {});
-    await admin.query(`DROP DATABASE IF EXISTS "${databaseName}"`).catch(() => {});
+    try {
+      await admin.query(`DROP DATABASE IF EXISTS "${databaseName}"`);
+      const proof = await admin.query('SELECT 1 FROM pg_database WHERE datname=$1', [databaseName]);
+      databaseRemoved = proof.rowCount === 0;
+    } catch (error) {
+      results.findings.push({ severity: 'high', title: 'Disposable database cleanup failed', detail: String(error?.message || error) });
+    }
     await admin.end().catch(() => {});
   }
+  results.cleanup = { database_name: databaseName, database_removed: databaseRemoved };
+  if (!databaseRemoved) results.verdict = 'FAIL';
   results.completed_at = new Date().toISOString();
   results.duration_seconds = Math.round((Date.now() - startedAt) / 100) / 10;
   results.api_log_tail = apiLog.split(/\r?\n/).slice(-40).join('\n');
   const reportDir = path.join(root, 'reports');
   await mkdir(reportDir, { recursive: true });
-  const stem = `deft-60-person-certification-${new Date().toISOString().slice(0, 10)}`;
+  const stem = `deft-${USERS}-person-certification-${runId}`;
   await writeFile(path.join(reportDir, `${stem}.json`), JSON.stringify(results, null, 2));
   await writeFile(path.join(reportDir, `${stem}.html`), renderReport(results));
   process.stdout.write(`[cert] ${results.verdict} in ${results.duration_seconds}s\n[cert] Report: ${path.join(reportDir, `${stem}.html`)}\n`);


### PR DESCRIPTION
## What changed

- make bulk notification-to-attention projection durable and asynchronous
- batch attention upserts, event ledger writes, and web-push scheduling
- preserve synchronous projection as a queue-insert fallback
- isolate worker polling per queue and group projection jobs by organization
- add source-accurate message metadata and deep links
- harden the 60-person certification harness with exact fanout, latency, recovery, and cleanup gates

## Why

The previous message fanout path synchronously projected one attention item at a time. At 60 concurrent users this pushed message write p95 beyond the certification budget and made attention latency difficult to measure truthfully.

## Impact

Human message writes return after the durable notification and projection job are recorded. Attention items remain retry-safe and replay-idempotent, while the scheduled worker performs bounded bulk projection and delivery scheduling.

## Validation

- API typecheck
- full API suite: 806 passed, 0 failed, on a disposable fresh schema
- focused attention/queue/push suite: 14 passed, 0 failed
- local 60-person certification: PASS
  - 180 writes
  - 10,620/10,620 attention events
  - 100% message and notification fanout
  - write p95 2.22s
  - attention end-to-end p95 318ms
  - cleanup verified
