### PR TITLE
chore(release): v0.3.0-preview.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,17 @@ env vars. Patch versions (`0.X.Y`) are non-breaking fixes only.
 
 ## [Unreleased]
 
+## [0.3.0-preview.2] — 2026-08-20
+
+Delta from `v0.3.0-preview.1`. Deft remains alpha.
+
 ### Changed
 
-- Multi-collection modules use header collection tabs on every viewport.
-  Desktop no longer renders a second left rail next to the workspace sidebar.
+- Multi-collection modules, including bundled Contacts, use header
+  collection tabs on every viewport. Desktop no longer renders a second
+  left rail next to the workspace sidebar.
+- Product browser smoke now asserts Contacts collection tabs and the
+  absence of a second collections aside.
 
 ## [0.3.0-preview.1] — 2026-08-19
 
@@ -182,7 +189,8 @@ The `0.1.0-alpha` tag was originally published under BSL 1.1. The current
 codebase has since been relicensed under [GNU AGPL v3.0 only](LICENSE); consult
 the license file present in the exact revision you use.
 
-[Unreleased]: https://github.com/Maneek21/Deft/compare/v0.3.0-preview.1...HEAD
+[Unreleased]: https://github.com/Maneek21/Deft/compare/v0.3.0-preview.2...HEAD
+[0.3.0-preview.2]: https://github.com/Maneek21/Deft/releases/tag/v0.3.0-preview.2
 [0.3.0-preview.1]: https://github.com/Maneek21/Deft/releases/tag/v0.3.0-preview.1
 [0.2.0-preview.1 — 0.2.0-preview.4]: https://github.com/Maneek21/Deft/releases/tag/v0.2.0-preview.4
 [0.1.0-alpha]: https://github.com/Maneek21/Deft/releases/tag/v0.1.0-alpha

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ BSL 1.1 license included in those revisions; relicensing this source tree does
 not retroactively change old tags or images.
 
 ```bash
-export DEFT_IMAGE=ghcr.io/maneek21/deft:0.3.0-preview.1
+export DEFT_IMAGE=ghcr.io/maneek21/deft:0.3.0-preview.2
 docker compose -f docker-compose.yml -f compose.prod.yml -f compose.release.yml pull
 docker compose -f docker-compose.yml -f compose.prod.yml -f compose.release.yml up -d postgres
 docker compose -f docker-compose.yml -f compose.prod.yml -f compose.release.yml run --rm init

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -13,15 +13,15 @@ alpha:
 - **Patch** (`0.X.Y`) — non-breaking fixes only. Safe to bump in place.
 
 Tag format: `vMAJOR.MINOR.PATCH[-channel]`. During alpha the channel is
-`preview` (for example `v0.3.0-preview.1`). Older docs mentioned
+`preview` (for example `v0.3.0-preview.2`). Older docs mentioned
 `alpha` / `beta` / `rc`; keep using `preview` unless the project
 explicitly changes channel. Once 1.0 ships, the channel suffix drops.
 
 The Git tag includes the leading `v`. The GHCR image tag does not:
 
 ```text
-git tag     v0.3.0-preview.1
-GHCR image  ghcr.io/maneek21/deft:0.3.0-preview.1
+git tag     v0.3.0-preview.2
+GHCR image  ghcr.io/maneek21/deft:0.3.0-preview.2
 ```
 
 ## Cutting a release

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deft",
-  "version": "0.3.0-preview.1",
+  "version": "0.3.0-preview.2",
   "private": true,
   "license": "AGPL-3.0-only",
   "repository": {


### PR DESCRIPTION
## Why

Cut the remaining OSS launch gate: `v0.3.0-preview.2` from current `master`.

`master` is one commit ahead of `v0.3.0-preview.1` (`#222` collection tabs). This prep PR records that delta and retargets the current named preview image.

## Change

- Bump root `package.json` to `0.3.0-preview.2`.
- Move the Unreleased collection-tab notes into `[0.3.0-preview.2]`.
- Point README named image to `ghcr.io/maneek21/deft:0.3.0-preview.2`.
- Update `RELEASING.md` format examples to the current preview tag.

Historical `preview.1` changelog, BSL-era tags, and the `v0.2.0-preview.1` upgrade baseline are unchanged.

## After merge

Per `RELEASING.md`: wait for this merge commit''s required checks, then annotated-tag `v0.3.0-preview.2` and let `release.yml` publish GHCR + GitHub Release. Do not run a second `gh release create`.