### PR TITLE
Hermes employee onboarding reliability and Agent Channel v2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,8 +47,14 @@ jobs:
           tag="${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}"
           [[ "$tag" == v* ]] || { echo "Release tag must start with v" >&2; exit 1; }
           git rev-parse "$tag^{commit}" >/dev/null
+          version="${tag#v}"
+          package_version="$(node -p "require('./package.json').version")"
+          [[ "$package_version" == "$version" ]] || {
+            echo "package.json version $package_version does not match release $version" >&2
+            exit 1
+          }
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
-          echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "sha=$(git rev-parse "$tag^{commit}")" >> "$GITHUB_OUTPUT"
 
       - uses: docker/setup-buildx-action@v4
@@ -86,6 +92,7 @@ jobs:
           # setting this only on the running container is too late.
           build-args: |
             NEXT_PUBLIC_FEATURE_HUDDLES=true
+            DEFT_RELEASE_VERSION=${{ steps.release.outputs.version }}
             VCS_REF=${{ steps.release.outputs.sha }}
             SOURCE_URL=https://github.com/${{ github.repository }}/tree/${{ steps.release.outputs.sha }}
 
@@ -177,7 +184,9 @@ jobs:
             "license": "AGPL-3.0-only",
             "source": "https://github.com/${{ github.repository }}/tree/${{ steps.release.outputs.sha }}",
             "platforms": ["linux/amd64"],
-            "upgrade_support": "versioned-from-v0.2.0-preview.1"
+            "upgrade_support": "versioned-from-v0.2.0-preview.1",
+            "agent_channel_protocol": "deft.agent_channel.v2",
+            "hermes_integration": "deft-hermes-integration-${{ steps.release.outputs.version }}.tar.gz"
           }
           JSON
 
@@ -189,6 +198,13 @@ jobs:
             --prefix="deft-${{ steps.release.outputs.version }}/" \
             --output="dist/deft-${{ steps.release.outputs.version }}-source.tar.gz" \
             "${{ steps.release.outputs.sha }}"
+
+      - name: Build matched Hermes integration bundle
+        shell: bash
+        run: |
+          node scripts/build-hermes-integration-bundle.mjs
+          tar -czf "dist/deft-hermes-integration-${{ steps.release.outputs.version }}.tar.gz" -C dist/hermes-integration .
+          rm -rf dist/hermes-integration
 
       - name: Generate SPDX SBOM
         uses: anchore/sbom-action@v0.24.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,32 @@ env vars. Patch versions (`0.X.Y`) are non-breaking fixes only.
 
 ## [Unreleased]
 
+## [0.3.0-preview.6] — 2026-08-23
+
+### Added
+
+- Agent Channel v2 compatibility negotiation, lease/fencing capability checks,
+  release and schema readiness metadata, and a release-pinned Hermes integration
+  bundle with complete checksums.
+- End-to-end employee certification now proves real channel delivery, Hermes
+  runtime inference, employee-scoped MCP calls, a nonce-bearing reply, terminal
+  outcome reporting, and wiki memory recall/writeback before showing Ready.
+
+### Changed
+
+- Runtime transport contact, health, and employee readiness are now distinct UI
+  states. A polling process can no longer make an uncertified employee appear
+  ready to work.
+- The Windows Hermes service uses structured semantic health and fails closed on
+  incompatible protocol versions instead of retrying malformed work forever.
+
+### Fixed
+
+- Prevented newer Hermes bridges from consuming older unclaimed Agent Channel
+  events, which previously caused silent non-response and unbounded redelivery.
+- Fresh-install and supported-upgrade gates now require Agent Channel leases and
+  wiki memory-sync schema before the API reports ready.
+
 ## [0.3.0-preview.3] — 2026-08-22
 
 Delta from `v0.3.0-preview.2`. Deft remains alpha.
@@ -233,7 +259,8 @@ The `0.1.0-alpha` tag was originally published under BSL 1.1. The current
 codebase has since been relicensed under [GNU AGPL v3.0 only](LICENSE); consult
 the license file present in the exact revision you use.
 
-[Unreleased]: https://github.com/Maneek21/Deft/compare/v0.3.0-preview.3...HEAD
+[Unreleased]: https://github.com/Maneek21/Deft/compare/v0.3.0-preview.6...HEAD
+[0.3.0-preview.6]: https://github.com/Maneek21/Deft/releases/tag/v0.3.0-preview.6
 [0.3.0-preview.3]: https://github.com/Maneek21/Deft/releases/tag/v0.3.0-preview.3
 [0.3.0-preview.2]: https://github.com/Maneek21/Deft/releases/tag/v0.3.0-preview.2
 [0.3.0-preview.1]: https://github.com/Maneek21/Deft/releases/tag/v0.3.0-preview.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,10 +28,12 @@ ARG NEXT_PUBLIC_APP_URL=__DEFT_APP_URL__
 ARG NEXT_PUBLIC_API_URL=__DEFT_API_URL__
 ARG NEXT_PUBLIC_WS_URL=__DEFT_WS_URL__
 ARG NEXT_PUBLIC_FEATURE_HUDDLES=false
+ARG DEFT_RELEASE_VERSION=0.3.0-preview.6
 ENV NEXT_PUBLIC_APP_URL=$NEXT_PUBLIC_APP_URL
 ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
 ENV NEXT_PUBLIC_WS_URL=$NEXT_PUBLIC_WS_URL
 ENV NEXT_PUBLIC_FEATURE_HUDDLES=$NEXT_PUBLIC_FEATURE_HUDDLES
+ENV DEFT_RELEASE_VERSION=$DEFT_RELEASE_VERSION
 
 COPY --from=deps /app/node_modules ./node_modules
 COPY --from=deps /app/apps/web/node_modules ./apps/web/node_modules
@@ -44,6 +46,7 @@ RUN pnpm --filter @deft/web build
 
 # Stage 3: Production
 FROM node:22-alpine AS runner
+ARG DEFT_RELEASE_VERSION=0.3.0-preview.6
 ARG VCS_REF=unknown
 ARG SOURCE_URL=https://github.com/Maneek21/Deft
 LABEL org.opencontainers.image.licenses="AGPL-3.0-only" \
@@ -59,6 +62,8 @@ WORKDIR /app
 ENV NODE_ENV=production
 ENV API_PORT=3001
 ENV DEFT_BUILD_SOURCE_URL=$SOURCE_URL
+ENV DEFT_RELEASE_VERSION=$DEFT_RELEASE_VERSION
+ENV DEFT_BUILD_COMMIT=$VCS_REF
 
 # Copy built artifacts
 COPY --from=builder /app/node_modules ./node_modules

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ BSL 1.1 license included in those revisions; relicensing this source tree does
 not retroactively change old tags or images.
 
 ```bash
-export DEFT_IMAGE=ghcr.io/maneek21/deft:0.3.0-preview.3
+export DEFT_IMAGE=ghcr.io/maneek21/deft:0.3.0-preview.6
 docker compose -f docker-compose.yml -f compose.prod.yml -f compose.release.yml pull
 docker compose -f docker-compose.yml -f compose.prod.yml -f compose.release.yml up -d postgres
 docker compose -f docker-compose.yml -f compose.prod.yml -f compose.release.yml run --rm init

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -13,15 +13,15 @@ alpha:
 - **Patch** (`0.X.Y`) — non-breaking fixes only. Safe to bump in place.
 
 Tag format: `vMAJOR.MINOR.PATCH[-channel]`. During alpha the channel is
-`preview` (for example `v0.3.0-preview.3`). Older docs mentioned
+`preview` (for example `v0.3.0-preview.6`). Older docs mentioned
 `alpha` / `beta` / `rc`; keep using `preview` unless the project
 explicitly changes channel. Once 1.0 ships, the channel suffix drops.
 
 The Git tag includes the leading `v`. The GHCR image tag does not:
 
 ```text
