### PR TITLE
fix: authenticate release provenance verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - name: Verify bundled module provenance
         run: pnpm module:verify
+      - name: Verify release publishing contract
+        run: pnpm test:release-workflow
       - name: Lint web
         run: pnpm --filter @deft/web lint
       - name: Test web realtime lifecycle state

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,11 @@ on:
         required: true
         default: true
         type: boolean
+      reuse_existing_image:
+        description: Reuse an already-published and tag-signed image after a packaging failure
+        required: true
+        default: false
+        type: boolean
 
 permissions:
   contents: write
@@ -65,6 +70,7 @@ jobs:
 
       - name: Build and publish amd64 image
         id: image
+        if: github.event_name != 'workflow_dispatch' || !inputs.reuse_existing_image
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -83,11 +89,42 @@ jobs:
             VCS_REF=${{ steps.release.outputs.sha }}
             SOURCE_URL=https://github.com/${{ github.repository }}/tree/${{ steps.release.outputs.sha }}
 
+      - name: Resolve existing signed image digest
+        id: existing
+        if: github.event_name == 'workflow_dispatch' && inputs.reuse_existing_image
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+        shell: bash
+        run: |
+          digest="$(docker buildx imagetools inspect \
+            "${REGISTRY}/${IMAGE_NAME}:${VERSION}" \
+            --format '{{json .Manifest.Digest}}' | tr -d '"')"
+          [[ "$digest" =~ ^sha256:[a-f0-9]{64}$ ]] || {
+            echo "Existing release image did not resolve to an immutable digest" >&2
+            exit 1
+          }
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve immutable release digest
+        id: digest
+        env:
+          BUILT_DIGEST: ${{ steps.image.outputs.digest }}
+          REUSED_DIGEST: ${{ steps.existing.outputs.digest }}
+        shell: bash
+        run: |
+          digest="${REUSED_DIGEST:-$BUILT_DIGEST}"
+          [[ "$digest" =~ ^sha256:[a-f0-9]{64}$ ]] || {
+            echo "Release image digest is missing or invalid" >&2
+            exit 1
+          }
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
+
       - name: Attest image provenance
+        if: steps.existing.outputs.digest == ''
         uses: actions/attest-build-provenance@v4
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          subject-digest: ${{ steps.image.outputs.digest }}
+          subject-digest: ${{ steps.digest.outputs.digest }}
           push-to-registry: true
 
       - name: Install Cosign
@@ -96,20 +133,31 @@ jobs:
           cosign-release: v3.0.6
 
       - name: Sign release image digest
+        if: steps.existing.outputs.digest == ''
         env:
-          IMAGE_REF: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.image.outputs.digest }}
+          IMAGE_REF: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.digest.outputs.digest }}
         shell: bash
         run: cosign sign --yes "$IMAGE_REF"
 
       - name: Verify signature and provenance
+        id: verification
         env:
-          IMAGE_REF: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.image.outputs.digest }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IMAGE_REF: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.digest.outputs.digest }}
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
+          REUSED_DIGEST: ${{ steps.existing.outputs.digest }}
         shell: bash
         run: |
+          if [[ -n "$REUSED_DIGEST" ]]; then
+            identity="https://github.com/${GITHUB_REPOSITORY}/.github/workflows/release.yml@refs/tags/${RELEASE_TAG}"
+          else
+            identity="https://github.com/${GITHUB_WORKFLOW_REF}"
+          fi
           cosign verify "$IMAGE_REF" \
-            --certificate-identity "https://github.com/${GITHUB_WORKFLOW_REF}" \
+            --certificate-identity "$identity" \
             --certificate-oidc-issuer "https://token.actions.githubusercontent.com" >/dev/null
           gh attestation verify "oci://$IMAGE_REF" --repo "$GITHUB_REPOSITORY"
+          echo "signature_identity=$identity" >> "$GITHUB_OUTPUT"
 
       - name: Generate release manifest
         shell: bash
@@ -122,9 +170,9 @@ jobs:
             "tag": "${{ steps.release.outputs.tag }}",
             "commit": "${{ steps.release.outputs.sha }}",
             "image": "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.release.outputs.version }}",
-            "digest": "${{ steps.image.outputs.digest }}",
+            "digest": "${{ steps.digest.outputs.digest }}",
             "signature": "sigstore-keyless",
-            "signature_identity": "https://github.com/${{ github.workflow_ref }}",
+            "signature_identity": "${{ steps.verification.outputs.signature_identity }}",
             "provenance": "github-build-attestation",
             "license": "AGPL-3.0-only",
             "source": "https://github.com/${{ github.repository }}/tree/${{ steps.release.outputs.sha }}",
@@ -145,7 +193,7 @@ jobs:
       - name: Generate SPDX SBOM
         uses: anchore/sbom-action@v0.24.0
         with:
-          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.image.outputs.digest }}
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.digest.outputs.digest }}
           format: spdx-json
           output-file: dist/deft-${{ steps.release.outputs.version }}.spdx.json
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -102,9 +102,13 @@ That workflow:
 the Release. If notes need a license banner or highlights, edit the
 Release body after the workflow finishes.
 
