### PR TITLE
Fix mobile dashboard grid clipping

### DIFF
--- a/apps/web/src/app/(app)/dashboard/grid/dashboard-grid.tsx
+++ b/apps/web/src/app/(app)/dashboard/grid/dashboard-grid.tsx
@@ -12,15 +12,14 @@
  * the registry + contract, not RGL. Swapping the engine later is contained
  * to this file.
  */
-import { useMemo } from 'react';
-import { Responsive, WidthProvider, type Layout } from 'react-grid-layout';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Responsive, type Layout } from 'react-grid-layout';
 import 'react-grid-layout/css/styles.css';
 import 'react-resizable/css/styles.css';
 import { getWidget } from '../lib/registry';
 import { WidgetShell } from './widget-shell';
+import { buildStackedLayout, type StackedLayoutSource } from './responsive-layout';
 import type { BreakpointLayoutEntry, DashboardLayout, WidgetContext } from '../lib/widget-types';
-
-const ResponsiveGridLayout = WidthProvider(Responsive);
 
 type ViewLinkResolver = (widgetId: string) => string | undefined;
 
@@ -49,6 +48,30 @@ export type DashboardGridProps = {
 export function DashboardGrid({
   layout, ctx, editMode = false, onLayoutChange, onRemove, onConfigChange, viewLink,
 }: DashboardGridProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [containerWidth, setContainerWidth] = useState(0);
+
+  useEffect(() => {
+    const node = containerRef.current;
+    if (!node) return;
+
+    const measure = () => {
+      const nextWidth = node.getBoundingClientRect().width;
+      if (nextWidth > 0) {
+        setContainerWidth((current) => Math.abs(current - nextWidth) < 0.5 ? current : nextWidth);
+      }
+    };
+
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(node);
+    window.addEventListener('resize', measure);
+    return () => {
+      observer.disconnect();
+      window.removeEventListener('resize', measure);
+    };
+  }, []);
+
   const placements = useMemo(() => layout.placements.filter(p => {
     const def = getWidget(p.widgetId);
     if (!def) return false;
@@ -97,13 +120,25 @@ export function DashboardGrid({
       }
       return out;
     };
+    const stackedSources: StackedLayoutSource[] = placements.map(p => {
+      const def = getWidget(p.widgetId)!;
+      return {
+        i: p.instanceId,
+        x: p.x,
+        y: p.y,
+        w: p.w,
+        h: p.h,
+        minH: def.minSize.h,
+        maxH: def.maxSize?.h,
+      };
+    });
     const overrides = layout.responsiveLayouts ?? {};
     return {
       lg,
       md: fromOverride(overrides.md) ?? lg,
-      sm: fromOverride(overrides.sm) ?? lg,
-      xs: fromOverride(overrides.xs) ?? lg,
-      xxs: fromOverride(overrides.xxs) ?? lg,
+      sm: buildStackedLayout(stackedSources, 6, overrides.sm),
+      xs: buildStackedLayout(stackedSources, 4, overrides.xs),
+      xxs: buildStackedLayout(stackedSources, 2, overrides.xxs),
     };
   }, [placements, layout.responsiveLayouts]);
 
@@ -132,45 +167,50 @@ export function DashboardGrid({
   };
 
   return (
-    <ResponsiveGridLayout
-      className="dashboard4-grid"
-      layouts={layouts}
-      breakpoints={{ lg: 1200, md: 996, sm: 768, xs: 480, xxs: 0 }}
-      cols={{ lg: 12, md: 12, sm: 6, xs: 4, xxs: 2 }}
-      rowHeight={60}
-      margin={[16, 16]}
-      containerPadding={[0, 0]}
-      compactType="vertical"
-      preventCollision={false}
-      isDraggable={editMode}
-      isResizable={editMode}
-      resizeHandles={['se', 'e', 's']}
-      draggableHandle=".widget-drag-handle"
-      onLayoutChange={handleChange}
-    >
-      {placements.map(p => {
-        const def = getWidget(p.widgetId)!;
-        const Component = def.Component;
-        const hrefResolved = viewLink?.(p.widgetId) ?? DEFAULT_VIEW_LINKS[p.widgetId];
-        return (
-          <div key={p.instanceId}>
-            <WidgetShell
-              title={def.title}
-              href={hrefResolved || undefined}
-              editMode={editMode}
-              onRemove={onRemove ? () => onRemove(p.instanceId) : undefined}
-            >
-              <Component
-                instanceId={p.instanceId}
-                size={{ w: p.w, h: p.h }}
-                config={(p.config ?? null) as any}
-                onConfigChange={onConfigChange ? (c: unknown) => onConfigChange(p.instanceId, c) : undefined}
-                editMode={editMode}
-              />
-            </WidgetShell>
-          </div>
-        );
-      })}
-    </ResponsiveGridLayout>
+    <div ref={containerRef} className="dashboard4-grid" data-edit={editMode || undefined}>
+      {containerWidth > 0 && (
+        <Responsive
+          className="dashboard4-responsive-grid"
+          width={containerWidth}
+          layouts={layouts}
+          breakpoints={{ lg: 1200, md: 996, sm: 768, xs: 480, xxs: 0 }}
+          cols={{ lg: 12, md: 12, sm: 6, xs: 4, xxs: 2 }}
+          rowHeight={60}
+          margin={[16, 16]}
+          containerPadding={[0, 0]}
+          compactType="vertical"
+          preventCollision={false}
+          isDraggable={editMode}
+          isResizable={editMode}
+          resizeHandles={['se', 'e', 's']}
+          draggableHandle=".widget-drag-handle"
+          onLayoutChange={handleChange}
+        >
+          {placements.map(p => {
+            const def = getWidget(p.widgetId)!;
+            const Component = def.Component;
+            const hrefResolved = viewLink?.(p.widgetId) ?? DEFAULT_VIEW_LINKS[p.widgetId];
+            return (
+              <div key={p.instanceId}>
+                <WidgetShell
+                  title={def.title}
+                  href={hrefResolved || undefined}
+                  editMode={editMode}
+                  onRemove={onRemove ? () => onRemove(p.instanceId) : undefined}
+                >
+                  <Component
+                    instanceId={p.instanceId}
+                    size={{ w: p.w, h: p.h }}
+                    config={(p.config ?? null) as any}
+                    onConfigChange={onConfigChange ? (c: unknown) => onConfigChange(p.instanceId, c) : undefined}
+                    editMode={editMode}
+                  />
+                </WidgetShell>
+              </div>
+            );
+          })}
+        </Responsive>
+      )}
+    </div>
   );
 }

--- a/apps/web/src/app/(app)/dashboard/grid/responsive-layout.ts
+++ b/apps/web/src/app/(app)/dashboard/grid/responsive-layout.ts
@@ -1,0 +1,58 @@
+import type { Layout } from 'react-grid-layout';
+import type { BreakpointLayoutEntry } from '../lib/widget-types';
+
+export type StackedLayoutSource = {
+  i: string;
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  minH: number;
+  maxH?: number;
+};
+
+/**
+ * Build a single-column responsive layout without carrying desktop widths or
+ * x positions into a narrower grid. Saved breakpoint entries still determine
+ * order and height, so vertical customization survives the normalization.
+ */
+export function buildStackedLayout(
+  sources: StackedLayoutSource[],
+  columns: number,
+  overrides?: BreakpointLayoutEntry[],
+): Layout[] {
+  const safeColumns = Math.max(1, Math.floor(columns));
+  const overrideById = new Map(overrides?.map((entry) => [entry.i, entry]) ?? []);
+
+  const ordered = sources
+    .map((source, index) => ({
+      source,
+      position: overrideById.get(source.i) ?? source,
+      index,
+    }))
+    .sort((left, right) =>
+      left.position.y - right.position.y ||
+      left.position.x - right.position.x ||
+      left.index - right.index,
+    );
+
+  let nextY = 0;
+  return ordered.map(({ source, position }) => {
+    const minH = Math.max(1, source.minH);
+    const requestedH = Math.max(minH, position.h);
+    const h = source.maxH === undefined ? requestedH : Math.min(requestedH, source.maxH);
+    const entry: Layout = {
+      i: source.i,
+      x: 0,
+      y: nextY,
+      w: safeColumns,
+      h,
+      minW: safeColumns,
+      maxW: safeColumns,
+      minH,
+      maxH: source.maxH,
+    };
+    nextY += h;
+    return entry;
+  });
+}

--- a/apps/web/src/app/(app)/dashboard/page.tsx
+++ b/apps/web/src/app/(app)/dashboard/page.tsx
@@ -590,16 +590,14 @@ function DashboardBody() {
           <EditBar onAdd={() => setAddOpen(true)} onReset={handleReset} />
         )}
 
-        <div className="dashboard4-grid" data-edit={editMode || undefined}>
-          <DashboardGrid
-            layout={layout}
-            ctx={widgetContext}
-            editMode={editMode}
-            onLayoutChange={handleLayoutChange}
-            onRemove={handleRemove}
-            onConfigChange={handleConfigChange}
-          />
-        </div>
+        <DashboardGrid
+          layout={layout}
+          ctx={widgetContext}
+          editMode={editMode}
+          onLayoutChange={handleLayoutChange}
+          onRemove={handleRemove}
+          onConfigChange={handleConfigChange}
+        />
       </div>
 
       <AddWidgetDrawer

--- a/apps/web/test/dashboard-responsive-layout.test.ts
+++ b/apps/web/test/dashboard-responsive-layout.test.ts
@@ -1,0 +1,32 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { buildStackedLayout, type StackedLayoutSource } from '../src/app/(app)/dashboard/grid/responsive-layout.js';
+
+const sources: StackedLayoutSource[] = [
+  { i: 'today', x: 0, y: 0, w: 8, h: 4, minH: 3 },
+  { i: 'calendar', x: 8, y: 0, w: 4, h: 6, minH: 5 },
+  { i: 'projects', x: 0, y: 9, w: 3, h: 4, minH: 3, maxH: 5 },
+];
+
+test('narrow dashboard layouts are full-width, stacked, and collision-free', () => {
+  const layout = buildStackedLayout(sources, 2);
+
+  assert.deepEqual(layout.map(({ i, x, y, w, minW, maxW }) => ({ i, x, y, w, minW, maxW })), [
+    { i: 'today', x: 0, y: 0, w: 2, minW: 2, maxW: 2 },
+    { i: 'calendar', x: 0, y: 4, w: 2, minW: 2, maxW: 2 },
+    { i: 'projects', x: 0, y: 10, w: 2, minW: 2, maxW: 2 },
+  ]);
+});
+
+test('saved narrow layouts preserve vertical order and clamp height bounds', () => {
+  const layout = buildStackedLayout(sources, 4, [
+    { i: 'projects', x: 0, y: 0, w: 1, h: 99 },
+    { i: 'today', x: 2, y: 3, w: 1, h: 1 },
+  ]);
+
+  assert.deepEqual(layout.map(({ i, y, w, h }) => ({ i, y, w, h })), [
+    { i: 'projects', y: 0, w: 4, h: 5 },
+    { i: 'calendar', y: 5, w: 4, h: 6 },
+    { i: 'today', y: 11, w: 4, h: 3 },
+  ]);
+});


### PR DESCRIPTION
## Summary\n\n- replace react-grid-layout's stale 1280px WidthProvider fallback with an explicit container ResizeObserver\n- normalize sm/xs/xxs dashboard layouts into deterministic full-width vertical stacks\n- preserve saved narrow-screen order and height while clamping unsafe widths\n- remove the redundant nested dashboard grid wrapper\n\n## Production finding\n\nThe post-deploy 390x844 probe showed a real hidden overflow: the dashboard container was 342px wide, but widgets were positioned against a 1280px grid (for example, Today was 848px wide and Calendar began at x=888). The page's overflow-x:hidden masked the defect from ordinary document-width checks.\n\n## Validation\n\n- focused responsive-layout tests: 2/2 passed\n- web TypeScript: passed\n- targeted ESLint: passed\n- Next.js production build: passed\n- exact 390x844 production regression will be rerun after the image is merged and deployed\n