### PR TITLE
fix: collection tabs instead of a second module sidebar

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
           src/lib/huddle-state.test.ts
           src/lib/socket.test.ts
           src/lib/space-socket.test.ts
+          src/lib/module-collection-nav.test.ts
       - name: Type check API
         run: cd apps/api && npx tsc --noEmit
       - name: Type check Web

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ env vars. Patch versions (`0.X.Y`) are non-breaking fixes only.
 
 ## [Unreleased]
 
+### Changed
+
+- Multi-collection modules use header collection tabs on every viewport.
+  Desktop no longer renders a second left rail next to the workspace sidebar.
+
 ## [0.3.0-preview.1] — 2026-08-19
 
 First AGPL-3.0-only preview. This is the delta from `v0.2.0-preview.4`.

--- a/apps/web/src/components/modules/module-collection-nav.tsx
+++ b/apps/web/src/components/modules/module-collection-nav.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { buildModuleCollectionNav } from '@/lib/module-collection-nav';
+
+export function ModuleCollectionNav({
+  moduleName,
+  collections,
+  activeKey,
+  onSelect,
+}: {
+  moduleName: string;
+  collections: ReadonlyArray<{ key: string; name: string }>;
+  activeKey: string | null;
+  onSelect: (key: string) => void;
+}) {
+  const nav = buildModuleCollectionNav(collections, activeKey);
+  if (!nav.show) return null;
+
+  return (
+    <nav
+      className="flex flex-shrink-0 gap-1 overflow-x-auto px-3 py-2 md:gap-1.5 md:px-6 md:py-2.5"
+      style={{ borderBottom: '1px solid var(--ghost-border)' }}
+      aria-label={`${moduleName} collections`}
+      role="tablist"
+    >
+      {nav.items.map((item) => (
+        <button
+          key={item.key}
+          type="button"
+          role="tab"
+          aria-selected={item.current}
+          aria-current={item.current ? 'page' : undefined}
+          onClick={() => onSelect(item.key)}
+          className="flex min-h-10 flex-shrink-0 items-center rounded-lg px-3 text-[0.8125rem] font-medium md:min-h-11 md:px-3.5"
+          style={{
+            color: item.current ? 'var(--on-surface)' : 'var(--on-surface-variant)',
+            background: item.current ? 'var(--bg-active)' : 'transparent',
+          }}
+        >
+          {item.name}
+        </button>
+      ))}
+    </nav>
+  );
+}

