### PR TITLE
fix: harden Hermes fresh-install reliability

### DIFF
--- a/docs/superpowers/audits/rita-hermes-fresh-install-fixes-2026-08-23.svg
+++ b/docs/superpowers/audits/rita-hermes-fresh-install-fixes-2026-08-23.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="720" viewBox="0 0 1280 720" role="img" aria-labelledby="title desc">
+  <title id="title">Rita Hermes fixes from the fresh-install gauntlet</title>
+  <desc id="desc">Four observed faults, their root causes, implemented fixes, and verification.</desc>
+  <rect width="1280" height="720" fill="#07131c"/>
+  <text x="64" y="72" fill="#f8fafc" font-family="Segoe UI, Arial, sans-serif" font-size="34" font-weight="700">Fault → root cause → fix → evidence</text>
+  <text x="64" y="108" fill="#94a3b8" font-family="Segoe UI, Arial, sans-serif" font-size="18">Changes kept at the integration seams; no schema migration required</text>
+
+  <g font-family="Segoe UI, Arial, sans-serif">
+    <g transform="translate(64 148)">
+      <rect width="1152" height="106" rx="15" fill="#102333" stroke="#27506e"/>
+      <text x="24" y="31" fill="#fca5a5" font-size="14" font-weight="700">STALE CREDENTIALS AFTER REINSTALL</text>
+      <text x="24" y="61" fill="#e2e8f0" font-size="17">Orphan PowerShell supervisor retained the old environment and reacquired the mutex.</text>
+      <text x="24" y="88" fill="#86efac" font-size="15">Fix: stop the verified bridge child and powershell/pwsh supervisor before replacing files.</text>
+    </g>
+
+    <g transform="translate(64 274)">
+      <rect width="1152" height="106" rx="15" fill="#102333" stroke="#27506e"/>
+      <text x="24" y="31" fill="#fca5a5" font-size="14" font-weight="700">DEFT MEMORY WRITE FALSELY BLOCKED</text>
+      <text x="24" y="61" fill="#e2e8f0" font-size="17">Hermes exposes Deft tools as mcp_deft_*, while the policy hook recognized other prefixes.</text>
+      <text x="24" y="88" fill="#86efac" font-size="15">Fix: recognize the real trusted namespace; external writes remain blocked by policy.</text>
+    </g>
+
+    <g transform="translate(64 400)">
+      <rect width="1152" height="106" rx="15" fill="#102333" stroke="#27506e"/>
+      <text x="24" y="31" fill="#fca5a5" font-size="14" font-weight="700">SUCCESSFUL WORK REPORTED AS VALIDATION FAILURE</text>
+      <text x="24" y="61" fill="#e2e8f0" font-size="17">Idle status serialized event_id as null although the API accepts an omitted optional string.</text>
+      <text x="24" y="88" fill="#86efac" font-size="15">Fix: omit event_id when idle; bridge contract test verifies the request shape.</text>
+    </g>
+
+    <g transform="translate(64 526)">
+      <rect width="1152" height="106" rx="15" fill="#102333" stroke="#27506e"/>
+      <text x="24" y="31" fill="#fca5a5" font-size="14" font-weight="700">DUPLICATE LONG AGENT RUN AFTER TRANSPORT DROP</text>
+      <text x="24" y="61" fill="#e2e8f0" font-size="17">A generic HTTP retry replayed the non-idempotent Hermes inference POST after ambiguous acceptance.</text>
+      <text x="24" y="88" fill="#86efac" font-size="15">Fix: no blind inference replay; fail closed and resume through the durable channel event.</text>
+    </g>
+
+    <text x="64" y="680" fill="#a7f3d0" font-size="16" font-weight="700">Verified: 12 bridge tests · 5 plugin tests · PowerShell parse · live fresh-install completion</text>
+  </g>
+</svg>

