### PR TITLE
chore(release): v0.3.0-preview.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,50 @@ env vars. Patch versions (`0.X.Y`) are non-breaking fixes only.
 
 ## [Unreleased]
 
+## [0.3.0-preview.3] — 2026-08-22
+
+Delta from `v0.3.0-preview.2`. Deft remains alpha.
+
+### Added
+
+- Structured text attachments are now bound to their exact org and message,
+  authorized through the same space-membership rules as chat, and presented to
+  the agent as untrusted user data with filename/type/size provenance.
+- Defty can deterministically compile an attached CSV into one governed,
+  full-review module bulk-import proposal. The generic importer resolves the
+  target from installed manifests, validates every header/value, limits batches
+  to 100 rows, and uses per-row receipts/idempotency so replay cannot duplicate
+  records.
+- The certified App Protocol v2 implementation contract now defines closed
+  Modules, provider-neutral Capabilities, staged App Packs, encrypted Governed
+  App Runs, cross-app references, explicit grants, and the Native Equivalence
+  branch gate.
+
+### Security
+
+- Retrieved wiki and agent-memory context remain outside system instructions
+  and are explicitly framed as untrusted data on the current user turn.
+- Agent-authored approval proposals use the canonical actor boundary, cannot
+  impersonate a human requester, and recheck live membership, module access,
+  employee health, trust, and action budgets before execution.
+- Signed action receipts redact secret-like input fields while preserving stable
+  verification semantics.
+- Attachment lookup is exact-message and exact-org scoped with path containment,
+  media/size limits, and no generic filesystem access.
+- Bulk-import approval/history/receipts retain row counts, field names, digests,
+  and resource IDs but scrub CSV row values and raw retry keys.
+
+### Changed
+
+- Release-tagged GHCR images are keylessly signed with Cosign. The release job
+  verifies the workflow identity and GitHub build provenance for the exact image
+  digest before it can create a GitHub Release.
+- Versioned-upgrade CI now snapshots representative chat, task, wiki, team, and
+  agent-action data from a populated `v0.2.0-preview.1` database, runs the entire
+  checksummed upgrade chain twice, and requires byte-for-byte preservation.
+- Self-hosting docs now provide digest-first signature/provenance verification
+  commands and explicitly document forward-only migration recovery.
+
 ## [0.3.0-preview.2] — 2026-08-20
 
 Delta from `v0.3.0-preview.1`. Deft remains alpha.
@@ -189,7 +233,8 @@ The `0.1.0-alpha` tag was originally published under BSL 1.1. The current
 codebase has since been relicensed under [GNU AGPL v3.0 only](LICENSE); consult
 the license file present in the exact revision you use.
 
-[Unreleased]: https://github.com/Maneek21/Deft/compare/v0.3.0-preview.2...HEAD
+[Unreleased]: https://github.com/Maneek21/Deft/compare/v0.3.0-preview.3...HEAD
+[0.3.0-preview.3]: https://github.com/Maneek21/Deft/releases/tag/v0.3.0-preview.3
 [0.3.0-preview.2]: https://github.com/Maneek21/Deft/releases/tag/v0.3.0-preview.2
 [0.3.0-preview.1]: https://github.com/Maneek21/Deft/releases/tag/v0.3.0-preview.1
 [0.2.0-preview.1 — 0.2.0-preview.4]: https://github.com/Maneek21/Deft/releases/tag/v0.2.0-preview.4

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ BSL 1.1 license included in those revisions; relicensing this source tree does
 not retroactively change old tags or images.
 
 ```bash
-export DEFT_IMAGE=ghcr.io/maneek21/deft:0.3.0-preview.2
+export DEFT_IMAGE=ghcr.io/maneek21/deft:0.3.0-preview.3
 docker compose -f docker-compose.yml -f compose.prod.yml -f compose.release.yml pull
 docker compose -f docker-compose.yml -f compose.prod.yml -f compose.release.yml up -d postgres
 docker compose -f docker-compose.yml -f compose.prod.yml -f compose.release.yml run --rm init

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -13,15 +13,15 @@ alpha:
 - **Patch** (`0.X.Y`) — non-breaking fixes only. Safe to bump in place.
 
 Tag format: `vMAJOR.MINOR.PATCH[-channel]`. During alpha the channel is
-`preview` (for example `v0.3.0-preview.2`). Older docs mentioned
+`preview` (for example `v0.3.0-preview.3`). Older docs mentioned
 `alpha` / `beta` / `rc`; keep using `preview` unless the project
 explicitly changes channel. Once 1.0 ships, the channel suffix drops.
 
 The Git tag includes the leading `v`. The GHCR image tag does not:
 
 ```text
-git tag     v0.3.0-preview.2
-GHCR image  ghcr.io/maneek21/deft:0.3.0-preview.2
+git tag     v0.3.0-preview.3
+GHCR image  ghcr.io/maneek21/deft:0.3.0-preview.3
 ```
 
 ## Cutting a release
@@ -90,8 +90,11 @@ Pushing a `v*` tag runs [`.github/workflows/release.yml`](.github/workflows/rele
 That workflow:
 
 - builds and pushes the `linux/amd64` GHCR image
-- attests provenance, attaches SPDX SBOM and corresponding source
-- writes `release-manifest.json` (`license: AGPL-3.0-only`)
+- publishes GitHub build provenance and keylessly signs the exact image digest
+- verifies the Cosign workflow identity and provenance before continuing
+- attaches the SPDX SBOM and corresponding source
+- writes `release-manifest.json` (`license: AGPL-3.0-only`) with the digest,
+  signing identity, and provenance type
 - creates the GitHub Release (`--generate-notes`, prerelease when the
   version contains `-`)
 
@@ -108,6 +111,11 @@ Confirm the GitHub Release includes `LICENSE`, `NOTICE`,
 checksums, and compose files. Confirm the image label
 `org.opencontainers.image.licenses=AGPL-3.0-only` (the production
 `Dockerfile` sets this; `release.yml` passes `VCS_REF` and `SOURCE_URL`).
+Run the digest-first Cosign and `gh attestation verify` commands in
+[`docs/self-hosting.md`](docs/self-hosting.md) against the published manifest.
+If signing, signature verification, provenance publication, or provenance
+verification fails, the workflow must stop before the GitHub Release is
+created.
 
 ## Hotfix releases
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deft",
-  "version": "0.3.0-preview.2",
+  "version": "0.3.0-preview.3",
   "private": true,
   "license": "AGPL-3.0-only",
   "repository": {


### PR DESCRIPTION
## Release delta
- agent trust-boundary and receipt-secret hardening
- exact-message structured attachments
- deterministic governed CSV imports for declarative modules
- representative-data versioned-upgrade certification
- keyless image signing and verified GitHub build provenance
- canonical App Protocol v2 implementation contract

## Verification
- vendored module provenance verified
- 12 upgrade/release tests passed
- git diff --check

After merge, the exact green master commit will receive an annotated v0.3.0-preview.3 tag. The release workflow must verify signature and provenance before publishing the GitHub Release.