--- a/apps/web/src/components/modules/module-workspace.tsx
+++ b/apps/web/src/components/modules/module-workspace.tsx
@@ -4,7 +4,6 @@ import { useDeferredValue, useEffect, useState } from 'react';
 import Link from 'next/link';
 import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import {
-  ChevronRight,
   Loader2,
   Plus,
   Settings2,
@@ -12,6 +11,7 @@ import {
 } from 'lucide-react';
 import { EmptyState } from '@/components/empty-state';
 import { useSetPageContext } from '@/components/app-header-context';
+import { ModuleCollectionNav } from '@/components/modules/module-collection-nav';
 import { ModuleRecordExplorer } from '@/components/modules/module-record-explorer';
 import { ModuleRecordFormDialog } from '@/components/modules/module-record-form';
 import { ModuleSavedViews } from '@/components/modules/module-saved-views';
@@ -247,50 +247,14 @@ export function ModuleWorkspace() {
         </div>
       </header>
 
-      {installedModule.manifest.collections.length > 1 && (
-        <nav
-          className="flex flex-shrink-0 gap-1 overflow-x-auto px-3 py-2 md:hidden"
-          style={{ borderBottom: '1px solid var(--ghost-border)' }}
-          aria-label={`${installedModule.manifest.name} collections`}
-        >
-          {installedModule.manifest.collections.map((candidate) => (
-            <CollectionButton
-              key={candidate.key}
-              name={candidate.name}
-              active={candidate.key === collection?.key}
-              onClick={() => chooseCollection(candidate.key)}
-              compact
-            />
-          ))}
-        </nav>
-      )}
+      <ModuleCollectionNav
+        moduleName={installedModule.manifest.name}
+        collections={installedModule.manifest.collections}
+        activeKey={collection?.key ?? null}
+        onSelect={chooseCollection}
+      />
 
-      <div className="flex min-h-0 flex-1">
-        {installedModule.manifest.collections.length > 1 && (
-          <aside
-            className="hidden w-52 flex-shrink-0 flex-col p-3 md:flex lg:w-60"
-            style={{ background: 'var(--surface-container-low)', borderRight: '1px solid var(--ghost-border)' }}
-          >
-            <p className="px-2 pb-2 pt-1 text-[0.625rem] font-semibold uppercase tracking-[0.08em]" style={{ color: 'var(--outline)' }}>
-              Collections
-            </p>
-            <nav className="space-y-1" aria-label={`${installedModule.manifest.name} collections`}>
-              {installedModule.manifest.collections.map((candidate) => (
-                <CollectionButton
-                  key={candidate.key}
-                  name={candidate.name}
-                  active={candidate.key === collection?.key}
-                  onClick={() => chooseCollection(candidate.key)}
-                />
-              ))}
-            </nav>
-            <div className="mt-auto px-2 pt-4 text-[0.625rem] leading-relaxed" style={{ color: 'var(--outline)' }}>
-              {installedModule.manifest.collections.length} collections · v{installedModule.manifest.version ?? '—'}
-            </div>
-          </aside>
-        )}
-
-        <main className="min-w-0 flex-1 overflow-y-auto px-4 pb-[max(1.5rem,env(safe-area-inset-bottom))] pt-4 md:px-6 md:pt-5">
+      <main className="min-h-0 min-w-0 flex-1 overflow-y-auto px-4 pb-[max(1.5rem,env(safe-area-inset-bottom))] pt-4 md:px-6 md:pt-5">
           {(actionError || notice) && (
             <div
               role={actionError ? 'alert' : 'status'}
@@ -381,8 +345,7 @@ export function ModuleWorkspace() {
               )}
             </div>
           )}
-        </main>
-      </div>
+      </main>
 
       {collection && (
         <ModuleRecordFormDialog
@@ -393,31 +356,5 @@ export function ModuleWorkspace() {
         />
       )}
     </div>
-  );
-}
-
-function CollectionButton({
-  name,
-  active,
-  onClick,
-  compact = false,
-}: {
-  name: string;
-  active: boolean;
-  onClick: () => void;
-  compact?: boolean;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      aria-current={active ? 'page' : undefined}
-      className={`flex min-h-10 items-center rounded-lg text-left text-[0.8125rem] font-medium ${compact ? 'flex-shrink-0 px-3' : 'w-full gap-2 px-2.5'}`}
-      style={{ color: active ? 'var(--on-surface)' : 'var(--on-surface-variant)', background: active ? 'var(--bg-active)' : 'transparent' }}
-    >
-      {!compact && <TableProperties size={14} className="flex-shrink-0" style={{ color: active ? 'var(--primary)' : 'var(--outline)' }} />}
-      <span className="min-w-0 flex-1 truncate">{name}</span>
-      {!compact && active && <ChevronRight size={13} className="flex-shrink-0" style={{ color: 'var(--outline)' }} />}
-    </button>
   );
 }

--- a/apps/web/src/lib/module-collection-nav.test.ts
+++ b/apps/web/src/lib/module-collection-nav.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Run: pnpm --filter @deft/web exec tsx --test src/lib/module-collection-nav.test.ts
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { buildModuleCollectionNav } from './module-collection-nav';
+
+const contacts = [
+  { key: 'contacts', name: 'Contacts' },
+  { key: 'companies', name: 'Companies' },
+  { key: 'deals', name: 'Deals' },
+  { key: 'activities', name: 'Activities' },
+];
+
+test('hides collection chrome for a single-collection module', () => {
+  const nav = buildModuleCollectionNav([{ key: 'entries', name: 'Entries' }], 'entries');
+  assert.equal(nav.show, false);
+  assert.deepEqual(nav.items, []);
+});
+
+test('shows Contacts collection tabs with the active collection marked current', () => {
+  const nav = buildModuleCollectionNav(contacts, 'companies');
+  assert.equal(nav.show, true);
+  assert.deepEqual(nav.items.map((item) => item.key), ['contacts', 'companies', 'deals', 'activities']);
+  assert.equal(nav.items.filter((item) => item.current).length, 1);
+  assert.equal(nav.items.find((item) => item.key === 'companies')?.current, true);
+});
+
+test('keeps eight collections as tabs instead of collapsing to a sidebar', () => {
+  const collections = Array.from({ length: 8 }, (_, index) => ({
+    key: `col_${index + 1}`,
+    name: `Collection ${index + 1}`,
+  }));
+  const nav = buildModuleCollectionNav(collections, 'col_8');
+  assert.equal(nav.show, true);
+  assert.equal(nav.items.length, 8);
+  assert.equal(nav.items.at(-1)?.current, true);
+});