--- a/docs/superpowers/audits/rita-hermes-fresh-install-gauntlet-overview-2026-08-23.svg
+++ b/docs/superpowers/audits/rita-hermes-fresh-install-gauntlet-overview-2026-08-23.svg
@@ -1,0 +1,56 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="720" viewBox="0 0 1280 720" role="img" aria-labelledby="title desc">
+  <title id="title">Rita Hermes fresh-install gauntlet overview</title>
+  <desc id="desc">A visual summary of the fresh installation, certification, three completed scenarios, and current readiness.</desc>
+  <rect width="1280" height="720" fill="#0b1220"/>
+  <text x="64" y="72" fill="#f8fafc" font-family="Segoe UI, Arial, sans-serif" font-size="34" font-weight="700">Rita / Hermes fresh-install gauntlet</text>
+  <text x="64" y="108" fill="#94a3b8" font-family="Segoe UI, Arial, sans-serif" font-size="18">demo.deft.ing · 23 Aug 2026 · gpt-5.6-sol · medium reasoning</text>
+
+  <g font-family="Segoe UI, Arial, sans-serif">
+    <rect x="64" y="150" width="250" height="118" rx="16" fill="#142238" stroke="#2b466e"/>
+    <text x="88" y="188" fill="#93c5fd" font-size="15" font-weight="700">FRESH DEPLOY</text>
+    <text x="88" y="222" fill="#f8fafc" font-size="24" font-weight="700">Release .6</text>
+    <text x="88" y="248" fill="#cbd5e1" font-size="15">Clean DB + pilot seed</text>
+
+    <rect x="346" y="150" width="250" height="118" rx="16" fill="#142238" stroke="#2b466e"/>
+    <text x="370" y="188" fill="#86efac" font-size="15" font-weight="700">ONBOARDING</text>
+    <text x="370" y="222" fill="#f8fafc" font-size="24" font-weight="700">Certified</text>
+    <text x="370" y="248" fill="#cbd5e1" font-size="15">Runtime + channel + memory</text>
+
+    <rect x="628" y="150" width="250" height="118" rx="16" fill="#142238" stroke="#2b466e"/>
+    <text x="652" y="188" fill="#facc15" font-size="15" font-weight="700">MODULE SETUP</text>
+    <text x="652" y="222" fill="#f8fafc" font-size="24" font-weight="700">Contacts opt-in</text>
+    <text x="652" y="248" fill="#cbd5e1" font-size="15">Install + scoped write grant</text>
+
+    <rect x="910" y="150" width="306" height="118" rx="16" fill="#142238" stroke="#2b466e"/>
+    <text x="934" y="188" fill="#c4b5fd" font-size="15" font-weight="700">RUNTIME EVIDENCE</text>
+    <text x="934" y="222" fill="#f8fafc" font-size="24" font-weight="700">Single final effect</text>
+    <text x="934" y="248" fill="#cbd5e1" font-size="15">3 companies, task in review</text>
+
+    <text x="64" y="330" fill="#f8fafc" font-size="22" font-weight="700">Completed diagnostic scenarios</text>
+
+    <rect x="64" y="356" width="360" height="176" rx="16" fill="#101c2f" stroke="#1e3a5f"/>
+    <text x="88" y="392" fill="#60a5fa" font-size="15" font-weight="700">COMPLEX CHAT</text>
+    <text x="88" y="428" fill="#f8fafc" font-size="26" font-weight="700">16 / 18</text>
+    <text x="88" y="458" fill="#cbd5e1" font-size="16">Separated facts and proposals</text>
+    <text x="88" y="484" fill="#cbd5e1" font-size="16">Preserved Diego, Lina, Sage rights</text>
+    <text x="88" y="510" fill="#fbbf24" font-size="14">Gap: new evidence task had no owner</text>
+
+    <rect x="460" y="356" width="360" height="176" rx="16" fill="#101c2f" stroke="#1e3a5f"/>
+    <text x="484" y="392" fill="#34d399" font-size="15" font-weight="700">EXPLICIT KNOWLEDGE</text>
+    <text x="484" y="428" fill="#f8fafc" font-size="26" font-weight="700">17 / 18</text>
+    <text x="484" y="458" fill="#cbd5e1" font-size="16">Reconciled wiki and live work</text>
+    <text x="484" y="484" fill="#cbd5e1" font-size="16">Created one missing quality gate</text>
+    <text x="484" y="510" fill="#fbbf24" font-size="14">Minor: recovered invalid status jump</text>
+
+    <rect x="856" y="356" width="360" height="176" rx="16" fill="#101c2f" stroke="#1e3a5f"/>
+    <text x="880" y="392" fill="#a78bfa" font-size="15" font-weight="700">IMPLICIT KNOWLEDGE + RESEARCH</text>
+    <text x="880" y="428" fill="#f8fafc" font-size="26" font-weight="700">14 / 18</text>
+    <text x="880" y="458" fill="#cbd5e1" font-size="16">Applied ICP without wiki hint</text>
+    <text x="880" y="484" fill="#cbd5e1" font-size="16">3 sourced, deduplicated companies</text>
+    <text x="880" y="510" fill="#fbbf24" font-size="14">Partial: no people or activities created</text>
+
+    <rect x="64" y="574" width="1152" height="92" rx="16" fill="#291d14" stroke="#92400e"/>
+    <text x="88" y="610" fill="#fbbf24" font-size="16" font-weight="700">CURRENT DECISION</text>
+    <text x="88" y="642" fill="#f8fafc" font-size="22" font-weight="700">Strong supervised-pilot evidence; full bounded-autonomy certification is still incomplete.</text>
+  </g>
+</svg>

