### PR TITLE
chore(release): v0.3.0-preview.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,7 +127,7 @@ jobs:
 
       - name: Generate checksums
         shell: bash
-        run: (cd dist && sha256sum * > SHA256SUMS)
+        run: (cd dist && sha256sum -- * .env.example > SHA256SUMS)
 
       - name: Create GitHub release
         env:
@@ -137,4 +137,5 @@ jobs:
         run: |
           args=(--repo "$GITHUB_REPOSITORY" --title "Deft ${{ steps.release.outputs.tag }}" --generate-notes --verify-tag)
           [[ "$PRERELEASE" == "true" ]] && args+=(--prerelease)
-          gh release create "${{ steps.release.outputs.tag }}" dist/* "${args[@]}"
+          # dist/* does not match dotfiles; attach .env.example explicitly.
+          gh release create "${{ steps.release.outputs.tag }}" dist/* dist/.env.example "${args[@]}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ line are not repeated here.
   tenant-scoped replacement, and deterministic planning.
 - Chat browser smoke assertions are scoped to actual message rows.
 - Cross-org receipt semantics are preserved in the module runtime.
+- Preview GitHub Releases now attach `.env.example` and include it in
+  `SHA256SUMS`. Shell `dist/*` previously omitted that dotfile.
 
 ## [0.2.0-preview.1 — 0.2.0-preview.4]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,34 +10,51 @@ env vars. Patch versions (`0.X.Y`) are non-breaking fixes only.
 
 ## [Unreleased]
 
+## [0.3.0-preview.1] — 2026-08-19
+
+First AGPL-3.0-only preview. This is the delta from `v0.2.0-preview.4`.
+Earlier `[Unreleased]` notes that already shipped on the `0.2.0-preview`
+line are not repeated here.
+
 ### Added
 
-- Tagged preview release workflow with a GHCR image, provenance attestation,
-  SPDX SBOM, checksums, and a machine-readable release manifest.
-- Runtime public-URL injection for portable prebuilt images.
-- Guided personal MCP connections for Codex, Claude, ChatGPT-compatible clients, and custom streamable HTTP MCP clients.
-- Operational headless MCP tools for unread triage, context packets, people, teams, tasks, messages, notes, wiki, decisions, and calendar workflows.
-- Task Table view, richer Timeline and Calendar interactions, persistent view preferences, and improved bulk operations.
-- Profile, member, team, and linked-resource management with team dashboard summaries.
-- Agent employee bridge supervision, structured-mention wakeup, assignment flows, and completion receipts.
-- Synthetic 60-person workspace certification for isolation, job backlog, notification volume, bulk operations, and recovery exercises.
+- Declarative Modules v1: first-class Deft applications defined through
+  strict `deft.module.json` manifests, reusing storage, permissions,
+  search, approvals, receipts, tasks, audit, and agent access.
+- Bundled Contacts module as a manifest-defined CRM surface for contacts,
+  companies, deals, and activities — not CRM code in core.
+- Module distribution, provenance locking, sideloading, immutable module
+  versions, compatible upgrades, and runtime verification for bundled
+  module artifacts.
 
 ### Changed
 
-- Relicensed the current codebase from BSL 1.1 to GNU AGPL v3.0 only, removed the hosted-service restriction, added source-offer metadata, and clarified that the one-workspace deployment boundary is a product limitation rather than a license condition.
-- Reworked Defty planning so natural-language requests resolve through model-generated structured drafts, deterministic validation, approval, execution, and confirmation.
-- Moved supported approval cards into the source conversation with an inbox mirror.
-- Reworked chat knowledge capture into settled-window episode processing with quiet receipts.
-- Simplified Connections, Agent employees, Inbox, Settings, Chat, Tasks, Knowledge, and Calendar interfaces across desktop and mobile.
-- Standardized public positioning on the self-hosted v1 integration contract and current alpha boundaries.
+- Relicensed the current release line from BSL 1.1 to GNU AGPL v3.0 only.
+  Historical tags through `v0.2.0-preview.4` retain the licenses shipped
+  in those revisions. Relicensing does not rewrite old tags or images.
+- Removed Redis/BullMQ from the supported runtime. Scheduled work uses
+  PostgreSQL `job_queue` with in-process workers.
+- Hardened live chat reconnect behavior so subscriptions survive socket
+  reconnects.
+- Updated dependency and security-tooling pins used by the release line
+  (pnpm action, CodeQL, patch/minor group).
 
 ### Fixed
 
-- Scheduled chat-to-knowledge jobs now reach their registered handler.
-- Agent task creation supports structured descriptions, subtasks, dependencies, and richer completion receipts.
-- Personal MCP unread and owner-operator workflows avoid hidden-tool and keyword-search fallbacks.
-- Mobile scrolling, navigation overlays, chat composers, avatar propagation, mentions, approval placement, and task-view interaction defects found during dogfooding.
-- Self-host bootstrap, environment validation, health checks, and production preflight coverage.
+- Destructive pilot knowledge-receipt seeding now uses real
+  message-backed sources, explicit simulated-history metadata,
+  tenant-scoped replacement, and deterministic planning.
+- Chat browser smoke assertions are scoped to actual message rows.
+- Cross-org receipt semantics are preserved in the module runtime.
+
+## [0.2.0-preview.1 — 0.2.0-preview.4]
+
+Historical BSL 1.1 preview releases. These tags introduced the portable
+preview-image and self-host upgrade line and remain licensed under the
+terms included in those revisions.
+
+See the GitHub Releases page and tag comparisons for exact historical
+contents.
 
 ## [0.1.0-alpha] — 2026-05-26
 
@@ -158,5 +175,7 @@ The `0.1.0-alpha` tag was originally published under BSL 1.1. The current
 codebase has since been relicensed under [GNU AGPL v3.0 only](LICENSE); consult
 the license file present in the exact revision you use.
 
-[Unreleased]: https://github.com/Maneek21/Deft/compare/v0.1.0-alpha...HEAD
+[Unreleased]: https://github.com/Maneek21/Deft/compare/v0.3.0-preview.1...HEAD
+[0.3.0-preview.1]: https://github.com/Maneek21/Deft/releases/tag/v0.3.0-preview.1
+[0.2.0-preview.1 — 0.2.0-preview.4]: https://github.com/Maneek21/Deft/releases/tag/v0.2.0-preview.4
 [0.1.0-alpha]: https://github.com/Maneek21/Deft/releases/tag/v0.1.0-alpha

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ BSL 1.1 license included in those revisions; relicensing this source tree does
 not retroactively change old tags or images.
 
 ```bash
-export DEFT_IMAGE=ghcr.io/maneek21/deft:<agpl-release-tag>
+export DEFT_IMAGE=ghcr.io/maneek21/deft:0.3.0-preview.1
 docker compose -f docker-compose.yml -f compose.prod.yml -f compose.release.yml pull
 docker compose -f docker-compose.yml -f compose.prod.yml -f compose.release.yml up -d postgres
 docker compose -f docker-compose.yml -f compose.prod.yml -f compose.release.yml run --rm init

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -104,8 +104,8 @@ the workflow with `workflow_dispatch` against the existing tag. If the
 published image is unusable, fix forward and cut the next preview tag.
 
 Confirm the GitHub Release includes `LICENSE`, `NOTICE`,
-`THIRD-PARTY-LICENSES.md`, the source archive, SBOM, checksums, and
-compose files. Confirm the image label
+`THIRD-PARTY-LICENSES.md`, `.env.example`, the source archive, SBOM,
+checksums, and compose files. Confirm the image label
 `org.opencontainers.image.licenses=AGPL-3.0-only` (the production
 `Dockerfile` sets this; `release.yml` passes `VCS_REF` and `SOURCE_URL`).
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -12,28 +12,36 @@ alpha:
   upgrading.
 - **Patch** (`0.X.Y`) — non-breaking fixes only. Safe to bump in place.
 
-Tag format: `vMAJOR.MINOR.PATCH[-channel]` where `channel` is one of
-`alpha` / `beta` / `rc`. Examples: `v0.1.0-alpha`, `v0.2.0-beta`,
-`v1.0.0-rc.1`. Once 1.0 ships, the channel suffix drops.
+Tag format: `vMAJOR.MINOR.PATCH[-channel]`. During alpha the channel is
+`preview` (for example `v0.3.0-preview.1`). Older docs mentioned
+`alpha` / `beta` / `rc`; keep using `preview` unless the project
+explicitly changes channel. Once 1.0 ships, the channel suffix drops.
+
+The Git tag includes the leading `v`. The GHCR image tag does not:
+
+```text
+git tag     v0.3.0-preview.1
+GHCR image  ghcr.io/maneek21/deft:0.3.0-preview.1
+```
 
 ## Cutting a release
 
 ### 1. Pre-flight
 
-On `master`, verify the four required CI checks are green:
+On `master`, confirm required check-runs are green on the latest commit
+(Type Check, Test API, Build, Production Image + Browser Smoke,
+Versioned Upgrade, CodeQL). Dependency Review runs on pull requests, not
+on push to `master`.
 
 ```bash
 git checkout master
-git pull origin master
-gh pr checks --required  # or visit the most recent commit's checks page
+git pull --ff-only origin master
 ```
 
-If any required check is red, fix that first — releases must come off a
-green master.
+If Production Image + Browser Smoke or Versioned Upgrade is red, stop.
+Releases must come off a green `master`.
 
 ### 2. Open a release-prep PR
-
-Create a branch and update both the version and CHANGELOG in one PR:
 
 ```bash
 git switch -c chore/release-vX.Y.Z-channel
@@ -44,60 +52,62 @@ Edit `package.json` (root) — bump the `version` field. Workspace
 carry independent versions; they all inherit the monorepo version.
 
 Edit `CHANGELOG.md`:
-- Move every item under `[Unreleased]` into a new section
-  `[X.Y.Z-channel] — YYYY-MM-DD` placed directly below `[Unreleased]`.
-- Leave a fresh empty `[Unreleased]` section at the top for next time.
+- Write an accurate **delta from the previous tag**. Do not dump the
+  entire `[Unreleased]` section if it still contains work that already
+  shipped on an earlier tag.
+- Leave a fresh empty `[Unreleased]` section at the top.
 - Update the comparison links at the bottom of the file:
   ```
   [Unreleased]: https://github.com/Maneek21/Deft/compare/vX.Y.Z-channel...HEAD
   [X.Y.Z-channel]: https://github.com/Maneek21/Deft/releases/tag/vX.Y.Z-channel
   ```
 
-Commit, push, open a PR titled `chore(release): vX.Y.Z-channel`, get the
-required CI checks green, squash-merge.
+If README or compose files still contain a placeholder image tag, replace
+it with the GHCR tag (no leading `v`) in the same PR. Merge the prep PR
+and push the annotated tag in the same release session so README never
+points at a missing image.
+
+Commit, push, open a PR titled `chore(release): vX.Y.Z-channel`, wait for
+required CI (including Dependency Review), squash-merge.
 
 ### 3. Tag the release
 
-After the prep PR lands on `master`:
+After the prep PR lands on `master` and that merge commit's check-runs
+are green:
 
 ```bash
 git checkout master
-git pull origin master
+git pull --ff-only origin master
 git tag -a vX.Y.Z-channel -m "Deft vX.Y.Z-channel"
 git push origin vX.Y.Z-channel
 ```
 
-Use **annotated** tags (`-a`), never lightweight tags — the release page
-shows the annotation message and `git describe` works correctly.
+Use **annotated** tags (`-a`), never lightweight tags.
 
-### 4. Create the GitHub Release
+### 4. GitHub Actions publishes the image and Release
 
-Extract the `[X.Y.Z-channel]` section of `CHANGELOG.md` into a temp file
-`release-notes-X.Y.Z.md`, then:
+Pushing a `v*` tag runs [`.github/workflows/release.yml`](.github/workflows/release.yml).
+That workflow:
 
-```bash
-gh release create vX.Y.Z-channel \
-  --title "vX.Y.Z-channel" \
-  --notes-file release-notes-X.Y.Z.md \
-  --prerelease   # omit once on 1.0+ stable
-```
+- builds and pushes the `linux/amd64` GHCR image
+- attests provenance, attaches SPDX SBOM and corresponding source
+- writes `release-manifest.json` (`license: AGPL-3.0-only`)
+- creates the GitHub Release (`--generate-notes`, prerelease when the
+  version contains `-`)
 
-`--prerelease` flags the release as not-production-ready. Drop the flag
-on `1.0.0` and later stable releases.
+**Do not run a second `gh release create`.** The workflow already creates
+the Release. If notes need a license banner or highlights, edit the
+Release body after the workflow finishes.
 
-### 5. (Optional) Publish Docker image
+If packaging fails after the tag exists, **do not move the tag**. Re-run
+the workflow with `workflow_dispatch` against the existing tag. If the
+published image is unusable, fix forward and cut the next preview tag.
 
-The `Docker Image Build` CI job builds the production `Dockerfile` on
-every PR but does not push to a registry. To publish a tagged image,
-build and push manually:
-
-```bash
-docker build -t ghcr.io/maneek21/deft:vX.Y.Z-channel .
-docker push ghcr.io/maneek21/deft:vX.Y.Z-channel
-```
-
-Or set up a `release.yml` workflow triggered on tag push that authenticates
-to GHCR / Docker Hub and pushes. Not wired up yet during alpha.
+Confirm the GitHub Release includes `LICENSE`, `NOTICE`,
+`THIRD-PARTY-LICENSES.md`, the source archive, SBOM, checksums, and
+compose files. Confirm the image label
+`org.opencontainers.image.licenses=AGPL-3.0-only` (the production
+`Dockerfile` sets this; `release.yml` passes `VCS_REF` and `SOURCE_URL`).
 
 ## Hotfix releases
 
@@ -106,16 +116,14 @@ For an urgent fix on a previously released minor version:
 1. Branch off the released tag: `git switch -c hotfix/vX.Y.Z+1 vX.Y.Z-channel`
 2. Cherry-pick or land the fix.
 3. Bump the patch number, update `CHANGELOG.md`, tag `vX.Y.Z+1-channel`.
-4. Push the tag and create the GitHub Release as above.
+4. Push the tag and let `release.yml` package it.
 5. Open a PR to merge the hotfix branch back into `master` so the fix
    isn't lost when the next minor goes out.
 
 ## License and source artifacts
 
-Every release is licensed under [GNU AGPL v3.0 only](LICENSE). Confirm that
-the GitHub release includes `LICENSE`, `NOTICE`, and
-`THIRD-PARTY-LICENSES.md`, and that the container image carries
-`org.opencontainers.image.licenses=AGPL-3.0-only` and an exact
-`org.opencontainers.image.source` URL for the released commit. GitHub's source
-archive plus the repository's build and installation scripts are the
-Corresponding Source offered with the official image.
+Every current-line release is licensed under [GNU AGPL v3.0 only](LICENSE).
+Historical tags through `v0.2.0-preview.4` retain BSL 1.1 as shipped.
+Do not rewrite those tags. GitHub's source archive plus the repository's
+build and installation scripts are the Corresponding Source offered with
+the official image.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -39,6 +39,6 @@ This roadmap communicates direction, not delivery dates. Deft is an alpha and pr
 
 ## Explicit non-commitments
 
-The roadmap does not currently promise native Slack, Gmail, GitHub, Google Calendar OAuth, Linear, or Notion connectors. It also does not promise a hosted multi-customer Deft service under the current BSL license. External tools should be connected through customer-owned agent or MCP runtimes unless the product contract changes.
+The roadmap does not currently promise native Slack, Gmail, GitHub, Google Calendar OAuth, Linear, or Notion connectors. A hosted multi-customer Deft service is not part of the current self-hosted product promise. External tools should be connected through customer-owned agent or MCP runtimes unless the product contract changes.
 
 See [current limitations](docs/current-limitations.md) for boundaries that apply today.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deft",
-  "version": "0.1.0-alpha",
+  "version": "0.3.0-preview.1",
   "private": true,
   "license": "AGPL-3.0-only",
   "repository": {


### PR DESCRIPTION
## Why

`master` is AGPL-3.0-only. The latest GitHub Release and GHCR image are still `v0.2.0-preview.4` (BSL). README still told operators to set `<agpl-release-tag>`.

This PR is release metadata only. After it is green on `master`, the annotated tag `v0.3.0-preview.1` should be pushed in the same session so `release.yml` publishes the first AGPL preview.

## Changes

- `package.json` version `0.3.0-preview.1`
- `CHANGELOG.md` records the **delta from `v0.2.0-preview.4`** (AGPL, modules/Contacts, Redis/BullMQ removal, chat reconnect, receipt seeding). It does not dump the old `[Unreleased]` block. Historical `0.2.0-preview.1`–`.4` stay BSL.
- README image example: `ghcr.io/maneek21/deft:0.3.0-preview.1`
- ROADMAP: drop leftover BSL hosted-service sentence
- `RELEASING.md`: tag push runs `release.yml`; do not run a second `gh release create`

## After merge

1. Wait for required check-runs on the squash commit.
2. Annotated tag `v0.3.0-preview.1`.
3. Watch `release.yml`.
4. Prepend the AGPL banner to the generated release notes.

Do not merge if Production Image + Browser Smoke or Versioned Upgrade is red.