### PR TITLE
fix: safely enable chat huddles

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,7 +66,8 @@ DEEPGRAM_API_KEY=
 NEXT_PUBLIC_API_URL=http://localhost:3001
 NEXT_PUBLIC_WS_URL=http://localhost:3001
 NEXT_PUBLIC_APP_URL=http://localhost:3000
-# Experimental voice huddles. Rebuild the web image after changing this value.
+# Source builds keep experimental voice huddles opt-in and bake this value into
+# the web bundle. Official prebuilt release images explicitly enable them.
 NEXT_PUBLIC_FEATURE_HUDDLES=false
 API_PORT=3001
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - name: Lint web
         run: pnpm --filter @deft/web lint
+      - name: Test web huddle lifecycle state
+        run: pnpm --filter @deft/web exec tsx --test src/lib/huddle-state.test.ts
       - name: Type check API
         run: cd apps/api && npx tsc --noEmit
       - name: Type check Web
@@ -221,10 +223,13 @@ jobs:
           tags: deft:ci
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          # Huddles are a compile-time Next.js flag. Keep this image aligned
+          # with the official release contract exercised by the smoke below.
           build-args: |
             NEXT_PUBLIC_APP_URL=http://localhost:3000
             NEXT_PUBLIC_API_URL=http://localhost:3001
             NEXT_PUBLIC_WS_URL=http://localhost:3001
+            NEXT_PUBLIC_FEATURE_HUDDLES=true
       - name: Smoke-test the image (binaries resolve)
         # Catches the "next CLI not on PATH from apps/web" and
         # "pnpm not in runner stage" classes of bug — both real bugs we hit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,6 +76,10 @@ jobs:
           sbom: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          # NEXT_PUBLIC feature flags are compiled into the browser bundle;
+          # setting this only on the running container is too late.
+          build-args: |
+            NEXT_PUBLIC_FEATURE_HUDDLES=true
 
       - name: Attest image provenance
         uses: actions/attest-build-provenance@v4

--- a/apps/api/src/huddle-rooms.ts
+++ b/apps/api/src/huddle-rooms.ts
@@ -1,13 +1,80 @@
-// In-memory huddle room state management
+// In-memory huddle room state management and untrusted socket payload parsing.
 