-git tag     v0.3.0-preview.3
-GHCR image  ghcr.io/maneek21/deft:0.3.0-preview.3
+git tag     v0.3.0-preview.6
+GHCR image  ghcr.io/maneek21/deft:0.3.0-preview.6
 ```
 
 ## Cutting a release

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -3,6 +3,14 @@ import { Hono } from 'hono';
 import { cors } from 'hono/cors';
 import { logger } from 'hono/logger';
 import { secureHeaders } from 'hono/secure-headers';
+import { sql } from 'drizzle-orm';
+import { db } from './lib/db.js';
+import {
+  AGENT_CHANNEL_PROTOCOL_VERSION,
+  DEFT_BUILD_COMMIT,
+  DEFT_RELEASE_VERSION,
+  DEFT_SCHEMA_HEAD,
+} from './lib/agent-channel.js';
 import { authRoutes } from './routes/auth.js';
 import { spaceRoutes } from './routes/spaces.js';
 import { messageRoutes } from './routes/messages.js';
@@ -219,7 +227,51 @@ app.route('/api/task-templates', taskTemplateRoutes);
 app.route('/api/work-intents', workIntentRoutes);
 app.route('/api/modules', moduleRoutes);
 
-app.get('/health', (c) => c.json({ status: 'ok' }));
+app.get('/health', (c) => c.json({
+  status: 'ok',
+  release: DEFT_RELEASE_VERSION,
+  commit: DEFT_BUILD_COMMIT,
+  schema_head: DEFT_SCHEMA_HEAD,
+  agent_channel_protocol: AGENT_CHANNEL_PROTOCOL_VERSION,
+}));
+
+app.get('/health/ready', async (c) => {
+  try {
+    const result = await db.execute(sql`
+      SELECT
+        COUNT(*) FILTER (
+          WHERE table_name = 'agent_channel_events'
+            AND column_name IN ('claim_token', 'claim_owner', 'lease_expires_at')
+        )::int AS channel_column_count,
+        EXISTS (
+          SELECT 1 FROM information_schema.tables
+          WHERE table_schema = 'public' AND table_name = 'wiki_memory_syncs'
+        ) AS has_memory_sync
+      FROM information_schema.columns
+      WHERE table_schema = 'public'
+    `);
+    const rows = Array.isArray(result) ? result : ('rows' in result ? result.rows : []);
+    const row = rows[0] as { channel_column_count?: number; has_memory_sync?: boolean } | undefined;
+    const ready = Number(row?.channel_column_count ?? 0) === 3 && row?.has_memory_sync === true;
+    return c.json({
+      status: ready ? 'ready' : 'not_ready',
+      release: DEFT_RELEASE_VERSION,
+      commit: DEFT_BUILD_COMMIT,
+      schema_head: DEFT_SCHEMA_HEAD,
+      agent_channel_protocol: AGENT_CHANNEL_PROTOCOL_VERSION,
+      checks: {
+        agent_channel_v2_schema: Number(row?.channel_column_count ?? 0) === 3,
+        wiki_memory_sync: row?.has_memory_sync === true,
+      },
+    }, ready ? 200 : 503);
+  } catch (err) {
+    return c.json({
+      status: 'not_ready',
+      error: 'Database readiness check failed',
+      code: 'DATABASE_NOT_READY',
+    }, 503);
+  }
+});
 
 app.get('/health/queue', async (c) => {
   const authError = requireMetricsBearer(c);

--- a/apps/api/src/lib/agent-channel.ts
+++ b/apps/api/src/lib/agent-channel.ts
@@ -12,7 +12,23 @@ import {
 import { McpAuthError } from './mcp-token.js';
 import { getIO } from '../socket.js';
 
-export const AGENT_CHANNEL_PROTOCOL_VERSION = 'deft.agent_channel.v1';
+export const AGENT_CHANNEL_PROTOCOL_VERSION = 'deft.agent_channel.v2';
+export const AGENT_CHANNEL_CAPABILITIES = [
+  'single_flight_claims',
+  'renewable_leases',
+  'fencing_tokens',
+  'terminal_outcomes',
+  'identity_bound_mcp',
+  'wiki_memory_sync_v1',
+] as const;
+export const AGENT_CHANNEL_REQUIRED_RUNTIME_CAPABILITIES = [
+  'renewable_leases',
+  'fencing_tokens',
+  'terminal_outcomes',
+] as const;
+export const DEFT_RELEASE_VERSION = process.env.DEFT_RELEASE_VERSION || '0.3.0-preview.6';
+export const DEFT_BUILD_COMMIT = process.env.DEFT_BUILD_COMMIT || process.env.VCS_REF || 'unknown';
+export const DEFT_SCHEMA_HEAD = '0.3.0-preview.6';
 export const AGENT_CHANNEL_DEFAULT_LEASE_MS = 120_000;
 export const AGENT_CHANNEL_MIN_LEASE_MS = 30_000;
 export const AGENT_CHANNEL_MAX_LEASE_MS = 600_000;
@@ -201,7 +217,12 @@ export async function publishAgentChannelEvent(input: PublishAgentChannelEventIn
 
 export async function touchAgentChannelConnection(
   principal: AgentChannelPrincipal,
-  opts?: { status?: 'connected' | 'degraded' | 'disconnected'; lastEventId?: string | null; lastError?: string | null },
+  opts?: {
+    status?: 'connected' | 'degraded' | 'disconnected';
+    lastEventId?: string | null;
+    lastError?: string | null;
+    metadata?: Record<string, unknown>;
+  },
 ) {
   const now = new Date();
   const id = crypto.randomUUID();
@@ -217,6 +238,7 @@ export async function touchAgentChannelConnection(
       last_seen_at: now,
       last_event_id: opts?.lastEventId ?? null,
       last_error: opts?.lastError ?? null,
+      metadata: opts?.metadata ?? {},
     })
     .onConflictDoUpdate({
       target: [
@@ -230,6 +252,7 @@ export async function touchAgentChannelConnection(
         last_seen_at: now,
         last_event_id: opts?.lastEventId ?? sql`${agentChannelConnections.last_event_id}`,
         last_error: opts?.lastError ?? null,
+        metadata: opts?.metadata ?? sql`${agentChannelConnections.metadata}`,
         updated_at: now,
       },
     })

--- a/apps/api/src/lib/agent-runtime-recovery.ts
+++ b/apps/api/src/lib/agent-runtime-recovery.ts
@@ -1,5 +1,5 @@
 export type AgentRuntimeRecovery = {
-  state: 'healthy' | 'setup_required' | 'offline' | 'delivery_failed' | 'backlogged';
+  state: 'healthy' | 'setup_required' | 'offline' | 'delivery_failed' | 'backlogged' | 'certifying';
   title: string;
   detail: string;
   action: 'none' | 'regenerate_channel_token' | 'send_channel_test' | 'inspect_queue';
@@ -11,6 +11,7 @@ export function describeAgentRuntimeRecovery(input: {
   lastSeenAt?: Date | null;
   failedDeliveries: number;
   pendingDeliveries: number;
+  certificationStatus?: string | null;
   now?: Date;
 }): AgentRuntimeRecovery {
   const now = input.now ?? new Date();
@@ -33,6 +34,12 @@ export function describeAgentRuntimeRecovery(input: {
     detail: 'Start the runtime and channel bridge, then send a test event. Deft will update this page when contact resumes.',
     action: 'send_channel_test',
   };
+  if (input.certificationStatus !== 'verified') return {
+    state: 'certifying',
+    title: 'Transport connected; employee check pending',
+    detail: 'Deft will mark this employee ready only after a real Agent Channel assignment, Hermes turn, MCP calls, reply, and memory probe complete.',
+    action: 'none',
+  };
   if (input.pendingDeliveries > 5) return {
     state: 'backlogged',
     title: `${input.pendingDeliveries} deliveries are waiting`,
@@ -42,7 +49,7 @@ export function describeAgentRuntimeRecovery(input: {
   return {
     state: 'healthy',
     title: 'Runtime is ready',
-    detail: 'The employee is connected and no delivery failures need attention.',
+    detail: 'The employee passed the end-to-end check, is connected, and has no delivery failures.',
     action: 'none',
   };
 }

--- a/apps/api/src/lib/env.ts
+++ b/apps/api/src/lib/env.ts
@@ -57,10 +57,14 @@ function resolveDockerDatabaseUrl(): string | null {
 export const DEVELOPMENT_ENCRYPTION_KEY = 'deft-dev-encryption-key-32ch';
 
 export function resolveEncryptionKey(
-  configured = process.env.ENCRYPTION_KEY,
+  configured?: string,
   nodeEnv = process.env.NODE_ENV,
 ): string {
-  const value = configured?.trim();
+  // An explicit `undefined` must remain distinguishable from an omitted
+  // argument so callers validating supplied production configuration cannot
+  // accidentally fall back to a key inherited from the parent process.
+  const resolved = arguments.length === 0 ? process.env.ENCRYPTION_KEY : configured;
+  const value = resolved?.trim();
   const insecure = !value
     || value === DEVELOPMENT_ENCRYPTION_KEY
     || value.includes('CHANGE_ME')

--- a/apps/api/src/lib/queues.ts
+++ b/apps/api/src/lib/queues.ts
@@ -89,7 +89,6 @@ export async function enqueue(
 ): Promise<void> {
   const executor = opts?.executor ?? db;
   const delay = Math.max(0, opts?.delay ?? 0);
-  const runAt = new Date(Date.now() + delay);
   const maxAttempts = positiveInteger(opts?.maxAttempts, 3);
   const orgId = inferOrgId(data, opts?.orgId);
   const dedupeKey = opts?.dedupeKey?.trim() || null;
@@ -107,7 +106,7 @@ export async function enqueue(
       ${JSON.stringify(data)}::jsonb,
       'pending',
       ${maxAttempts},
-      ${runAt},
+      now() + (${delay} * interval '1 millisecond'),
       ${dedupeKey}
     )
     ON CONFLICT DO NOTHING
@@ -269,7 +268,7 @@ export async function ensureCronJob(
   data?: Record<string, unknown>,
   delay?: number,
 ): Promise<void> {
-  const runAt = new Date(Date.now() + Math.max(0, delay ?? 0));
+  const delayMs = Math.max(0, delay ?? 0);
   await db.execute(sql`
     INSERT INTO job_queue (
       id, queue, name, data, status, max_attempts, run_at, cron_key
@@ -280,7 +279,7 @@ export async function ensureCronJob(
       ${JSON.stringify(data ?? {})}::jsonb,
       'pending',
       2,
-      ${runAt},
+      now() + (${delayMs} * interval '1 millisecond'),
       ${cronKey}
     )
     ON CONFLICT DO NOTHING

--- a/apps/api/src/routes/agent-channel.ts
+++ b/apps/api/src/routes/agent-channel.ts
@@ -1,5 +1,5 @@
 /**
- * Agent Channel API v1.
+ * Agent Channel API transport path v1, protocol contract v2.
  *
  * This is the live delivery plane for always-on BYOA runtimes. MCP remains the
  * tool plane; this route lets a runtime receive Deft workplace events, ack
@@ -23,7 +23,12 @@ import {
 } from '../lib/mcp-token.js';
 import {
   AGENT_CHANNEL_PROTOCOL_VERSION,
+  AGENT_CHANNEL_CAPABILITIES,
+  AGENT_CHANNEL_REQUIRED_RUNTIME_CAPABILITIES,
   AGENT_CHANNEL_DEFAULT_LEASE_MS,
+  DEFT_BUILD_COMMIT,
+  DEFT_RELEASE_VERSION,
+  DEFT_SCHEMA_HEAD,
   getAgentChannelPrincipal,
   hasActiveAgentChannelClaim,
   listPendingChannelEvents,
@@ -38,6 +43,17 @@ import { executeSendMessage } from '../lib/mcp-tools/writes.js';
 import { buildAgentChannelLifecyclePatch } from '../lib/agent-channel-lifecycle.js';
 
 export const agentChannelRoutes = new Hono();
+
+function channelContract() {
+  return {
+    protocol_version: AGENT_CHANNEL_PROTOCOL_VERSION,
+    server_release: DEFT_RELEASE_VERSION,
+    server_commit: DEFT_BUILD_COMMIT,
+    schema_head: DEFT_SCHEMA_HEAD,
+    capabilities: [...AGENT_CHANNEL_CAPABILITIES],
+    required_runtime_capabilities: [...AGENT_CHANNEL_REQUIRED_RUNTIME_CAPABILITIES],
+  };
+}
 
 function emitTaskProgress(event: typeof agentChannelEvents.$inferSelect, employeeId: string, status: string, detail?: string | null) {
   if (event.source_kind !== 'task' || !event.source_id) return;
@@ -87,8 +103,43 @@ const statusSchema = z.object({
   caller_employee_slug: z.string().optional(),
 });
 
-function errorResponse(c: Context, status: 400 | 401 | 403 | 404 | 409 | 500, code: string, message: string) {
+function errorResponse(c: Context, status: 400 | 401 | 403 | 404 | 409 | 426 | 500, code: string, message: string) {
   return c.json({ error: message, code }, status);
+}
+
+function channelCompatibility(c: Context): {
+  adapterVersion: string;
+  capabilities: string[];
+} | Response {
+  const protocolVersion = c.req.query('protocol_version')?.trim() ?? '';
+  const adapterVersion = c.req.query('adapter_version')?.trim() ?? '';
+  const capabilities = (c.req.query('capabilities') ?? '')
+    .split(',')
+    .map((value) => value.trim())
+    .filter(Boolean);
+  const missingCapabilities = AGENT_CHANNEL_REQUIRED_RUNTIME_CAPABILITIES
+    .filter((capability) => !capabilities.includes(capability));
+
+  if (protocolVersion !== AGENT_CHANNEL_PROTOCOL_VERSION || !adapterVersion || missingCapabilities.length > 0) {
+    return c.json({
+      error: [
+        `Agent Channel runtime is incompatible with ${AGENT_CHANNEL_PROTOCOL_VERSION}.`,
+        protocolVersion ? `Runtime requested ${protocolVersion}.` : 'Runtime did not declare a protocol version.',
+        adapterVersion ? null : 'Runtime did not declare an adapter version.',
+        missingCapabilities.length > 0 ? `Missing capabilities: ${missingCapabilities.join(', ')}.` : null,
+        `Install the Hermes integration bundle for Deft ${DEFT_RELEASE_VERSION}.`,
+      ].filter(Boolean).join(' '),
+      code: 'INCOMPATIBLE_CHANNEL',
+      protocol_version: AGENT_CHANNEL_PROTOCOL_VERSION,
+      server_release: DEFT_RELEASE_VERSION,
+      server_commit: DEFT_BUILD_COMMIT,
+      schema_head: DEFT_SCHEMA_HEAD,
+      capabilities: [...AGENT_CHANNEL_CAPABILITIES],
+      required_runtime_capabilities: [...AGENT_CHANNEL_REQUIRED_RUNTIME_CAPABILITIES],
+    }, 426);
+  }
+
+  return { adapterVersion, capabilities };
 }
 
 async function resolveChannelPrincipal(c: Context, callerSlug?: string | null): Promise<AgentChannelPrincipal | Response> {
@@ -116,7 +167,7 @@ async function resolveChannelPrincipal(c: Context, callerSlug?: string | null): 
   }
 }
 
-function isResponse(value: AgentChannelPrincipal | Response): value is Response {
+function isResponse<T>(value: T | Response): value is Response {
   return value instanceof Response;
 }
 
@@ -170,16 +221,32 @@ async function closeFallbackWorkForEvent(params: {
     ));
 }
 
+agentChannelRoutes.get('/contract', (c) => c.json(channelContract()));
+
 agentChannelRoutes.get('/connect', async (c) => {
   const principal = await resolveChannelPrincipal(c, c.req.query('caller_employee_slug'));
   if (isResponse(principal)) return principal;
+  const compatibility = channelCompatibility(c);
+  if (isResponse(compatibility)) return compatibility;
 
-  const connection = await touchAgentChannelConnection(principal);
+  const connection = await touchAgentChannelConnection(principal, {
+    metadata: {
+      adapter_version: compatibility.adapterVersion,
+      runtime_capabilities: compatibility.capabilities,
+      server_release: DEFT_RELEASE_VERSION,
+      server_commit: DEFT_BUILD_COMMIT,
+      schema_head: DEFT_SCHEMA_HEAD,
+    },
+  });
   await updateAgentChannelCursor({ principal, connectionId: connection?.id ?? null });
 
   return c.json({
     ok: true,
     protocol_version: AGENT_CHANNEL_PROTOCOL_VERSION,
+    server_release: DEFT_RELEASE_VERSION,
+    server_commit: DEFT_BUILD_COMMIT,
+    schema_head: DEFT_SCHEMA_HEAD,
+    capabilities: [...AGENT_CHANNEL_CAPABILITIES],
     employee: {
       id: principal.employee_id,
       slug: principal.employee_slug,
@@ -193,6 +260,8 @@ agentChannelRoutes.get('/connect', async (c) => {
 agentChannelRoutes.get('/events', async (c) => {
   const principal = await resolveChannelPrincipal(c, c.req.query('caller_employee_slug'));
   if (isResponse(principal)) return principal;
+  const compatibility = channelCompatibility(c);
+  if (isResponse(compatibility)) return compatibility;
 
   const limit = Number.parseInt(c.req.query('limit') ?? '25', 10);
   const workerId = c.req.query('worker_id')?.trim();
@@ -221,6 +290,7 @@ agentChannelRoutes.get('/events', async (c) => {
   return c.json({
     ok: true,
     protocol_version: AGENT_CHANNEL_PROTOCOL_VERSION,
+    capabilities: [...AGENT_CHANNEL_CAPABILITIES],
     cursor: lastEventId,
     events,
   });

--- a/apps/api/src/routes/agent-employees.ts
+++ b/apps/api/src/routes/agent-employees.ts
@@ -21,6 +21,7 @@ import {
   agentMcpCallAudit,
   agentCooperativeLog,
   agentChannelConnections,
+  agentChannelDeliveryAttempts,
   agentChannelEvents,
   agentChannelTokens,
   projects,
@@ -29,6 +30,8 @@ import {
 import type { SkillAgentConfig } from '../lib/skill-config.js';
 import {
   AGENT_CHANNEL_PROTOCOL_VERSION,
+  AGENT_CHANNEL_CAPABILITIES,
+  DEFT_RELEASE_VERSION,
   issueAgentChannelToken,
   publishAgentChannelEvent,
 } from '../lib/agent-channel.js';
@@ -38,6 +41,7 @@ import { MODULE_WRITE_ACTION_NAMES } from '../lib/module-action-visibility.js';
 import { summarizeAgentChannelLifecycle, summarizeAgentChannelMetrics } from '../lib/agent-channel-lifecycle.js';
 import { loadAgentActivity } from '../lib/agent-activity.js';
 import { describeAgentRuntimeRecovery } from '../lib/agent-runtime-recovery.js';
+import { ensureAgentConversationSpace } from '../lib/ensure-agent-conversation-space.js';
 
 export const agentEmployeeRoutes = new Hono();
 
@@ -547,10 +551,17 @@ function agentChannelEndpointUrl(): string {
   return `${apiBase.replace(/\/$/, '')}/api/agent-channel/v1`;
 }
 
+function hermesIntegrationBundleUrl(): string {
+  return process.env.DEFT_HERMES_BUNDLE_URL?.trim()
+    || `https://github.com/Maneek21/Deft/releases/download/v${DEFT_RELEASE_VERSION}/deft-hermes-integration-${DEFT_RELEASE_VERSION}.tar.gz`;
+}
+
 const CERTIFICATION_REQUIRED_TOOLS = [
   'platform_context',
   'task_query',
   'ping_alive',
+  'memory_write',
+  'memory_recall',
   'record_conversation_turn',
   'record_decision',
 ] as const;
@@ -565,6 +576,9 @@ type RuntimeSetup = {
   runtime_kind: string;
   tool_server_name: string | null;
   channel_protocol_version: string;
+  channel_capabilities: string[];
+  integration_version: string | null;
+  integration_bundle_url: string | null;
   mcp_endpoint_url: string;
   channel_endpoint_url: string;
   tool_name_style: 'bare' | 'server_prefixed';
@@ -589,6 +603,11 @@ type CertificationChallengeEvidence = {
   missingTools: string[];
   nonceSeen: boolean;
   auditCount: number;
+  channelEventSeen: boolean;
+  channelCompleted: boolean;
+  channelReplyNonceSeen: boolean;
+  singleDelivery: boolean;
+  runtimeSessionSeen: boolean;
   completed: boolean;
 };
 
@@ -604,6 +623,7 @@ async function loadCertificationChallengeEvidence(params: {
   orgId: string;
   employeeId: string;
   challenge: {
+    id: string;
     nonce: string;
     required_tools: string[];
     status: string;
@@ -648,12 +668,68 @@ async function loadCertificationChallengeEvidence(params: {
     : challenge.required_tools.filter((tool) => !seenTools.has(tool));
   const nonceSeen = persistedComplete || nonceRows.length > 0;
 
+  const [channelEvent] = await db
+    .select({
+      id: agentChannelEvents.id,
+      status: agentChannelEvents.status,
+      delivery_count: agentChannelEvents.delivery_count,
+      runtime_session_key: agentChannelEvents.runtime_session_key,
+      work_outcome: agentChannelEvents.work_outcome,
+    })
+    .from(agentChannelEvents)
+    .where(and(
+      eq(agentChannelEvents.org_id, orgId),
+      eq(agentChannelEvents.agent_employee_id, employeeId),
+      eq(agentChannelEvents.kind, 'certification.challenge'),
+      eq(agentChannelEvents.source_kind, 'certification'),
+      eq(agentChannelEvents.source_id, challenge.id),
+      gte(agentChannelEvents.created_at, challenge.started_at),
+    ))
+    .orderBy(desc(agentChannelEvents.created_at))
+    .limit(1);
+  const replyRows = channelEvent
+    ? await db
+        .select({ id: agentChannelDeliveryAttempts.id })
+        .from(agentChannelDeliveryAttempts)
+        .where(and(
+          eq(agentChannelDeliveryAttempts.org_id, orgId),
+          eq(agentChannelDeliveryAttempts.agent_employee_id, employeeId),
+          eq(agentChannelDeliveryAttempts.event_id, channelEvent.id),
+          eq(agentChannelDeliveryAttempts.direction, 'inbound_reply'),
+          eq(agentChannelDeliveryAttempts.status, 'completed'),
+          sql`COALESCE(${agentChannelDeliveryAttempts.request_json}->>'content', '') ILIKE ${`%${challenge.nonce}%`}`,
+        ))
+        .limit(1)
+    : [];
+  const channelEventSeen = persistedComplete || Boolean(channelEvent);
+  const channelCompleted = persistedComplete || (
+    channelEvent?.status === 'completed'
+    && channelEvent.work_outcome === 'completed'
+  );
+  const channelReplyNonceSeen = persistedComplete || replyRows.length > 0;
+  const singleDelivery = persistedComplete || channelEvent?.delivery_count === 1;
+  const runtimeSessionSeen = persistedComplete || Boolean(channelEvent?.runtime_session_key);
+  const completed = persistedComplete || (
+    missingTools.length === 0
+    && nonceSeen
+    && channelEventSeen
+    && channelCompleted
+    && channelReplyNonceSeen
+    && singleDelivery
+    && runtimeSessionSeen
+  );
+
   return {
     seenTools,
     missingTools,
     nonceSeen,
     auditCount: auditRows.length,
-    completed: persistedComplete || (missingTools.length === 0 && nonceSeen),
+    channelEventSeen,
+    channelCompleted,
+    channelReplyNonceSeen,
+    singleDelivery,
+    runtimeSessionSeen,
+    completed,
   };
 }
 
@@ -768,7 +844,6 @@ function buildCertificationPrompt(
 ): string {
   const runtimeKind = runtimeKindOf(employee);
   const toolNames = CERTIFICATION_REQUIRED_TOOLS.map((tool) => runtimeToolName(runtimeKind, tool));
-  const taskCreate = runtimeToolName(runtimeKind, 'task_create');
   const prefixNote = runtimeKind === 'hermes'
     ? 'Hermes exposes Deft MCP tools to the model as mcp_deft_<tool>, so use the exact names below.'
     : 'Use the Deft MCP tools below.';
@@ -778,8 +853,10 @@ function buildCertificationPrompt(
     prefixNote,
     `Use caller_employee_slug exactly as "${employee.slug}" on every Deft MCP tool call.`,
     `Call these tools now: ${toolNames.join(', ')}.`,
+    `Use ${runtimeToolName(runtimeKind, 'memory_write')} to save a private certification memory whose title and body contain ${nonce}; use idempotency_key "certification:${nonce}".`,
+    `Then call ${runtimeToolName(runtimeKind, 'memory_recall')} with query "${nonce}" and confirm the memory is returned.`,
     `Include this exact certification nonce in record_conversation_turn and record_decision: ${nonce}.`,
-    `If ${taskCreate} is available, create one small useful task for the organization after certification.`,
+    `Your final reply must contain this exact nonce: ${nonce}.`,
     'Finish with a short natural-language summary. Do not prefix every future message with your own name.',
   ].join('\n');
 }
@@ -798,12 +875,16 @@ function buildRuntimeSetup(
       runtime_kind: runtimeKind,
       tool_server_name: 'deft',
       channel_protocol_version: AGENT_CHANNEL_PROTOCOL_VERSION,
+      channel_capabilities: [...AGENT_CHANNEL_CAPABILITIES],
+      integration_version: '0.2.0',
+      integration_bundle_url: hermesIntegrationBundleUrl(),
       mcp_endpoint_url: endpoint,
       channel_endpoint_url: channelEndpoint,
       tool_name_style: 'server_prefixed',
       tool_call_names: CERTIFICATION_REQUIRED_TOOLS.map((tool) => runtimeToolName(runtimeKind, tool)),
       setup_steps: [
-        'Save the Deft stdio bridge as deft-mcp-stdio.mjs on the machine where Hermes runs.',
+        `Download and extract the immutable Hermes integration bundle for Deft ${DEFT_RELEASE_VERSION}.`,
+        'Use the bundled Deft MCP stdio bridge and Hermes plugins; do not copy these files from another Deft checkout.',
         'Add the mcp_servers.deft block to the active Hermes config.yaml.',
         'Enable the authenticated Hermes Responses API and start the Hermes gateway.',
         'Set the Agent Channel quick-config variables shown below, including the Hermes API URL, key, and model.',
@@ -814,6 +895,11 @@ function buildRuntimeSetup(
         'Use mcp_deft_memory_recall for Deft wiki context; mcp_deft_wiki_search is accepted as a compatibility alias.',
       ],
       commands: [
+        {
+          label: 'Download matched Deft integration',
+          command: `curl -fL -o deft-hermes-integration-${DEFT_RELEASE_VERSION}.tar.gz ${hermesIntegrationBundleUrl()}`,
+          description: `Downloads the checksummed Hermes integration built for Deft ${DEFT_RELEASE_VERSION}.`,
+        },
         {
           label: 'List configured MCP servers',
           command: 'hermes mcp list',
@@ -836,7 +922,7 @@ function buildRuntimeSetup(
         },
         {
           label: 'Start live Deft delivery',
-          command: 'pnpm agent:hermes-channel',
+          command: 'node ./deft-hermes-integration/scripts/hermes-agent-channel-bridge.mjs',
           description: 'Consumes the durable Agent Channel inbox, asks Hermes, and posts exactly one reply through Deft.',
         },
         {
@@ -866,7 +952,8 @@ function buildRuntimeSetup(
         'Use mcp_deft_memory_recall for wiki context; mcp_deft_wiki_search exists only for compatibility with older/native wording.',
         'If Hermes exits before tool calls with a provider/auth error, fix Hermes model credentials first.',
         'Avoid passing a toolset override that disables MCP tools for the run.',
-        'DEFT_CHANNEL_URL and DEFT_CHANNEL_TOKEN alone do not wake Hermes; the Hermes API and pnpm agent:hermes-channel process must both be running.',
+        'DEFT_CHANNEL_URL and DEFT_CHANNEL_TOKEN alone do not wake Hermes; the Hermes API and the matched bundled Agent Channel bridge must both be running.',
+        `If the bridge reports INCOMPATIBLE_CHANNEL, install the integration bundle for Deft ${DEFT_RELEASE_VERSION}; do not enable a legacy fallback.`,
         'If a channel reply appears twice, stop any older bridge process and verify Hermes is not calling chat-writing MCP tools directly.',
       ],
     };
@@ -876,6 +963,9 @@ function buildRuntimeSetup(
     runtime_kind: runtimeKind,
     tool_server_name: null,
     channel_protocol_version: AGENT_CHANNEL_PROTOCOL_VERSION,
+    channel_capabilities: [...AGENT_CHANNEL_CAPABILITIES],
+    integration_version: null,
+    integration_bundle_url: null,
     mcp_endpoint_url: endpoint,
     channel_endpoint_url: channelEndpoint,
     tool_name_style: 'bare',
@@ -921,6 +1011,11 @@ function buildCertificationStages(params: {
   missingTools: string[];
   nonceSeen: boolean;
   auditCount: number;
+  channelEventSeen: boolean;
+  channelCompleted: boolean;
+  channelReplyNonceSeen: boolean;
+  singleDelivery: boolean;
+  runtimeSessionSeen: boolean;
   completed: boolean;
 }): CertificationStage[] {
   const runtimeKind = runtimeKindOf(params.employee);
@@ -945,6 +1040,22 @@ function buildCertificationStages(params: {
           : 'Connect the runtime to the Deft MCP endpoint.',
     },
     {
+      key: 'channel_delivered',
+      label: 'Assignment delivered',
+      status: params.channelEventSeen && params.singleDelivery ? 'pass' : 'pending',
+      detail: params.channelEventSeen && params.singleDelivery
+        ? 'The certification assignment was claimed exactly once through Agent Channel.'
+        : 'Waiting for a compatible runtime to claim the certification assignment exactly once.',
+    },
+    {
+      key: 'runtime_inference',
+      label: 'Runtime inference completed',
+      status: params.channelCompleted && params.runtimeSessionSeen ? 'pass' : 'pending',
+      detail: params.channelCompleted && params.runtimeSessionSeen
+        ? 'Hermes completed the assignment and reported a terminal outcome.'
+        : 'Waiting for Hermes to run the assignment and report a terminal outcome.',
+    },
+    {
       key: 'required_tools_called',
       label: 'Required tools called',
       status: toolsCalled ? 'pass' : 'pending',
@@ -959,6 +1070,14 @@ function buildCertificationStages(params: {
       detail: params.nonceSeen
         ? 'The challenge nonce was recorded in the cooperative log.'
         : 'Call record_conversation_turn or record_decision with the challenge nonce.',
+    },
+    {
+      key: 'channel_reply_verified',
+      label: 'Reply verified',
+      status: params.channelReplyNonceSeen ? 'pass' : 'pending',
+      detail: params.channelReplyNonceSeen
+        ? 'The Agent Channel reply contains the one-time certification nonce.'
+        : 'Waiting for a nonce-bearing reply through Agent Channel.',
     },
     {
       key: 'verified',
@@ -978,8 +1097,21 @@ function certificationFailureReason(params: {
   missingTools: string[];
   nonceSeen: boolean;
   auditCount: number;
+  channelEventSeen: boolean;
+  channelCompleted: boolean;
+  channelReplyNonceSeen: boolean;
+  singleDelivery: boolean;
+  runtimeSessionSeen: boolean;
 }): string | null {
-  if (params.missingTools.length === 0 && params.nonceSeen) return null;
+  if (
+    params.missingTools.length === 0
+    && params.nonceSeen
+    && params.channelEventSeen
+    && params.channelCompleted
+    && params.channelReplyNonceSeen
+    && params.singleDelivery
+    && params.runtimeSessionSeen
+  ) return null;
   const runtimeKind = runtimeKindOf(params.employee);
   const mcpReachable = params.auditCount > 0 || Boolean(params.employee.last_mcp_call_at);
   if (!mcpReachable) {
@@ -987,12 +1119,45 @@ function certificationFailureReason(params: {
       ? 'Hermes has not reached Deft MCP yet. Run `hermes mcp test deft` and check the bridge config.'
       : 'The runtime has not reached Deft MCP yet.';
   }
+  if (!params.channelEventSeen) return 'The Hermes runtime has not claimed the Agent Channel certification assignment.';
+  if (!params.singleDelivery) return 'The certification assignment was delivered more than once. Reset certification after fixing runtime stability.';
+  if (!params.channelCompleted || !params.runtimeSessionSeen) return 'Hermes has not completed a real runtime turn for the certification assignment.';
   if (params.missingTools.length > 0) {
     return runtimeKind === 'hermes'
       ? `Hermes can reach Deft MCP, but its model loop has not called: ${params.missingTools.map((tool) => runtimeToolName('hermes', tool)).join(', ')}. Check model auth and use the mcp_deft_* tool names.`
       : `The runtime has not called: ${params.missingTools.join(', ')}.`;
   }
+  if (!params.channelReplyNonceSeen) return 'Hermes completed tool calls but did not reply through Agent Channel with the certification nonce.';
   return 'Required tools were called, but the challenge nonce was not recorded in the cooperative log.';
+}
+
+async function cancelPendingCertification(orgId: string, employeeId: string, reason: string) {
+  await db.execute(sql`
+    UPDATE agent_certification_challenges
+    SET status = 'reset',
+        failure_reason = ${reason},
+        completed_at = now(),
+        updated_at = now()
+    WHERE org_id = ${orgId}
+      AND employee_id = ${employeeId}
+      AND status = 'pending'
+  `);
+  await db.execute(sql`
+    UPDATE agent_channel_events
+    SET status = 'cancelled',
+        completed_at = COALESCE(completed_at, now()),
+        work_outcome = 'cancelled',
+        outcome_detail = ${reason},
+        outcome_at = now(),
+        claim_owner = NULL,
+        claim_token = NULL,
+        lease_expires_at = NULL,
+        updated_at = now()
+    WHERE org_id = ${orgId}
+      AND agent_employee_id = ${employeeId}
+      AND source_kind = 'certification'
+      AND status IN ('pending', 'delivered', 'acknowledged', 'running', 'approval_pending')
+  `);
 }
 
 async function issueMcpToken({
@@ -2132,6 +2297,11 @@ agentEmployeeRoutes.get('/:id/developer', async (c) => {
               missingTools: challengeEvidence?.missingTools ?? [],
               nonceSeen: challengeEvidence?.nonceSeen ?? false,
               auditCount: challengeEvidence?.auditCount ?? 0,
+              channelEventSeen: challengeEvidence?.channelEventSeen ?? false,
+              channelCompleted: challengeEvidence?.channelCompleted ?? false,
+              channelReplyNonceSeen: challengeEvidence?.channelReplyNonceSeen ?? false,
+              singleDelivery: challengeEvidence?.singleDelivery ?? false,
+              runtimeSessionSeen: challengeEvidence?.runtimeSessionSeen ?? false,
               completed: challengeEvidence?.completed ?? false,
             }),
           }
@@ -2173,6 +2343,7 @@ agentEmployeeRoutes.get('/:id/developer', async (c) => {
           lastSeenAt: channelConnection?.last_seen_at,
           failedDeliveries: channelQueue.failed ?? 0,
           pendingDeliveries: channelQueue.pending ?? 0,
+          certificationStatus: employee.certification_status,
         }),
       },
     });
@@ -2249,6 +2420,7 @@ agentEmployeeRoutes.post('/:id/certification/start', async (c) => {
       .limit(1);
     if (!employee) return c.json({ error: 'Agent employee not found', code: 'NOT_FOUND' }, 404);
 
+    await cancelPendingCertification(user.org_id, employee.id, 'Superseded by a new certification challenge');
     const nonce = `deft-cert-${employee.slug}-${crypto.randomBytes(6).toString('hex')}`;
     const [challenge] = await db
       .insert(agentCertificationChallenges)
@@ -2260,6 +2432,33 @@ agentEmployeeRoutes.post('/:id/certification/start', async (c) => {
         status: 'pending',
       })
       .returning();
+    if (!challenge) throw new Error('Certification challenge insert returned no row');
+
+    await ensureAgentConversationSpace({
+      orgId: user.org_id,
+      userId: user.id,
+      agentUserId: employee.user_id,
+      conversationId: challenge.id,
+      title: `${employee.name} onboarding check`,
+    });
+    const { event: channelEvent } = await publishAgentChannelEvent({
+      orgId: user.org_id,
+      employeeId: employee.id,
+      kind: 'certification.challenge',
+      sourceKind: 'certification',
+      sourceId: challenge.id,
+      spaceId: challenge.id,
+      actorUserId: user.id,
+      idempotencyKey: `employee-certification:${challenge.id}`,
+      payload: {
+        nonce,
+        employee_slug: employee.slug,
+        is_dm: true,
+        parent_id: null,
+        certification_prompt: buildCertificationPrompt(employee, nonce),
+        expected_reply_contains: nonce,
+      },
+    });
 
     await db
       .update(agentEmployees)
@@ -2268,6 +2467,8 @@ agentEmployeeRoutes.post('/:id/certification/start', async (c) => {
 
     return c.json({
       challenge,
+      channel_event: channelEvent,
+      conversation_id: challenge.id,
       instructions: certificationInstructions(employee, nonce),
       runtime_setup: buildRuntimeSetup(employee, nonce),
       mcp_endpoint_url: mcpEndpointUrl(),
@@ -2326,6 +2527,11 @@ agentEmployeeRoutes.get('/:id/certification', async (c) => {
               missingTools: challengeEvidence?.missingTools ?? challenge.required_tools,
               nonceSeen: challengeEvidence?.nonceSeen ?? false,
               auditCount: challengeEvidence?.auditCount ?? 0,
+              channelEventSeen: challengeEvidence?.channelEventSeen ?? false,
+              channelCompleted: challengeEvidence?.channelCompleted ?? false,
+              channelReplyNonceSeen: challengeEvidence?.channelReplyNonceSeen ?? false,
+              singleDelivery: challengeEvidence?.singleDelivery ?? false,
+              runtimeSessionSeen: challengeEvidence?.runtimeSessionSeen ?? false,
               completed: challengeEvidence?.completed ?? false,
             }),
           }
@@ -2373,6 +2579,11 @@ agentEmployeeRoutes.post('/:id/certification/check', async (c) => {
       missingTools,
       nonceSeen: nonce_seen,
       auditCount,
+      channelEventSeen,
+      channelCompleted,
+      channelReplyNonceSeen,
+      singleDelivery,
+      runtimeSessionSeen,
       completed,
     } = challengeEvidence;
     const stages = buildCertificationStages({
@@ -2380,6 +2591,11 @@ agentEmployeeRoutes.post('/:id/certification/check', async (c) => {
       missingTools,
       nonceSeen: nonce_seen,
       auditCount,
+      channelEventSeen,
+      channelCompleted,
+      channelReplyNonceSeen,
+      singleDelivery,
+      runtimeSessionSeen,
       completed,
     });
     const failureReason = certificationFailureReason({
@@ -2387,6 +2603,11 @@ agentEmployeeRoutes.post('/:id/certification/check', async (c) => {
       missingTools,
       nonceSeen: nonce_seen,
       auditCount,
+      channelEventSeen,
+      channelCompleted,
+      channelReplyNonceSeen,
+      singleDelivery,
+      runtimeSessionSeen,
     });
 
     if (completed) {
@@ -2411,6 +2632,11 @@ agentEmployeeRoutes.post('/:id/certification/check', async (c) => {
       completed,
       missing_tools: missingTools,
       nonce_seen,
+      channel_event_seen: channelEventSeen,
+      channel_completed: channelCompleted,
+      channel_reply_nonce_seen: channelReplyNonceSeen,
+      single_delivery: singleDelivery,
+      runtime_session_seen: runtimeSessionSeen,
       seen_tools: Array.from(seenTools),
       required_tools: challenge.required_tools,
       instructions: certificationInstructions(employee, challenge.nonce),
@@ -2439,16 +2665,7 @@ agentEmployeeRoutes.post('/:id/certification/reset', async (c) => {
       .limit(1);
     if (!employee) return c.json({ error: 'Agent employee not found', code: 'NOT_FOUND' }, 404);
 
-    await db.execute(sql`
-      UPDATE agent_certification_challenges
-      SET status = 'reset',
-          failure_reason = 'Reset by operator',
-          completed_at = now(),
-          updated_at = now()
-      WHERE org_id = ${user.org_id}
-        AND employee_id = ${id}
-        AND status = 'pending'
-    `);
+    await cancelPendingCertification(user.org_id, id, 'Reset by operator');
     await db
       .update(agentEmployees)
       .set({ certification_status: employee.last_mcp_call_at ? 'mcp_reachable' : 'token_issued' })

--- a/apps/api/test/agent-certification-stability.test.ts
+++ b/apps/api/test/agent-certification-stability.test.ts
@@ -141,6 +141,14 @@ before(async () => {
 after(async () => {
   await withClient(async (client) => {
     await client.query('DELETE FROM agent_channel_events WHERE agent_employee_id = $1', [AUTH_EMPLOYEE_ID]);
+    await client.query(
+      'DELETE FROM space_members WHERE user_id IN ($1, $2, $3, $4)',
+      [SHADOW_USER_ID, ADMIN_USER_ID, MEMBER_USER_ID, AUTH_SHADOW_USER_ID],
+    );
+    await client.query(
+      "DELETE FROM spaces WHERE org_id = $1 AND created_by = $2 AND type = 'agent_conversation'",
+      [ORG_ID, ADMIN_USER_ID],
+    );
     await client.query('DELETE FROM agent_cooperative_log WHERE employee_id = $1', [EMPLOYEE_ID]);
     await client.query('DELETE FROM agent_mcp_call_audit WHERE employee_id = $1', [EMPLOYEE_ID]);
     await client.query('DELETE FROM agent_certification_challenges WHERE employee_id IN ($1, $2)', [EMPLOYEE_ID, AUTH_EMPLOYEE_ID]);
@@ -251,12 +259,72 @@ test('owner can use guarded routes without exposing a prompt-bearing shell comma
     { method: 'POST' },
   );
   assert.equal(startResponse.status, 201);
+  const startBody = await startResponse.json() as any;
+  assert.equal(startBody.channel_event.kind, 'certification.challenge');
+  assert.equal(startBody.channel_event.source_id, startBody.challenge.id);
+  assert.equal(startBody.channel_event.space_id, startBody.challenge.id);
+  assert.ok(startBody.challenge.required_tools.includes('memory_recall'));
+  assert.ok(startBody.challenge.required_tools.includes('memory_write'));
+  assert.match(startBody.runtime_setup.certification_prompt, /final reply.*nonce/i);
 
-  const checkResponse = await app().request(
+  await withClient(async (client) => {
+    for (const tool of startBody.challenge.required_tools) {
+      await client.query(
+        `INSERT INTO agent_mcp_call_audit
+           (id, org_id, employee_id, tool_name, success, created_at)
+         VALUES (gen_random_uuid()::text, $1, $2, $3, true, now())`,
+        [ORG_ID, AUTH_EMPLOYEE_ID, tool],
+      );
+    }
+    await client.query(
+      `INSERT INTO agent_cooperative_log
+         (id, org_id, employee_id, kind, summary, created_at)
+       VALUES (gen_random_uuid()::text, $1, $2, 'decision', $3, now())`,
+      [ORG_ID, AUTH_EMPLOYEE_ID, `Certification ${startBody.challenge.nonce}`],
+    );
+  });
+
+  const mcpOnlyCheck = await app().request(
     `/api/agent-employees/${AUTH_EMPLOYEE_ID}/certification/check`,
     { method: 'POST' },
   );
-  assert.equal(checkResponse.status, 200);
+  assert.equal(mcpOnlyCheck.status, 200);
+  const mcpOnlyBody = await mcpOnlyCheck.json() as any;
+  assert.equal(mcpOnlyBody.completed, false, 'MCP evidence alone must not certify an employee');
+  assert.equal(mcpOnlyBody.channel_completed, false);
+
+  await withClient(async (client) => {
+    await client.query(
+      `UPDATE agent_channel_events
+       SET status = 'completed', delivery_count = 1, delivered_at = now(), acked_at = now(),
+           completed_at = now(), work_outcome = 'completed', outcome_at = now(),
+           runtime_session_key = 'hermes:certification:test'
+       WHERE id = $1`,
+      [startBody.channel_event.id],
+    );
+    await client.query(
+      `INSERT INTO agent_channel_delivery_attempts
+         (id, org_id, agent_employee_id, event_id, direction, idempotency_key, status, request_json)
+       VALUES (gen_random_uuid()::text, $1, $2, $3, 'inbound_reply', $4, 'completed', $5::jsonb)`,
+      [
+        ORG_ID,
+        AUTH_EMPLOYEE_ID,
+        startBody.channel_event.id,
+        `certification-reply-${startBody.challenge.id}`,
+        JSON.stringify({ content: `Certification complete ${startBody.challenge.nonce}` }),
+      ],
+    );
+  });
+
+  const deepCheckResponse = await app().request(
+    `/api/agent-employees/${AUTH_EMPLOYEE_ID}/certification/check`,
+    { method: 'POST' },
+  );
+  assert.equal(deepCheckResponse.status, 200);
+  const deepCheckBody = await deepCheckResponse.json() as any;
+  assert.equal(deepCheckBody.completed, true);
+  assert.equal(deepCheckBody.single_delivery, true);
+  assert.equal(deepCheckBody.channel_reply_nonce_seen, true);
 
   const resetResponse = await app().request(
     `/api/agent-employees/${AUTH_EMPLOYEE_ID}/certification/reset`,

--- a/apps/api/test/agent-channel.test.ts
+++ b/apps/api/test/agent-channel.test.ts
@@ -475,7 +475,7 @@ async function publishMessageEvent(
 }
 
 async function claimChannelEvent(eventId: string, workerId = `worker-${crypto.randomUUID()}`) {
-  const res = await app.request(`/api/agent-channel/v1/events?limit=100&worker_id=${encodeURIComponent(workerId)}&lease_ms=120000`, {
+  const res = await app.request(`/api/agent-channel/v1/events?limit=100&worker_id=${encodeURIComponent(workerId)}&lease_ms=120000&${channelCompatibilityQuery()}`, {
     headers: { authorization: `Bearer ${bearer}` },
   });
   const body = await res.json() as any;
@@ -486,18 +486,28 @@ async function claimChannelEvent(eventId: string, workerId = `worker-${crypto.ra
   return claimed;
 }
 
+function channelCompatibilityQuery() {
+  return new URLSearchParams({
+    protocol_version: 'deft.agent_channel.v2',
+    adapter_version: '0.2.0-test',
+    capabilities: 'single_flight_claims,renewable_leases,fencing_tokens,terminal_outcomes,identity_bound_mcp,wiki_memory_sync_v1',
+  }).toString();
+}
+
 test('GET /connect requires a bearer token', async () => {
   const res = await app.request('/api/agent-channel/v1/connect');
   assert.equal(res.status, 401);
 });
 
-test('GET /connect authenticates an agent bearer and records connection', async () => {
-  const res = await app.request('/api/agent-channel/v1/connect', {
+test('GET /connect authenticates a compatible agent bearer and records connection', async () => {
+  const res = await app.request(`/api/agent-channel/v1/connect?${channelCompatibilityQuery()}`, {
     headers: { authorization: `Bearer ${bearer}` },
   });
   const body = await res.json() as any;
   assert.equal(res.status, 200, JSON.stringify(body));
   assert.equal(body.ok, true);
+  assert.equal(body.protocol_version, 'deft.agent_channel.v2');
+  assert.ok(body.capabilities.includes('fencing_tokens'));
   assert.equal(body.employee.slug, employeeSlug);
   assert.equal(body.connection.status, 'connected');
 
@@ -509,11 +519,31 @@ test('GET /connect authenticates an agent bearer and records connection', async 
   assert.ok(connection?.last_seen_at);
 });
 
+test('GET /contract advertises the lease-safe public compatibility contract', async () => {
+  const res = await app.request('/api/agent-channel/v1/contract');
+  const body = await res.json() as any;
+  assert.equal(res.status, 200);
+  assert.equal(body.protocol_version, 'deft.agent_channel.v2');
+  assert.ok(body.capabilities.includes('fencing_tokens'));
+  assert.ok(body.required_runtime_capabilities.includes('terminal_outcomes'));
+});
+
+test('GET /connect rejects a legacy runtime before recording it as connected', async () => {
+  const res = await app.request('/api/agent-channel/v1/connect?protocol_version=deft.agent_channel.v1&adapter_version=0.1.0&capabilities=terminal_outcomes', {
+    headers: { authorization: `Bearer ${bearer}` },
+  });
+  const body = await res.json() as any;
+  assert.equal(res.status, 426, JSON.stringify(body));
+  assert.equal(body.code, 'INCOMPATIBLE_CHANNEL');
+  assert.equal(body.protocol_version, 'deft.agent_channel.v2');
+  assert.ok(body.capabilities.includes('fencing_tokens'));
+});
+
 test('GET /events returns pending events once and marks them delivered', async () => {
   const first = await publishMessageEvent('agent-channel-events-once');
   await publishMessageEvent('agent-channel-events-once');
 
-  const res = await app.request('/api/agent-channel/v1/events?limit=10&worker_id=events-once&lease_ms=120000', {
+  const res = await app.request(`/api/agent-channel/v1/events?limit=10&worker_id=events-once&lease_ms=120000&${channelCompatibilityQuery()}`, {
     headers: { authorization: `Bearer ${bearer}` },
   });
   const body = await res.json() as any;
@@ -538,7 +568,7 @@ test('GET /events returns pending events once and marks them delivered', async (
 test('concurrent bridge polls grant one active claim per event', async () => {
   const event = await publishMessageEvent(`agent-channel-single-flight-${crypto.randomUUID()}`);
   const poll = (workerId: string) => app.request(
-    `/api/agent-channel/v1/events?limit=100&worker_id=${workerId}&lease_ms=120000`,
+    `/api/agent-channel/v1/events?limit=100&worker_id=${workerId}&lease_ms=120000&${channelCompatibilityQuery()}`,
     { headers: { authorization: `Bearer ${bearer}` } },
   ).then(async (response) => ({ response, body: await response.json() as any }));
 

--- a/apps/api/test/agent-runtime-recovery.test.ts
+++ b/apps/api/test/agent-runtime-recovery.test.ts
@@ -3,7 +3,15 @@ import test from 'node:test';
 import { describeAgentRuntimeRecovery } from '../src/lib/agent-runtime-recovery.js';
 
 const now = new Date('2026-07-13T12:00:00Z');
-const base = { hasChannelToken: true, connectionStatus: 'connected', lastSeenAt: now, failedDeliveries: 0, pendingDeliveries: 0, now };
+const base = {
+  hasChannelToken: true,
+  connectionStatus: 'connected',
+  lastSeenAt: now,
+  failedDeliveries: 0,
+  pendingDeliveries: 0,
+  certificationStatus: 'verified',
+  now,
+};
 
 test('runtime recovery prioritizes setup, failures, offline state, and backlog', () => {
   assert.equal(describeAgentRuntimeRecovery({ ...base, hasChannelToken: false }).action, 'regenerate_channel_token');
@@ -11,4 +19,8 @@ test('runtime recovery prioritizes setup, failures, offline state, and backlog',
   assert.equal(describeAgentRuntimeRecovery({ ...base, lastSeenAt: new Date(now.getTime() - 180_000) }).state, 'offline');
   assert.equal(describeAgentRuntimeRecovery({ ...base, pendingDeliveries: 6 }).state, 'backlogged');
   assert.equal(describeAgentRuntimeRecovery(base).state, 'healthy');
+});
+
+test('runtime recovery does not report an uncertified transport as healthy', () => {
+  assert.equal(describeAgentRuntimeRecovery({ ...base, certificationStatus: 'challenge_issued' }).state, 'certifying');
 });

--- a/apps/api/test/job-queue-reliability.test.ts
+++ b/apps/api/test/job-queue-reliability.test.ts
@@ -33,15 +33,19 @@ async function rowFor(name: string) {
 }
 
 async function makeReady(id: string): Promise<void> {
-  await db.update(jobQueue)
-    .set({ run_at: new Date(Date.now() - 1_000) })
-    .where(eq(jobQueue.id, id));
+  await db.execute(sql`
+    UPDATE job_queue
+    SET run_at = now() - interval '1 second'
+    WHERE id = ${id}
+  `);
 }
 
 async function expireLease(id: string): Promise<void> {
-  await db.update(jobQueue)
-    .set({ lock_expires_at: new Date(Date.now() - 1_000) })
-    .where(eq(jobQueue.id, id));
+  await db.execute(sql`
+    UPDATE job_queue
+    SET lock_expires_at = now() - interval '1 second'
+    WHERE id = ${id}
+  `);
 }
 
 test('concurrent dequeue claims a job once with a unique ownership token', async () => {

--- a/apps/web/src/app/(app)/settings/agent-employees/[id]/developer/page.tsx
+++ b/apps/web/src/app/(app)/settings/agent-employees/[id]/developer/page.tsx
@@ -48,6 +48,9 @@ type DeveloperPayload = {
     runtime_kind: string;
     tool_server_name: string | null;
     channel_protocol_version: string;
+    channel_capabilities: string[];
+    integration_version: string | null;
+    integration_bundle_url: string | null;
     mcp_endpoint_url: string;
     channel_endpoint_url: string;
     tool_name_style: 'bare' | 'server_prefixed';
@@ -424,7 +427,7 @@ export default function DeveloperPage() {
           onCopy={() => copy('slug', data.employee.slug)}
         />
         <Field
-          label="Connection"
+          label="Last runtime signal"
           value={connectionLabel}
         />
         <Field
@@ -506,7 +509,7 @@ export default function DeveloperPage() {
           )}
         />
         <Field
-          label="Channel status"
+          label="Channel transport"
           value={`${channelConnectionLabel} - pending ${data.channel.queue.pending} - failed ${data.channel.queue.failed}`}
         />
         <Field
@@ -598,6 +601,11 @@ export default function DeveloperPage() {
           <div className="mt-1 text-[11px] text-muted-foreground">
             Agent Channel: {data.runtime_setup.channel_protocol_version}
           </div>
+          {data.runtime_setup.integration_version && (
+            <div className="mt-1 text-[11px] text-muted-foreground">
+              Matched Hermes integration: {data.runtime_setup.integration_version}
+            </div>
+          )}
           <ol className="mt-3 list-decimal space-y-1 pl-4 text-xs">
             {data.runtime_setup.setup_steps.map((step) => (
               <li key={step}>{step}</li>
@@ -625,7 +633,7 @@ export default function DeveloperPage() {
           <div className="mt-3">
             <div className="mb-1 text-xs text-muted-foreground">Certification prompt</div>
             <p className="mb-1 text-[11px] text-muted-foreground">
-              Paste this prompt into the interactive runtime chat; it is intentionally kept separate from executable commands.
+              Deft sends this prompt through Agent Channel during certification. Paste it manually only when diagnosing the model loop.
             </p>
             <CodeBlock
               value={data.runtime_setup.certification_prompt}

--- a/apps/web/src/lib/agent-employee-status.test.ts
+++ b/apps/web/src/lib/agent-employee-status.test.ts
@@ -35,6 +35,18 @@ test('connected runtime without recent work is online', () => {
   assert.equal(status.label, 'Online');
 });
 
+test('transport contact cannot make an uncertified employee look ready', () => {
+  const status = agentEmployeeLifecycle({
+    ...base,
+    certification_status: 'challenge_issued',
+    channel_status: 'connected',
+    channel_last_seen_at: '2026-07-12T11:59:00Z',
+    last_mcp_call_at: '2026-07-12T11:59:00Z',
+  }, NOW);
+  assert.equal(status.label, 'Certifying');
+  assert.match(status.detail, /end-to-end/i);
+});
+
 test('missing required workspace skill blocks readiness', () => {
   const status = agentEmployeeLifecycle({
     ...base,

--- a/apps/web/src/lib/agent-employee-status.ts
+++ b/apps/web/src/lib/agent-employee-status.ts
@@ -70,6 +70,19 @@ export function agentEmployeeLifecycle(emp: AgentEmployeeHealth, now = Date.now(
     return { label: 'Setup incomplete', detail: 'Deft Workspace skill is missing', tone: 'amber' };
   }
 
+  if (emp.certification_status !== 'verified') {
+    if (emp.certification_status === 'challenge_issued') {
+      return { label: 'Certifying', detail: 'waiting for the end-to-end employee check', tone: 'amber' };
+    }
+    if (emp.certification_status === 'mcp_reachable') {
+      return { label: 'Setup incomplete', detail: 'MCP works, but the employee check has not passed', tone: 'amber' };
+    }
+    if (emp.certification_status === 'token_issued') {
+      return { label: 'Setup incomplete', detail: 'waiting for the first runtime call', tone: 'amber' };
+    }
+    return { label: 'Draft', detail: 'finish setup and certify the runtime', tone: 'gray' };
+  }
+
   const contact = latestAgentContact(emp);
   const contactAt = validTime(contact);
   const workAt = latestTime(emp.last_work_outcome_at, emp.last_turn_at);
@@ -77,16 +90,9 @@ export function agentEmployeeLifecycle(emp: AgentEmployeeHealth, now = Date.now(
   const workAge = workAt ? Math.max(0, now - workAt) : Number.POSITIVE_INFINITY;
 
   if (!contactAt) {
-    if (emp.certification_status === 'challenge_issued') {
-      return { label: 'Certifying', detail: 'waiting for the runtime challenge', tone: 'amber' };
-    }
-    if (emp.certification_status === 'verified' || emp.certification_status === 'mcp_reachable') {
+    if (emp.certification_status === 'verified') {
       return { label: 'Ready to connect', detail: 'certified, but no runtime contact yet', tone: 'purple' };
     }
-    if (emp.certification_status === 'token_issued') {
-      return { label: 'Setup incomplete', detail: 'waiting for the first runtime call', tone: 'amber' };
-    }
-    return { label: 'Draft', detail: 'finish setup and connect a runtime', tone: 'gray' };
   }
 
   if ((emp.pending_action_count ?? 0) > 0) {

--- a/docs/hermes-agent-channel-service.md
+++ b/docs/hermes-agent-channel-service.md
@@ -1,6 +1,6 @@
 # Hermes Agent Channel service
 
-The Windows service wrapper keeps a Hermes agent employee connected to Deft. It runs the Node bridge under Task Scheduler and is designed to survive temporary Deft, network, and Hermes outages.
+The Windows service wrapper keeps a Hermes agent employee connected to Deft. Install it from the immutable Hermes integration bundle linked on the employee's Developer page; the bundle is pinned to the running Deft release and Agent Channel contract.
 
 ## Install
 
@@ -18,12 +18,12 @@ The installer creates:
 - one supervised bridge process (`MultipleInstances=IgnoreNew`);
 - a rotating 10 MB log with one retained previous file.
 
-The bridge also emits a heartbeat once per minute after a successful poll.
+The bridge also writes `health.json` after successful protocol negotiation and each poll. A process that is merely alive but cannot consume work is not healthy.
 
 ## Operate
 
 ```powershell
-# Includes task state, process count, log freshness, and the last log line.
+# Includes semantic runtime state, versions, process state, and the last log line.
 .\scripts\hermes-channel-service.ps1 -Action Status
 
 # No-op when healthy; otherwise stops stale processes and starts a clean service.
@@ -33,11 +33,13 @@ The bridge also emits a heartbeat once per minute after a successful poll.
 .\scripts\hermes-channel-service.ps1 -Action Start
 ```
 
-`Healthy=True` requires a running scheduled task, exactly one bridge process, and a log heartbeat written within the last three minutes. The service log lives at `%LOCALAPPDATA%\Deft\hermes-channel\service.log`.
+`Healthy=True` requires a running scheduled task, exactly one bridge process, and a fresh `health.json` whose state is `healthy`. The status output includes adapter, protocol, and server-release information plus a bounded error code. The service log lives at `%LOCALAPPDATA%\Deft\hermes-channel\service.log`.
 
 ## Failure behavior
 
 - HTTP 429 and 5xx responses retry with bounded exponential backoff inside the bridge.
+- Protocol or capability mismatches fail closed before the first event poll with `INCOMPATIBLE_CHANNEL`.
+- Exit code 78 stops the tight supervisor restart loop; install the bundle for the running Deft release instead of enabling a legacy fallback.
 - A bridge process exit is restarted by the PowerShell supervisor after five seconds.
 - A supervisor exit is restarted by Task Scheduler.
 - A stopped task is started by the five-minute watchdog trigger or immediately with `-Action Repair`.

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -66,7 +66,7 @@ upgrade baseline. Release-tagged images are signed by the release workflow and
 carry GitHub build provenance. Verify the digest before deploying it:
 
 ```bash
-export TAG=v0.3.0-preview.3
+export TAG=v0.3.0-preview.6
 export VERSION="${TAG#v}"
 export IMAGE=ghcr.io/maneek21/deft
 export DIGEST="$(docker buildx imagetools inspect "$IMAGE:$VERSION" --format '{{json .Manifest.Digest}}' | tr -d '"')"

--- a/docs/superpowers/specs/2026-08-23-hermes-employee-onboarding-reliability.md
+++ b/docs/superpowers/specs/2026-08-23-hermes-employee-onboarding-reliability.md
@@ -1,0 +1,219 @@
+# Hermes Employee Onboarding Reliability
+
+**Date:** 2026-08-23
+**Status:** Accepted; implementation in verification
+**Decision owner:** Deft
+**Scope:** Hermes/OpenClaw-style BYOA employees connected through Deft MCP and Agent Channel
+
+## Outcome
+
+A newly onboarded Hermes employee must not be shown as ready until it has received a real Deft event, run a real Hermes model turn, used its employee-scoped Deft MCP identity, and reported the result back through Agent Channel. Incompatible Deft and Hermes integration versions must fail before polling work, with one actionable error instead of an endless retry loop.
+
+Deft should provide the workspace, identity, event delivery, approvals, audit, and memory synchronization. Hermes should continue to provide reasoning, research, browser/computer use, external tools, MCP clients, skills, and its open-source ecosystem. This design does not rebuild those runtime capabilities inside Deft.
+
+## Incident observed on demo.deft.ing
+
+Rita appeared connected in Deft, but did not reply to direct messages. The Developer surface showed one pending event, five failed events, and an older event with more than 526 deliveries. The local bridge and Windows scheduled task were both alive.
+
+The bridge repeatedly reported:
+
+```text
+Channel event <event-id> has no claim token
+```
+
+The live demo API identified itself as `deft.agent_channel.v1`, but its event representation did not contain `claim_token`, `claim_owner`, or `lease_expires_at`. The current bridge requires those fields before acknowledging or executing an event.
+
+The repository contains the lease/fencing schema upgrade as `0.3.0-preview.4-agent-channel-leases.sql` and the memory-sync upgrade as `0.3.0-preview.5-wiki-memory-sync.sql`, while the repository package version remains `0.3.0-preview.3`. Rita's locally copied bridge was therefore newer than the deployed Deft Agent Channel server.
+
+This was not a model-quality or contacts-module failure. Work never reached Hermes inference.
+
+## Root causes
+
+### 1. A breaking protocol change retained the same protocol version
+
+Agent Channel added mandatory claim tokens, renewable leases, and fencing semantics without changing `deft.agent_channel.v1` or advertising required capabilities. A bridge cannot determine safely whether a server supports its execution contract.
+
+### 2. Runtime artifacts are not coupled to the Deft release
+
+The onboarding page currently tells operators to run `pnpm agent:hermes-channel` and provides configuration snippets. That can execute a bridge from an arbitrary repository checkout against a differently versioned Deft server. The Hermes plugins also do not declare a compatible Deft release, Agent Channel version, or required capabilities.
+
+### 3. “Connected” proves transport liveness, not employee readiness
+
+Calling `/connect` or polling `/events` updates the connection record. The UI can therefore show connected even when every event is unusable. The Windows service health check verifies that a process exists and that its log is fresh; repeating errors satisfy both conditions.
+
+### 4. Certification proves MCP discovery, not the employee loop
+
+The current certification challenge checks a set of MCP tools and a nonce. It does not prove Agent Channel delivery, event claiming, a Hermes inference turn, an employee-scoped tool call, a reply, or a terminal event outcome.
+
+### 5. Release smoke tests omit the Agent Channel contract
+
+The self-host smoke test checks API health, auth, and MCP basics. It does not exercise the Deft event -> bridge -> Hermes -> Deft path. The application can pass deployment checks while agent employees are unable to work.
+
+## Architecture decision
+
+Adopt a release-pinned Hermes integration bundle, an explicit Agent Channel compatibility handshake, and deep employee certification. Treat transport connection, runtime health, and employee readiness as separate states.
+
+### Responsibility boundary
+
+| Deft owns | Hermes owns |
+| --- | --- |
+| Employee identity and org-scoped credentials | Planning and reasoning |
+| Native workspace MCP tools | Web research and computer use |
+| Agent Channel queue, leases, fencing, and idempotency | External MCP servers and plugins |
+| Trust, approvals, audit, and activity receipts | General-purpose skill ecosystem |
+| Wiki/memory synchronization contract | Runtime memory and skill execution |
+| Onboarding certification and visible readiness | Model/provider configuration |
+
+## Contract changes
+
+### Protocol version and capabilities
+
+The lease/fencing contract is a breaking change and must use `deft.agent_channel.v2`. `/connect` must return a capability document even after future additive changes:
+
+```json
+{
+  "protocol_version": "deft.agent_channel.v2",
+  "server_release": "0.3.0-preview.5",
+  "server_commit": "<sha>",
+  "schema_head": "0.3.0-preview.5",
+  "capabilities": [
+    "single_flight_claims",
+    "renewable_leases",
+    "fencing_tokens",
+    "terminal_outcomes",
+    "identity_bound_mcp",
+    "wiki_memory_sync_v1"
+  ]
+}
+```
+
+The bridge sends its adapter version, Hermes version, supported protocol majors, and required capabilities. If the intersection is empty or a required capability is absent, `/connect` returns an explicit incompatibility response, preferably HTTP 426 with a stable error code and the compatible integration version.
+
+The bridge must validate the handshake before its first event poll. It must not silently downgrade to legacy unclaimed processing.
+
+### Fail-fast runtime behavior
+
+A missing claim token under v2 is an invalid server response, not a retryable event failure. The bridge must:
+
+1. stop polling;
+2. publish a bounded `incompatible_channel` runtime status when possible;
+3. write a structured local health record;
+4. exit non-zero so its supervisor can apply bounded backoff; and
+5. never increment the same event's delivery count indefinitely.
+
+The local service health check must use structured state such as `last_success_at`, `last_error_code`, `protocol_version`, and `adapter_version`. Process existence and log freshness are diagnostics, not health.
+
+### Release-pinned integration bundle
+
+Each Deft release must publish or serve one immutable Hermes integration bundle containing:
+
+- the Agent Channel bridge;
+- the Deft employee and memory adapters;
+- a manifest with adapter version, compatible Deft release range, protocol majors, required capabilities, supported Hermes versions, and file checksums; and
+- an install/upgrade command pinned to the running Deft release.
+
+The onboarding UI must generate this pinned installation path. It must not depend on the operator having a matching Deft source checkout. Existing Hermes MCP servers and skills remain in Hermes; the bundle only implements the Deft boundary.
+
+## Employee readiness certification
+
+Readiness is earned through an end-to-end challenge:
+
+1. **Identity:** validate the employee bearer and discover the required Deft MCP tools.
+2. **Transport:** complete the v2 compatibility handshake.
+3. **Delivery:** Deft publishes a certification event carrying a one-time nonce; the bridge claims it once and renews the lease if required.
+4. **Inference:** Hermes runs a real model turn using the configured model and reasoning level.
+5. **Workspace use:** the model calls `platform_context` through the employee-scoped MCP identity and returns the nonce.
+6. **Report back:** Hermes posts a channel reply and terminal outcome. Deft verifies employee identity, nonce, claim token, single delivery, and terminal state.
+7. **Memory:** run a small wiki recall and memory-writeback probe without exposing secrets.
+
+Only a successful challenge sets `ready_at`. A simple poll updates transport state but cannot mark an employee ready.
+
+Suggested visible states:
+
+- `setup_required`
+- `transport_connected`
+- `certifying`
+- `ready`
+- `degraded`
+- `incompatible`
+- `offline`
+
+The UI must show the exact remediation for `incompatible`, including installed adapter version, server release, and the pinned upgrade command.
+
+## Release and deployment gates
+
+Before publishing a release:
+
+- bump the package/release version whenever the protocol or required schema advances;
+- require the release image, migration manifest, and Hermes bundle manifest to agree on protocol and minimum schema;
+- expose release, commit, and schema head in a safe version/readiness endpoint;
+- fail API readiness when required Agent Channel columns or migrations are absent; and
+- add an Agent Channel compatibility and certification smoke test to CI and `selfhost:smoke`.
+
+The normal combined Deft image already avoids independent web/API drift. Upgrades must continue to apply versioned database migrations before recreating the app, then run the deeper smoke test before declaring success.
+
+## Immediate recovery for demo
+
+Do not add a legacy claim-token bypass to the current bridge.
+
+1. Cut a named Deft release that includes the Agent Channel lease migration and wiki memory-sync migration, with a correctly bumped package version.
+2. Build and deploy the combined immutable image to the real demo host.
+3. Apply the supported database upgrade and verify the schema head.
+4. Install the Hermes integration bundle produced by that release for Rita.
+5. Run the deep certification challenge using `gpt-5.6-sol` at medium reasoning.
+6. Cancel obsolete malformed deliveries, retry only valid pending work, and rerun the employee gauntlet.
+
+If an emergency rollback is necessary, the only safe temporary pairing is the old server with its exact bundled old adapter. That pairing should not be certified as fully autonomous because it lacks the newer lease/fencing guarantees.
+
+## Work order
+
+### Minimum work for maximum experience
+
+1. Bump Agent Channel to v2 and add the bidirectional capability handshake.
+2. Make the bridge fail closed on incompatible or malformed channel responses.
+3. Separate transport, health, and readiness states in API and UI.
+4. Implement the real end-to-end onboarding certification challenge.
+5. Package and publish a release-pinned Hermes integration bundle.
+6. Add version/schema metadata and Agent Channel checks to release and self-host smoke gates.
+7. Deploy the matched release and bundle to demo, certify Rita, and rerun the gauntlet.
+
+### Should follow immediately
+
+1. Automatic adapter update availability and `needs_recertification` state for existing employees.
+2. Semantic local-service health and bounded backoff/circuit breaking.
+3. A one-click diagnostic export containing versions, capabilities, recent status codes, and redacted queue state.
+4. Scheduled synthetic certification for demo and production canaries.
+5. Memory-sync certification expanded to conflict, provenance, and permission cases.
+
+### Park for later
+
+- Reimplementing Hermes skills, universal MCP support, browsing, or computer use in Deft.
+- A broad plugin marketplace beyond the existing curated/runtime-owned model.
+- Hot-swapping protocol majors without restarting the bridge.
+- Cross-runtime orchestration that is unrelated to onboarding reliability.
+
+## Acceptance tests
+
+The change is complete only when all of these pass:
+
+- A fresh Deft install can onboard a clean Hermes runtime using only the pinned release instructions.
+- A v2 bridge against a v1 server is rejected before the first event poll and produces one actionable UI error.
+- A compatible employee completes the real inference certification with exactly one delivery and one terminal outcome.
+- Bridge restart, Hermes restart, expired lease, stale claimant, duplicate delivery, child-process failure, revoked MCP credential, and memory-sync outage each produce truthful state without duplicate external writes.
+- The UI never labels transport-only connectivity as employee readiness.
+- No credential or claim token appears in logs, diagnostics, or certification replies.
+- Rita completes three consecutive multi-step research/workspace scenarios, including a long-running task, and reports progress, blockers, and final artifacts correctly.
+
+## Rejected alternatives
+
+### Accept missing claim tokens in the new bridge
+
+Rejected. It would mask the deployment mismatch and remove the concurrency guarantees that prevent overlapping or stale execution.
+
+### Fix only the demo deployment
+
+Rejected as the full solution. A matched deploy restores Rita, but the current onboarding and health model allows the same mismatch to recur for the next customer.
+
+### Move general Hermes capabilities into Deft
+
+Rejected. It duplicates Hermes's ecosystem, expands Deft's security surface, and weakens the value of onboarding a capable external agent runtime.

--- a/integrations/hermes/deft-employee/plugin.yaml
+++ b/integrations/hermes/deft-employee/plugin.yaml
@@ -1,6 +1,6 @@
 name: deft-employee
 description: Deft assignment context, generic runtime policy, and sanitized outcome reporting.
-version: 0.1.0
+version: 0.2.0
 hooks:
   - pre_llm_call
   - pre_tool_call

--- a/integrations/hermes/deft-mcp-stdio.mjs
+++ b/integrations/hermes/deft-mcp-stdio.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+
+import { stdin, stdout } from 'node:process';
+
+const endpoint = process.env.DEFT_MCP_URL;
+const token = process.env.DEFT_MCP_TOKEN;
+
+if (!endpoint || !token) {
+  console.error('DEFT_MCP_URL and DEFT_MCP_TOKEN are required.');
+  process.exit(1);
+}
+
+let buffer = Buffer.alloc(0);
+let replyMode = 'content-length';
+
+stdin.on('data', (chunk) => {
+  buffer = Buffer.concat([buffer, chunk]);
+  drain();
+});
+
+function drain() {
+  while (buffer.length > 0) {
+    const text = buffer.toString('utf8');
+    const headerEnd = text.indexOf('\r\n\r\n');
+    if (headerEnd !== -1) {
+      const header = text.slice(0, headerEnd);
+      const match = header.match(/Content-Length:\s*(\d+)/i);
+      if (!match) {
+        buffer = buffer.subarray(headerEnd + 4);
+        continue;
+      }
+      const length = Number(match[1]);
+      const start = Buffer.byteLength(text.slice(0, headerEnd + 4));
+      if (buffer.length < start + length) return;
+      replyMode = 'content-length';
+      handleEnvelope(buffer.subarray(start, start + length).toString('utf8'));
+      buffer = buffer.subarray(start + length);
+      continue;
+    }
+
+    const newline = text.indexOf('\n');
+    if (newline === -1) return;
+    const line = text.slice(0, newline).trim();
+    buffer = buffer.subarray(Buffer.byteLength(text.slice(0, newline + 1)));
+    if (line) {
+      replyMode = 'line';
+      handleEnvelope(line);
+    }
+  }
+}
+
+async function handleEnvelope(raw) {
+  let envelope;
+  try {
+    envelope = JSON.parse(raw);
+  } catch {
+    return;
+  }
+
+  const isNotification = envelope.id === undefined || envelope.id === null;
+  try {
+    const res = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(envelope),
+    });
+    const text = await res.text();
+    if (isNotification) return;
+    if (!text.trim()) {
+      writeEnvelope({
+        jsonrpc: '2.0',
+        id: envelope.id,
+        error: { code: -32000, message: `Deft MCP returned HTTP ${res.status} with an empty body` },
+      });
+      return;
+    }
+    writeEnvelope(JSON.parse(text));
+  } catch (err) {
+    if (isNotification) return;
+    writeEnvelope({
+      jsonrpc: '2.0',
+      id: envelope.id,
+      error: { code: -32000, message: err instanceof Error ? err.message : String(err) },
+    });
+  }
+}
+
+function writeEnvelope(payload) {
+  const body = JSON.stringify(payload);
+  if (replyMode === 'line') {
+    stdout.write(`${body}\n`);
+    return;
+  }
+  stdout.write(`Content-Length: ${Buffer.byteLength(body, 'utf8')}\r\n\r\n${body}`);
+}

--- a/integrations/hermes/deft-memory/plugin.yaml
+++ b/integrations/hermes/deft-memory/plugin.yaml
@@ -1,4 +1,4 @@
 name: deft-memory
 description: Token-bound Deft wiki recall, turn reporting, and idempotent Hermes memory mirroring.
-version: 0.1.0
+version: 0.2.0
 kind: exclusive

--- a/integrations/hermes/integration-manifest.json
+++ b/integrations/hermes/integration-manifest.json
@@ -1,0 +1,25 @@
+{
+  "schema": "deft.hermes.integration.v1",
+  "integration_version": "0.2.0",
+  "deft_release": "0.3.0-preview.6",
+  "deft_release_compatibility": "=0.3.0-preview.6",
+  "agent_channel_protocols": ["deft.agent_channel.v2"],
+  "required_channel_capabilities": [
+    "single_flight_claims",
+    "renewable_leases",
+    "fencing_tokens",
+    "terminal_outcomes",
+    "identity_bound_mcp",
+    "wiki_memory_sync_v1"
+  ],
+  "hermes_compatibility": ">=0.1.0",
+  "contents": [
+    "scripts/hermes-agent-channel-bridge.mjs",
+    "scripts/hermes-channel-service.ps1",
+    "scripts/run-hermes-channel-service.ps1",
+    "scripts/deft-mcp-stdio.mjs",
+    "plugins/deft-employee",
+    "plugins/deft-memory",
+    "README.md"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deft",
-  "version": "0.3.0-preview.3",
+  "version": "0.3.0-preview.6",
   "private": true,
   "license": "AGPL-3.0-only",
   "repository": {
@@ -59,6 +59,7 @@
     "test:product-browser": "node scripts/product-browser-smoke.mjs",
     "test:product-browser:seed": "tsx scripts/seed-product-browser-smoke.ts",
     "agent:hermes-channel": "node scripts/hermes-agent-channel-bridge.mjs",
+    "agent:hermes-bundle": "node scripts/build-hermes-integration-bundle.mjs",
     "test:hermes-channel": "node --test scripts/hermes-agent-channel-bridge.test.mjs",
     "chat:certify": "tsx scripts/reports/chat-ui-certification.ts",
     "certify:60-person": "node scripts/certify-60-person.mjs",

--- a/packages/db/scripts/upgrade.test.ts
+++ b/packages/db/scripts/upgrade.test.ts
@@ -13,6 +13,7 @@ import {
 import { upgradeManifest } from '../upgrades/manifest.ts';
 import {
   agentChannelEvents,
+  agentChannelConnections,
   moduleInstallations,
   moduleMutationReceipts,
   moduleRecordRelations,
@@ -489,4 +490,20 @@ test('wiki memory sync schema converges across fresh installs and supported upgr
   assert.match(upgradeSql, /wiki_memory_sync_identity_unique/i);
   assert.match(upgradeSql, /content_digest/i);
   assert.match(upgradeSql, /page_version/i);
+});
+
+test('Agent Channel v2 is the fresh-install default and supported upgrade boundary', () => {
+  const migration = upgradeManifest.migrations.find(
+    (item) => item.version === '0.3.0-preview.6',
+  );
+  assert.ok(migration, 'Agent Channel v2 migration must remain in the supported upgrade path');
+
+  const scriptsDir = dirname(fileURLToPath(import.meta.url));
+  const upgradeSql = readFileSync(resolve(scriptsDir, '..', 'upgrades', migration.file), 'utf8');
+  assert.match(upgradeSql, /ALTER COLUMN "protocol_version" SET DEFAULT 'deft\.agent_channel\.v2'/i);
+  assert.match(upgradeSql, /SET "status" = 'disconnected'/i);
+
+  const table = getTableConfig(agentChannelConnections);
+  const protocolColumn = table.columns.find((column) => column.name === 'protocol_version');
+  assert.equal(protocolColumn?.default, 'deft.agent_channel.v2');
 });

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -2267,7 +2267,7 @@ export const agentChannelConnections = pgTable('agent_channel_connections', {
   agent_employee_id: text('agent_employee_id').notNull().references(() => agentEmployees.id, { onDelete: 'cascade' }),
   runtime_kind: text('runtime_kind').default('custom_mcp').notNull(),
   status: text('status').default('disconnected').notNull(),
-  protocol_version: text('protocol_version').default('deft.agent_channel.v1').notNull(),
+  protocol_version: text('protocol_version').default('deft.agent_channel.v2').notNull(),
   last_seen_at: timestamp('last_seen_at'),
   last_event_id: text('last_event_id'),
   last_error: text('last_error'),

--- a/packages/db/upgrades/0.3.0-preview.6-agent-channel-v2.sql
+++ b/packages/db/upgrades/0.3.0-preview.6-agent-channel-v2.sql
@@ -1,0 +1,8 @@
+ALTER TABLE "agent_channel_connections"
+  ALTER COLUMN "protocol_version" SET DEFAULT 'deft.agent_channel.v2';
+
+UPDATE "agent_channel_connections"
+SET "status" = 'disconnected',
+    "last_error" = 'Hermes integration must reconnect and certify with Agent Channel v2',
+    "updated_at" = now()
+WHERE "protocol_version" <> 'deft.agent_channel.v2';

--- a/packages/db/upgrades/manifest.ts
+++ b/packages/db/upgrades/manifest.ts
@@ -77,6 +77,11 @@ export const upgradeManifest = {
       file: '0.3.0-preview.5-wiki-memory-sync.sql',
       description: 'Add idempotent Hermes-to-wiki memory reconciliation receipts',
     },
+    {
+      version: '0.3.0-preview.6',
+      file: '0.3.0-preview.6-agent-channel-v2.sql',
+      description: 'Require the lease-safe Agent Channel v2 compatibility contract',
+    },
   ] satisfies UpgradeMigration[],
 } as const;
 

--- a/scripts/build-hermes-integration-bundle.mjs
+++ b/scripts/build-hermes-integration-bundle.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+
+import { createHash } from 'node:crypto';
+import { cp, mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises';
+import { dirname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+const outputRoot = join(repoRoot, 'dist', 'hermes-integration');
+const manifestPath = join(repoRoot, 'integrations', 'hermes', 'integration-manifest.json');
+const packagePath = join(repoRoot, 'package.json');
+const files = [
+  ['scripts/hermes-agent-channel-bridge.mjs', 'scripts/hermes-agent-channel-bridge.mjs'],
+  ['scripts/hermes-channel-service.ps1', 'scripts/hermes-channel-service.ps1'],
+  ['scripts/run-hermes-channel-service.ps1', 'scripts/run-hermes-channel-service.ps1'],
+  ['integrations/hermes/deft-mcp-stdio.mjs', 'scripts/deft-mcp-stdio.mjs'],
+  ['integrations/hermes/deft-employee', 'plugins/deft-employee'],
+  ['integrations/hermes/deft-memory', 'plugins/deft-memory'],
+];
+
+const manifest = JSON.parse(await readFile(manifestPath, 'utf8'));
+const packageJson = JSON.parse(await readFile(packagePath, 'utf8'));
+if (manifest.deft_release !== packageJson.version) {
+  throw new Error(`Hermes manifest targets ${manifest.deft_release}, but package.json is ${packageJson.version}`);
+}
+
+const relativeOutput = relative(repoRoot, outputRoot);
+if (!relativeOutput || relativeOutput.startsWith('..') || relativeOutput.includes(':')) {
+  throw new Error(`Refusing to replace unsafe bundle output path: ${outputRoot}`);
+}
+await rm(outputRoot, { recursive: true, force: true });
+await mkdir(outputRoot, { recursive: true });
+for (const [source, target] of files) {
+  const destination = join(outputRoot, target);
+  await mkdir(dirname(destination), { recursive: true });
+  await cp(join(repoRoot, source), destination, { recursive: true, force: true });
+}
+
+const readme = `# Deft Hermes integration ${manifest.integration_version}\n\n` +
+  `This immutable boundary bundle is for Deft ${manifest.deft_release} and Agent Channel ${manifest.agent_channel_protocols.join(', ')}.\n\n` +
+  'It contains only Deft MCP, delivery, identity, and memory-sync adapters. Hermes remains responsible for reasoning, external tools, MCP servers, skills, browser/computer use, and model configuration.\n\n' +
+  'Install the two bundled plugins in the active Hermes profile, configure the bundled stdio bridge, then run scripts/hermes-agent-channel-bridge.mjs beside the authenticated Hermes gateway. The bridge fails closed if the Deft server is incompatible.\n';
+await writeFile(join(outputRoot, 'README.md'), readme, 'utf8');
+
+const checksums = {};
+async function bundledFiles(directory) {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const paths = [];
+  for (const entry of entries.sort((left, right) => left.name.localeCompare(right.name))) {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) paths.push(...await bundledFiles(path));
+    else paths.push(path);
+  }
+  return paths;
+}
+for (const path of await bundledFiles(outputRoot)) {
+  const target = relative(outputRoot, path).replaceAll('\\', '/');
+  if (target === 'manifest.json') continue;
+  const bytes = await readFile(path);
+  checksums[target] = createHash('sha256').update(bytes).digest('hex');
+}
+await writeFile(
+  join(outputRoot, 'manifest.json'),
+  `${JSON.stringify({ ...manifest, checksums }, null, 2)}\n`,
+  'utf8',
+);
+
+console.log(`Built Deft Hermes integration ${manifest.integration_version} for ${manifest.deft_release} at ${outputRoot}`);

--- a/scripts/hermes-agent-channel-bridge.mjs
+++ b/scripts/hermes-agent-channel-bridge.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { randomUUID } from 'node:crypto';
+import { writeFile } from 'node:fs/promises';
 import { pathToFileURL } from 'node:url';
 
 const DEFAULT_POLL_MS = 3000;
@@ -8,6 +9,31 @@ const DEFAULT_MAX_RETRIES = 5;
 const DEFAULT_RETRY_BASE_MS = 1000;
 const DEFAULT_HEARTBEAT_MS = 60000;
 const DEFAULT_LEASE_MS = 120000;
+export const HERMES_DEFT_ADAPTER_VERSION = '0.2.0';
+export const AGENT_CHANNEL_PROTOCOL_VERSION = 'deft.agent_channel.v2';
+export const AGENT_CHANNEL_CAPABILITIES = [
+  'single_flight_claims',
+  'renewable_leases',
+  'fencing_tokens',
+  'terminal_outcomes',
+  'identity_bound_mcp',
+  'wiki_memory_sync_v1',
+];
+export const AGENT_CHANNEL_REQUIRED_SERVER_CAPABILITIES = [
+  'single_flight_claims',
+  'renewable_leases',
+  'fencing_tokens',
+  'terminal_outcomes',
+  'identity_bound_mcp',
+];
+
+export class AgentChannelCompatibilityError extends Error {
+  constructor(message) {
+    super(`INCOMPATIBLE_CHANNEL: ${message}`);
+    this.name = 'AgentChannelCompatibilityError';
+    this.code = 'INCOMPATIBLE_CHANNEL';
+  }
+}
 
 function requiredEnv(env, key) {
   const value = env[key]?.trim();
@@ -45,6 +71,8 @@ export function configFromEnv(env = process.env) {
       Math.max(5000, Math.floor(positiveInteger(env.DEFT_CHANNEL_LEASE_MS, DEFAULT_LEASE_MS) / 3)),
     ),
     workerId: env.DEFT_CHANNEL_WORKER_ID?.trim() || `hermes-bridge:${randomUUID()}`,
+    adapterVersion: env.DEFT_CHANNEL_ADAPTER_VERSION?.trim() || HERMES_DEFT_ADAPTER_VERSION,
+    healthFile: env.DEFT_CHANNEL_HEALTH_FILE?.trim() || null,
     once: ['1', 'true', 'yes'].includes((env.DEFT_CHANNEL_ONCE ?? '').toLowerCase()),
   };
 }
@@ -137,6 +165,7 @@ export class HermesAgentChannelBridge {
     this.now = options.now ?? (() => Date.now());
     this.setInterval = options.setIntervalImpl ?? globalThis.setInterval;
     this.clearInterval = options.clearIntervalImpl ?? globalThis.clearInterval;
+    this.healthWriter = options.healthWriter ?? (async (path, value) => writeFile(path, `${JSON.stringify(value, null, 2)}\n`, 'utf8'));
     this.lastHeartbeatAt = 0;
     this.stopped = false;
   }
@@ -177,7 +206,11 @@ export class HermesAgentChannelBridge {
       }
 
       const message = body?.error?.message || body?.error || body?.raw || `HTTP ${response.status}`;
-      throw new Error(typeof message === 'string' ? message : JSON.stringify(message));
+      const prefix = typeof body?.code === 'string' ? `${body.code}: ` : '';
+      const error = new Error(`${prefix}${typeof message === 'string' ? message : JSON.stringify(message)}`);
+      error.code = body?.code;
+      error.status = response.status;
+      throw error;
     }
   }
 
@@ -190,8 +223,51 @@ export class HermesAgentChannelBridge {
     return this.request(`${this.config.channelUrl}${path}`, { ...init, headers });
   }
 
+  compatibilityParams() {
+    return {
+      protocol_version: AGENT_CHANNEL_PROTOCOL_VERSION,
+      adapter_version: this.config.adapterVersion ?? HERMES_DEFT_ADAPTER_VERSION,
+      capabilities: AGENT_CHANNEL_CAPABILITIES.join(','),
+    };
+  }
+
+  validateConnection(connection) {
+    const actualProtocol = connection?.protocol_version ?? 'missing';
+    const serverCapabilities = Array.isArray(connection?.capabilities) ? connection.capabilities : [];
+    const missing = AGENT_CHANNEL_REQUIRED_SERVER_CAPABILITIES
+      .filter((capability) => !serverCapabilities.includes(capability));
+    if (actualProtocol !== AGENT_CHANNEL_PROTOCOL_VERSION || missing.length > 0) {
+      throw new AgentChannelCompatibilityError([
+        `server protocol ${actualProtocol}; adapter requires ${AGENT_CHANNEL_PROTOCOL_VERSION}`,
+        missing.length > 0 ? `missing server capabilities: ${missing.join(', ')}` : null,
+        connection?.server_release ? `server release ${connection.server_release}` : null,
+      ].filter(Boolean).join('; '));
+    }
+    return connection;
+  }
+
+  async writeHealth(state, details = {}) {
+    if (!this.config.healthFile) return;
+    const value = {
+      state,
+      checked_at: new Date(this.now()).toISOString(),
+      adapter_version: this.config.adapterVersion ?? HERMES_DEFT_ADAPTER_VERSION,
+      protocol_version: AGENT_CHANNEL_PROTOCOL_VERSION,
+      worker_id: this.config.workerId,
+      ...details,
+    };
+    await this.healthWriter(this.config.healthFile, value).catch((error) => {
+      this.log.warn?.(`[deft-channel] could not write health state: ${error instanceof Error ? error.message : String(error)}`);
+    });
+  }
+
   async connect() {
-    return this.channel(`/connect?caller_employee_slug=${encodeURIComponent(this.config.employeeSlug)}`);
+    const query = new URLSearchParams({
+      caller_employee_slug: this.config.employeeSlug,
+      ...this.compatibilityParams(),
+    });
+    const connection = await this.channel(`/connect?${query.toString()}`);
+    return this.validateConnection(connection);
   }
 
   async status(state, eventId = null, detail = null) {
@@ -293,7 +369,9 @@ export class HermesAgentChannelBridge {
   }
 
   async processEvent(event) {
-    if (!event.claim_token) throw new Error(`Channel event ${event.id} has no claim token`);
+    if (!event.claim_token) {
+      throw new AgentChannelCompatibilityError(`channel event ${event.id} has no claim token`);
+    }
     const sessionKey = conversationKey(event, this.config.employeeSlug);
     this.currentClaimToken = event.claim_token;
     await this.ack(event.id, 'received', { runtimeSessionKey: sessionKey, claimToken: event.claim_token });
@@ -340,8 +418,10 @@ export class HermesAgentChannelBridge {
       limit: '1',
       worker_id: this.config.workerId,
       lease_ms: String(this.config.leaseMs),
+      ...this.compatibilityParams(),
     });
     const body = await this.channel(`/events?${query.toString()}`);
+    this.validateConnection(body);
     for (const event of body.events ?? []) {
       await this.processEvent(event);
     }
@@ -360,13 +440,45 @@ export class HermesAgentChannelBridge {
   }
 
   async run() {
-    const connection = await this.connect();
+    await this.writeHealth('connecting');
+    let connection;
+    try {
+      connection = await this.connect();
+    } catch (error) {
+      if (error?.code === 'INCOMPATIBLE_CHANNEL') {
+        await this.status('error', null, error instanceof Error ? error.message : String(error)).catch(() => {});
+      }
+      await this.writeHealth(error?.code === 'INCOMPATIBLE_CHANNEL' ? 'incompatible' : 'degraded', {
+        last_error_code: error?.code ?? 'CONNECT_FAILED',
+        last_error: error instanceof Error ? error.message : String(error),
+      });
+      throw error;
+    }
     this.log.info?.(`[deft-channel] connected as ${connection.employee?.slug ?? this.config.employeeSlug}`);
+    await this.writeHealth('healthy', {
+      server_release: connection.server_release ?? null,
+      server_commit: connection.server_commit ?? null,
+      schema_head: connection.schema_head ?? null,
+      last_success_at: new Date(this.now()).toISOString(),
+    });
     do {
       try {
         const eventCount = await this.pollOnce();
         this.logHeartbeat(eventCount);
+        await this.writeHealth('healthy', {
+          server_release: connection.server_release ?? null,
+          server_commit: connection.server_commit ?? null,
+          schema_head: connection.schema_head ?? null,
+          last_success_at: new Date(this.now()).toISOString(),
+          last_event_count: eventCount,
+        });
       } catch (error) {
+        const incompatible = error?.code === 'INCOMPATIBLE_CHANNEL' || error instanceof AgentChannelCompatibilityError;
+        await this.writeHealth(incompatible ? 'incompatible' : 'degraded', {
+          last_error_code: error?.code ?? 'POLL_FAILED',
+          last_error: error instanceof Error ? error.message : String(error),
+        });
+        if (incompatible) throw error;
         if (this.config.once) throw error;
         const message = error instanceof Error ? error.message : String(error);
         this.log.warn?.(`[deft-channel] poll failed; staying alive: ${message}`);
@@ -387,6 +499,6 @@ export async function main() {
 if (process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url) {
   main().catch((error) => {
     console.error(`[deft-channel] ${error instanceof Error ? error.message : String(error)}`);
-    process.exitCode = 1;
+    process.exitCode = error?.code === 'INCOMPATIBLE_CHANNEL' ? 78 : 1;
   });
 }

--- a/scripts/hermes-agent-channel-bridge.test.mjs
+++ b/scripts/hermes-agent-channel-bridge.test.mjs
@@ -46,6 +46,21 @@ function config() {
   };
 }
 
+const compatibleConnection = {
+  ok: true,
+  protocol_version: 'deft.agent_channel.v2',
+  server_release: '0.3.0-preview.6',
+  capabilities: [
+    'single_flight_claims',
+    'renewable_leases',
+    'fencing_tokens',
+    'terminal_outcomes',
+    'identity_bound_mcp',
+    'wiki_memory_sync_v1',
+  ],
+  employee: { slug: 'maya' },
+};
+
 test('buildEventPrompt preserves the event and pins the employee identity', () => {
   const prompt = buildEventPrompt(event, 'maya');
   assert.match(prompt, /bearer token binds your employee identity/);
@@ -167,7 +182,7 @@ test('request retries a transient channel rate limit instead of killing the brid
         headers: { 'content-type': 'application/json', 'retry-after': '0' },
       });
     }
-    return jsonResponse({ ok: true, employee: { slug: 'maya' } });
+    return jsonResponse(compatibleConnection);
   };
   const bridge = new HermesAgentChannelBridge(config(), {
     fetchImpl,
@@ -181,12 +196,48 @@ test('request retries a transient channel rate limit instead of killing the brid
   assert.deepEqual(sleeps, [5]);
 });
 
+test('connect rejects a legacy Agent Channel before polling any work', async () => {
+  const urls = [];
+  const bridge = new HermesAgentChannelBridge(config(), {
+    fetchImpl: async (url) => {
+      urls.push(url);
+      return jsonResponse({
+        ok: true,
+        protocol_version: 'deft.agent_channel.v1',
+        employee: { slug: 'maya' },
+      });
+    },
+    logger: { info() {}, warn() {}, error() {} },
+  });
+
+  await assert.rejects(
+    () => bridge.run(),
+    /INCOMPATIBLE_CHANNEL.*deft\.agent_channel\.v1.*deft\.agent_channel\.v2/,
+  );
+  assert.equal(urls.filter((url) => url.includes('/events')).length, 0, 'an incompatible bridge must stop before GET /events');
+  assert.match(urls[0], /protocol_version=deft\.agent_channel\.v2/);
+  assert.match(urls[0], /adapter_version=/);
+  assert.match(urls[0], /capabilities=/);
+});
+
+test('connect rejects a v2 server that omits a required capability', async () => {
+  const bridge = new HermesAgentChannelBridge(config(), {
+    fetchImpl: async () => jsonResponse({
+      ...compatibleConnection,
+      capabilities: compatibleConnection.capabilities.filter((name) => name !== 'fencing_tokens'),
+    }),
+    logger: { info() {}, warn() {}, error() {} },
+  });
+
+  await assert.rejects(() => bridge.connect(), /INCOMPATIBLE_CHANNEL.*fencing_tokens/);
+});
+
 test('pollOnce claims only one event so queued leases cannot expire behind active work', async () => {
   const urls = [];
   const bridge = new HermesAgentChannelBridge(config(), {
     fetchImpl: async (url) => {
       urls.push(url);
-      return jsonResponse({ ok: true, events: [] });
+      return jsonResponse({ ...compatibleConnection, events: [] });
     },
     logger: { info() {}, warn() {}, error() {} },
   });

--- a/scripts/hermes-channel-service.ps1
+++ b/scripts/hermes-channel-service.ps1
@@ -112,14 +112,23 @@ switch ($Action) {
     $info = if ($task) { Get-ScheduledTaskInfo -TaskName $TaskName } else { $null }
     $processes = @(Get-ServiceProcess)
     $logPath = Join-Path $ServiceRoot 'service.log'
+    $healthPath = Join-Path $ServiceRoot 'health.json'
     $logItem = Get-Item -LiteralPath $logPath -ErrorAction SilentlyContinue
+    $healthItem = Get-Item -LiteralPath $healthPath -ErrorAction SilentlyContinue
+    $health = if ($healthItem) {
+      try { Get-Content -LiteralPath $healthPath -Raw | ConvertFrom-Json } catch { $null }
+    } else { $null }
     $taskState = if ($task) { [string]$task.State } else { 'NotInstalled' }
     $logAgeSeconds = if ($logItem) {
       [Math]::Round(((Get-Date) - $logItem.LastWriteTime).TotalSeconds)
     } else { $null }
+    $healthAgeSeconds = if ($health -and $health.checked_at) {
+      [Math]::Round(((Get-Date) - [datetime]$health.checked_at).TotalSeconds)
+    } else { $null }
+    $semanticallyHealthy = $health -and $health.state -eq 'healthy' -and $healthAgeSeconds -le 180
     [pscustomobject]@{
       Installed = [bool]$task
-      Healthy = [bool]($task -and $taskState -eq 'Running' -and $processes.Count -eq 1 -and $logItem -and $logAgeSeconds -le 180)
+      Healthy = [bool]($task -and $taskState -eq 'Running' -and $processes.Count -eq 1 -and $semanticallyHealthy)
       TaskState = $taskState
       ProcessCount = $processes.Count
       LastRunTime = $info.LastRunTime
@@ -127,6 +136,13 @@ switch ($Action) {
       ConfigPresent = Test-Path -LiteralPath $configTarget
       LastLogWriteTime = $logItem.LastWriteTime
       LogAgeSeconds = $logAgeSeconds
+      RuntimeState = if ($health) { $health.state } else { 'unknown' }
+      ProtocolVersion = if ($health) { $health.protocol_version } else { $null }
+      AdapterVersion = if ($health) { $health.adapter_version } else { $null }
+      ServerRelease = if ($health) { $health.server_release } else { $null }
+      LastErrorCode = if ($health) { $health.last_error_code } else { $null }
+      LastError = if ($health) { $health.last_error } else { $null }
+      HealthAgeSeconds = $healthAgeSeconds
       LastLogLine = if ($logItem) { Get-Content -LiteralPath $logPath -Tail 1 } else { $null }
     }
   }
@@ -134,9 +150,12 @@ switch ($Action) {
     $task = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
     if (-not $task) { throw "'$TaskName' is not installed. Run Install first." }
     Assert-Config $configTarget
-    $logItem = Get-Item -LiteralPath (Join-Path $ServiceRoot 'service.log') -ErrorAction SilentlyContinue
-    $logIsFresh = $logItem -and ((Get-Date) - $logItem.LastWriteTime).TotalSeconds -le 180
-    if ([string]$task.State -ne 'Running' -or @(Get-ServiceProcess).Count -ne 1 -or -not $logIsFresh) {
+    $healthPath = Join-Path $ServiceRoot 'health.json'
+    $health = if (Test-Path -LiteralPath $healthPath) {
+      try { Get-Content -LiteralPath $healthPath -Raw | ConvertFrom-Json } catch { $null }
+    } else { $null }
+    $healthIsFresh = $health -and $health.state -eq 'healthy' -and ((Get-Date) - [datetime]$health.checked_at).TotalSeconds -le 180
+    if ([string]$task.State -ne 'Running' -or @(Get-ServiceProcess).Count -ne 1 -or -not $healthIsFresh) {
       Stop-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
       Get-ServiceProcess | ForEach-Object { Stop-Process -Id $_.ProcessId -Force }
       Start-ScheduledTask -TaskName $TaskName

--- a/scripts/release-workflow.test.mjs
+++ b/scripts/release-workflow.test.mjs
@@ -39,3 +39,11 @@ test('release manifest records signature and provenance metadata', () => {
   assert.match(workflow, /"signature_identity": "\$\{\{ steps\.verification\.outputs\.signature_identity \}\}"/);
   assert.match(workflow, /"provenance": "github-build-attestation"/);
 });
+
+test('release couples the image, package version, and Hermes integration bundle', () => {
+  assert.match(workflow, /package\.json version \$package_version does not match release \$version/);
+  assert.match(workflow, /DEFT_RELEASE_VERSION=\$\{\{ steps\.release\.outputs\.version \}\}/);
+  assert.match(workflow, /node scripts\/build-hermes-integration-bundle\.mjs/);
+  assert.match(workflow, /deft-hermes-integration-\$\{\{ steps\.release\.outputs\.version \}\}\.tar\.gz/);
+  assert.match(workflow, /"agent_channel_protocol": "deft\.agent_channel\.v2"/);
+});

--- a/scripts/run-hermes-channel-service.ps1
+++ b/scripts/run-hermes-channel-service.ps1
@@ -10,6 +10,7 @@ $ErrorActionPreference = 'Stop'
 $configPath = Join-Path $ServiceRoot 'service.env'
 $bridgePath = Join-Path $ServiceRoot 'hermes-agent-channel-bridge.mjs'
 $logPath = Join-Path $ServiceRoot 'service.log'
+$healthPath = Join-Path $ServiceRoot 'health.json'
 $mutex = [Threading.Mutex]::new($false, $MutexName)
 
 function Rotate-ServiceLog {
@@ -40,6 +41,7 @@ try {
     }
     [Environment]::SetEnvironmentVariable($parts[0], $parts[1], 'Process')
   }
+  [Environment]::SetEnvironmentVariable('DEFT_CHANNEL_HEALTH_FILE', $healthPath, 'Process')
 
   $node = (Get-Command node.exe -ErrorAction Stop).Source
   while ($true) {
@@ -59,6 +61,10 @@ try {
       $ErrorActionPreference = $previousErrorActionPreference
     }
 
+    if ($bridgeExitCode -eq 78) {
+      Write-ServiceLog 'bridge stopped because the Deft server and Hermes adapter are incompatible; install the bundle for the running Deft release'
+      exit 78
+    }
     Write-ServiceLog "bridge exited with code $bridgeExitCode; restarting in $RestartDelaySeconds seconds"
     Start-Sleep -Seconds $RestartDelaySeconds
   }

--- a/scripts/selfhost-smoke.ts
+++ b/scripts/selfhost-smoke.ts
@@ -43,11 +43,50 @@ async function fetchJson<T = any>(url: string, init?: RequestInit): Promise<{ st
 }
 
 async function checkHealth(): Promise<Check> {
-  const res = await fetchText(`${API_URL}/health`);
+  const res = await fetchJson(`${API_URL}/health`);
+  const body = res.json as any;
+  const ok = res.status === 200
+    && body?.status === 'ok'
+    && body?.agent_channel_protocol === 'deft.agent_channel.v2'
+    && typeof body?.release === 'string';
   return {
     name: 'API health',
-    ok: res.status === 200,
-    detail: res.status === 200 ? `${API_URL}/health returned 200` : `${API_URL}/health returned ${res.status}: ${res.text.slice(0, 160)}`,
+    ok,
+    detail: ok
+      ? `${API_URL}/health release=${body.release}; channel=${body.agent_channel_protocol}`
+      : `${API_URL}/health returned ${res.status}: ${res.text.slice(0, 160)}`,
+  };
+}
+
+async function checkReadiness(): Promise<Check> {
+  const res = await fetchJson(`${API_URL}/health/ready`);
+  const body = res.json as any;
+  const ok = res.status === 200
+    && body?.status === 'ready'
+    && body?.checks?.agent_channel_v2_schema === true
+    && body?.checks?.wiki_memory_sync === true;
+  return {
+    name: 'Release/schema readiness',
+    ok,
+    detail: ok
+      ? `schema=${body.schema_head}; Agent Channel v2 and wiki memory sync are ready`
+      : `readiness returned ${res.status}: ${res.text.slice(0, 200)}`,
+  };
+}
+
+async function checkAgentChannelContract(): Promise<Check> {
+  const res = await fetchJson(`${API_URL}/api/agent-channel/v1/contract`);
+  const body = res.json as any;
+  const required = ['single_flight_claims', 'renewable_leases', 'fencing_tokens', 'terminal_outcomes', 'identity_bound_mcp'];
+  const ok = res.status === 200
+    && body?.protocol_version === 'deft.agent_channel.v2'
+    && required.every((capability) => body?.capabilities?.includes(capability));
+  return {
+    name: 'Agent Channel compatibility contract',
+    ok,
+    detail: ok
+      ? `protocol=${body.protocol_version}; release=${body.server_release}`
+      : `contract returned ${res.status}: ${res.text.slice(0, 200)}`,
   };
 }
 
@@ -175,6 +214,8 @@ async function main() {
 
   const checks = [
     await checkHealth(),
+    await checkReadiness(),
+    await checkAgentChannelContract(),
     await checkProtectedResource(),
     await checkAuthorizationServer(),
     await checkDynamicClientRegistration(),


### PR DESCRIPTION
## Outcome

Makes a fresh Hermes employee fail fast on incompatible Deft releases and remain unready until a real Agent Channel assignment, model turn, employee-scoped MCP calls, reply, terminal outcome, and memory probe complete.

## Includes

- Agent Channel v2 capability handshake, leases/fencing contract, semantic bridge health, and fail-closed incompatibility behavior
- release-pinned Hermes integration bundle with checksums
- deep onboarding certification and truthful UI/runtime state
- release/schema readiness and self-host smoke gates
- production encryption-key validation fix
- timezone-independent PostgreSQL queue scheduling

## Verification

- API tail batch: 233/233
- focused queue/security/recovery: 30/30
- Agent Channel API: 19/19
- certification stability: 4/4
- bridge: 11/11
- release workflow: 4/4
- DB upgrade convergence: 12/12
- self-host upgrade plan: 3/3
- API typecheck + build
- web typecheck + lint + production build
- fresh db:push-full, platform seed, demo seed, readiness/self-host smoke
- staged secret and scope audit clean