### PR TITLE
Allow capacity certification in production containers

### DIFF
--- a/scripts/certify-60-person.mjs
+++ b/scripts/certify-60-person.mjs
@@ -296,9 +296,14 @@ let sockets = [];
 let tempDbUrl = '';
 let databaseRemoved = false;
 try {
-  const envFile = parseEnv(await readFile(path.join(root, '.env'), 'utf8'));
+  let envFile = {};
+  try {
+    envFile = parseEnv(await readFile(path.join(root, '.env'), 'utf8'));
+  } catch (error) {
+    if (error?.code !== 'ENOENT') throw error;
+  }
   const baseDbUrl = process.env.DATABASE_URL || envFile.DATABASE_URL;
-  if (!baseDbUrl) throw new Error('DATABASE_URL is required in .env');
+  if (!baseDbUrl) throw new Error('DATABASE_URL is required via the environment or .env');
   const parsed = new URL(baseDbUrl);
   const adminUrl = new URL(baseDbUrl);
   adminUrl.pathname = '/postgres';


### PR DESCRIPTION
## What changed

Treat the repository `.env` file as optional in the 60-person certification harness and continue to prefer `DATABASE_URL` from the process environment.

## Why

The production container correctly receives its database URL through Docker Compose but does not copy `.env` into the image. The post-merge VPS certification therefore failed before creating a disposable database.

## Validation

- `node --check scripts/certify-60-person.mjs`
- live failure was immediate and created no test database
- full certification will be rerun on the VPS after merge and redeploy