### PR TITLE
Keep live chat subscriptions across reconnects

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,12 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - name: Lint web
         run: pnpm --filter @deft/web lint
-      - name: Test web huddle lifecycle state
-        run: pnpm --filter @deft/web exec tsx --test src/lib/huddle-state.test.ts
+      - name: Test web realtime lifecycle state
+        run: >-
+          pnpm --filter @deft/web exec tsx --test
+          src/lib/huddle-state.test.ts
+          src/lib/socket.test.ts
+          src/lib/space-socket.test.ts
       - name: Type check API
         run: cd apps/api && npx tsc --noEmit
       - name: Type check Web

--- a/apps/web/src/components/space-chat.tsx
+++ b/apps/web/src/components/space-chat.tsx
@@ -7,6 +7,7 @@ import { api } from '@/lib/api';
 import { openDeftyDm } from '@/lib/quick-actions';
 import { sanitizeHtml } from '@/lib/sanitize';
 import { getSocket } from '@/lib/socket';
+import { subscribeToSpace } from '@/lib/space-socket';
 import { useAuth } from '@/lib/auth-context';
 import { useChatContext } from '@/lib/chat-context';
 import { HUDDLES_ENABLED } from '@/lib/feature-flags';
@@ -934,7 +935,7 @@ export function SpaceChat({
     const token = localStorage.getItem('deft-access-token');
     if (!token) return;
     const socket = getSocket(token);
-    socket.emit('space:join', spaceId);
+    const unsubscribeFromSpace = subscribeToSpace(socket, spaceId);
 
     const onNew = (msg: Message & { parent_id?: string | null; metadata?: { is_agent_reply?: boolean } }) => {
       // Thread replies should NOT appear in the main message list
@@ -1069,7 +1070,7 @@ export function SpaceChat({
     socket.on('message:unpinned', onMessageUnpinned);
 
     return () => {
-      socket.emit('space:leave', spaceId);
+      unsubscribeFromSpace();
       socket.off('message:new', onNew);
       socket.off('message:edited', onEdited);
       socket.off('message:deleted', onDeleted);

--- a/apps/web/src/lib/socket.test.ts
+++ b/apps/web/src/lib/socket.test.ts
@@ -1,0 +1,42 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import type { Socket } from 'socket.io-client';
+import { prepareSocketForUse } from './socket';
+
+function socketHarness(active: boolean, token = 'old-token') {
+  let connectCalls = 0;
+  const socket = {
+    active,
+    auth: { token },
+    connect() {
+      connectCalls += 1;
+      return socket;
+    },
+  } as unknown as Socket;
+
+  return {
+    socket,
+    get connectCalls() {
+      return connectCalls;
+    },
+  };
+}
+
+test('updates auth without interrupting an active reconnect cycle', () => {
+  const harness = socketHarness(true);
+
+  const result = prepareSocketForUse(harness.socket, 'fresh-token');
+
+  assert.equal(result, harness.socket);
+  assert.deepEqual(harness.socket.auth, { token: 'fresh-token' });
+  assert.equal(harness.connectCalls, 0);
+});
+
+test('restarts an inactive socket with the latest token', () => {
+  const harness = socketHarness(false);
+
+  prepareSocketForUse(harness.socket, 'replacement-token');
+
+  assert.deepEqual(harness.socket.auth, { token: 'replacement-token' });
+  assert.equal(harness.connectCalls, 1);
+});

--- a/apps/web/src/lib/socket.ts
+++ b/apps/web/src/lib/socket.ts
@@ -17,12 +17,26 @@ function notifyConnectionChange(connected: boolean) {
   connectionListeners.forEach(l => l(connected));
 }
 
+/** Update a shared socket without interrupting an in-progress reconnect cycle. */
+export function prepareSocketForUse(existing: Socket, token: string): Socket {
+  // Socket.IO reads `auth` for every new connection attempt, so keep it current
+  // even when the singleton was created with an older access token.
+  existing.auth = { token };
+
+  // `active` means Socket.IO is connected or will reconnect automatically.
+  // An inactive socket (for example after a denied namespace connection) needs
+  // an explicit connect, while calling connect during backoff would race it.
+  if (!existing.active) existing.connect();
+
+  return existing;
+}
+
 export function getSocket(token: string): Socket {
   // Reuse a disconnected socket while Socket.IO performs its configured
   // reconnect cycle. Replacing it would strand listeners on the old instance.
-  if (socket) return socket;
+  if (socket) return prepareSocketForUse(socket, token);
 
-  socket = io(WS_URL, {
+  const createdSocket = io(WS_URL, {
     auth: { token },
     transports: ['websocket', 'polling'],
     reconnection: true,
@@ -30,44 +44,51 @@ export function getSocket(token: string): Socket {
     reconnectionDelay: 1000,
     reconnectionDelayMax: 10000,
   });
+  socket = createdSocket;
 
-  socket.on('connect', () => {
+  createdSocket.on('connect', () => {
+    if (socket !== createdSocket) return;
     notifyConnectionChange(true);
   });
 
-  socket.on('disconnect', (reason) => {
+  createdSocket.on('disconnect', (reason) => {
+    if (socket !== createdSocket) return;
     notifyConnectionChange(false);
     if (reason === 'io server disconnect') {
       // Server forced disconnect — likely auth failure, don't auto-reconnect
-      socket?.connect();
+      createdSocket.connect();
     }
   });
 
-  socket.on('reconnect', () => {
+  createdSocket.on('reconnect', () => {
+    if (socket !== createdSocket) return;
     notifyConnectionChange(true);
   });
 
-  socket.on('connect_error', async (err) => {
+  createdSocket.on('connect_error', async (err) => {
     const msg = err?.message ?? '';
     if (/invalid token|expired|unauthori[sz]ed/i.test(msg)) {
       // Auth-shaped error: attempt a silent token refresh and reconnect once.
       // The server key for socket auth is `token` (confirmed via socket.handshake.auth.token).
       const fresh = await refreshAccessToken();
-      if (fresh && socket) {
-        socket.auth = { token: fresh };
-        socket.connect();
+      // A logout/login may have replaced the singleton while refresh was in
+      // flight. Never mutate or disconnect that newer socket from this handler.
+      if (socket !== createdSocket) return;
+      if (fresh) {
+        createdSocket.auth = { token: fresh };
+        createdSocket.connect();
         return;
       }
       // Refresh failed — stop reconnect attempts to avoid a login-redirect loop.
       console.warn('[socket] auth refresh failed; stopping reconnect attempts');
-      socket?.disconnect();
+      createdSocket.disconnect();
       return;
     }
     // Non-auth errors fall through and use Socket.io's built-in reconnection backoff.
     console.warn('[socket] Connection error:', msg);
   });
 
-  return socket;
+  return createdSocket;
 }
 
 export function disconnectSocket() {

--- a/apps/web/src/lib/socket.ts
+++ b/apps/web/src/lib/socket.ts
@@ -18,7 +18,9 @@ function notifyConnectionChange(connected: boolean) {
 }
 
 export function getSocket(token: string): Socket {
-  if (socket?.connected) return socket;
+  // Reuse a disconnected socket while Socket.IO performs its configured
+  // reconnect cycle. Replacing it would strand listeners on the old instance.
+  if (socket) return socket;
 
   socket = io(WS_URL, {
     auth: { token },

--- a/apps/web/src/lib/space-socket.test.ts
+++ b/apps/web/src/lib/space-socket.test.ts
@@ -1,0 +1,51 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { subscribeToSpace } from './space-socket';
+
+function socketHarness(connected: boolean) {
+  const emitted: Array<[string, ...unknown[]]> = [];
+  const listeners = new Map<string, Set<() => void>>();
+  return {
+    socket: {
+      connected,
+      emit(event: string, ...args: unknown[]) {
+        emitted.push([event, ...args]);
+      },
+      on(event: string, listener: () => void) {
+        const handlers = listeners.get(event) ?? new Set();
+        handlers.add(listener);
+        listeners.set(event, handlers);
+      },
+      off(event: string, listener: () => void) {
+        listeners.get(event)?.delete(listener);
+      },
+    },
+    emitted,
+    fire(event: string) {
+      for (const listener of listeners.get(event) ?? []) listener();
+    },
+  };
+}
+
+test('joins immediately and rejoins after reconnect', () => {
+  const harness = socketHarness(true);
+  const unsubscribe = subscribeToSpace(harness.socket, 'space-1');
+
+  harness.fire('connect');
+  assert.deepEqual(harness.emitted, [
+    ['space:join', 'space-1'],
+    ['space:join', 'space-1'],
+  ]);
+
+  unsubscribe();
+  assert.deepEqual(harness.emitted.at(-1), ['space:leave', 'space-1']);
+});
+
+test('waits for connect before joining a disconnected socket', () => {
+  const harness = socketHarness(false);
+  subscribeToSpace(harness.socket, 'space-2');
+
+  assert.deepEqual(harness.emitted, []);
+  harness.fire('connect');
+  assert.deepEqual(harness.emitted, [['space:join', 'space-2']]);
+});

--- a/apps/web/src/lib/space-socket.ts
+++ b/apps/web/src/lib/space-socket.ts
@@ -1,0 +1,19 @@
+type SpaceSocket = {
+  connected: boolean;
+  emit: (event: string, ...args: unknown[]) => unknown;
+  on: (event: string, listener: () => void) => unknown;
+  off: (event: string, listener: () => void) => unknown;
+};
+
+/** Keep the active space subscription alive across Socket.IO reconnects. */
+export function subscribeToSpace(socket: SpaceSocket, spaceId: string) {
+  const join = () => socket.emit('space:join', spaceId);
+
+  if (socket.connected) join();
+  socket.on('connect', join);
+
+  return () => {
+    socket.off('connect', join);
+    if (socket.connected) socket.emit('space:leave', spaceId);
+  };
+}


### PR DESCRIPTION
## Summary

Preserves the shared Socket.IO instance during reconnects and rejoins the active space after transport recovery, preventing live chat listeners from being stranded.

## Changes

- Reuse active/reconnecting socket instances while updating auth.
- Add a focused space subscription helper that joins immediately and rejoins after reconnect.
- Wire `SpaceChat` through the helper.
- Add socket and space reconnect lifecycle tests.
- Run both new tests in the CI typecheck job alongside the existing huddle lifecycle test.

## Validation

- Realtime lifecycle tests: 10/10 passed.
- Web typecheck passed.
- Web lint passed.
- Frozen offline install passed.
- `git diff --check` passed.

Full GitHub CI, especially production browser smoke, is the merge gate.