### PR TITLE
ci: certify upgrades and release provenance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,58 @@ jobs:
               END IF;
             END \$\$;
           "
+      - name: Seed and snapshot representative preview data
+        run: |
+          set -euo pipefail
+          psql "$DATABASE_URL" -v ON_ERROR_STOP=1 <<'SQL'
+          WITH target AS (
+            SELECT o.id AS org_id, u.id AS user_id, s.id AS space_id, m.id AS message_id
+            FROM orgs o
+            JOIN org_members om ON om.org_id = o.id
+            JOIN users u ON u.id = om.user_id
+            JOIN space_members sm ON sm.user_id = u.id
+            JOIN spaces s ON s.id = sm.space_id AND s.org_id = o.id
+            JOIN messages m ON m.space_id = s.id AND m.org_id = o.id
+            WHERE o.slug = 'testers-tomatoes'
+            ORDER BY u.id, s.id, m.id
+            LIMIT 1
+          )
+          INSERT INTO teams (
+            id, org_id, name, handle, description, type, visibility,
+            lead_user_id, default_space_id, is_archived, created_by
+          )
+          SELECT
+            'upgrade-cert-team-v1', org_id, 'Upgrade Certification Team',
+            'upgrade-certification', 'Representative team retained across upgrades',
+            'functional', 'org', user_id, space_id, false, user_id
+          FROM target
+          ON CONFLICT (org_id, handle) DO NOTHING;
+
+          WITH target AS (
+            SELECT o.id AS org_id, u.id AS user_id, s.id AS space_id, m.id AS message_id
+            FROM orgs o
+            JOIN org_members om ON om.org_id = o.id
+            JOIN users u ON u.id = om.user_id
+            JOIN space_members sm ON sm.user_id = u.id
+            JOIN spaces s ON s.id = sm.space_id AND s.org_id = o.id
+            JOIN messages m ON m.space_id = s.id AND m.org_id = o.id
+            WHERE o.slug = 'testers-tomatoes'
+            ORDER BY u.id, s.id, m.id
+            LIMIT 1
+          )
+          INSERT INTO agent_actions (
+            id, org_id, user_id, conversation_id, message_id, source, action,
+            params, result, approval_tier, approval_status
+          )
+          SELECT
+            'upgrade-cert-agent-action-v1', org_id, user_id, space_id, message_id,
+            'native', 'post_message',
+            '{"content":"upgrade preservation fixture"}'::jsonb,
+            '{"status":"fixture"}'::jsonb, 'auto', 'approved'
+          FROM target
+          ON CONFLICT (id) DO NOTHING;
+          SQL
+          bash scripts/ci/snapshot-upgrade-data.sh "$RUNNER_TEMP/upgrade-before"
       - name: Inspect and dry-run without writing a ledger
         run: |
           if pnpm db:assert-fresh; then
@@ -189,6 +241,8 @@ jobs:
               END IF;
             END \$\$;
           "
+          bash scripts/ci/snapshot-upgrade-data.sh "$RUNNER_TEMP/upgrade-after"
+          diff --recursive --unified "$RUNNER_TEMP/upgrade-before" "$RUNNER_TEMP/upgrade-after"
       - name: Run upgrade unit tests
         run: pnpm test:upgrade
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,6 +90,27 @@ jobs:
           subject-digest: ${{ steps.image.outputs.digest }}
           push-to-registry: true
 
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6
+        with:
+          cosign-release: v3.0.6
+
+      - name: Sign release image digest
+        env:
+          IMAGE_REF: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.image.outputs.digest }}
+        shell: bash
+        run: cosign sign --yes "$IMAGE_REF"
+
+      - name: Verify signature and provenance
+        env:
+          IMAGE_REF: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.image.outputs.digest }}
+        shell: bash
+        run: |
+          cosign verify "$IMAGE_REF" \
+            --certificate-identity "https://github.com/${GITHUB_WORKFLOW_REF}" \
+            --certificate-oidc-issuer "https://token.actions.githubusercontent.com" >/dev/null
+          gh attestation verify "oci://$IMAGE_REF" --repo "$GITHUB_REPOSITORY"
+
       - name: Generate release manifest
         shell: bash
         run: |
@@ -102,6 +123,9 @@ jobs:
             "commit": "${{ steps.release.outputs.sha }}",
             "image": "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.release.outputs.version }}",
             "digest": "${{ steps.image.outputs.digest }}",
+            "signature": "sigstore-keyless",
+            "signature_identity": "https://github.com/${{ github.workflow_ref }}",
+            "provenance": "github-build-attestation",
             "license": "AGPL-3.0-only",
             "source": "https://github.com/${{ github.repository }}/tree/${{ steps.release.outputs.sha }}",
             "platforms": ["linux/amd64"],

--- a/docs/current-limitations.md
+++ b/docs/current-limitations.md
@@ -11,7 +11,10 @@ Deft is an alpha. It is suitable for technical evaluation, internal use, and con
 - Named GHCR preview images are currently amd64-only.
 - Historical databases created before `v0.2.0-preview.1` are not automatically adopted. The upgrader refuses unknown or incomplete schemas rather than mutating them.
 - Raw `pnpm db:migrate` remains unsupported; the release upgrader owns the checksum ledger and compatibility checks.