-type Participant = {
+import { z } from 'zod';
+
+const identifierSchema = z.string().trim().min(1).max(128);
+const huddleIdSchema = z.string().uuid();
+const MAX_SIGNAL_BYTES = 64 * 1024;
+
+function isBoundedSignal(value: unknown): boolean {
+  try {
+    const encoded = JSON.stringify(value);
+    return encoded !== undefined && Buffer.byteLength(encoded, 'utf8') <= MAX_SIGNAL_BYTES;
+  } catch {
+    return false;
+  }
+}
+
+const createPayloadSchema = z.object({ space_id: identifierSchema }).strict();
+const listPayloadSchema = z.object({}).strict();
+const roomPayloadSchema = z.object({ huddle_id: huddleIdSchema }).strict();
+const signalPayloadSchema = z.object({
+  huddle_id: huddleIdSchema,
+  target_user_id: identifierSchema,
+  signal_data: z.record(z.string(), z.unknown())
+    .refine(isBoundedSignal, `signal_data must be valid JSON smaller than ${MAX_SIGNAL_BYTES} bytes`),
+}).strict();
+const mutePayloadSchema = z.object({
+  huddle_id: huddleIdSchema,
+  muted: z.boolean(),
+}).strict();
+
+export type HuddleCreatePayload = z.infer<typeof createPayloadSchema>;
+export type HuddleListPayload = z.infer<typeof listPayloadSchema>;
+export type HuddleRoomPayload = z.infer<typeof roomPayloadSchema>;
+export type HuddleSignalPayload = z.infer<typeof signalPayloadSchema>;
+export type HuddleMutePayload = z.infer<typeof mutePayloadSchema>;
+
+type PayloadResult<T> =
+  | { success: true; data: T }
+  | { success: false };
+
+function parsePayload<T>(schema: z.ZodType<T>, value: unknown): PayloadResult<T> {
+  const parsed = schema.safeParse(value);
+  return parsed.success ? { success: true, data: parsed.data } : { success: false };
+}
+
+export function parseCreatePayload(value: unknown): PayloadResult<HuddleCreatePayload> {
+  return parsePayload(createPayloadSchema, value);
+}
+
+export function parseListPayload(value: unknown): PayloadResult<HuddleListPayload> {
+  return parsePayload(listPayloadSchema, value ?? {});
+}
+
+export function parseRoomPayload(value: unknown): PayloadResult<HuddleRoomPayload> {
+  return parsePayload(roomPayloadSchema, value);
+}
+
+export function parseSignalPayload(value: unknown): PayloadResult<HuddleSignalPayload> {
+  return parsePayload(signalPayloadSchema, value);
+}
+
+export function parseMutePayload(value: unknown): PayloadResult<HuddleMutePayload> {
+  return parsePayload(mutePayloadSchema, value);
+}
+
+export type PublicParticipant = {
   user_id: string;
   user_name: string;
   muted: boolean;
+};
+
+type Participant = PublicParticipant & {
   socket_id: string;
 };
 
-type HuddleRoom = {
+export type HuddleRoom = {
   id: string;
   space_id: string;
   org_id: string;
@@ -15,6 +82,13 @@ type HuddleRoom = {
   participants: Map<string, Participant>;
   created_at: Date;
   grace_timer?: ReturnType<typeof setTimeout>;
+};
+
+export type ActiveRoomSnapshot = {
+  huddle_id: string;
+  space_id: string;
+  created_by: string;
+  participants: PublicParticipant[];
 };
 
 const rooms = new Map<string, HuddleRoom>();
@@ -32,13 +106,24 @@ export function createRoom(id: string, spaceId: string, orgId: string, createdBy
   return room;
 }
 
+export function reserveRoom(
+  id: string,
+  spaceId: string,
+  orgId: string,
+  createdBy: string,
+): { room: HuddleRoom; created: boolean } {
+  const existing = getRoomBySpace(spaceId, orgId);
+  if (existing) return { room: existing, created: false };
+  return { room: createRoom(id, spaceId, orgId, createdBy), created: true };
+}
+
 export function getRoom(id: string): HuddleRoom | undefined {
   return rooms.get(id);
 }
 
-export function getRoomBySpace(spaceId: string): HuddleRoom | undefined {
+export function getRoomBySpace(spaceId: string, orgId: string): HuddleRoom | undefined {
   for (const room of rooms.values()) {
-    if (room.space_id === spaceId) return room;
+    if (room.space_id === spaceId && room.org_id === orgId) return room;
   }
   return undefined;
 }
@@ -46,6 +131,8 @@ export function getRoomBySpace(spaceId: string): HuddleRoom | undefined {
 export function addParticipant(roomId: string, participant: Participant): boolean {
   const room = rooms.get(roomId);
   if (!room) return false;
+  const existing = room.participants.get(participant.user_id);
+  if (existing && existing.socket_id !== participant.socket_id) return false;
   // Clear grace timer if room was about to close
   if (room.grace_timer) {
     clearTimeout(room.grace_timer);
@@ -55,18 +142,40 @@ export function addParticipant(roomId: string, participant: Participant): boolea
   return true;
 }
 
-export function removeParticipant(roomId: string, userId: string): { empty: boolean; room?: HuddleRoom } {
-  const room = rooms.get(roomId);
-  if (!room) return { empty: true };
-  room.participants.delete(userId);
-  return { empty: room.participants.size === 0, room };
+export function isParticipant(roomId: string, userId: string, socketId?: string): boolean {
+  const participant = rooms.get(roomId)?.participants.get(userId);
+  return Boolean(participant && (!socketId || participant.socket_id === socketId));
 }
 
-export function setMuted(roomId: string, userId: string, muted: boolean): void {
+export function getParticipantSocketId(roomId: string, userId: string): string | undefined {
+  return rooms.get(roomId)?.participants.get(userId)?.socket_id;
+}
+
+export function isParticipantOnDifferentSocket(roomId: string, userId: string, socketId: string): boolean {
+  const participantSocketId = getParticipantSocketId(roomId, userId);
+  return Boolean(participantSocketId && participantSocketId !== socketId);
+}
+
+export function removeParticipant(
+  roomId: string,
+  userId: string,
+  socketId?: string,
+): { removed: boolean; empty: boolean; room?: HuddleRoom } {
   const room = rooms.get(roomId);
-  if (!room) return;
-  const p = room.participants.get(userId);
-  if (p) p.muted = muted;
+  if (!room) return { removed: false, empty: true };
+  const participant = room.participants.get(userId);
+  if (!participant || (socketId && participant.socket_id !== socketId)) {
+    return { removed: false, empty: room.participants.size === 0, room };
+  }
+  room.participants.delete(userId);
+  return { removed: true, empty: room.participants.size === 0, room };
+}
+
+export function setMuted(roomId: string, userId: string, socketId: string, muted: boolean): boolean {
+  const participant = rooms.get(roomId)?.participants.get(userId);
+  if (!participant || participant.socket_id !== socketId) return false;
+  participant.muted = muted;
+  return true;
 }
 
 export function destroyRoom(roomId: string): void {
@@ -82,16 +191,59 @@ export function setGraceTimer(roomId: string, callback: () => void, ms = 5000): 
   room.grace_timer = setTimeout(callback, ms);
 }
 
-export function getParticipantList(roomId: string): Participant[] {
+export function getParticipantList(roomId: string): PublicParticipant[] {
   const room = rooms.get(roomId);
   if (!room) return [];
-  return Array.from(room.participants.values());
+  return Array.from(room.participants.values(), ({ user_id, user_name, muted }) => ({
+    user_id,
+    user_name,
+    muted,
+  })).sort((left, right) => left.user_id.localeCompare(right.user_id));
 }
 
-export function getActiveRooms(): { id: string; space_id: string; participant_count: number }[] {
-  const result: { id: string; space_id: string; participant_count: number }[] = [];
+export function getActiveRoomSnapshots(orgId: string, allowedSpaceIds: ReadonlySet<string>): ActiveRoomSnapshot[] {
+  const snapshots: ActiveRoomSnapshot[] = [];
   for (const room of rooms.values()) {
-    result.push({ id: room.id, space_id: room.space_id, participant_count: room.participants.size });
+    if (room.org_id !== orgId || !allowedSpaceIds.has(room.space_id) || room.participants.size === 0) continue;
+    snapshots.push({
+      huddle_id: room.id,
+      space_id: room.space_id,
+      created_by: room.created_by,
+      participants: getParticipantList(room.id),
+    });
   }
-  return result;
+  return snapshots.sort((left, right) => left.space_id.localeCompare(right.space_id));
+}
+
+export function getRoomIdsForSocket(socketId: string): string[] {
+  const roomIds: string[] = [];
+  for (const room of rooms.values()) {
+    if (Array.from(room.participants.values()).some((participant) => participant.socket_id === socketId)) {
+      roomIds.push(room.id);
+    }
+  }
+  return roomIds;
+}
+
+export function getRoomIdsForUser(userId: string, orgId: string): string[] {
+  const roomIds: string[] = [];
+  for (const room of rooms.values()) {
+    if (room.org_id === orgId && room.participants.has(userId)) roomIds.push(room.id);
+  }
+  return roomIds;
+}
+
+export function getRoomIdsForScope(orgId: string, spaceId?: string, userId?: string): string[] {
+  const roomIds: string[] = [];
+  for (const room of rooms.values()) {
+    if (room.org_id !== orgId) continue;
+    if (spaceId && room.space_id !== spaceId) continue;
+    if (userId && !room.participants.has(userId)) continue;
+    roomIds.push(room.id);
+  }
+  return roomIds;
+}
+
+export function getConflictingRoomId(userId: string, orgId: string, allowedRoomId?: string): string | undefined {
+  return getRoomIdsForUser(userId, orgId).find((roomId) => roomId !== allowedRoomId);
 }

--- a/apps/api/src/routes/members.ts
+++ b/apps/api/src/routes/members.ts
@@ -29,6 +29,7 @@ import {
 import { env } from '../lib/env.js';
 import { DEFTY_EMAIL } from '../lib/ensure-defty-membership.js';
 import { OrgMembershipError, requireOrgAdminOrOwner } from '../lib/org-membership.js';
+import { evictActiveHuddleParticipants } from '../socket.js';
 
 const INVITE_TTL = '7d';
 const RECOVERY_TTL = '24h';
@@ -124,6 +125,12 @@ async function revokeMemberWorkspaceAccess(orgId: string, memberId: string, deac
         WHERE ${spaces.org_id} = ${orgId}
       )
   `);
+
+  await evictActiveHuddleParticipants({
+    orgId,
+    userId: memberId,
+    reason: 'org_membership_revoked',
+  });
 
   await db.delete(teamMembers)
     .where(and(eq(teamMembers.org_id, orgId), eq(teamMembers.user_id, memberId)));

--- a/apps/api/src/routes/spaces.ts
+++ b/apps/api/src/routes/spaces.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { eq, and, desc, sql, inArray } from 'drizzle-orm';
 import { db } from '../lib/db.js';
 import { spaces, spaceMembers, users, messages, agentEmployees, orgMembers } from '@deft/db/schema';
-import { getIO } from '../socket.js';
+import { evictActiveHuddleParticipants, getIO } from '../socket.js';
 import { requireSpaceMembership } from '../lib/space-membership.js';
 import { DEFTY_EMAIL } from '../lib/ensure-defty-membership.js';
 
@@ -541,6 +541,13 @@ spaceRoutes.delete('/:id/members/:userId', async (c) => {
       return c.json({ error: 'User is not a member of this space', code: 'NOT_FOUND' }, 404);
     }
 
+    await evictActiveHuddleParticipants({
+      orgId: user.org_id,
+      spaceId,
+      userId,
+      reason: 'space_membership_revoked',
+    });
+
     return c.json({ success: true });
   } catch (err) {
     console.error('Failed to remove space member:', err);
@@ -554,6 +561,14 @@ spaceRoutes.delete('/:id/members/me', async (c) => {
     const user = c.get('user');
     const spaceId = c.req.param('id');
 
+    const [space] = await db.select({ id: spaces.id })
+      .from(spaces)
+      .where(and(eq(spaces.id, spaceId), eq(spaces.org_id, user.org_id)))
+      .limit(1);
+    if (!space) {
+      return c.json({ error: 'Space not found', code: 'NOT_FOUND' }, 404);
+    }
+
     const deleted = await db.delete(spaceMembers)
       .where(
         and(
@@ -566,6 +581,13 @@ spaceRoutes.delete('/:id/members/me', async (c) => {
     if (deleted.length === 0) {
       return c.json({ error: 'Not a member of this space', code: 'NOT_FOUND' }, 404);
     }
+
+    await evictActiveHuddleParticipants({
+      orgId: user.org_id,
+      spaceId,
+      userId: user.id,
+      reason: 'space_membership_revoked',
+    });
 
     return c.json({ success: true });
   } catch (err) {
@@ -601,6 +623,12 @@ spaceRoutes.delete('/:id', async (c) => {
     await db.update(spaces)
       .set({ is_archived: true })
       .where(eq(spaces.id, spaceId));
+
+    await evictActiveHuddleParticipants({
+      orgId: user.org_id,
+      spaceId,
+      reason: 'space_archived',
+    });
 
     // Notify connected clients
     try {

--- a/apps/api/src/socket.ts
+++ b/apps/api/src/socket.ts
@@ -3,17 +3,229 @@ import type { Server as HTTPServer } from 'node:http';
 import jwt from 'jsonwebtoken';
 import { env } from './lib/env.js';
 import { db } from './lib/db.js';
-import { users, spaceMembers, spaces } from '@deft/db/schema';
+import { users, orgMembers, spaceMembers, spaces } from '@deft/db/schema';
 import { eq, and, ne } from 'drizzle-orm';
 import * as huddle from './huddle-rooms.js';
 import { requireActiveOrgMembership } from './lib/org-membership.js';
 import { createNotificationIfAllowed } from './lib/notification-policy.js';
+
+export type SocketUser = { id: string; email: string; org_id: string };
+type HuddleEventName = 'huddle:create' | 'huddle:list' | 'huddle:join' | 'huddle:leave' | 'huddle:signal' | 'huddle:mute';
+type HuddleErrorCode = 'INVALID_PAYLOAD' | 'FORBIDDEN' | 'ROOM_NOT_FOUND' | 'NOT_PARTICIPANT' | 'TARGET_NOT_FOUND' | 'ALREADY_IN_HUDDLE' | 'INTERNAL_ERROR';
+
+export async function getHuddleSpaceAccess(spaceId: string, user: SocketUser) {
+  const [access] = await db.select({
+    space_id: spaces.id,
+    space_name: spaces.name,
+    user_name: users.name,
+  })
+    .from(spaceMembers)
+    .innerJoin(spaces, eq(spaceMembers.space_id, spaces.id))
+    .innerJoin(users, eq(spaceMembers.user_id, users.id))
+    .innerJoin(orgMembers, and(
+      eq(orgMembers.user_id, spaceMembers.user_id),
+      eq(orgMembers.org_id, spaces.org_id),
+    ))
+    .where(and(
+      eq(spaceMembers.space_id, spaceId),
+      eq(spaceMembers.user_id, user.id),
+      eq(spaces.org_id, user.org_id),
+      eq(spaces.is_archived, false),
+      eq(orgMembers.is_active, true),
+    ))
+    .limit(1);
+  return access;
+}
+
+export async function getAccessibleHuddleSpaceIds(user: SocketUser): Promise<Set<string>> {
+  const memberships = await db.select({ space_id: spaceMembers.space_id })
+    .from(spaceMembers)
+    .innerJoin(spaces, eq(spaceMembers.space_id, spaces.id))
+    .innerJoin(orgMembers, and(
+      eq(orgMembers.user_id, spaceMembers.user_id),
+      eq(orgMembers.org_id, spaces.org_id),
+    ))
+    .where(and(
+      eq(spaceMembers.user_id, user.id),
+      eq(spaces.org_id, user.org_id),
+      eq(spaces.is_archived, false),
+      eq(orgMembers.is_active, true),
+    ));
+  return new Set(memberships.map((membership) => membership.space_id));
+}
+
+export async function getAuthorizedHuddleRecipientIds(
+  spaceId: string,
+  orgId: string,
+  excludedUserId: string,
+): Promise<string[]> {
+  const recipients = await db.select({ user_id: spaceMembers.user_id })
+    .from(spaceMembers)
+    .innerJoin(spaces, eq(spaceMembers.space_id, spaces.id))
+    .innerJoin(orgMembers, and(
+      eq(orgMembers.user_id, spaceMembers.user_id),
+      eq(orgMembers.org_id, orgId),
+      eq(orgMembers.is_active, true),
+    ))
+    .where(and(
+      eq(spaceMembers.space_id, spaceId),
+      eq(spaces.org_id, orgId),
+      eq(spaces.is_archived, false),
+      ne(spaceMembers.user_id, excludedUserId),
+    ));
+  return recipients.map((recipient) => recipient.user_id);
+}
 
 function updateLastSeen(userId: string) {
   db.update(users).set({ last_seen_at: new Date() }).where(eq(users.id, userId)).catch(() => {});
 }
 
 let io: SocketIOServer | null = null;
+let realtimeAccessGeneration = 0;
+
+export function captureRealtimeAccessGeneration(): number {
+  return realtimeAccessGeneration;
+}
+
+export function isRealtimeAccessGenerationCurrent(generation: number): boolean {
+  return generation === realtimeAccessGeneration;
+}
+
+export function bumpRealtimeAccessGeneration(_scope: HuddleEvictionScope): number {
+  realtimeAccessGeneration += 1;
+  return realtimeAccessGeneration;
+}
+
+export type HuddleEvictionReason = 'space_membership_revoked' | 'org_membership_revoked' | 'space_archived';
+
+export type HuddleEvictionScope =
+  | {
+      orgId: string;
+      spaceId: string;
+      userId: string;
+      reason: 'space_membership_revoked';
+    }
+  | {
+      orgId: string;
+      spaceId: string;
+      reason: 'space_archived';
+    }
+  | {
+      orgId: string;
+      userId: string;
+      reason: 'org_membership_revoked';
+    };
+
+export type RealtimeRevocationServer = {
+  in(room: string): {
+    socketsLeave(room: string): void;
+    disconnectSockets(close?: boolean): void;
+  };
+};
+
+/**
+ * Remove realtime access after the durable membership/archive mutation has
+ * succeeded. This is deliberately independent of active huddle state: a user
+ * who is not currently in a huddle must still stop receiving space/org events.
+ */
+export function revokeRealtimeAccess(
+  scope: HuddleEvictionScope,
+  server: RealtimeRevocationServer | null = io,
+): void {
+  if (!server) return;
+
+  try {
+    if (scope.reason === 'space_membership_revoked') {
+      server
+        .in(`org-user:${scope.orgId}:${scope.userId}`)
+        .socketsLeave(`space:${scope.spaceId}`);
+      return;
+    }
+
+    if (scope.reason === 'space_archived') {
+      server.in(`space:${scope.spaceId}`).socketsLeave(`space:${scope.spaceId}`);
+      return;
+    }
+
+    // A revoked org member must not retain the org room or any space room that
+    // the socket joined before revocation. Disconnecting the scoped sockets is
+    // the only atomic Socket.IO operation that removes all of those rooms.
+    server.in(`org-user:${scope.orgId}:${scope.userId}`).disconnectSockets(true);
+  } catch (error) {
+    // The access mutation has already committed. Realtime cleanup is best
+    // effort and must not change the route's persistence/error semantics.
+    console.error('Failed to revoke realtime socket access:', error);
+  }
+}
+
+export async function evictActiveHuddleParticipants(scope: HuddleEvictionScope): Promise<number> {
+  // This must happen before the first await and before the room scan. A stale
+  // async authorization either mutates before this scan (and is evicted) or
+  // observes the new generation and rolls itself back.
+  bumpRealtimeAccessGeneration(scope);
+  let evicted = 0;
+  const spaceId = 'spaceId' in scope ? scope.spaceId : undefined;
+  const userId = 'userId' in scope ? scope.userId : undefined;
+  const roomIds = huddle.getRoomIdsForScope(scope.orgId, spaceId, userId);
+  for (const roomId of roomIds) {
+    try {
+      const room = huddle.getRoom(roomId);
+      if (!room) continue;
+      const targetUserIds = userId
+        ? [userId]
+        : huddle.getParticipantList(roomId).map((participant) => participant.user_id);
+
+      for (const targetUserId of targetUserIds) {
+        const participantSocketId = huddle.getParticipantSocketId(roomId, targetUserId);
+        if (!participantSocketId) continue;
+        const removed = huddle.removeParticipant(roomId, targetUserId, participantSocketId);
+        if (!removed.removed) continue;
+        evicted += 1;
+
+        const participantSocket = io?.sockets.sockets.get(participantSocketId);
+        try {
+          await participantSocket?.leave(`huddle:${roomId}`);
+        } catch (error) {
+          console.warn('Failed to remove revoked participant from socket room:', error);
+        }
+
+        io?.to(participantSocketId).emit('huddle:ended', {
+          huddle_id: roomId,
+          space_id: room.space_id,
+          reason: scope.reason,
+        });
+        io?.to(`huddle:${roomId}`).emit('huddle:user_left', {
+          huddle_id: roomId,
+          user_id: targetUserId,
+          participants: huddle.getParticipantList(roomId),
+        });
+      }
+
+      const participants = huddle.getParticipantList(roomId);
+      if (participants.length === 0) {
+        huddle.destroyRoom(roomId);
+        const ended = { huddle_id: roomId, space_id: room.space_id, reason: scope.reason };
+        io?.to(`space:${room.space_id}`).emit('huddle:ended', ended);
+        io?.to(`org:${room.org_id}`).emit('huddle:ended', ended);
+      } else {
+        io?.to(`space:${room.space_id}`).emit('huddle:updated', {
+          huddle_id: roomId,
+          space_id: room.space_id,
+          participants,
+        });
+      }
+    } catch (error) {
+      // Revocation already succeeded in the database. Realtime cleanup must not
+      // change the route's persistence/error semantics or abort other rooms.
+      console.error('Failed to evict revoked huddle participant:', error);
+    }
+  }
+
+  // Do this after huddle teardown so direct huddle:ended/user_left events can
+  // be delivered before an org socket is disconnected or a space room emptied.
+  revokeRealtimeAccess(scope);
+  return evicted;
+}
 
 // Track online users: userId → Set of socket IDs (user can have multiple tabs)
 const onlineUsers = new Map<string, Set<string>>();
@@ -30,6 +242,10 @@ export function emitToUser(userId: string, event: string, data: unknown): void {
   if (io) {
     io.to(`user:${userId}`).emit(event, data);
   }
+}
+
+function emitToOrgUser(orgId: string, userId: string, event: string, data: unknown): void {
+  io?.to(`org-user:${orgId}:${userId}`).emit(event, data);
 }
 
 /** Get all currently online user IDs */
@@ -62,16 +278,46 @@ export function setupSocket(server: HTTPServer) {
     }
     try {
       const payload = jwt.verify(token, env.JWT_SECRET) as { id: string; email: string; org_id: string };
+      const authorizationGeneration = captureRealtimeAccessGeneration();
       const membership = await requireActiveOrgMembership(payload.org_id, payload.id);
+      if (!isRealtimeAccessGenerationCurrent(authorizationGeneration)) {
+        return next(new Error('Workspace access changed; reconnect'));
+      }
       (socket as any).user = { ...payload, role: membership.role };
+      (socket as any).realtimeAccessGeneration = authorizationGeneration;
       next();
     } catch {
       next(new Error('Invalid token'));
     }
   });
 
-  io.on('connection', (socket) => {
-    const user = (socket as any).user as { id: string; email: string; org_id: string };
+  io.on('connection', async (socket) => {
+    const user = (socket as any).user as SocketUser;
+    const connectionGeneration = (socket as any).realtimeAccessGeneration as number;
+    if (!socket.connected || !isRealtimeAccessGenerationCurrent(connectionGeneration)) {
+      socket.disconnect(true);
+      return;
+    }
+
+    try {
+      await socket.join([
+        `org:${user.org_id}`,
+        `user:${user.id}`,
+        `org-user:${user.org_id}:${user.id}`,
+      ]);
+    } catch (error) {
+      console.error('Failed to initialize socket rooms:', error);
+      socket.disconnect(true);
+      return;
+    }
+    if (!socket.connected || !isRealtimeAccessGenerationCurrent(connectionGeneration)) {
+      socket.disconnect(true);
+      return;
+    }
+
+    const emitHuddleError = (event: HuddleEventName, code: HuddleErrorCode, message: string) => {
+      socket.emit('huddle:error', { event, code, message });
+    };
 
     // Track this socket
     if (!onlineUsers.has(user.id)) {
@@ -80,10 +326,6 @@ export function setupSocket(server: HTTPServer) {
     onlineUsers.get(user.id)!.add(socket.id);
     userOrgs.set(user.id, user.org_id);
     idleUsers.delete(user.id);
-
-    // Join rooms
-    socket.join(`org:${user.org_id}`);
-    socket.join(`user:${user.id}`);
 
     // Update last_seen_at on connect
     updateLastSeen(user.id);
@@ -107,13 +349,31 @@ export function setupSocket(server: HTTPServer) {
 
     // Space rooms
     socket.on('space:join', async (spaceId: string) => {
-      const [member] = await db.select({ id: spaceMembers.id })
-        .from(spaceMembers)
-        .where(and(eq(spaceMembers.space_id, spaceId), eq(spaceMembers.user_id, user.id)))
-        .limit(1);
-      if (member) {
-        socket.join(`space:${spaceId}`);
+      if (typeof spaceId !== 'string' || spaceId.length === 0 || spaceId.length > 128) return;
+      const authorizationGeneration = captureRealtimeAccessGeneration();
+      const access = await getHuddleSpaceAccess(spaceId, user).catch(() => undefined);
+      if (!access || !isRealtimeAccessGenerationCurrent(authorizationGeneration)) return;
+      try {
+        await socket.join(`space:${spaceId}`);
+      } catch {
+        return;
       }
+      if (!isRealtimeAccessGenerationCurrent(authorizationGeneration)) {
+        try {
+          await socket.leave(`space:${spaceId}`);
+        } catch {}
+        return;
+      }
+      const room = huddle.getRoomBySpace(spaceId, user.org_id);
+      if (!room) return;
+      const participants = huddle.getParticipantList(room.id);
+      if (participants.length === 0) return;
+      socket.emit('huddle:started', {
+        huddle_id: room.id,
+        space_id: room.space_id,
+        created_by: room.created_by,
+        participants,
+      });
     });
 
     socket.on('space:leave', (spaceId: string) => {
@@ -160,9 +420,59 @@ export function setupSocket(server: HTTPServer) {
 
     // ── Huddle signaling ──
 
-    socket.on('huddle:create', (data: { space_id: string }) => {
+    socket.on('huddle:list', async (rawData: unknown) => {
+      const parsed = huddle.parseListPayload(rawData);
+      if (!parsed.success) {
+        emitHuddleError('huddle:list', 'INVALID_PAYLOAD', 'Invalid huddle list request');
+        return;
+      }
+      try {
+        const authorizationGeneration = captureRealtimeAccessGeneration();
+        const allowedSpaceIds = await getAccessibleHuddleSpaceIds(user);
+        if (!isRealtimeAccessGenerationCurrent(authorizationGeneration)) {
+          emitHuddleError('huddle:list', 'FORBIDDEN', 'Workspace access changed; retry the request');
+          return;
+        }
+        socket.emit('huddle:snapshot', {
+          huddles: huddle.getActiveRoomSnapshots(user.org_id, allowedSpaceIds),
+        });
+      } catch (error) {
+        console.error('Failed to list huddles:', error);
+        emitHuddleError('huddle:list', 'INTERNAL_ERROR', 'Unable to list active huddles');
+      }
+    });
+
+    socket.on('huddle:create', async (rawData: unknown) => {
+      const parsed = huddle.parseCreatePayload(rawData);
+      if (!parsed.success) {
+        emitHuddleError('huddle:create', 'INVALID_PAYLOAD', 'Invalid huddle create request');
+        return;
+      }
+      const data = parsed.data;
+      const authorizationGeneration = captureRealtimeAccessGeneration();
+      let access: Awaited<ReturnType<typeof getHuddleSpaceAccess>>;
+      try {
+        access = await getHuddleSpaceAccess(data.space_id, user);
+      } catch (error) {
+        console.error('Failed to authorize huddle creation:', error);
+        emitHuddleError('huddle:create', 'INTERNAL_ERROR', 'Unable to start huddle');
+        return;
+      }
+      if (!isRealtimeAccessGenerationCurrent(authorizationGeneration)) {
+        emitHuddleError('huddle:create', 'FORBIDDEN', 'Workspace access changed; retry the request');
+        return;
+      }
+      if (!access) {
+        emitHuddleError('huddle:create', 'FORBIDDEN', 'You are not a member of this space');
+        return;
+      }
       // Check if there's already an active huddle in this space
-      let room = huddle.getRoomBySpace(data.space_id);
+      let room = huddle.getRoomBySpace(data.space_id, user.org_id);
+      const otherRoom = huddle.getConflictingRoomId(user.id, user.org_id, room?.id);
+      if (otherRoom) {
+        emitHuddleError('huddle:create', 'ALREADY_IN_HUDDLE', 'Leave your current huddle before starting another');
+        return;
+      }
       if (room) {
         if (huddle.getParticipantList(room.id).length === 0) {
           // Room is empty (grace period) — destroy it and create fresh
@@ -176,9 +486,44 @@ export function setupSocket(server: HTTPServer) {
         }
       }
       const id = crypto.randomUUID();
-      room = huddle.createRoom(id, data.space_id, user.org_id, user.id);
-      huddle.addParticipant(id, { user_id: user.id, user_name: user.email, muted: false, socket_id: socket.id });
-      socket.join(`huddle:${id}`);
+      const creatorName = access.user_name || user.email;
+      const reservation = huddle.reserveRoom(id, data.space_id, user.org_id, user.id);
+      if (!reservation.created) {
+        socket.emit('huddle:exists', { huddle_id: reservation.room.id });
+        return;
+      }
+      room = reservation.room;
+      const participantAdded = huddle.addParticipant(id, {
+        user_id: user.id,
+        user_name: creatorName,
+        muted: false,
+        socket_id: socket.id,
+      });
+      if (!participantAdded) {
+        huddle.destroyRoom(id);
+        emitHuddleError('huddle:create', 'INTERNAL_ERROR', 'Unable to start huddle');
+        return;
+      }
+      const rollbackReservation = () => {
+        const removed = huddle.removeParticipant(id, user.id, socket.id);
+        if (removed.empty) huddle.destroyRoom(id);
+      };
+      try {
+        await socket.join(`huddle:${id}`);
+      } catch (error) {
+        rollbackReservation();
+        console.error('Failed to join newly created huddle socket room:', error);
+        emitHuddleError('huddle:create', 'INTERNAL_ERROR', 'Unable to start huddle');
+        return;
+      }
+      if (!isRealtimeAccessGenerationCurrent(authorizationGeneration)) {
+        rollbackReservation();
+        try {
+          await socket.leave(`huddle:${id}`);
+        } catch {}
+        emitHuddleError('huddle:create', 'FORBIDDEN', 'Workspace access changed; retry the request');
+        return;
+      }
       // Broadcast to the space that a huddle started
       io!.to(`space:${data.space_id}`).emit('huddle:started', {
         huddle_id: id,
@@ -188,31 +533,27 @@ export function setupSocket(server: HTTPServer) {
       });
       socket.emit('huddle:joined', { huddle_id: id, participants: huddle.getParticipantList(id) });
 
-      // Ring all non-muted space members (fire-and-forget)
+      // Propagate room state to every authorized member. Notification policy
+      // controls attention/ring delivery, not discovery of the live room.
       (async () => {
         try {
-          // Get space name
-          const [space] = await db.select({ name: spaces.name }).from(spaces)
-            .where(eq(spaces.id, data.space_id)).limit(1);
-          // Get creator name
-          const [creator] = await db.select({ name: users.name }).from(users)
-            .where(eq(users.id, user.id)).limit(1);
-          const spaceName = space?.name || 'Unknown';
-          const creatorName = creator?.name || user.email;
+          const fanoutGeneration = captureRealtimeAccessGeneration();
+          const spaceName = access.space_name;
+          const recipientIds = await getAuthorizedHuddleRecipientIds(data.space_id, user.org_id, user.id);
+          if (!isRealtimeAccessGenerationCurrent(fanoutGeneration) || huddle.getRoom(id) !== room) return;
+          const participants = huddle.getParticipantList(id);
 
-          // Get all space members except creator
-          const members = await db.select({
-            user_id: spaceMembers.user_id,
-          }).from(spaceMembers)
-            .where(and(
-              eq(spaceMembers.space_id, data.space_id),
-              ne(spaceMembers.user_id, user.id),
-            ));
-
-          for (const member of members) {
+          for (const recipientId of recipientIds) {
+            if (!isRealtimeAccessGenerationCurrent(fanoutGeneration) || huddle.getRoom(id) !== room) return;
+            emitToOrgUser(user.org_id, recipientId, 'huddle:started', {
+              huddle_id: id,
+              space_id: data.space_id,
+              created_by: user.id,
+              participants,
+            });
             const notification = await createNotificationIfAllowed({
               org_id: user.org_id,
-              user_id: member.user_id,
+              user_id: recipientId,
               type: 'huddle_started',
               title: `${creatorName} started a huddle`,
               body: `#${spaceName}`,
@@ -224,20 +565,19 @@ export function setupSocket(server: HTTPServer) {
               isMention: false,
               respectDnd: true,
             }).catch(() => null);
+            if (!isRealtimeAccessGenerationCurrent(fanoutGeneration) || huddle.getRoom(id) !== room) return;
             if (!notification) continue;
 
-            // Emit ring event
-            emitToUser(member.user_id, 'huddle:ring', {
+            emitToOrgUser(user.org_id, recipientId, 'huddle:ring', {
               huddle_id: id,
               space_id: data.space_id,
               space_name: spaceName,
               created_by: user.id,
               created_by_name: creatorName,
-              participants: huddle.getParticipantList(id),
+              participants,
             });
 
-            // Also emit notification:new for badge count
-            emitToUser(member.user_id, 'notification:new', notification);
+            emitToOrgUser(user.org_id, recipientId, 'notification:new', notification);
           }
         } catch (err) {
           console.error('Failed to send huddle rings:', err);
@@ -245,27 +585,133 @@ export function setupSocket(server: HTTPServer) {
       })();
     });
 
-    socket.on('huddle:join', (data: { huddle_id: string }) => {
+    socket.on('huddle:join', async (rawData: unknown) => {
+      const parsed = huddle.parseRoomPayload(rawData);
+      if (!parsed.success) {
+        emitHuddleError('huddle:join', 'INVALID_PAYLOAD', 'Invalid huddle join request');
+        return;
+      }
+      const data = parsed.data;
       const room = huddle.getRoom(data.huddle_id);
-      if (!room) { socket.emit('huddle:error', { message: 'Room not found' }); return; }
-      huddle.addParticipant(data.huddle_id, { user_id: user.id, user_name: user.email, muted: false, socket_id: socket.id });
-      socket.join(`huddle:${data.huddle_id}`);
-      // Notify existing participants
+      if (!room || room.org_id !== user.org_id) {
+        emitHuddleError('huddle:join', 'ROOM_NOT_FOUND', 'Huddle not found');
+        return;
+      }
+      const authorizationGeneration = captureRealtimeAccessGeneration();
+      let access: Awaited<ReturnType<typeof getHuddleSpaceAccess>>;
+      try {
+        access = await getHuddleSpaceAccess(room.space_id, user);
+      } catch (error) {
+        console.error('Failed to authorize huddle join:', error);
+        emitHuddleError('huddle:join', 'INTERNAL_ERROR', 'Unable to join huddle');
+        return;
+      }
+      if (!isRealtimeAccessGenerationCurrent(authorizationGeneration)) {
+        emitHuddleError('huddle:join', 'FORBIDDEN', 'Workspace access changed; retry the request');
+        return;
+      }
+      if (!access) {
+        emitHuddleError('huddle:join', 'FORBIDDEN', 'You are not a member of this space');
+        return;
+      }
+      const currentRoom = huddle.getRoom(data.huddle_id);
+      if (!currentRoom || currentRoom !== room || currentRoom.org_id !== user.org_id) {
+        emitHuddleError('huddle:join', 'ROOM_NOT_FOUND', 'Huddle no longer exists');
+        return;
+      }
+      const otherRoom = huddle.getConflictingRoomId(user.id, user.org_id, data.huddle_id);
+      if (otherRoom) {
+        emitHuddleError('huddle:join', 'ALREADY_IN_HUDDLE', 'Leave your current huddle before joining another');
+        return;
+      }
+      if (huddle.isParticipantOnDifferentSocket(data.huddle_id, user.id, socket.id)) {
+        emitHuddleError('huddle:join', 'ALREADY_IN_HUDDLE', 'This huddle is already active in another tab');
+        return;
+      }
+
+      try {
+        await socket.join(`huddle:${data.huddle_id}`);
+      } catch (error) {
+        console.error('Failed to join huddle socket room:', error);
+        emitHuddleError('huddle:join', 'INTERNAL_ERROR', 'Unable to join huddle');
+        return;
+      }
+
+      const roomAfterJoin = huddle.getRoom(data.huddle_id);
+      const conflictingRoomAfterJoin = huddle.getConflictingRoomId(user.id, user.org_id, data.huddle_id);
+      const joinedElsewhereAfterJoin = huddle.isParticipantOnDifferentSocket(data.huddle_id, user.id, socket.id);
+      if (
+        !isRealtimeAccessGenerationCurrent(authorizationGeneration)
+        || !roomAfterJoin
+        || roomAfterJoin !== room
+        || conflictingRoomAfterJoin
+        || joinedElsewhereAfterJoin
+      ) {
+        try {
+          await socket.leave(`huddle:${data.huddle_id}`);
+        } catch {}
+        if (!isRealtimeAccessGenerationCurrent(authorizationGeneration)) {
+          emitHuddleError('huddle:join', 'FORBIDDEN', 'Workspace access changed; retry the request');
+        } else if (conflictingRoomAfterJoin || joinedElsewhereAfterJoin) {
+          emitHuddleError('huddle:join', 'ALREADY_IN_HUDDLE', 'Huddle state changed; retry the request');
+        } else {
+          emitHuddleError('huddle:join', 'ROOM_NOT_FOUND', 'Huddle no longer exists');
+        }
+        return;
+      }
+
+      const alreadyJoinedOnThisSocket = huddle.isParticipant(data.huddle_id, user.id, socket.id);
+      if (alreadyJoinedOnThisSocket) {
+        socket.emit('huddle:joined', {
+          huddle_id: data.huddle_id,
+          participants: huddle.getParticipantList(data.huddle_id),
+        });
+        return;
+      }
+      const added = huddle.addParticipant(data.huddle_id, {
+        user_id: user.id,
+        user_name: access.user_name || user.email,
+        muted: false,
+        socket_id: socket.id,
+      });
+      if (!added) {
+        try {
+          await socket.leave(`huddle:${data.huddle_id}`);
+        } catch {}
+        emitHuddleError('huddle:join', 'ROOM_NOT_FOUND', 'Huddle no longer exists');
+        return;
+      }
+      const participants = huddle.getParticipantList(data.huddle_id);
       socket.to(`huddle:${data.huddle_id}`).emit('huddle:user_joined', {
         huddle_id: data.huddle_id,
         user_id: user.id,
-        participants: huddle.getParticipantList(data.huddle_id),
+        participants,
       });
-      // Notify the space
       io!.to(`space:${room.space_id}`).emit('huddle:updated', {
         huddle_id: data.huddle_id,
-        participants: huddle.getParticipantList(data.huddle_id),
+        space_id: room.space_id,
+        participants,
       });
-      socket.emit('huddle:joined', { huddle_id: data.huddle_id, participants: huddle.getParticipantList(data.huddle_id) });
+      socket.emit('huddle:joined', { huddle_id: data.huddle_id, participants });
     });
 
-    socket.on('huddle:leave', (data: { huddle_id: string }) => {
-      const { empty, room } = huddle.removeParticipant(data.huddle_id, user.id);
+    socket.on('huddle:leave', (rawData: unknown) => {
+      const parsed = huddle.parseRoomPayload(rawData);
+      if (!parsed.success) {
+        emitHuddleError('huddle:leave', 'INVALID_PAYLOAD', 'Invalid huddle leave request');
+        return;
+      }
+      const data = parsed.data;
+      const existingRoom = huddle.getRoom(data.huddle_id);
+      if (!existingRoom || existingRoom.org_id !== user.org_id) {
+        emitHuddleError('huddle:leave', 'ROOM_NOT_FOUND', 'Huddle not found');
+        return;
+      }
+      if (!huddle.isParticipant(data.huddle_id, user.id, socket.id)) {
+        emitHuddleError('huddle:leave', 'NOT_PARTICIPANT', 'You are not an active participant in this huddle');
+        return;
+      }
+      const { empty, room } = huddle.removeParticipant(data.huddle_id, user.id, socket.id);
       socket.leave(`huddle:${data.huddle_id}`);
       if (empty && room) {
         // Start 30s grace period before destroying
@@ -286,26 +732,56 @@ export function setupSocket(server: HTTPServer) {
       if (room) {
         io!.to(`space:${room.space_id}`).emit('huddle:updated', {
           huddle_id: data.huddle_id,
+          space_id: room.space_id,
           participants: huddle.getParticipantList(data.huddle_id),
         });
       }
     });
 
-    socket.on('huddle:signal', (data: { huddle_id: string; target_user_id: string; signal_data: any }) => {
-      // Relay WebRTC signaling data to the target user
-      const participants = huddle.getParticipantList(data.huddle_id);
-      const target = participants.find(p => p.user_id === data.target_user_id);
-      if (target) {
-        io!.to(target.socket_id).emit('huddle:signal', {
-          huddle_id: data.huddle_id,
-          from_user_id: user.id,
-          signal_data: data.signal_data,
-        });
+    socket.on('huddle:signal', (rawData: unknown) => {
+      const parsed = huddle.parseSignalPayload(rawData);
+      if (!parsed.success) {
+        emitHuddleError('huddle:signal', 'INVALID_PAYLOAD', 'Invalid huddle signal request');
+        return;
       }
+      const data = parsed.data;
+      const room = huddle.getRoom(data.huddle_id);
+      if (!room || room.org_id !== user.org_id) {
+        emitHuddleError('huddle:signal', 'ROOM_NOT_FOUND', 'Huddle not found');
+        return;
+      }
+      if (!huddle.isParticipant(data.huddle_id, user.id, socket.id)) {
+        emitHuddleError('huddle:signal', 'NOT_PARTICIPANT', 'You are not an active participant in this huddle');
+        return;
+      }
+      const targetSocketId = huddle.getParticipantSocketId(data.huddle_id, data.target_user_id);
+      if (!targetSocketId) {
+        emitHuddleError('huddle:signal', 'TARGET_NOT_FOUND', 'Target participant not found');
+        return;
+      }
+      io!.to(targetSocketId).emit('huddle:signal', {
+        huddle_id: data.huddle_id,
+        from_user_id: user.id,
+        signal_data: data.signal_data,
+      });
     });
 
-    socket.on('huddle:mute', (data: { huddle_id: string; muted: boolean }) => {
-      huddle.setMuted(data.huddle_id, user.id, data.muted);
+    socket.on('huddle:mute', (rawData: unknown) => {
+      const parsed = huddle.parseMutePayload(rawData);
+      if (!parsed.success) {
+        emitHuddleError('huddle:mute', 'INVALID_PAYLOAD', 'Invalid huddle mute request');
+        return;
+      }
+      const data = parsed.data;
+      const room = huddle.getRoom(data.huddle_id);
+      if (!room || room.org_id !== user.org_id) {
+        emitHuddleError('huddle:mute', 'ROOM_NOT_FOUND', 'Huddle not found');
+        return;
+      }
+      if (!huddle.setMuted(data.huddle_id, user.id, socket.id, data.muted)) {
+        emitHuddleError('huddle:mute', 'NOT_PARTICIPANT', 'You are not an active participant in this huddle');
+        return;
+      }
       socket.to(`huddle:${data.huddle_id}`).emit('huddle:mute_changed', {
         huddle_id: data.huddle_id,
         user_id: user.id,
@@ -316,24 +792,22 @@ export function setupSocket(server: HTTPServer) {
     // Disconnect
     socket.on('disconnect', () => {
       // Auto-leave any huddle the user was in
-      for (const room of huddle.getActiveRooms()) {
-        const participants = huddle.getParticipantList(room.id);
-        const inRoom = participants.find(p => p.socket_id === socket.id);
-        if (inRoom) {
-          const { empty, room: r } = huddle.removeParticipant(room.id, user.id);
-          socket.to(`huddle:${room.id}`).emit('huddle:user_left', {
-            huddle_id: room.id, user_id: user.id, participants: huddle.getParticipantList(room.id),
+      for (const roomId of huddle.getRoomIdsForSocket(socket.id)) {
+        const { removed, empty, room } = huddle.removeParticipant(roomId, user.id, socket.id);
+        if (removed && room) {
+          socket.to(`huddle:${roomId}`).emit('huddle:user_left', {
+            huddle_id: roomId, user_id: user.id, participants: huddle.getParticipantList(roomId),
           });
-          if (r) {
-            io!.to(`space:${r.space_id}`).emit('huddle:updated', {
-              huddle_id: room.id, participants: huddle.getParticipantList(room.id),
-            });
-          }
-          if (empty && r) {
-            huddle.setGraceTimer(room.id, () => {
-              const orgId = r.org_id;
-              const spaceId = r.space_id;
-              const hid = room.id;
+          io!.to(`space:${room.space_id}`).emit('huddle:updated', {
+            huddle_id: roomId,
+            space_id: room.space_id,
+            participants: huddle.getParticipantList(roomId),
+          });
+          if (empty) {
+            huddle.setGraceTimer(roomId, () => {
+              const orgId = room.org_id;
+              const spaceId = room.space_id;
+              const hid = roomId;
               huddle.destroyRoom(hid);
               io!.to(`space:${spaceId}`).emit('huddle:ended', { huddle_id: hid, space_id: spaceId });
               io!.to(`org:${orgId}`).emit('huddle:ended', { huddle_id: hid, space_id: spaceId });

--- a/apps/api/test/huddle-safety.test.ts
+++ b/apps/api/test/huddle-safety.test.ts
@@ -1,0 +1,294 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  bumpRealtimeAccessGeneration,
+  captureRealtimeAccessGeneration,
+  isRealtimeAccessGenerationCurrent,
+  revokeRealtimeAccess,
+  type RealtimeRevocationServer,
+} from '../src/socket.js';
+import {
+  addParticipant,
+  createRoom,
+  destroyRoom,
+  getActiveRoomSnapshots,
+  getConflictingRoomId,
+  getParticipantList,
+  getParticipantSocketId,
+  getRoomBySpace,
+  getRoomIdsForSocket,
+  getRoomIdsForScope,
+  isParticipant,
+  isParticipantOnDifferentSocket,
+  parseCreatePayload,
+  parseListPayload,
+  parseMutePayload,
+  parseRoomPayload,
+  parseSignalPayload,
+  removeParticipant,
+  reserveRoom,
+  setMuted,
+} from '../src/huddle-rooms.js';
+
+const ROOM_A = '11111111-1111-4111-8111-111111111111';
+const ROOM_B = '22222222-2222-4222-8222-222222222222';
+const ROOM_C = '33333333-3333-4333-8333-333333333333';
+
+test('every access-revocation scope invalidates stale authorization generations', () => {
+  let staleGeneration = captureRealtimeAccessGeneration();
+  assert.equal(isRealtimeAccessGenerationCurrent(staleGeneration), true);
+  bumpRealtimeAccessGeneration({
+    orgId: 'org-a',
+    spaceId: 'space-a',
+    userId: 'user-a',
+    reason: 'space_membership_revoked',
+  });
+  assert.equal(isRealtimeAccessGenerationCurrent(staleGeneration), false);
+
+  staleGeneration = captureRealtimeAccessGeneration();
+  bumpRealtimeAccessGeneration({
+    orgId: 'org-a',
+    userId: 'user-a',
+    reason: 'org_membership_revoked',
+  });
+  assert.equal(isRealtimeAccessGenerationCurrent(staleGeneration), false);
+
+  staleGeneration = captureRealtimeAccessGeneration();
+  bumpRealtimeAccessGeneration({
+    orgId: 'org-a',
+    spaceId: 'space-a',
+    reason: 'space_archived',
+  });
+  assert.equal(isRealtimeAccessGenerationCurrent(staleGeneration), false);
+  assert.equal(isRealtimeAccessGenerationCurrent(captureRealtimeAccessGeneration()), true);
+});
+
+test('realtime access revocation works without an active huddle room', () => {
+  const calls: Array<{ operation: 'leave' | 'disconnect'; selector: string; target?: string; close?: boolean }> = [];
+  const server: RealtimeRevocationServer = {
+    in(selector) {
+      return {
+        socketsLeave(target) {
+          calls.push({ operation: 'leave', selector, target });
+        },
+        disconnectSockets(close) {
+          calls.push({ operation: 'disconnect', selector, close });
+        },
+      };
+    },
+  };
+
+  revokeRealtimeAccess({
+    orgId: 'org-a',
+    spaceId: 'space-a',
+    userId: 'user-a',
+    reason: 'space_membership_revoked',
+  }, server);
+  revokeRealtimeAccess({
+    orgId: 'org-a',
+    spaceId: 'space-a',
+    reason: 'space_archived',
+  }, server);
+  revokeRealtimeAccess({
+    orgId: 'org-a',
+    userId: 'user-a',
+    reason: 'org_membership_revoked',
+  }, server);
+
+  assert.deepEqual(calls, [
+    {
+      operation: 'leave',
+      selector: 'org-user:org-a:user-a',
+      target: 'space:space-a',
+    },
+    {
+      operation: 'leave',
+      selector: 'space:space-a',
+      target: 'space:space-a',
+    },
+    {
+      operation: 'disconnect',
+      selector: 'org-user:org-a:user-a',
+      close: true,
+    },
+  ]);
+});
+
+test('huddle payload parsers reject malformed and oversized socket input', () => {
+  const create = parseCreatePayload({ space_id: '  space-a  ' });
+  assert.equal(create.success, true);
+  if (create.success) assert.equal(create.data.space_id, 'space-a');
+  assert.equal(parseCreatePayload({ space_id: '' }).success, false);
+  assert.equal(parseCreatePayload({ space_id: 'space-a', unexpected: true }).success, false);
+
+  assert.equal(parseListPayload(undefined).success, true);
+  assert.equal(parseListPayload({}).success, true);
+  assert.equal(parseListPayload({ org_id: 'org-b' }).success, false);
+
+  assert.equal(parseRoomPayload({ huddle_id: ROOM_A }).success, true);
+  assert.equal(parseRoomPayload({ huddle_id: 'not-a-room-id' }).success, false);
+  assert.equal(parseMutePayload({ huddle_id: ROOM_A, muted: true }).success, true);
+  assert.equal(parseMutePayload({ huddle_id: ROOM_A, muted: 'true' }).success, false);
+
+  assert.equal(parseSignalPayload({
+    huddle_id: ROOM_A,
+    target_user_id: 'user-b',
+    signal_data: { type: 'offer', sdp: 'small' },
+  }).success, true);
+  assert.equal(parseSignalPayload({
+    huddle_id: ROOM_A,
+    target_user_id: 'user-b',
+    signal_data: 'not-an-object',
+  }).success, false);
+  assert.equal(parseSignalPayload({
+    huddle_id: ROOM_A,
+    target_user_id: 'user-b',
+    signal_data: { sdp: 'x'.repeat(65 * 1024) },
+  }).success, false);
+});
+
+test('conflict detection permits only the requested active room for a user', () => {
+  createRoom(ROOM_A, 'space-a', 'org-a', 'user-a');
+  createRoom(ROOM_B, 'space-b', 'org-a', 'user-b');
+  try {
+    addParticipant(ROOM_A, {
+      user_id: 'user-a',
+      user_name: 'Alice',
+      muted: false,
+      socket_id: 'socket-a',
+    });
+    assert.equal(getConflictingRoomId('user-a', 'org-a', ROOM_A), undefined);
+
+    // Simulate pre-existing malformed state from an older server process. The
+    // socket handlers use this helper to reject creating/joining another room.
+    addParticipant(ROOM_B, {
+      user_id: 'user-a',
+      user_name: 'Alice',
+      muted: false,
+      socket_id: 'socket-a-2',
+    });
+    assert.equal(getConflictingRoomId('user-a', 'org-a', ROOM_A), ROOM_B);
+    assert.equal(getConflictingRoomId('user-a', 'org-b', ROOM_A), undefined);
+  } finally {
+    destroyRoom(ROOM_A);
+    destroyRoom(ROOM_B);
+  }
+});
+
+test('room reservation keeps one active room per org and space', () => {
+  const first = reserveRoom(ROOM_A, 'space-a', 'org-a', 'user-a');
+  const second = reserveRoom(ROOM_B, 'space-a', 'org-a', 'user-b');
+  try {
+    assert.equal(first.created, true);
+    assert.equal(second.created, false);
+    assert.equal(second.room.id, ROOM_A);
+    assert.deepEqual(getRoomIdsForScope('org-a', 'space-a'), [ROOM_A]);
+  } finally {
+    destroyRoom(ROOM_A);
+    destroyRoom(ROOM_B);
+  }
+});
+
+test('a second socket cannot replace the active socket for the same participant', () => {
+  createRoom(ROOM_A, 'space-a', 'org-a', 'user-a');
+  try {
+    assert.equal(addParticipant(ROOM_A, {
+      user_id: 'user-a',
+      user_name: 'Alice',
+      muted: false,
+      socket_id: 'socket-a',
+    }), true);
+    assert.equal(isParticipantOnDifferentSocket(ROOM_A, 'user-a', 'socket-a'), false);
+    assert.equal(isParticipantOnDifferentSocket(ROOM_A, 'user-a', 'socket-b'), true);
+    assert.equal(addParticipant(ROOM_A, {
+      user_id: 'user-a',
+      user_name: 'Alice',
+      muted: false,
+      socket_id: 'socket-b',
+    }), false);
+    assert.equal(getParticipantSocketId(ROOM_A, 'user-a'), 'socket-a');
+    assert.deepEqual(getRoomIdsForSocket('socket-a'), [ROOM_A]);
+    assert.deepEqual(getRoomIdsForSocket('socket-b'), []);
+  } finally {
+    destroyRoom(ROOM_A);
+  }
+});
+
+test('room operations enforce socket ownership and never expose socket ids', () => {
+  createRoom(ROOM_A, 'space-a', 'org-a', 'user-a');
+  try {
+    assert.equal(addParticipant(ROOM_A, {
+      user_id: 'user-a',
+      user_name: 'Alice',
+      muted: false,
+      socket_id: 'socket-a',
+    }), true);
+    assert.equal(addParticipant(ROOM_A, {
+      user_id: 'user-b',
+      user_name: 'Bob',
+      muted: false,
+      socket_id: 'socket-b',
+    }), true);
+
+    assert.equal(isParticipant(ROOM_A, 'user-a', 'socket-a'), true);
+    assert.equal(isParticipant(ROOM_A, 'user-a', 'socket-other'), false);
+    assert.equal(getParticipantSocketId(ROOM_A, 'user-b'), 'socket-b');
+    assert.equal(setMuted(ROOM_A, 'user-a', 'socket-other', true), false);
+    assert.equal(setMuted(ROOM_A, 'user-a', 'socket-a', true), true);
+
+    const participants = getParticipantList(ROOM_A);
+    assert.deepEqual(participants, [
+      { user_id: 'user-a', user_name: 'Alice', muted: true },
+      { user_id: 'user-b', user_name: 'Bob', muted: false },
+    ]);
+    assert.equal(Object.hasOwn(participants[0]!, 'socket_id'), false);
+
+    assert.deepEqual(removeParticipant(ROOM_A, 'user-a', 'socket-other'), {
+      removed: false,
+      empty: false,
+      room: getRoomBySpace('space-a', 'org-a'),
+    });
+    const removed = removeParticipant(ROOM_A, 'user-a', 'socket-a');
+    assert.equal(removed.removed, true);
+    assert.equal(removed.empty, false);
+    assert.deepEqual(getRoomIdsForSocket('socket-b'), [ROOM_A]);
+  } finally {
+    destroyRoom(ROOM_A);
+  }
+});
+
+test('active room snapshots are tenant- and membership-scoped', () => {
+  createRoom(ROOM_A, 'space-shared', 'org-a', 'user-a');
+  createRoom(ROOM_B, 'space-shared', 'org-b', 'user-b');
+  createRoom(ROOM_C, 'space-empty', 'org-a', 'user-a');
+  try {
+    addParticipant(ROOM_A, {
+      user_id: 'user-a',
+      user_name: 'Alice',
+      muted: false,
+      socket_id: 'socket-a',
+    });
+    addParticipant(ROOM_B, {
+      user_id: 'user-b',
+      user_name: 'Bob',
+      muted: false,
+      socket_id: 'socket-b',
+    });
+
+    assert.equal(getRoomBySpace('space-shared', 'org-a')?.id, ROOM_A);
+    assert.equal(getRoomBySpace('space-shared', 'org-b')?.id, ROOM_B);
+    assert.deepEqual(getRoomIdsForScope('org-a', 'space-shared', 'user-a'), [ROOM_A]);
+    assert.deepEqual(getRoomIdsForScope('org-a', 'space-shared', 'user-b'), []);
+    assert.deepEqual(getActiveRoomSnapshots('org-a', new Set(['space-shared', 'space-empty'])), [{
+      huddle_id: ROOM_A,
+      space_id: 'space-shared',
+      created_by: 'user-a',
+      participants: [{ user_id: 'user-a', user_name: 'Alice', muted: false }],
+    }]);
+    assert.deepEqual(getActiveRoomSnapshots('org-a', new Set(['space-not-joined'])), []);
+  } finally {
+    destroyRoom(ROOM_A);
+    destroyRoom(ROOM_B);
+    destroyRoom(ROOM_C);
+  }
+});

--- a/apps/api/test/huddle-space-access.test.ts
+++ b/apps/api/test/huddle-space-access.test.ts
@@ -1,0 +1,146 @@
+import { after, before, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { and, eq, inArray } from 'drizzle-orm';
+import { orgMembers, orgs, spaceMembers, spaces, users } from '@deft/db/schema';
+import { db } from '../src/lib/db.js';
+import {
+  evictActiveHuddleParticipants,
+  getAccessibleHuddleSpaceIds,
+  getAuthorizedHuddleRecipientIds,
+  getHuddleSpaceAccess,
+} from '../src/socket.js';
+import { addParticipant, createRoom, destroyRoom, getParticipantList, getRoom } from '../src/huddle-rooms.js';
+
+let orgAId = '';
+let orgBId = '';
+let memberId = '';
+let nonmemberId = '';
+let foreignMemberId = '';
+let activeSpaceId = '';
+let archivedSpaceId = '';
+let crossOrgSpaceId = '';
+
+before(async () => {
+  const stamp = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  const createdOrgs = await db.insert(orgs).values([
+    { name: `Huddle Access A ${stamp}`, slug: `huddle-access-a-${stamp}` },
+    { name: `Huddle Access B ${stamp}`, slug: `huddle-access-b-${stamp}` },
+  ]).returning();
+  orgAId = createdOrgs[0]!.id;
+  orgBId = createdOrgs[1]!.id;
+
+  const createdUsers = await db.insert(users).values([
+    { email: `huddle-member-${stamp}@test.local`, name: 'Huddle Member', kind: 'human' },
+    { email: `huddle-nonmember-${stamp}@test.local`, name: 'Huddle Nonmember', kind: 'human' },
+    { email: `huddle-foreign-${stamp}@test.local`, name: 'Huddle Foreign Member', kind: 'human' },
+  ]).returning();
+  memberId = createdUsers[0]!.id;
+  nonmemberId = createdUsers[1]!.id;
+  foreignMemberId = createdUsers[2]!.id;
+  await db.insert(orgMembers).values([
+    { org_id: orgAId, user_id: memberId, role: 'member' },
+    { org_id: orgAId, user_id: nonmemberId, role: 'member' },
+    { org_id: orgBId, user_id: foreignMemberId, role: 'member' },
+  ]);
+
+  const createdSpaces = await db.insert(spaces).values([
+    { org_id: orgAId, name: `Active ${stamp}`, type: 'private', created_by: memberId },
+    { org_id: orgAId, name: `Archived ${stamp}`, type: 'private', created_by: memberId, is_archived: true },
+    { org_id: orgBId, name: `Cross org ${stamp}`, type: 'private', created_by: memberId },
+  ]).returning();
+  activeSpaceId = createdSpaces[0]!.id;
+  archivedSpaceId = createdSpaces[1]!.id;
+  crossOrgSpaceId = createdSpaces[2]!.id;
+
+  // The cross-org row is deliberately malformed tenant data. The access query
+  // must still reject it by checking the owning space's org_id.
+  await db.insert(spaceMembers).values([
+    { space_id: activeSpaceId, user_id: memberId },
+    { space_id: archivedSpaceId, user_id: memberId },
+    { space_id: crossOrgSpaceId, user_id: memberId },
+    { space_id: activeSpaceId, user_id: foreignMemberId },
+  ]);
+});
+
+after(async () => {
+  const spaceIds = [activeSpaceId, archivedSpaceId, crossOrgSpaceId].filter(Boolean);
+  if (spaceIds.length > 0) await db.delete(spaceMembers).where(inArray(spaceMembers.space_id, spaceIds));
+  if (orgAId) await db.delete(spaces).where(eq(spaces.org_id, orgAId));
+  if (orgBId) await db.delete(spaces).where(eq(spaces.org_id, orgBId));
+  const orgIds = [orgAId, orgBId].filter(Boolean);
+  if (orgIds.length > 0) await db.delete(orgMembers).where(inArray(orgMembers.org_id, orgIds));
+  const userIds = [memberId, nonmemberId, foreignMemberId].filter(Boolean);
+  if (userIds.length > 0) await db.delete(users).where(inArray(users.id, userIds));
+  if (orgIds.length > 0) await db.delete(orgs).where(inArray(orgs.id, orgIds));
+});
+
+test('huddle space access requires same-org active space membership', async () => {
+  const member = { id: memberId, email: 'member@test.local', org_id: orgAId };
+  const nonmember = { id: nonmemberId, email: 'nonmember@test.local', org_id: orgAId };
+
+  const allowed = await getHuddleSpaceAccess(activeSpaceId, member);
+  assert.equal(allowed?.space_id, activeSpaceId);
+  assert.equal(allowed?.user_name, 'Huddle Member');
+  assert.equal(await getHuddleSpaceAccess(activeSpaceId, nonmember), undefined);
+  assert.equal(await getHuddleSpaceAccess(crossOrgSpaceId, member), undefined);
+  assert.equal(await getHuddleSpaceAccess(archivedSpaceId, member), undefined);
+
+  const accessibleIds = await getAccessibleHuddleSpaceIds(member);
+  assert.deepEqual([...accessibleIds], [activeSpaceId]);
+  assert.deepEqual(
+    await getAuthorizedHuddleRecipientIds(activeSpaceId, orgAId, 'not-a-user'),
+    [memberId],
+  );
+  assert.deepEqual(await getAuthorizedHuddleRecipientIds(activeSpaceId, orgAId, memberId), []);
+  assert.deepEqual(
+    await getAuthorizedHuddleRecipientIds(crossOrgSpaceId, orgAId, 'not-a-user'),
+    [],
+  );
+
+  await db.update(orgMembers).set({ is_active: false }).where(and(
+    eq(orgMembers.org_id, orgAId),
+    eq(orgMembers.user_id, memberId),
+  ));
+  assert.equal(await getHuddleSpaceAccess(activeSpaceId, member), undefined);
+  assert.deepEqual([...await getAccessibleHuddleSpaceIds(member)], []);
+});
+
+test('realtime eviction removes revoked users and ends an emptied room', async () => {
+  const roomId = '44444444-4444-4444-8444-444444444444';
+  createRoom(roomId, activeSpaceId, orgAId, memberId);
+  try {
+    addParticipant(roomId, {
+      user_id: memberId,
+      user_name: 'Huddle Member',
+      muted: false,
+      socket_id: 'socket-member',
+    });
+    addParticipant(roomId, {
+      user_id: nonmemberId,
+      user_name: 'Huddle Nonmember',
+      muted: false,
+      socket_id: 'socket-nonmember',
+    });
+
+    assert.equal(await evictActiveHuddleParticipants({
+      orgId: orgAId,
+      spaceId: activeSpaceId,
+      userId: memberId,
+      reason: 'space_membership_revoked',
+    }), 1);
+    assert.deepEqual(getParticipantList(roomId), [{
+      user_id: nonmemberId,
+      user_name: 'Huddle Nonmember',
+      muted: false,
+    }]);
+
+    assert.equal(await evictActiveHuddleParticipants({
+      orgId: orgAId,
+      spaceId: activeSpaceId,
+      reason: 'space_archived',
+    }), 1);
+    assert.equal(getRoom(roomId), undefined);
+  } finally {
+    destroyRoom(roomId);
+  }
+});

--- a/apps/web/src/app/(app)/layout.tsx
+++ b/apps/web/src/app/(app)/layout.tsx
@@ -15,7 +15,7 @@ import { getSocket } from '@/lib/socket';
 import { useHuddle } from '@/hooks/use-huddle';
 import { useAudioLevels } from '@/hooks/use-audio-levels';
 import { HuddleOverlay } from '@/components/huddle-overlay';
-import { HuddleRingToast } from '@/components/huddle-ring-toast';
+import { HuddleErrorToast, HuddleRingToast } from '@/components/huddle-ring-toast';
 import { HUDDLES_ENABLED } from '@/lib/feature-flags';
 import { Logo } from '@/components/brand/logo';
 
@@ -63,7 +63,8 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
   const unreadMutationVersions = useRef<Map<string, number>>(new Map());
   const pendingReadRequests = useRef<Map<string, number>>(new Map());
   const spacesLoadGeneration = useRef(0);
-  const huddleState = useHuddle();
+  // Preserve hook ordering while keeping disabled builds free of huddle socket work.
+  const huddleState = useHuddle(HUDDLES_ENABLED);
   const huddleStreams = huddleState.getStreams();
   const speakingMap = useAudioLevels(huddleStreams.localStream, user?.id || null, huddleStreams.peers);
 
@@ -486,6 +487,9 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
         startHuddle: huddleState.startHuddle,
         joinHuddleBySpace: huddleState.joinHuddleBySpace,
         huddleSpaceId: huddleState.active ? huddleState.spaceId : null,
+        huddleBusy: huddleState.busy,
+        huddleError: huddleState.error,
+        clearHuddleError: huddleState.clearError,
         activeHuddles: huddleState.activeHuddles,
       }}
     >
@@ -522,9 +526,13 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
           {HUDDLES_ENABLED && huddleState.pendingRings.length > 0 && (
             <HuddleRingToast
               rings={huddleState.pendingRings}
+              busy={huddleState.busy}
               onJoin={huddleState.joinHuddleBySpace}
               onDismiss={huddleState.dismissRing}
             />
+          )}
+          {HUDDLES_ENABLED && huddleState.error && (
+            <HuddleErrorToast error={huddleState.error} onDismiss={huddleState.clearError} />
           )}
         </div>
       </AppHeaderProvider>

--- a/apps/web/src/components/huddle-overlay.tsx
+++ b/apps/web/src/components/huddle-overlay.tsx
@@ -475,16 +475,18 @@ function CompactBarDesktop({
         )}
       </div>
 
-      <button onClick={onToggleMute}
+      <button type="button" onClick={onToggleMute}
         className="p-1.5 rounded-full transition-colors flex-shrink-0"
         style={{ background: muted ? '#ef4444' : 'var(--surface-container-low)', color: muted ? 'white' : 'var(--text-primary)' }}
+        aria-label={muted ? 'Unmute huddle microphone' : 'Mute huddle microphone'}
         title={muted ? 'Unmute' : 'Mute'}>
         {muted ? <MicOff size={13} /> : <Mic size={13} />}
       </button>
 
-      <button onClick={onToggleExpanded}
+      <button type="button" onClick={onToggleExpanded}
         className="p-1 rounded-full flex-shrink-0"
         style={{ color: 'var(--text-tertiary)' }}
+        aria-label={expanded ? 'Minimize huddle' : 'Expand huddle'}
         title={expanded ? 'Minimize' : 'Expand'}>
         {expanded ? <ChevronDown size={14} /> : <ChevronUp size={14} />}
       </button>
@@ -538,7 +540,8 @@ function ExpandedPanelDesktop({
             {formatDuration(duration)} &middot; {participants.length} {participants.length === 1 ? 'person' : 'people'}
           </div>
         </div>
-        <button onClick={onMinimize} className="p-1.5 rounded-md hover:opacity-70"
+        <button type="button" onClick={onMinimize} className="p-1.5 rounded-md hover:opacity-70"
+          aria-label="Minimize huddle"
           style={{ color: 'var(--text-tertiary)' }} title="Minimize">
           <ChevronDown size={16} />
         </button>
@@ -572,28 +575,32 @@ function ExpandedPanelDesktop({
 
       <div className="flex items-center justify-center gap-3 px-4 py-3"
         style={{ borderTop: '1px solid var(--border-default)' }}>
-        <button onClick={onToggleMute}
+        <button type="button" onClick={onToggleMute}
           className="p-2.5 rounded-full transition-colors"
           style={{ background: muted ? '#ef4444' : 'var(--surface-container-low)', color: muted ? 'white' : 'var(--text-primary)' }}
+          aria-label={muted ? 'Unmute huddle microphone' : 'Mute huddle microphone'}
           title={muted ? 'Unmute' : 'Mute'}>
           {muted ? <MicOff size={18} /> : <Mic size={18} />}
         </button>
 
-        <button className="p-2.5 rounded-full opacity-40 cursor-not-allowed"
+        <button type="button" className="p-2.5 rounded-full opacity-40 cursor-not-allowed"
+          aria-label="Screen share coming soon"
           style={{ background: 'var(--surface-container-low)', color: 'var(--text-tertiary)' }}
           title="Screen share (coming soon)" disabled>
           <Monitor size={18} />
         </button>
 
-        <button className="p-2.5 rounded-full opacity-40 cursor-not-allowed"
+        <button type="button" className="p-2.5 rounded-full opacity-40 cursor-not-allowed"
+          aria-label="Invite to huddle coming soon"
           style={{ background: 'var(--surface-container-low)', color: 'var(--text-tertiary)' }}
           title="Invite (coming soon)" disabled>
           <UserPlus size={18} />
         </button>
 
-        <button onClick={onLeave}
+        <button type="button" onClick={onLeave}
           className="p-2.5 rounded-full transition-colors hover:opacity-90"
           style={{ background: '#ef4444', color: 'white' }}
+          aria-label="Leave huddle"
           title="Leave huddle">
           <PhoneOff size={18} />
         </button>

--- a/apps/web/src/components/huddle-ring-toast.tsx
+++ b/apps/web/src/components/huddle-ring-toast.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
-import { Headphones, X } from 'lucide-react';
+import { AlertCircle, Headphones, X } from 'lucide-react';
 import type { HuddleRing } from '@/hooks/use-huddle';
+import type { HuddleClientError } from '@/lib/huddle-types';
 
 const AUTO_DISMISS_MS = 15000;
 
@@ -46,10 +47,9 @@ function sendBrowserNotification(ring: HuddleRing) {
   if (document.hasFocus()) return;
   if (typeof Notification === 'undefined') return;
 
-  if (Notification.permission === 'default') {
-    Notification.requestPermission();
-    return;
-  }
+  // A background socket event is not a user gesture. Browsers may suppress or
+  // penalize unsolicited permission prompts, so permission is requested only
+  // from an explicit settings/user flow elsewhere.
   if (Notification.permission !== 'granted') return;
 
   const notif = new Notification(`Huddle in #${ring.space_name}`, {
@@ -60,25 +60,32 @@ function sendBrowserNotification(ring: HuddleRing) {
 }
 
 export function HuddleRingToast({
-  rings, onJoin, onDismiss,
+  rings, busy, onJoin, onDismiss,
 }: {
   rings: HuddleRing[];
+  busy: boolean;
   onJoin: (spaceId: string) => void;
   onDismiss: (ringId: string) => void;
 }) {
   return (
-    <div className="fixed top-4 right-4 z-[70] flex flex-col gap-2" style={{ maxWidth: 360 }}>
+    <div
+      className="fixed left-4 right-4 top-4 z-[70] flex flex-col gap-2 sm:left-auto sm:w-[360px]"
+      role="region"
+      aria-label="Huddle invitations"
+      aria-live="polite"
+    >
       {rings.map((ring) => (
-        <RingCard key={ring.id} ring={ring} onJoin={onJoin} onDismiss={onDismiss} />
+        <RingCard key={ring.id} ring={ring} busy={busy} onJoin={onJoin} onDismiss={onDismiss} />
       ))}
     </div>
   );
 }
 
 function RingCard({
-  ring, onJoin, onDismiss,
+  ring, busy, onJoin, onDismiss,
 }: {
   ring: HuddleRing;
+  busy: boolean;
   onJoin: (spaceId: string) => void;
   onDismiss: (ringId: string) => void;
 }) {
@@ -119,12 +126,14 @@ function RingCard({
   }, [ring.id, onDismiss]);
 
   const handleJoin = () => {
+    if (busy) return;
     onJoin(ring.space_id);
     onDismiss(ring.id);
   };
 
   return (
     <div
+      role="status"
       className="rounded-xl overflow-hidden"
       style={{
         background: 'var(--surface-container-highest, #1e1e2e)',
@@ -162,12 +171,14 @@ function RingCard({
           {/* Actions */}
           <div className="flex items-center gap-2 mt-2.5">
             <button onClick={handleJoin}
-              className="px-3.5 py-1.5 rounded-lg text-[11px] font-semibold transition-colors hover:opacity-90"
+              disabled={busy}
+              aria-busy={busy}
+              className="min-h-[44px] px-3.5 py-1.5 rounded-lg text-[11px] font-semibold transition-colors hover:opacity-90 disabled:cursor-wait disabled:opacity-60"
               style={{ background: '#22c55e', color: 'white' }}>
-              Join
+              {busy ? 'Connecting…' : 'Join'}
             </button>
             <button onClick={() => onDismiss(ring.id)}
-              className="px-3 py-1.5 rounded-lg text-[11px] font-medium transition-colors hover:opacity-80"
+              className="min-h-[44px] px-3 py-1.5 rounded-lg text-[11px] font-medium transition-colors hover:opacity-80"
               style={{ color: 'var(--text-secondary)', background: 'var(--surface-container-low)' }}>
               Dismiss
             </button>
@@ -176,7 +187,8 @@ function RingCard({
 
         {/* Close */}
         <button onClick={() => onDismiss(ring.id)}
-          className="p-1 rounded hover:opacity-70 flex-shrink-0"
+          className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded hover:opacity-70 flex-shrink-0"
+          aria-label={`Dismiss huddle invitation from ${ring.created_by_name}`}
           style={{ color: 'var(--text-tertiary)' }}>
           <X size={14} />
         </button>
@@ -194,6 +206,49 @@ function RingCard({
           to { transform: translateX(0); opacity: 1; }
         }
       `}</style>
+    </div>
+  );
+}
+
+export function HuddleErrorToast({
+  error,
+  onDismiss,
+}: {
+  error: HuddleClientError;
+  onDismiss: () => void;
+}) {
+  return (
+    <div
+      key={error.id}
+      className="fixed bottom-4 left-4 right-4 z-[72] rounded-xl p-3 sm:left-auto sm:w-[360px]"
+      style={{
+        background: 'var(--surface-container-highest, #1e1e2e)',
+        border: '1px solid var(--status-red, #ef4444)',
+        boxShadow: '0 8px 32px rgba(0,0,0,0.3)',
+      }}
+      role="alert"
+      aria-live="assertive"
+    >
+      <div className="flex items-start gap-3">
+        <AlertCircle size={20} className="mt-0.5 flex-shrink-0" style={{ color: 'var(--status-red, #ef4444)' }} />
+        <div className="min-w-0 flex-1">
+          <p className="text-[12px] font-semibold" style={{ color: 'var(--text-primary)' }}>
+            Huddle unavailable
+          </p>
+          <p className="mt-0.5 text-[11px]" style={{ color: 'var(--text-secondary)' }}>
+            {error.message}
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={onDismiss}
+          className="flex min-h-[44px] min-w-[44px] flex-shrink-0 items-center justify-center rounded hover:opacity-70"
+          style={{ color: 'var(--text-tertiary)' }}
+          aria-label="Dismiss huddle error"
+        >
+          <X size={16} />
+        </button>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/components/sidebar.tsx
+++ b/apps/web/src/components/sidebar.tsx
@@ -109,7 +109,7 @@ function ChatSidebarContent({
   onOpenCreateSpace: () => void;
 }) {
   const { user } = useAuth();
-  const { unreadCounts, mentionCounts, orgMembers, openDmWith, activeHuddles, joinHuddleBySpace } = useChatContext();
+  const { unreadCounts, mentionCounts, orgMembers, openDmWith, activeHuddles, huddleBusy, joinHuddleBySpace } = useChatContext();
   const pathname = usePathname();
   const router = useRouter();
   const [createDmOpen, setCreateDmOpen] = useState(false);
@@ -233,7 +233,11 @@ function ChatSidebarContent({
               {HUDDLES_ENABLED && activeHuddles.has(space.id) && (
                 <button
                   onClick={(e) => { e.stopPropagation(); joinHuddleBySpace?.(space.id); }}
-                  className="absolute right-2 top-1/2 -translate-y-1/2 flex items-center gap-1 text-[9px] font-medium flex-shrink-0 px-1.5 py-0.5 rounded-full hover:opacity-80"
+                  type="button"
+                  disabled={huddleBusy}
+                  aria-busy={huddleBusy}
+                  aria-label={`Join huddle in ${space.name} with ${activeHuddles.get(space.id)!.participants.length} participants`}
+                  className="absolute right-1 top-1/2 -translate-y-1/2 flex min-h-[32px] min-w-[44px] items-center justify-center gap-1 text-[9px] font-medium flex-shrink-0 px-1.5 py-0.5 rounded-full hover:opacity-80 disabled:cursor-wait disabled:opacity-60"
                   style={{ background: 'rgba(34,197,94,0.15)', color: '#22c55e' }}
                   title="Join huddle"
                 >

--- a/apps/web/src/components/space-chat.tsx
+++ b/apps/web/src/components/space-chat.tsx
@@ -620,7 +620,7 @@ export function SpaceChat({
 }) {
   const { user } = useAuth();
   const router = useRouter();
-  const { setThreadMessage, markSpaceRead, presence, spaces, orgMembers, startHuddle, joinHuddleBySpace, huddleSpaceId, activeHuddles, openDmWith } = useChatContext();
+  const { setThreadMessage, markSpaceRead, presence, spaces, orgMembers, startHuddle, joinHuddleBySpace, huddleSpaceId, huddleBusy, activeHuddles, openDmWith } = useChatContext();
   const [messages, setMessages] = useState<Message[]>([]);
   const [typingUsers, setTypingUsers] = useState<Map<string, string>>(new Map());
   // presence is provided by ChatContext — no local state needed
@@ -1348,7 +1348,8 @@ export function SpaceChat({
 
               if (inThisHuddle) {
                 return (
-                  <button className="deft-pill min-h-[38px] md:min-h-[30px]"
+                  <button type="button" disabled aria-label={`You are in the huddle in ${displayName}`}
+                    className="deft-pill min-h-[44px] md:min-h-[30px]"
                     style={{ background: '#22c55e', color: 'white' }} title="You're in this huddle">
                     <Mic size={13} strokeWidth={1.5} />
                     <span className="hidden md:inline">In Huddle</span>
@@ -1357,22 +1358,28 @@ export function SpaceChat({
               }
               if (othersInHuddle) {
                 return (
-                  <button onClick={() => joinHuddleBySpace?.(spaceId)}
-                    className="deft-pill min-h-[38px] animate-pulse md:min-h-[30px]"
+                  <button type="button" onClick={() => joinHuddleBySpace?.(spaceId)}
+                    disabled={huddleBusy}
+                    aria-label={`Join huddle in ${displayName} with ${huddleHere!.participants.length} participants`}
+                    aria-busy={huddleBusy}
+                    className="deft-pill min-h-[44px] animate-pulse disabled:cursor-wait disabled:opacity-60 md:min-h-[30px]"
                     style={{ background: 'rgba(34,197,94,0.15)', color: '#22c55e' }}
                     title={`${huddleHere!.participants.length} in huddle — click to join`}>
                     <Mic size={13} strokeWidth={1.5} />
-                    <span className="hidden md:inline">Join ({huddleHere!.participants.length})</span>
+                    <span className="hidden md:inline">{huddleBusy ? 'Connecting…' : `Join (${huddleHere!.participants.length})`}</span>
                   </button>
                 );
               }
               return (
-                <button onClick={() => startHuddle?.(spaceId)}
-                  className="deft-pill min-h-[38px] md:min-h-[30px]"
+                <button type="button" onClick={() => startHuddle?.(spaceId)}
+                  disabled={huddleBusy}
+                  aria-label={`Start a huddle in ${displayName}`}
+                  aria-busy={huddleBusy}
+                  className="deft-pill min-h-[44px] disabled:cursor-wait disabled:opacity-60 md:min-h-[30px]"
                   style={{ color: 'var(--on-surface-variant)' }}
                   title="Start a huddle">
                   <Mic size={13} strokeWidth={1.5} />
-                  <span className="hidden md:inline">Huddle</span>
+                  <span className="hidden md:inline">{huddleBusy ? 'Connecting…' : 'Huddle'}</span>
                 </button>
               );
             })()}

--- a/apps/web/src/hooks/use-huddle.ts
+++ b/apps/web/src/hooks/use-huddle.ts
@@ -2,25 +2,28 @@
 
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { getSocket } from '@/lib/socket';
+import {
+  applyHuddleUpdate,
+  HUDDLE_RESPONSE_TIMEOUT_MS,
+  huddleResponseTimeoutMessage,
+  huddlesFromSnapshot,
+  removeEndedHuddle,
+  shouldCleanupEndedHuddle,
+} from '@/lib/huddle-state';
+import type {
+  ActiveHuddleInfo,
+  HuddleClientError,
+  HuddleParticipant,
+  HuddleSocketError,
+  HuddleSummary,
+} from '@/lib/huddle-types';
 import SimplePeer from 'simple-peer';
-
-type Participant = {
-  user_id: string;
-  user_name: string;
-  muted: boolean;
-  socket_id: string;
-};
-
-type ActiveHuddleInfo = {
-  huddle_id: string;
-  participants: Participant[];
-};
 
 type HuddleState = {
   active: boolean;
   huddleId: string | null;
   spaceId: string | null;
-  participants: Participant[];
+  participants: HuddleParticipant[];
   muted: boolean;
   duration: number;
   expanded: boolean;
@@ -32,11 +35,11 @@ export type HuddleRing = {
   space_id: string;
   space_name: string;
   created_by_name: string;
-  participants: Participant[];
+  participants: HuddleParticipant[];
   received_at: number;
 };
 
-export function useHuddle() {
+export function useHuddle(enabled: boolean) {
   const [state, setState] = useState<HuddleState>({
     active: false,
     huddleId: null,
@@ -49,6 +52,8 @@ export function useHuddle() {
 
   const [activeHuddles, setActiveHuddles] = useState<Map<string, ActiveHuddleInfo>>(new Map());
   const [pendingRings, setPendingRings] = useState<HuddleRing[]>([]);
+  const [error, setError] = useState<HuddleClientError | null>(null);
+  const [busy, setBusy] = useState(false);
 
   // ═══ REFS — always-current values for use inside closures ═══
   const activeRef = useRef(false);
@@ -57,7 +62,10 @@ export function useHuddle() {
   const peersRef = useRef<Map<string, SimplePeer.Instance>>(new Map());
   const streamRef = useRef<MediaStream | null>(null);
   const durationRef = useRef<ReturnType<typeof setInterval>>(undefined);
+  const responseTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
   const socketRef = useRef<ReturnType<typeof getSocket> | null>(null);
+  const pendingRef = useRef<{ event: 'huddle:create' | 'huddle:join'; spaceId: string; huddleId?: string } | null>(null);
+  const errorIdRef = useRef(0);
 
   // Keep refs in sync with state
   useEffect(() => { activeRef.current = state.active; }, [state.active]);
@@ -131,24 +139,113 @@ export function useHuddle() {
     }
   }, []);
 
+  const reportError = useCallback((
+    source: HuddleClientError['source'],
+    message: string,
+    code?: string,
+  ) => {
+    errorIdRef.current += 1;
+    setError({ id: errorIdRef.current, source, message, code });
+  }, []);
+
+  const clearError = useCallback(() => setError(null), []);
+
+  const clearResponseWatchdog = useCallback(() => {
+    if (responseTimerRef.current) {
+      clearTimeout(responseTimerRef.current);
+      responseTimerRef.current = undefined;
+    }
+  }, []);
+
+  const resetLocalSession = useCallback(() => {
+    activeRef.current = false;
+    huddleIdRef.current = null;
+    spaceIdRef.current = null;
+    pendingRef.current = null;
+    clearResponseWatchdog();
+    setBusy(false);
+    cleanup();
+    setState({
+      active: false,
+      huddleId: null,
+      spaceId: null,
+      participants: [],
+      muted: false,
+      duration: 0,
+      expanded: false,
+    });
+  }, [cleanup, clearResponseWatchdog]);
+
+  const armResponseWatchdog = useCallback((pending: NonNullable<typeof pendingRef.current>) => {
+    clearResponseWatchdog();
+    responseTimerRef.current = setTimeout(() => {
+      if (pendingRef.current !== pending) return;
+      resetLocalSession();
+      reportError('connection', huddleResponseTimeoutMessage(pending.event), 'RESPONSE_TIMEOUT');
+    }, HUDDLE_RESPONSE_TIMEOUT_MS);
+  }, [clearResponseWatchdog, reportError, resetLocalSession]);
+
+  const acquireMicrophone = useCallback(async (): Promise<MediaStream | null> => {
+    if (!navigator.mediaDevices?.getUserMedia) {
+      reportError('microphone', 'Voice huddles are not supported by this browser.');
+      return null;
+    }
+
+    try {
+      return await navigator.mediaDevices.getUserMedia({ audio: true, video: false });
+    } catch (err) {
+      const name = err instanceof DOMException ? err.name : '';
+      const message = name === 'NotAllowedError' || name === 'SecurityError'
+        ? 'Microphone access is required to join a huddle. Allow access in your browser and try again.'
+        : name === 'NotFoundError'
+          ? 'No microphone was found. Connect one and try again.'
+          : 'Deft could not access your microphone. Check your audio device and try again.';
+      reportError('microphone', message, name || undefined);
+      return null;
+    }
+  }, [reportError]);
+
   // ═══ Socket initialization + all event listeners ═══
   useEffect(() => {
+    if (!enabled) return;
     const token = localStorage.getItem('deft-access-token');
     if (!token) return;
     socketRef.current = getSocket(token);
     const socket = socketRef.current;
 
-    const onJoined = (data: { huddle_id: string; participants: Participant[] }) => {
+    const onJoined = (data: { huddle_id: string; space_id?: string; participants: HuddleParticipant[] }) => {
+      const joinedSpaceId = data.space_id ?? pendingRef.current?.spaceId ?? spaceIdRef.current;
+      if (!joinedSpaceId) {
+        socket.emit('huddle:leave', { huddle_id: data.huddle_id });
+        resetLocalSession();
+        reportError('server', 'The huddle joined without a valid space. Please try again.', 'INVALID_STATE');
+        return;
+      }
+
+      activeRef.current = true;
+      huddleIdRef.current = data.huddle_id;
+      spaceIdRef.current = joinedSpaceId;
+      clearResponseWatchdog();
+      pendingRef.current = null;
+      setBusy(false);
+      setError(null);
       setState(prev => ({
         ...prev,
         active: true,
         huddleId: data.huddle_id,
+        spaceId: joinedSpaceId,
         participants: data.participants,
         duration: 0,
       }));
+      setActiveHuddles(prev => applyHuddleUpdate(prev, {
+        huddle_id: data.huddle_id,
+        space_id: joinedSpaceId,
+        participants: data.participants,
+      }));
     };
 
-    const onUserJoined = (data: { huddle_id: string; user_id: string; participants: Participant[] }) => {
+    const onUserJoined = (data: { huddle_id: string; user_id: string; participants: HuddleParticipant[] }) => {
+      if (huddleIdRef.current !== data.huddle_id) return;
       setState(prev => {
         if (prev.huddleId !== data.huddle_id) return prev;
         return { ...prev, participants: data.participants };
@@ -158,7 +255,8 @@ export function useHuddle() {
       }
     };
 
-    const onUserLeft = (data: { huddle_id: string; user_id: string; participants: Participant[] }) => {
+    const onUserLeft = (data: { huddle_id: string; user_id: string; participants: HuddleParticipant[] }) => {
+      if (huddleIdRef.current !== data.huddle_id) return;
       setState(prev => {
         if (prev.huddleId !== data.huddle_id) return prev;
         return { ...prev, participants: data.participants };
@@ -168,6 +266,7 @@ export function useHuddle() {
     };
 
     const onSignal = (data: { huddle_id: string; from_user_id: string; signal_data: any }) => {
+      if (!activeRef.current || huddleIdRef.current !== data.huddle_id) return;
       let peer = peersRef.current.get(data.from_user_id);
       if (!peer) {
         peer = createPeer(data.from_user_id, false);
@@ -175,7 +274,8 @@ export function useHuddle() {
       try { peer.signal(data.signal_data); } catch {}
     };
 
-    const onMuteChanged = (data: { user_id: string; muted: boolean }) => {
+    const onMuteChanged = (data: { huddle_id?: string; user_id: string; muted: boolean }) => {
+      if (data.huddle_id && data.huddle_id !== huddleIdRef.current) return;
       setState(prev => ({
         ...prev,
         participants: prev.participants.map(p =>
@@ -185,61 +285,75 @@ export function useHuddle() {
     };
 
     const onEnded = (data: { huddle_id: string; space_id?: string }) => {
-      // Always clean up activeHuddles — try by space_id first, then scan by huddle_id
-      setActiveHuddles(prev => {
-        const m = new Map(prev);
-        if (data.space_id) {
-          m.delete(data.space_id);
-        } else {
-          // Scan for the huddle_id and remove
-          for (const [spaceId, info] of m) {
-            if (info.huddle_id === data.huddle_id) { m.delete(spaceId); break; }
-          }
-        }
-        return m;
-      });
+      // Every client tracks room indicators, but only the matching active call owns our media.
+      setActiveHuddles(prev => removeEndedHuddle(prev, data));
       setPendingRings(prev => prev.filter(r => r.huddle_id !== data.huddle_id));
-      setState(prev => {
-        if (prev.huddleId !== data.huddle_id) return prev;
-        return { active: false, huddleId: null, spaceId: null, participants: [], muted: false, duration: 0, expanded: false };
-      });
-      cleanup();
+      if (pendingRef.current?.huddleId === data.huddle_id) {
+        resetLocalSession();
+        reportError('state', 'The huddle ended before you could join it.');
+        return;
+      }
+      if (shouldCleanupEndedHuddle(huddleIdRef.current, data.huddle_id)) {
+        resetLocalSession();
+      }
     };
 
     const onExists = (data: { huddle_id: string }) => {
+      if (!pendingRef.current || activeRef.current) return;
+      pendingRef.current = { ...pendingRef.current, event: 'huddle:join', huddleId: data.huddle_id };
+      armResponseWatchdog(pendingRef.current);
       socket.emit('huddle:join', { huddle_id: data.huddle_id });
     };
 
-    const onHuddleStarted = (data: { huddle_id: string; space_id: string; participants: Participant[] }) => {
-      setActiveHuddles(prev => new Map(prev).set(data.space_id, { huddle_id: data.huddle_id, participants: data.participants }));
+    const onHuddleStarted = (data: { huddle_id: string; space_id: string; participants: HuddleParticipant[] }) => {
+      setActiveHuddles(prev => applyHuddleUpdate(prev, data));
     };
 
-    const onHuddleRing = (data: { huddle_id: string; space_id: string; space_name: string; created_by_name: string; participants: Participant[] }) => {
-      setActiveHuddles(prev => new Map(prev).set(data.space_id, { huddle_id: data.huddle_id, participants: data.participants }));
+    const onHuddleRing = (data: { huddle_id: string; space_id: string; space_name: string; created_by_name: string; participants: HuddleParticipant[] }) => {
+      setActiveHuddles(prev => applyHuddleUpdate(prev, data));
       if (activeRef.current) return;
-      setPendingRings(prev => [...prev, {
-        id: `${data.huddle_id}-${Date.now()}`,
-        ...data,
-        received_at: Date.now(),
-      }]);
+      setPendingRings(prev => prev.some(ring => ring.huddle_id === data.huddle_id)
+        ? prev
+        : [...prev, {
+            id: `${data.huddle_id}-${Date.now()}`,
+            ...data,
+            received_at: Date.now(),
+          }]);
     };
 
-    const onHuddleUpdated = (data: { huddle_id: string; participants: Participant[] }) => {
-      setActiveHuddles(prev => {
-        const m = new Map(prev);
-        for (const [spaceId, info] of m) {
-          if (info.huddle_id === data.huddle_id) {
-            if (data.participants.length === 0) {
-              // No participants left — remove indicator immediately
-              m.delete(spaceId);
-            } else {
-              m.set(spaceId, { ...info, participants: data.participants });
-            }
-            break;
-          }
+    const onHuddleUpdated = (data: { huddle_id: string; space_id?: string; participants: HuddleParticipant[] }) => {
+      setActiveHuddles(prev => applyHuddleUpdate(prev, data));
+    };
+
+    const onHuddleSnapshot = (data: { huddles: HuddleSummary[] }) => {
+      setActiveHuddles(previous => {
+        const next = huddlesFromSnapshot(Array.isArray(data?.huddles) ? data.huddles : []);
+        const activeSpaceId = spaceIdRef.current;
+        const activeHuddleId = huddleIdRef.current;
+        if (activeRef.current && activeSpaceId && activeHuddleId && !next.has(activeSpaceId)) {
+          const current = previous.get(activeSpaceId);
+          if (current?.huddle_id === activeHuddleId) next.set(activeSpaceId, current);
         }
-        return m;
+        return next;
       });
+    };
+
+    const onHuddleError = (data: HuddleSocketError) => {
+      reportError('server', data.message || 'The huddle request failed. Please try again.', data.code);
+      if ((data.event === 'huddle:create' || data.event === 'huddle:join') && pendingRef.current) {
+        resetLocalSession();
+      }
+      if (data.event === 'huddle:leave') {
+        socket.emit('huddle:list', {});
+      }
+    };
+
+    const requestHuddleSnapshot = () => socket.emit('huddle:list', {});
+
+    const onSocketDisconnect = () => {
+      if (!activeRef.current && !pendingRef.current) return;
+      resetLocalSession();
+      reportError('connection', 'The huddle disconnected. Reconnect and join again.');
     };
 
     socket.on('huddle:joined', onJoined);
@@ -252,6 +366,12 @@ export function useHuddle() {
     socket.on('huddle:started', onHuddleStarted);
     socket.on('huddle:updated', onHuddleUpdated);
     socket.on('huddle:ring', onHuddleRing);
+    socket.on('huddle:snapshot', onHuddleSnapshot);
+    socket.on('huddle:error', onHuddleError);
+    socket.on('connect', requestHuddleSnapshot);
+    socket.on('disconnect', onSocketDisconnect);
+
+    if (socket.connected) requestHuddleSnapshot();
 
     return () => {
       socket.off('huddle:joined', onJoined);
@@ -264,60 +384,136 @@ export function useHuddle() {
       socket.off('huddle:started', onHuddleStarted);
       socket.off('huddle:updated', onHuddleUpdated);
       socket.off('huddle:ring', onHuddleRing);
+      socket.off('huddle:snapshot', onHuddleSnapshot);
+      socket.off('huddle:error', onHuddleError);
+      socket.off('connect', requestHuddleSnapshot);
+      socket.off('disconnect', onSocketDisconnect);
+      clearResponseWatchdog();
+      cleanup();
     };
-  }, [createPeer, cleanup]);
+  }, [armResponseWatchdog, clearResponseWatchdog, createPeer, cleanup, enabled, reportError, resetLocalSession]);
 
   // ═══ Actions ═══
 
   const startHuddle = useCallback(async (spaceId: string) => {
-    try {
-      const stream = await navigator.mediaDevices.getUserMedia({ audio: true, video: false });
-      streamRef.current = stream;
-      setState(prev => ({ ...prev, spaceId }));
-      setPendingRings(prev => prev.filter(r => r.space_id !== spaceId));
-      socketRef.current?.emit('huddle:create', { space_id: spaceId });
-    } catch (err) {
-      console.error('Failed to get audio:', err);
+    if (!enabled) return;
+    if (activeRef.current) {
+      reportError(
+        'state',
+        spaceIdRef.current === spaceId
+          ? 'You are already in this huddle.'
+          : 'Leave your current huddle before starting another one.',
+      );
+      return;
     }
-  }, []);
+    if (pendingRef.current) {
+      reportError('state', 'A huddle connection is already in progress.');
+      return;
+    }
+    const socket = socketRef.current;
+    if (!socket?.connected) {
+      reportError('connection', 'Chat is reconnecting. Try starting the huddle again in a moment.');
+      return;
+    }
 
-  const joinHuddle = useCallback(async (huddleId: string) => {
-    try {
-      const stream = await navigator.mediaDevices.getUserMedia({ audio: true, video: false });
-      streamRef.current = stream;
-      socketRef.current?.emit('huddle:join', { huddle_id: huddleId });
-    } catch (err) {
-      console.error('Failed to get audio:', err);
+    const pending = { event: 'huddle:create' as const, spaceId };
+    pendingRef.current = pending;
+    setBusy(true);
+    setError(null);
+    const stream = await acquireMicrophone();
+    if (!stream) {
+      if (pendingRef.current === pending) pendingRef.current = null;
+      setBusy(false);
+      return;
     }
-  }, []);
+    if (pendingRef.current !== pending || !socket.connected) {
+      stream.getTracks().forEach(track => track.stop());
+      if (pendingRef.current === pending) {
+        pendingRef.current = null;
+        setBusy(false);
+        reportError('connection', 'Chat disconnected before the huddle could start. Try again.');
+      }
+      return;
+    }
+
+    streamRef.current = stream;
+    spaceIdRef.current = spaceId;
+    setState(prev => ({ ...prev, spaceId }));
+    setPendingRings(prev => prev.filter(r => r.space_id !== spaceId));
+    armResponseWatchdog(pending);
+    socket.emit('huddle:create', { space_id: spaceId });
+  }, [acquireMicrophone, armResponseWatchdog, enabled, reportError]);
+
+  const joinHuddle = useCallback(async (huddleId: string, spaceId: string) => {
+    if (!enabled) return;
+    if (activeRef.current) {
+      if (huddleIdRef.current === huddleId) return;
+      reportError('state', 'Leave your current huddle before joining another one.');
+      return;
+    }
+    if (pendingRef.current) {
+      reportError('state', 'A huddle connection is already in progress.');
+      return;
+    }
+    const socket = socketRef.current;
+    if (!socket?.connected) {
+      reportError('connection', 'Chat is reconnecting. Try joining the huddle again in a moment.');
+      return;
+    }
+
+    const pending = { event: 'huddle:join' as const, spaceId, huddleId };
+    pendingRef.current = pending;
+    setBusy(true);
+    setError(null);
+    const stream = await acquireMicrophone();
+    if (!stream) {
+      if (pendingRef.current === pending) pendingRef.current = null;
+      setBusy(false);
+      return;
+    }
+    if (pendingRef.current !== pending || !socket.connected) {
+      stream.getTracks().forEach(track => track.stop());
+      if (pendingRef.current === pending) {
+        pendingRef.current = null;
+        setBusy(false);
+        reportError('connection', 'Chat disconnected before the huddle could join. Try again.');
+      }
+      return;
+    }
+
+    streamRef.current = stream;
+    spaceIdRef.current = spaceId;
+    setState(prev => ({ ...prev, spaceId }));
+    setPendingRings(prev => prev.filter(r => r.space_id !== spaceId));
+    armResponseWatchdog(pending);
+    socket.emit('huddle:join', { huddle_id: huddleId });
+  }, [acquireMicrophone, armResponseWatchdog, enabled, reportError]);
 
   const joinHuddleBySpace = useCallback(async (spaceId: string) => {
+    if (!enabled) return;
     const info = activeHuddles.get(spaceId);
     let huddleId = info?.huddle_id;
     if (!huddleId) {
       const ring = pendingRings.find(r => r.space_id === spaceId);
       huddleId = ring?.huddle_id;
     }
-    if (huddleId) {
-      setState(prev => ({ ...prev, spaceId }));
-      setPendingRings(prev => prev.filter(r => r.space_id !== spaceId));
-      await joinHuddle(huddleId);
+    if (!huddleId) {
+      reportError('state', 'This huddle is no longer available. Refreshing active huddles…');
+      socketRef.current?.emit('huddle:list', {});
+      return;
     }
-  }, [activeHuddles, pendingRings, joinHuddle]);
+    await joinHuddle(huddleId, spaceId);
+  }, [activeHuddles, enabled, pendingRings, joinHuddle, reportError]);
 
   const leaveHuddle = useCallback(() => {
     const hid = huddleIdRef.current;
-    const sid = spaceIdRef.current;
     if (hid) {
       socketRef.current?.emit('huddle:leave', { huddle_id: hid });
     }
-    // Immediately clear local indicators (don't wait for server grace timer)
-    if (sid) {
-      setActiveHuddles(prev => { const m = new Map(prev); m.delete(sid); return m; });
-    }
-    cleanup();
-    setState({ active: false, huddleId: null, spaceId: null, participants: [], muted: false, duration: 0, expanded: false });
-  }, [cleanup]);
+    // Keep the room indicator. The server's space-aware update will preserve a
+    // Join affordance when other participants remain, or remove an empty room.
+    resetLocalSession();
+  }, [resetLocalSession]);
 
   const toggleMute = useCallback(() => {
     if (streamRef.current) {
@@ -348,6 +544,8 @@ export function useHuddle() {
 
   return {
     ...state,
+    busy,
+    error,
     activeHuddles,
     pendingRings,
     startHuddle,
@@ -357,6 +555,7 @@ export function useHuddle() {
     toggleMute,
     toggleExpanded,
     dismissRing,
+    clearError,
     getStreams,
   };
 }

--- a/apps/web/src/lib/chat-context.tsx
+++ b/apps/web/src/lib/chat-context.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { createContext, useContext } from 'react';
+import type { ActiveHuddleInfo, HuddleClientError } from './huddle-types';
 
 type Space = {
   id: string;
@@ -57,10 +58,13 @@ type ChatContextType = {
   refreshSpaces: () => void;
   orgMembers: OrgMember[];
   openDmWith: (memberId: string) => Promise<void>;
-  startHuddle?: (spaceId: string) => void;
-  joinHuddleBySpace?: (spaceId: string) => void;
+  startHuddle?: (spaceId: string) => Promise<void>;
+  joinHuddleBySpace?: (spaceId: string) => Promise<void>;
   huddleSpaceId?: string | null;
-  activeHuddles: Map<string, { huddle_id: string; participants: { user_id: string; user_name: string; muted: boolean }[] }>;
+  huddleBusy: boolean;
+  huddleError: HuddleClientError | null;
+  clearHuddleError: () => void;
+  activeHuddles: Map<string, ActiveHuddleInfo>;
 };
 
 export const ChatContext = createContext<ChatContextType>({
@@ -79,6 +83,9 @@ export const ChatContext = createContext<ChatContextType>({
   openDmWith: async () => {},
   startHuddle: async () => {},
   joinHuddleBySpace: async () => {},
+  huddleBusy: false,
+  huddleError: null,
+  clearHuddleError: () => {},
   activeHuddles: new Map(),
 });
 

--- a/apps/web/src/lib/huddle-state.test.ts
+++ b/apps/web/src/lib/huddle-state.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Run: pnpm --filter @deft/web exec tsx --test src/lib/huddle-state.test.ts
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  applyHuddleUpdate,
+  HUDDLE_RESPONSE_TIMEOUT_MS,
+  huddleResponseTimeoutMessage,
+  huddlesFromSnapshot,
+  removeEndedHuddle,
+  shouldCleanupEndedHuddle,
+} from './huddle-state';
+
+const alex = { user_id: 'user-alex', user_name: 'Alex', muted: false };
+const bea = { user_id: 'user-bea', user_name: 'Bea', muted: true };
+
+test('snapshot replaces stale room indicators with the authorized server view', () => {
+  const result = huddlesFromSnapshot([{
+    huddle_id: 'huddle-current',
+    space_id: 'space-current',
+    created_by: alex.user_id,
+    participants: [alex],
+  }]);
+
+  assert.deepEqual([...result.entries()], [[
+    'space-current',
+    { huddle_id: 'huddle-current', participants: [alex] },
+  ]]);
+});
+
+test('space-aware updates discover late rooms and preserve rejoin state after leaving', () => {
+  const result = applyHuddleUpdate(new Map(), {
+    huddle_id: 'huddle-current',
+    space_id: 'space-current',
+    participants: [bea],
+  });
+
+  assert.deepEqual(result.get('space-current'), {
+    huddle_id: 'huddle-current',
+    participants: [bea],
+  });
+});
+
+test('empty updates remove ended room indicators', () => {
+  const current = huddlesFromSnapshot([{
+    huddle_id: 'huddle-current',
+    space_id: 'space-current',
+    participants: [alex],
+  }]);
+
+  const result = applyHuddleUpdate(current, {
+    huddle_id: 'huddle-current',
+    space_id: 'space-current',
+    participants: [],
+  });
+
+  assert.equal(result.has('space-current'), false);
+});
+
+test('an old ended event cannot remove a newer room in the same space', () => {
+  const current = huddlesFromSnapshot([{
+    huddle_id: 'huddle-new',
+    space_id: 'space-current',
+    participants: [alex],
+  }]);
+
+  const result = removeEndedHuddle(current, {
+    huddle_id: 'huddle-old',
+    space_id: 'space-current',
+  });
+
+  assert.deepEqual(result, current);
+});
+
+test('only the matching active huddle owns media cleanup', () => {
+  assert.equal(shouldCleanupEndedHuddle('huddle-active', 'huddle-other'), false);
+  assert.equal(shouldCleanupEndedHuddle('huddle-active', 'huddle-active'), true);
+  assert.equal(shouldCleanupEndedHuddle(null, 'huddle-active'), false);
+});
+
+test('create and join waits have a bounded, actionable timeout', () => {
+  assert.equal(HUDDLE_RESPONSE_TIMEOUT_MS, 15_000);
+  assert.match(huddleResponseTimeoutMessage('huddle:create'), /too long to start.*microphone was released/i);
+  assert.match(huddleResponseTimeoutMessage('huddle:join'), /too long to join.*microphone was released/i);
+});

--- a/apps/web/src/lib/huddle-state.ts
+++ b/apps/web/src/lib/huddle-state.ts
@@ -1,0 +1,76 @@
+import type { ActiveHuddleInfo, HuddleSummary } from './huddle-types';
+
+export const HUDDLE_RESPONSE_TIMEOUT_MS = 15_000;
+
+export function huddleResponseTimeoutMessage(event: 'huddle:create' | 'huddle:join'): string {
+  return event === 'huddle:create'
+    ? 'The huddle took too long to start. Your microphone was released; please try again.'
+    : 'The huddle took too long to join. Your microphone was released; please try again.';
+}
+
+export type HuddleUpdate = {
+  huddle_id: string;
+  space_id?: string;
+  participants: ActiveHuddleInfo['participants'];
+};
+
+export function huddlesFromSnapshot(huddles: HuddleSummary[]): Map<string, ActiveHuddleInfo> {
+  return new Map(huddles.map((huddle) => [
+    huddle.space_id,
+    { huddle_id: huddle.huddle_id, participants: huddle.participants },
+  ]));
+}
+
+export function applyHuddleUpdate(
+  current: Map<string, ActiveHuddleInfo>,
+  update: HuddleUpdate,
+): Map<string, ActiveHuddleInfo> {
+  const next = new Map(current);
+  let spaceId = update.space_id;
+
+  if (!spaceId) {
+    for (const [candidateSpaceId, info] of next) {
+      if (info.huddle_id === update.huddle_id) {
+        spaceId = candidateSpaceId;
+        break;
+      }
+    }
+  }
+
+  if (!spaceId) return next;
+  if (update.participants.length === 0) {
+    next.delete(spaceId);
+  } else {
+    next.set(spaceId, {
+      huddle_id: update.huddle_id,
+      participants: update.participants,
+    });
+  }
+  return next;
+}
+
+export function removeEndedHuddle(
+  current: Map<string, ActiveHuddleInfo>,
+  ended: { huddle_id: string; space_id?: string },
+): Map<string, ActiveHuddleInfo> {
+  const next = new Map(current);
+  if (ended.space_id) {
+    const currentAtSpace = next.get(ended.space_id);
+    if (!currentAtSpace || currentAtSpace.huddle_id === ended.huddle_id) {
+      next.delete(ended.space_id);
+    }
+    return next;
+  }
+
+  for (const [spaceId, info] of next) {
+    if (info.huddle_id === ended.huddle_id) {
+      next.delete(spaceId);
+      break;
+    }
+  }
+  return next;
+}
+
+export function shouldCleanupEndedHuddle(activeHuddleId: string | null, endedHuddleId: string): boolean {
+  return activeHuddleId === endedHuddleId;
+}

--- a/apps/web/src/lib/huddle-types.ts
+++ b/apps/web/src/lib/huddle-types.ts
@@ -1,0 +1,28 @@
+export type HuddleParticipant = {
+  user_id: string;
+  user_name: string;
+  muted: boolean;
+};
+
+export type ActiveHuddleInfo = {
+  huddle_id: string;
+  participants: HuddleParticipant[];
+};
+
+export type HuddleSummary = ActiveHuddleInfo & {
+  space_id: string;
+  created_by?: string;
+};
+
+export type HuddleSocketError = {
+  event: 'huddle:create' | 'huddle:list' | 'huddle:join' | 'huddle:leave' | 'huddle:signal' | 'huddle:mute';
+  code: 'INVALID_PAYLOAD' | 'FORBIDDEN' | 'ROOM_NOT_FOUND' | 'NOT_PARTICIPANT' | 'TARGET_NOT_FOUND' | 'ALREADY_IN_HUDDLE' | 'INTERNAL_ERROR';
+  message: string;
+};
+
+export type HuddleClientError = {
+  id: number;
+  source: 'microphone' | 'connection' | 'server' | 'state';
+  message: string;
+  code?: string;
+};

--- a/scripts/product-browser-smoke.mjs
+++ b/scripts/product-browser-smoke.mjs
@@ -25,6 +25,15 @@ async function settle(page, path) {
 async function main() {
   const browser = await chromium.launch({ headless: true });
   const context = await browser.newContext({ viewport: { width: 1440, height: 900 } });
+  await context.addInitScript(() => {
+    window.__deftGetUserMediaCalls = 0;
+    const originalGetUserMedia = navigator.mediaDevices?.getUserMedia;
+    if (!originalGetUserMedia) return;
+    navigator.mediaDevices.getUserMedia = (...args) => {
+      window.__deftGetUserMediaCalls += 1;
+      return originalGetUserMedia.apply(navigator.mediaDevices, args);
+    };
+  });
   const page = await context.newPage();
   const pageErrors = [];
   page.on('pageerror', (error) => pageErrors.push(error.message));
@@ -42,6 +51,14 @@ async function main() {
     await settle(page, '/chat');
     const general = page.getByText('general', { exact: true }).first();
     await general.click();
+    const huddleControl = page.locator('button[title="Start a huddle"]');
+    await huddleControl.waitFor({ state: 'visible', timeout: 10_000 });
+    const mediaRequests = await page.evaluate(() => window.__deftGetUserMediaCalls ?? 0);
+    if (mediaRequests !== 0) {
+      throw new Error(`Rendering the huddle control requested microphone access ${mediaRequests} time(s)`);
+    }
+    record('Expose the huddle start control without requesting microphone access', '#general');
+
     const composer = page.locator('[contenteditable="true"]').last();
     await composer.waitFor({ state: 'visible', timeout: 10_000 });
     await composer.fill(chatMarker);


### PR DESCRIPTION
## What changed

- fixes the demo/release contract so official production images compile the Huddle client with `NEXT_PUBLIC_FEATURE_HUDDLES=true`
- keeps source/self-host builds opt-in by default
- hardens Socket.IO huddle authorization, tenant isolation, payload validation, participant ownership, reconnect snapshots, and revocation handling
- closes authorization-vs-revocation races and prevents duplicate room creation
- makes Huddle client lifecycle recover cleanly from server errors, mic denial, timeouts, disconnects, and unrelated room events
- adds accessible controls and a release-image browser smoke assertion that rendering the control never requests microphone access

## Root cause

The demo container already had `NEXT_PUBLIC_FEATURE_HUDDLES=true` at runtime, but the published image was built with the Dockerfile default (`false`). Next compiled and tree-shook the Huddle UI/event client out of the browser bundle, so restarting or changing the runtime env could not restore it.

## Risk and rollout

No database migration is required. The official image is rebuilt with the feature enabled; existing source/self-host defaults remain unchanged. Server authorization is enforced before exposing the control.

## Validation

- production web build with Huddles enabled
- API and web typechecks
- targeted web lint
- focused Huddle regression suite: 14/14
- API socket safety suite: 8/8
- web state suite: 6/6
- independent release-blocker review: clear
- `git diff --check`
- DB-backed tenant/membership integration test is included and runs in CI
- production browser smoke now requires a visible Start Huddle control and asserts zero `getUserMedia` calls while rendering