--- a/docs/superpowers/audits/rita-hermes-fresh-install-gauntlet-report-2026-08-23.md
+++ b/docs/superpowers/audits/rita-hermes-fresh-install-gauntlet-report-2026-08-23.md
@@ -1,0 +1,168 @@
+# Rita / Hermes fresh-install gauntlet report — 2026-08-23
+
+## Decision
+
+The freshly onboarded Rita demonstrates a strong **supervised agent-employee** loop: she can enter a multi-person conversation, distinguish facts from proposals and human decision rights, ground work in company Knowledge without always being told where to look, conduct public research with Hermes-native capabilities, make governed Deft writes, and report a truthful result with durable evidence.
+
+This run is **not a completed bounded-autonomy certification**. Three diagnostic scenarios were completed. The research-to-Contacts path needed product setup and exposed reliability defects; the approved-send, memory-correction, privacy, adversarial, and reliability-rerun gates remain outstanding.
+
+![Fresh-install gauntlet overview](./rita-hermes-fresh-install-gauntlet-overview-2026-08-23.svg)
+
+## Environment and fresh-install proof
+
+- Deft: `https://demo.deft.ing`
+- Release: `v0.3.0-preview.6`, commit `e3bb3037c54e5ccd4c49e505b7e502515b8af02c`
+- Exact image: `ghcr.io/maneek21/deft@sha256:b76b2b80e669bbc2cda3ca0f81b920bf47089ceba6986c3b809eb04807be6e6c`
+- Fresh schema path: `pnpm db:push-full`, followed by `pnpm db:seed:pilot`
+- Rita employee: `cb6013e1-df80-49c0-b6db-cdbf532074f5`
+- Runtime: Hermes with `gpt-5.6-sol`, medium reasoning, `openai-codex`
+- Certification: passed runtime inference, Deft MCP reachability, required tools, memory write/read, channel delivery/reply, and employee verification
+- Public site readback: HTTP 200; Deft and Caddy containers running; PostgreSQL healthy
+
+The old demo database was backed up before replacement. SSH access was recovered from the existing local key and prior logs; no password or token had to be resent.
+
+## Scenario results
+
+Scores use the six 0–3 dimensions in the gauntlet plan: understanding, context, execution, integrity/idempotency, judgment, and reporting.
+
+| Scenario | Score | Result | Durable evidence | Weakest point |
+| --- | ---: | --- | --- | --- |
+| Complex multi-person operations conversation | 16/18 | Passed | Rita reply `714a4a0b-a762-4558-ad95-8e3a2890665c`; only missing work created as task `710ac278-c2a6-41c3-aa04-340ab16aab2d` | The new evidence task was unassigned instead of carrying a concrete owner/dependency |
+| Explicit Release Checklist task | 17/18 | Passed | Task `f2de615e-5195-4c57-afc7-ecea2c00a861` moved to review; plan comment `378366f3-84de-4c56-8656-af201dd9261e`; handoff `cfe39393-90a0-4aa5-ac2c-c736eb79f5e4`; one missing gate `7138c1b6-aad6-40c5-95a4-0d0a71640ca6` with three Sage-owned subtasks | One invalid direct status transition was attempted, then corrected through the valid sequence |
+| Implicit company context, public research, and Contacts | 14/18 | Partial pass | Task `d2453cb1-67f6-4693-a724-711a62901b69` moved to review; three deduplicated company records created and read back | Contacts required admin setup; two interrupted runs preceded the clean completion; no person or qualification-activity records were created |
+
+### Conversation understanding
+
+In the shared operations space, Rita correctly separated:
+
+- the confirmed 08:45 carrier availability;
+- the proposed slot hold;
+- the still-unconfirmed 09:20 route decision;
+- Lina's permitted acknowledgement from an unapproved buyer promise; and
+- Sage's unreleased quality lots from releasable inventory.
+
+She reused the existing route work, preserved Diego's operations decision, Lina's buyer-communication right, and Sage's release right, and did not claim a release or make an external promise.
+
+### Knowledge-grounded release work
+
+When explicitly pointed to the Release Checklist, Rita reconciled the page against live operations and quality work before creating anything. She preserved review ownership, created only the missing evidence-verification gate, and moved the assignment to `in_review`, not done.
+
+### Implicit knowledge and research-to-Contacts
+
+The assignment did not mention the ICP page, Knowledge, Contacts, or a browser. Rita independently retrieved company context, delegated public research, applied current sources, checked duplicates, and ultimately created exactly three company prospects:
+
+| Company | Record ID | Verified evidence retained |
+| --- | --- | --- |
+| Oliver’s Market | `70e66f9b-9ed3-4ac1-9bdc-a0577feb788b` | Official local-partner and store pages; qualification questions; no invented buyer identity |
+| Rainbow Grocery Cooperative | `0ba60baa-5450-4d9e-bd50-ac40592b0628` | Official cooperative, produce, and contact pages; organic/vendor caveat |
+| SingleThread Farm, Restaurant & Inn | `b7b289b9-3ad8-42d2-be3d-042f7cea5b5b` | Official farm and restaurant pages plus Michelin; own-farm disqualifier explicitly retained |
+
+Each record contains an official website/domain, rationale, source URLs, follow-up questions, and the instruction not to invent a person or email. Rita read-verified the records and reported their IDs. It did not create a person-level contact or a qualification activity, so this is not a full pass for the richer Contacts workflow.
+
+## Faults reproduced and fixes implemented
+
+![Fresh-install fixes](./rita-hermes-fresh-install-fixes-2026-08-23.svg)
+
+### 1. Reinstall could preserve stale credentials
+
+**Observed:** replacing the service and token did not replace the running worker.
+
+**Root cause:** the installer stopped the scheduled task and Node child, but an orphan PowerShell supervisor retained the old environment, restarted the old bridge, and reacquired the mutex.
+
+**Fix:** the service manager now finds and stops both the path-verified bridge child and its `powershell.exe` or `pwsh.exe` supervisor before replacing files, and waits for both to exit.
+
+### 2. Deft memory writes were misclassified as external writes
+
+**Observed:** certification reached the real memory tool, but the Hermes employee policy asked for external-write approval.
+
+**Root cause:** Hermes exposes the Deft MCP namespace as `mcp_deft_*`; the hook recognized `mcp__deft*` and `deft_*` only.
+
+**Fix:** the policy recognizes `mcp_deft_*` as a governed Deft tool. The existing block on non-Deft external writes remains intact.
+
+### 3. Successful work could end with an API validation error
+
+**Observed:** a reply or task mutation succeeded, then the bridge logged `VALIDATION_ERROR: Invalid input` while returning to idle.
+
+**Root cause:** idle status serialized `event_id: null`; the API accepts an optional string, not null.
+
+**Fix:** omit `event_id` when there is no active event.
+
+### 4. A transport drop could duplicate a long Hermes run
+
+**Observed:** after the inference request was accepted, a dropped local response triggered the generic HTTP retry and started duplicate parent and child research runs.
+
+**Root cause:** the bridge treated a non-idempotent `/v1/responses` POST like a retry-safe request.
+
+**Fix:** Deft channel calls retain bounded retries, but Hermes inference does not replay after an ambiguous transport failure. The event fails closed and can be resumed from durable Deft context. A future Hermes idempotency key would permit safer automatic recovery.
+
+The final continuation event completed once with `delivery_count = 1`. It created one set of three company records and moved the task to review. The two earlier ambiguous events are truthfully recorded as failed with `fetch failed`; no false completion was recorded.
+
+## Onboarding and product findings
+
+### Contacts capability is secure but opaque on a fresh install
+
+`db:seed:pilot` does not install the bundled Contacts module. Installing Contacts defaults agent access to `none`; an admin must separately grant write access. Rita correctly reported that Contacts was unavailable before that setup.
+
+The security default should remain opt-in. The onboarding experience should add a capability check that explains:
+
+1. which requested Deft modules are missing;
+2. which are installed but unavailable to the employee;
+3. the exact scoped access an admin is granting; and
+4. a post-grant read/write certification for the selected collections.
+
+This makes Hermes better in Deft without rebuilding Hermes's browser, delegation, skills, MCP ecosystem, or research runtime.
+
+### Action budget and long-run context need clearer controls
+
+The initial 250-action daily budget was exhausted during delegated research after duplicate execution and extensive source work. It was raised to 1,000 for continued testing. That is test configuration, not a recommended production default.
+
+Hermes also ran a background skill-library review after the long task. That demonstrates the value of onboarding the full Hermes ecosystem, but it adds context and action cost. Deft should expose policy and telemetry for such background work rather than reimplementing it.
+
+### Memory sync remains a Deft-native requirement
+
+Hermes should continue to own private runtime memory and its open-source capabilities. Deft should own the governed shared-memory bridge:
+
+- consume current authorized Wiki context at assignment time;
+- propose verified reusable learnings with provenance;
+- require the appropriate write authority before promoting them into shared Knowledge;
+- prefer a newer human-edited Wiki version over stale runtime memory; and
+- never sync secrets, untrusted page instructions, or restricted-space facts across scope.
+
+That is the minimum integration needed to make Hermes company-aware without recreating Hermes inside Deft.
+
+## Architecture decision
+
+No data migration or new service abstraction is needed for these fixes.
+
+- **Chosen:** fix the three existing seams—the policy namespace classifier, the service lifecycle controller, and request retry policy—and cover their user-visible failure modes with focused tests.
+- **Rejected:** retry every Hermes inference, because acceptance is ambiguous and the resulting effects are not idempotent.
+- **Deferred:** add a bridge-owned inference ledger or proxy. It adds durable state and recovery complexity without eliminating the need for runtime idempotency.
+
+Rollback is a single integration commit. Failure remains visible as a failed Agent Channel event, which is safer than duplicate work or false success.
+
+## Verification
+
+- Hermes bridge tests: 12 passed
+- Deft employee plugin tests: 5 passed
+- PowerShell service script: parser validation passed
+- Fresh certification: passed after the namespace fix
+- Live final research continuation: completed once, `delivery_count = 1`
+- Persisted Contacts readback: exactly three active company records for the scenario
+- Public demo: HTTP 200 on the exact release digest
+
+## Readiness and next work
+
+**Ready now:** supervised pilot testing of chat, assigned internal work, Knowledge retrieval, public research, governed Deft writes, human escalation, and scoped Contacts company creation.
+
+**Must follow immediately:**
+
+1. merge and release the four integration fixes so a reinstall receives them without manual profile/service patching;
+2. add the onboarding capability/access preflight for selected modules;
+3. run the remaining core scenarios, especially approved external outreach, blocked/resume, reusable Knowledge creation, fresh-session correction, delegated partial failure, and the multi-surface brief;
+4. run privacy/injection/secret hard gates;
+5. run duplicate delivery, bridge restart, Hermes restart, credential revocation, approval delay/rejection, and budget-exhaustion reruns; and
+6. return the temporary Rita action budget to the intended policy after testing.
+
+**Can be parked:** universal MCP installation, a Deft-owned skills runtime, generic browser/research infrastructure, duplicate local memory, and bespoke CRM behavior in core. Hermes already provides those capabilities; Deft should govern identity, context, permissions, durable work, approvals, memory promotion, and receipts.
+
+Until the remaining gates pass, the truthful label is **supervised pilot**, not broad unattended autonomy.