-- Operators should pin a commit, back up Postgres and uploads, and rehearse restore before updating.
+- Schema migrations are forward-only; successful upgrades do not have an
+  automatic downgrade. Operators should pin an image digest, back up Postgres
+  and uploads, and rehearse restoring both with the previous image digest
+  before updating.
 
 ## Deployment contract
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -61,9 +61,27 @@ docker compose -f docker-compose.yml -f compose.prod.yml -f compose.release.yml 
 ```
 
 Release assets include `SHA256SUMS`, an SPDX SBOM, and a manifest containing
-the exact commit, image digest, and upgrade baseline. Use `init` only for a
-fresh database. Versioned release upgrades begin at `v0.2.0-preview.1` and use
-the dedicated `upgrade` service described below.
+the exact commit, image digest, keyless-signing identity, provenance type, and
+upgrade baseline. Release-tagged images are signed by the release workflow and
+carry GitHub build provenance. Verify the digest before deploying it:
+
+```bash
+export TAG=v0.3.0-preview.3
+export VERSION="${TAG#v}"
+export IMAGE=ghcr.io/maneek21/deft
+export DIGEST="$(docker buildx imagetools inspect "$IMAGE:$VERSION" --format '{{json .Manifest.Digest}}' | tr -d '"')"
+cosign verify "$IMAGE@$DIGEST" \
+  --certificate-identity "https://github.com/Maneek21/Deft/.github/workflows/release.yml@refs/tags/$TAG" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
+gh attestation verify "oci://$IMAGE@$DIGEST" --repo Maneek21/Deft
+```
+
+Compare `DIGEST` with `release-manifest.json`, then set `DEFT_IMAGE` to the
+immutable `ghcr.io/maneek21/deft@<digest>` reference. A release workflow fails
+before creating the GitHub release if signing, signature verification,
+provenance publication, or provenance verification fails. Use `init` only for
+a fresh database. Versioned release upgrades begin at `v0.2.0-preview.1` and
+use the dedicated `upgrade` service described below.
 
 ### Fast path: one-command bootstrap
 
@@ -452,6 +470,13 @@ The wrapper builds or pulls the target image before downtime, stops app writes,
 writes a compressed Postgres backup, runs the `upgrade` service, recreates the
 app, and requires doctor plus MCP smoke to pass. Site-specific overlays can be
 appended with `--compose-file <file>`.
+
+Schema upgrades are forward-only. The migration ledger is checksummed and a
+failed migration transaction rolls back, but there is no automatic downgrade
+path after a successful upgrade. Recovery means stopping Deft, restoring the
+pre-upgrade Postgres backup and uploads backup, and running the exact previous
+image digest. Rehearse that restore on a disposable host before upgrading data
+that cannot be recreated.
 
 Preview the exact sequence without changing data:
 

--- a/scripts/ci/snapshot-upgrade-data.sh
+++ b/scripts/ci/snapshot-upgrade-data.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+output_dir="${1:?usage: snapshot-upgrade-data.sh OUTPUT_DIR}"
+: "${DATABASE_URL:?DATABASE_URL is required}"
+
+mkdir -p "$output_dir"
+
+psql "$DATABASE_URL" -v ON_ERROR_STOP=1 <<'SQL'
+DO $$
+DECLARE
+  relation_name text;
+  representative_row integer;
+BEGIN
+  FOREACH relation_name IN ARRAY ARRAY['messages', 'tasks', 'wiki_pages', 'teams', 'agent_actions']
+  LOOP
+    IF (SELECT count(*) FROM pg_catalog.pg_class WHERE relname = relation_name AND relkind = 'r') <> 1 THEN
+      RAISE EXCEPTION 'required upgrade-certification relation % is missing', relation_name;
+    END IF;
+    representative_row := NULL;
+    EXECUTE format('SELECT 1 FROM %I LIMIT 1', relation_name) INTO representative_row;
+    IF representative_row IS NULL THEN
+      RAISE EXCEPTION 'required upgrade-certification relation % is empty', relation_name;
+    END IF;
+  END LOOP;
+END $$;
+SQL
+
+psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -c "\copy (
+  SELECT id, org_id, space_id, user_id, content, parent_id, is_pinned, is_deleted
+  FROM messages ORDER BY id
+) TO '$output_dir/messages.csv' WITH (FORMAT csv, HEADER true)"
+
+psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -c "\copy (
+  SELECT id, org_id, project_id, number, title, description, status, priority,
+         assignee_id, created_by, is_template, recurrence, source_message_id,
+         parent_task_id, is_deleted
+  FROM tasks ORDER BY id
+) TO '$output_dir/tasks.csv' WITH (FORMAT csv, HEADER true)"
+
+psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -c "\copy (
+  SELECT id, org_id, scope, space_id, user_id, type, title, slug, summary,
+         content, confidence, version, previous_content, is_deleted
+  FROM wiki_pages ORDER BY id
+) TO '$output_dir/wiki-pages.csv' WITH (FORMAT csv, HEADER true)"
+
+psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -c "\copy (
+  SELECT id, org_id, name, handle, description, type, visibility, lead_user_id,
+         default_space_id, is_archived, created_by
+  FROM teams ORDER BY id
+) TO '$output_dir/teams.csv' WITH (FORMAT csv, HEADER true)"
+
+psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -c "\copy (
+  SELECT id, org_id, user_id, conversation_id, message_id, agent_employee_id,
+         tool_use_id, source, action, params, result, approval_tier,
+         approval_status, error, before_state, after_state
+  FROM agent_actions ORDER BY id
+) TO '$output_dir/agent-actions.csv' WITH (FORMAT csv, HEADER true)"


### PR DESCRIPTION
## Summary
- snapshot representative chat, task, wiki, team, and agent-action data around the full versioned upgrade chain and compare byte-for-byte after two runs
- keylessly sign the exact release image digest and verify both its Cosign identity and GitHub build provenance before release creation
- document digest-first verification and the forward-only rollback/recovery contract

Closes #178
Closes #173

## Local verification
- pnpm test:upgrade (12 passed)
- Git Bash syntax check for scripts/ci/snapshot-upgrade-data.sh
- git diff --check

The release workflow itself will be exercised by the preview.3 tag after this PR merges.