--- a/apps/web/src/lib/module-collection-nav.ts
+++ b/apps/web/src/lib/module-collection-nav.ts
@@ -1,0 +1,28 @@
+export type ModuleCollectionNavItem = {
+  key: string;
+  name: string;
+  current: boolean;
+};
+
+export type ModuleCollectionNavModel = {
+  show: boolean;
+  items: ModuleCollectionNavItem[];
+};
+
+export function buildModuleCollectionNav(
+  collections: ReadonlyArray<{ key: string; name: string }>,
+  activeKey: string | null,
+): ModuleCollectionNavModel {
+  if (collections.length <= 1) {
+    return { show: false, items: [] };
+  }
+
+  return {
+    show: true,
+    items: collections.map((collection) => ({
+      key: collection.key,
+      name: collection.name,
+      current: collection.key === activeKey,
+    })),
+  };
+}

--- a/scripts/product-browser-smoke.mjs
+++ b/scripts/product-browser-smoke.mjs
@@ -113,8 +113,31 @@ async function main() {
     }
     record('Navigate core settings surfaces');
 
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await settle(page, '/settings/modules');
+    const availableTab = page.getByRole('button', { name: /Available/i }).first();
+    if (await availableTab.count()) await availableTab.click();
+    const installModule = page.getByRole('button', { name: 'Install module' }).first();
+    if (await installModule.count()) {
+      await installModule.click();
+      await page.getByText(/installed and ready/i).first().waitFor({ timeout: 15_000 });
+    }
+    await settle(page, '/modules/contacts/contacts');
+    const collectionTabs = page.getByRole('tablist', { name: /contacts collections/i });
+    await collectionTabs.waitFor({ state: 'visible', timeout: 10_000 });
+    const collectionAside = page.locator('aside').filter({ hasText: /^Collections$/ });
+    if (await collectionAside.count()) {
+      throw new Error('Desktop Contacts still renders a second collections sidebar');
+    }
+    for (const label of ['Contacts', 'Companies', 'Deals', 'Activities']) {
+      await collectionTabs.getByRole('tab', { name: label, exact: true }).waitFor({ state: 'visible' });
+    }
+    await collectionTabs.getByRole('tab', { name: 'Companies', exact: true }).click();
+    await page.waitForURL((url) => url.pathname.includes('/modules/contacts/companies'), { timeout: 10_000 });
+    record('Contacts uses collection tabs without a second left rail');
+
     await page.setViewportSize({ width: 390, height: 844 });
-    const mobilePaths = ['/chat', '/tasks', '/knowledge', '/calendar', '/notes', '/inbox', '/settings'];
+    const mobilePaths = ['/chat', '/tasks', '/knowledge', '/calendar', '/notes', '/inbox', '/settings', '/modules/contacts/contacts'];
     for (const path of mobilePaths) {
       await settle(page, path);
       const overflow = await page.evaluate(() => document.documentElement.scrollWidth - window.innerWidth);


### PR DESCRIPTION
## Why

Contacts (and any module with more than one collection) rendered:

```text
Deft sidebar | Collections aside | content
```

on desktop. That is Deft chrome in `module-workspace.tsx`, not something `deft.module.json` can declare. Contacts stays one four-collection module.

## Change

- Remove the desktop collections `<aside>`.
- Promote the existing horizontal collection strip to every viewport, under the module header.
- Keep `chooseCollection()` / URL behavior.
- Do **not** add a manifest `collections_chrome` key.

## Tests

- Unit: single-collection hides chrome; Contacts four tabs; eight collections stay tabs.
- CI Type Check now runs `module-collection-nav.test.ts`.
- Product browser smoke installs Contacts (if needed), asserts no Collections aside, asserts Contacts/Companies/Deals/Activities tabs, clicks Companies, and includes the Contacts route in the mobile overflow pass.

## Out of scope

- Contacts repo / manifest
- Record-detail right inspector
- Workspace nav still has a single Contacts item