--- a/integrations/hermes/deft-employee/__init__.py
+++ b/integrations/hermes/deft-employee/__init__.py
@@ -71,7 +71,11 @@ class DeftEmployeeHooks:
         rendered = _sanitize(args, 2000)
         if tool_name in {"terminal", "process"} and DESTRUCTIVE_COMMAND.search(rendered):
             return {"action": "block", "message": "Destructive command blocked by Deft employee policy."}
-        is_deft_tool = tool_name.startswith("mcp__deft") or tool_name.startswith("deft_")
+        is_deft_tool = (
+            tool_name.startswith("mcp__deft")
+            or tool_name.startswith("mcp_deft_")
+            or tool_name.startswith("deft_")
+        )
         if WRITE_HINT.search(tool_name) and not is_deft_tool and not self.policy.get("allow_external_writes", False):
             return {"action": "block", "message": "External write needs Deft human approval for this assignment."}
         self.tool_calls += 1

--- a/integrations/hermes/deft-employee/test_deft_employee.py
+++ b/integrations/hermes/deft-employee/test_deft_employee.py
@@ -15,6 +15,14 @@ class DeftEmployeeHookTests(unittest.TestCase):
         decision = hooks.pre_tool_call(tool_name="gmail_send_email", args={"to": "a@example.com"})
         self.assertEqual(decision["action"], "block")
 
