### PR TITLE
Fix chat notification deep links

### DIFF
--- a/apps/api/src/routes/messages.ts
+++ b/apps/api/src/routes/messages.ts
@@ -515,7 +515,7 @@ messageRoutes.post('/:spaceId', async (c) => {
           type: 'mention',
           title: `${userData?.name ?? 'Someone'} mentioned you`,
           body: normalizedContent.slice(0, 200),
-          link: `/spaces/${spaceId}?message=${message!.id}`,
+          link: `/chat?space=${encodeURIComponent(spaceId)}&message=${encodeURIComponent(message!.id)}`,
         }, { channel: 'chat', spaceId, isMention: true });
 
         if (notification) {
@@ -543,7 +543,7 @@ messageRoutes.post('/:spaceId', async (c) => {
             type: 'mention',
             title: `${userData?.name ?? 'Someone'} replied to your message`,
             body: normalizedContent.slice(0, 200),
-            link: `/spaces/${spaceId}?message=${parsed.data.parent_id}`,
+            link: `/chat?space=${encodeURIComponent(spaceId)}&message=${encodeURIComponent(parsed.data.parent_id)}`,
           }, { channel: 'chat', spaceId, isMention: true });
 
           if (notification) {

--- a/apps/api/src/workers/handlers/blocked-alert.ts
+++ b/apps/api/src/workers/handlers/blocked-alert.ts
@@ -129,7 +129,7 @@ export async function handleBlockedAlert(job: JobData): Promise<void> {
         type: 'agent_suggestion',
         title: 'Blocked Team Member',
         body: message,
-        link: `/spaces/${spaceId}?message=${messageId}`,
+        link: `/chat?space=${encodeURIComponent(spaceId)}&message=${encodeURIComponent(messageId)}`,
         metadata: {
           task_id: task.id,
           nudge_type: 'blocked',

--- a/apps/api/test/agent-mention-detection.test.ts
+++ b/apps/api/test/agent-mention-detection.test.ts
@@ -225,6 +225,21 @@ test('structured mention of Defty user triggers agent-reply dispatch', async () 
   assert.ok(body.id, 'response should include message id');
   createdMessageIds.push(body.id!);
 
+  const [mentionNotification] = await db
+    .select({ link: notifications.link })
+    .from(notifications)
+    .where(and(
+      eq(notifications.user_id, deftyUserId),
+      eq(notifications.type, 'mention'),
+      eq(notifications.link, `/chat?space=${spaceId}&message=${body.id}`),
+    ))
+    .limit(1);
+  assert.equal(
+    mentionNotification?.link,
+    `/chat?space=${spaceId}&message=${body.id}`,
+    'mention notification should deep-link to the message on the chat surface',
+  );
+
   const dispatched = await findAgentReplyJob(body.id!);
   assert.ok(dispatched, 'agent-reply job should be enqueued for Defty mention');
   const employeeQueued = await findAgentEmployeeMessageJob(body.id!);


### PR DESCRIPTION
## Summary
- point mention and thread-reply notifications at the canonical chat route
- fix blocked-member alert deep links
- add regression coverage for message-level mention navigation

## Verification
- API typecheck
- agent mention integration suite on a fresh disposable database: 8/8