### PR TITLE
Scope chat smoke assertion to message rows

### DIFF
--- a/scripts/product-browser-smoke.mjs
+++ b/scripts/product-browser-smoke.mjs
@@ -63,7 +63,12 @@ async function main() {
     await composer.waitFor({ state: 'visible', timeout: 10_000 });
     await composer.fill(chatMarker);
     await composer.press('Enter');
-    await page.getByText(chatMarker, { exact: true }).waitFor({ timeout: 10_000 });
+    const renderedMessages = page.locator('[data-message-id]').filter({ hasText: chatMarker });
+    await renderedMessages.first().waitFor({ timeout: 10_000 });
+    const renderedMessageCount = await renderedMessages.count();
+    if (renderedMessageCount !== 1) {
+      throw new Error(`Expected one rendered chat message, found ${renderedMessageCount}`);
+    }
     record('Post and render a chat message', '#general');
 
     await settle(page, '/tasks');


### PR DESCRIPTION
## Summary

Scopes the production chat smoke assertion to persisted message rows and preserves a real duplicate-render failure.

## Root cause

The API broadcasts `message:new` before its HTTP response finishes. `RichComposer` deliberately keeps the submitted `<p>` until that response succeeds, so a global text locator can briefly see the marker in both the persisted message and the composer. CI showed exactly one message POST and one insert; product deduplication was working.

## Change

Wait for `[data-message-id]` rows containing the unique marker, then assert exactly one such row exists. The test still fails on an actual duplicate message while ignoring the transient composer copy.

## Validation

- `node --check scripts/product-browser-smoke.mjs`
- `git diff --check`
- Full production image/browser smoke is the merge gate.