+    def test_model_visible_deft_write_is_governed_by_deft(self):
+        hooks = MOD.DeftEmployeeHooks()
+        decision = hooks.pre_tool_call(
+            tool_name="mcp_deft_memory_write",
+            args={"title": "Certification memory"},
+        )
+        self.assertIsNone(decision)
+
     def test_destructive_command_is_blocked(self):
         hooks = MOD.DeftEmployeeHooks()
         decision = hooks.pre_tool_call(tool_name="terminal", args={"command": "rm -rf /tmp/work"})

--- a/scripts/hermes-agent-channel-bridge.mjs
+++ b/scripts/hermes-agent-channel-bridge.mjs
@@ -170,13 +170,14 @@ export class HermesAgentChannelBridge {
     this.stopped = false;
   }
 
-  async request(url, init = {}) {
+  async request(url, init = {}, options = {}) {
+    const allowRetry = options.retry !== false;
     for (let attempt = 0; ; attempt += 1) {
       let response;
       try {
         response = await this.fetch(url, init);
       } catch (error) {
-        if (attempt >= this.config.maxRetries) throw error;
+        if (!allowRetry || attempt >= this.config.maxRetries) throw error;
         const delayMs = this.config.retryBaseMs * (2 ** attempt);
         this.log.warn?.(`[deft-channel] transport error; retrying in ${delayMs}ms`);
         await this.sleep(delayMs);
@@ -195,7 +196,7 @@ export class HermesAgentChannelBridge {
       if (response.ok) return body ?? {};
 
       const retryable = response.status === 429 || response.status >= 500;
-      if (retryable && attempt < this.config.maxRetries) {
+      if (allowRetry && retryable && attempt < this.config.maxRetries) {
         const retryAfterSeconds = Number.parseFloat(response.headers.get('retry-after') ?? '');
         const delayMs = Number.isFinite(retryAfterSeconds) && retryAfterSeconds > 0
           ? Math.ceil(retryAfterSeconds * 1000)
@@ -275,7 +276,7 @@ export class HermesAgentChannelBridge {
       method: 'POST',
       body: JSON.stringify({
         state,
-        event_id: eventId,
+        event_id: eventId ?? undefined,
         claim_token: eventId ? this.currentClaimToken : undefined,
         lease_ms: eventId ? this.config.leaseMs : undefined,
         detail,
@@ -337,7 +338,7 @@ export class HermesAgentChannelBridge {
         instructions: 'Act as an accountable Deft Agent Employee. Use Deft MCP tools for workspace facts and governed actions.',
         store: true,
       }),
-    });
+    }, { retry: false });
     const text = extractHermesText(response);
     return { decision: parseHermesDecision(text), sessionKey, responseId: response.id ?? null };
   }

--- a/scripts/hermes-agent-channel-bridge.test.mjs
+++ b/scripts/hermes-agent-channel-bridge.test.mjs
@@ -124,7 +124,7 @@ test('processEvent acks, marks working, invokes Hermes, replies once, and return
   assert.equal(calls[3].body.idempotency_key, 'hermes-channel:event-1');
   assert.equal(calls[3].body.outcome, 'needs_human');
   assert.equal(calls[4].body.state, 'idle');
-  assert.equal(calls[4].body.event_id, null);
+  assert.equal('event_id' in calls[4].body, false);
   assert.equal(calls[2].init.headers['X-Hermes-Session-Key'], 'deft:maya:thread-1');
 });
 
@@ -140,6 +140,20 @@ test('processEvent reports runtime failures to the channel', async () => {
   const terminalCalls = calls.slice(-2);
   assert.equal(terminalCalls[0].body.state, 'failed');
   assert.equal(terminalCalls[1].body.state, 'degraded');
+});
+
+test('processEvent does not replay an ambiguous Hermes transport failure', async () => {
+  let inferenceAttempts = 0;
+  const fetchImpl = async (url) => {
+    if (url.includes('/v1/responses')) {
+      inferenceAttempts += 1;
+      throw new Error('connection closed after request');
+    }
+    return jsonResponse({ ok: true });
+  };
+  const bridge = new HermesAgentChannelBridge(config(), { fetchImpl, logger: { info() {}, error() {} } });
+  await assert.rejects(() => bridge.processEvent(event), /connection closed after request/);
+  assert.equal(inferenceAttempts, 1);
 });
 
 test('top-level DM replies stay in the main conversation instead of opening a thread', async () => {

--- a/scripts/hermes-channel-service.ps1
+++ b/scripts/hermes-channel-service.ps1
@@ -56,6 +56,19 @@ function Get-ServiceProcess {
   }
 }
 
+function Get-ServiceSupervisorProcess {
+  Get-CimInstance Win32_Process | Where-Object {
+    $_.Name -in @('powershell.exe', 'pwsh.exe') -and $_.CommandLine -like "*$runnerTarget*"
+  }
+}
+
+function Stop-ServiceProcesses {
+  # Stop the bridge before its supervisor, then stop the supervisor before it
+  # can restart the bridge with environment values cached before an upgrade.
+  Get-ServiceProcess | ForEach-Object { Stop-Process -Id $_.ProcessId -Force }
+  Get-ServiceSupervisorProcess | ForEach-Object { Stop-Process -Id $_.ProcessId -Force }
+}
+
 switch ($Action) {
   'Install' {
     if (-not $ConfigPath) { throw 'Install requires -ConfigPath.' }
@@ -65,10 +78,14 @@ switch ($Action) {
     # Upgrades must replace the running copy as well as the files. Otherwise the
     # old supervisor keeps the mutex and the newly registered task exits idle.
     Stop-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
-    Get-ServiceProcess | ForEach-Object { Stop-Process -Id $_.ProcessId -Force }
+    Stop-ServiceProcesses
     for ($attempt = 0; $attempt -lt 20; $attempt += 1) {
       $existingTask = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
-      if ((-not $existingTask -or [string]$existingTask.State -ne 'Running') -and @(Get-ServiceProcess).Count -eq 0) {
+      if (
+        (-not $existingTask -or [string]$existingTask.State -ne 'Running') -and
+        @(Get-ServiceProcess).Count -eq 0 -and
+        @(Get-ServiceSupervisorProcess).Count -eq 0
+      ) {
         break
       }
       Start-Sleep -Milliseconds 250
@@ -104,7 +121,7 @@ switch ($Action) {
   }
   'Stop' {
     Stop-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
-    Get-ServiceProcess | ForEach-Object { Stop-Process -Id $_.ProcessId -Force }
+    Stop-ServiceProcesses
     Write-Output "Stopped '$TaskName'."
   }
   'Status' {
@@ -157,7 +174,7 @@ switch ($Action) {
     $healthIsFresh = $health -and $health.state -eq 'healthy' -and ((Get-Date) - [datetime]$health.checked_at).TotalSeconds -le 180
     if ([string]$task.State -ne 'Running' -or @(Get-ServiceProcess).Count -ne 1 -or -not $healthIsFresh) {
       Stop-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
-      Get-ServiceProcess | ForEach-Object { Stop-Process -Id $_.ProcessId -Force }
+      Stop-ServiceProcesses
       Start-ScheduledTask -TaskName $TaskName
       Write-Output "Repaired and started '$TaskName'."
     } else {
@@ -166,7 +183,7 @@ switch ($Action) {
   }
   'Uninstall' {
     Stop-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
-    Get-ServiceProcess | ForEach-Object { Stop-Process -Id $_.ProcessId -Force }
+    Stop-ServiceProcesses
     Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false -ErrorAction SilentlyContinue
     Remove-Item -LiteralPath $ServiceRoot -Recurse -Force -ErrorAction SilentlyContinue
     Write-Output "Removed '$TaskName'."


### PR DESCRIPTION
## Summary
- stop stale Hermes bridge supervisors during reinstall so refreshed credentials take effect
- recognize Hermes's `mcp_deft_*` namespace as governed Deft tools
- omit null idle event IDs and prevent ambiguous non-idempotent inference replay
- add the fresh-install Rita gauntlet report and two rendered evidence visuals

## Live evidence
- fresh `v0.3.0-preview.6` install and pilot seed on demo.deft.ing
- fresh Rita certification passed on `gpt-5.6-sol` with medium reasoning
- final research continuation completed once with delivery count 1
- exactly three deduplicated, sourced company records persisted and the assignment moved to review

## Verification
- `node --test scripts/hermes-agent-channel-bridge.test.mjs` (12 passed)
- `PYTHONDONTWRITEBYTECODE=1 python -m unittest integrations/hermes/deft-employee/test_deft_employee.py` (5 passed)
- PowerShell parser validation passed
- `pnpm agent:hermes-bundle`
- `pnpm typecheck`
- SVG render inspection at 1280x720