-If packaging fails after the tag exists, **do not move the tag**. Re-run
-the workflow with `workflow_dispatch` against the existing tag. If the
-published image is unusable, fix forward and cut the next preview tag.
+If packaging fails after the tag exists, **do not move the tag**. If the failed
+run already completed image build, provenance attestation, and signing, fix the
+workflow on `master`, dispatch it against the existing tag, and select
+`reuse_existing_image`. Recovery then verifies and packages the original
+tag-signed digest without rebuilding it. Do not select reuse when the original
+image/signature steps did not complete. If the published image itself is
+unusable, fix forward and cut the next preview tag.
 
 Confirm the GitHub Release includes `LICENSE`, `NOTICE`,
 `THIRD-PARTY-LICENSES.md`, `.env.example`, the source archive, SBOM,

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -70,8 +70,9 @@ export TAG=v0.3.0-preview.3
 export VERSION="${TAG#v}"
 export IMAGE=ghcr.io/maneek21/deft
 export DIGEST="$(docker buildx imagetools inspect "$IMAGE:$VERSION" --format '{{json .Manifest.Digest}}' | tr -d '"')"
+export SIGNATURE_IDENTITY="$(jq -r .signature_identity release-manifest.json)"
 cosign verify "$IMAGE@$DIGEST" \
-  --certificate-identity "https://github.com/Maneek21/Deft/.github/workflows/release.yml@refs/tags/$TAG" \
+  --certificate-identity "$SIGNATURE_IDENTITY" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 gh attestation verify "oci://$IMAGE@$DIGEST" --repo Maneek21/Deft
 ```

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "selfhost:smoke": "tsx scripts/selfhost-smoke.ts",
     "selfhost:upgrade": "tsx scripts/selfhost-upgrade.ts",
     "test:upgrade": "pnpm --filter @deft/db test:upgrade && tsx --test scripts/selfhost-upgrade.test.ts",
+    "test:release-workflow": "node --test scripts/release-workflow.test.mjs",
     "test:public-env": "node --test scripts/inject-public-env.test.mjs",
     "typecheck": "pnpm -r --parallel typecheck"
   },

--- a/scripts/release-workflow.test.mjs
+++ b/scripts/release-workflow.test.mjs
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const workflow = readFileSync(new URL('../.github/workflows/release.yml', import.meta.url), 'utf8');
+
+function position(label) {
+  const index = workflow.indexOf(label);
+  assert.notEqual(index, -1, `release workflow is missing: ${label}`);
+  return index;
+}
+
+test('release publication signs and verifies the exact image digest before creating a release', () => {
+  assert.match(workflow, /id-token:\s*write/);
+  assert.match(workflow, /attestations:\s*write/);
+  assert.match(workflow, /IMAGE_REF:\s*\$\{\{ env\.REGISTRY \}\}\/\$\{\{ env\.IMAGE_NAME \}\}@\$\{\{ steps\.digest\.outputs\.digest \}\}/);
+  assert.match(workflow, /cosign sign --yes "\$IMAGE_REF"/);
+  assert.match(workflow, /GH_TOKEN:\s*\$\{\{ secrets\.GITHUB_TOKEN \}\}/);
+  assert.match(workflow, /gh attestation verify "oci:\/\/\$IMAGE_REF" --repo "\$GITHUB_REPOSITORY"/);
+
+  const attest = position('- name: Attest image provenance');
+  const sign = position('- name: Sign release image digest');
+  const verify = position('- name: Verify signature and provenance');
+  const publish = position('- name: Create GitHub release');
+  assert.ok(attest < sign && sign < verify && verify < publish);
+});
+
+test('manual recovery reuses and verifies the original tag-signed digest', () => {
+  assert.match(workflow, /reuse_existing_image:/);
+  assert.match(workflow, /Resolve existing signed image digest/);
+  assert.match(workflow, /if: steps\.existing\.outputs\.digest == ''/);
+  assert.match(workflow, /refs\/tags\/\$\{RELEASE_TAG\}/);
+  assert.match(workflow, /"digest": "\$\{\{ steps\.digest\.outputs\.digest \}\}"/);
+  assert.match(workflow, /"signature_identity": "\$\{\{ steps\.verification\.outputs\.signature_identity \}\}"/);
+});
+
+test('release manifest records signature and provenance metadata', () => {
+  assert.match(workflow, /"signature": "sigstore-keyless"/);
+  assert.match(workflow, /"signature_identity": "\$\{\{ steps\.verification\.outputs\.signature_identity \}\}"/);
+  assert.match(workflow, /"provenance": "github-build-attestation"/);
+});


### PR DESCRIPTION
## Failure
The preview.3 tag run built, attested, signed, and Cosign-verified digest sha256:77e20bd3f9bfee242dd8fcb46ddbe9299251acef03a0e67904bccc2acf71fcbb. GitHub provenance verification then exited because gh had no GH_TOKEN, so the release gate correctly skipped manifest/assets/GitHub Release creation.

## Fix
- expose GITHUB_TOKEN only to provenance verification
- add explicit workflow-dispatch recovery that reuses the existing tag-signed digest instead of rebuilding or moving the tag
- verify the original tag workflow identity and record the actual identity in the manifest
- document recovery and manifest-driven verification
- add three release-workflow contract tests and run them in CI

After this merges green, dispatch Release for v0.3.0-preview.3 with reuse_existing_image=true.