### PR TITLE
fix: make receipt HMAC CodeQL suppression attach to the sink

### DIFF
--- a/apps/api/src/lib/receipts.ts
+++ b/apps/api/src/lib/receipts.ts
@@ -158,12 +158,11 @@ function buildSignedEnvelope(params: {
 }
 
 function computeHmac(payload: string): string {
-  return crypto
-    .createHmac('sha256', env.ENCRYPTION_KEY)
-    // HMAC-SHA256 authenticates an audit receipt; this is not password storage.
-    // codeql[js/insufficient-password-hash]
-    .update(payload)
-    .digest('hex');
+  const hmac = crypto.createHmac('sha256', env.ENCRYPTION_KEY);
+  // HMAC-SHA256 authenticates an audit receipt; this is not password storage.
+  // codeql[js/insufficient-password-hash]
+  hmac.update(payload); // lgtm[js/insufficient-password-hash]
+  return hmac.digest('hex');
 }
 
 /**


### PR DESCRIPTION
## Why

PR #225 redacted secrets from signed receipts and added `// codeql[js/insufficient-password-hash]` immediately before `.update(payload)` in a method chain.

Default-branch CodeQL on `86b3eacd` still reported [alert #42](https://github.com/Maneek21/Deft/security/code-scanning/42) at `apps/api/src/lib/receipts.ts:165`. The uploaded SARIF has `suppressions: null` — the comment never attached.

`js/insufficient-password-hash` is a false positive here: HMAC-SHA256 authenticates a canonical audit envelope, it is not password storage. Account passwords remain bcrypt.

## Change

- Unchain `computeHmac` so the sink is a simple statement.
- Keep the documented `codeql[js/insufficient-password-hash]` comment on the preceding line.
- Add `lgtm[js/insufficient-password-hash]` on the `hmac.update(payload)` line so CodeQL covers the alert columns (13–20 on `payload`).

HMAC-SHA256, receipt payload, sanitization, and application behavior are unchanged.

## Scope

This is a follow-up to PR 1 (#225) only. It does not touch agent prompts (PR #226).