### PR TITLE
Hermes distributed onboarding readiness

### DIFF
--- a/apps/api/src/lib/agent-channel.ts
+++ b/apps/api/src/lib/agent-channel.ts
@@ -22,12 +22,14 @@ export const AGENT_CHANNEL_CAPABILITIES = [
   'identity_bound_mcp',
   'wiki_memory_sync_v1',
   'runtime_reconciliation_v1',
+  'runtime_attestation_v1',
 ] as const;
 export const AGENT_CHANNEL_REQUIRED_RUNTIME_CAPABILITIES = [
   'renewable_leases',
   'fencing_tokens',
   'terminal_outcomes',
   'runtime_reconciliation_v1',
+  'runtime_attestation_v1',
 ] as const;
 export const DEFT_RELEASE_VERSION = process.env.DEFT_RELEASE_VERSION || '0.3.0-preview.7';
 export const DEFT_BUILD_COMMIT = process.env.DEFT_BUILD_COMMIT || process.env.VCS_REF || 'unknown';
@@ -251,14 +253,40 @@ export async function publishAgentChannelEvent(input: PublishAgentChannelEventIn
 export async function touchAgentChannelConnection(
   principal: AgentChannelPrincipal,
   opts?: {
-    status?: 'connected' | 'degraded' | 'disconnected';
+    status?: 'connected' | 'degraded' | 'disconnected' | 'incompatible';
     lastEventId?: string | null;
     lastError?: string | null;
     metadata?: Record<string, unknown>;
+    workerId?: string | null;
   },
 ) {
   const now = new Date();
   const id = crypto.randomUUID();
+  const insertMetadata = {
+    ...(opts?.metadata ?? {}),
+    ...(opts?.workerId ? { worker_id: opts.workerId, restart_count: 0 } : {}),
+  };
+  const mergedMetadata = opts?.workerId
+    ? sql`coalesce(${agentChannelConnections.metadata}, '{}'::jsonb)
+        || ${JSON.stringify(opts.metadata ?? {})}::jsonb
+        || jsonb_build_object(
+          'worker_id', cast(${opts.workerId} as text),
+          'restart_count', case
+            when coalesce(${agentChannelConnections.metadata}->>'worker_id', '') <> ''
+              and ${agentChannelConnections.metadata}->>'worker_id' <> cast(${opts.workerId} as text)
+            then coalesce((${agentChannelConnections.metadata}->>'restart_count')::integer, 0) + 1
+            else coalesce((${agentChannelConnections.metadata}->>'restart_count')::integer, 0)
+          end,
+          'last_restart_at', case
+            when coalesce(${agentChannelConnections.metadata}->>'worker_id', '') <> ''
+              and ${agentChannelConnections.metadata}->>'worker_id' <> cast(${opts.workerId} as text)
+            then cast(${now.toISOString()} as text)
+            else ${agentChannelConnections.metadata}->>'last_restart_at'
+          end
+        )`
+    : opts?.metadata
+      ? sql`coalesce(${agentChannelConnections.metadata}, '{}'::jsonb) || ${JSON.stringify(opts.metadata)}::jsonb`
+      : sql`${agentChannelConnections.metadata}`;
   const [connection] = await db
     .insert(agentChannelConnections)
     .values({
@@ -271,7 +299,7 @@ export async function touchAgentChannelConnection(
       last_seen_at: now,
       last_event_id: opts?.lastEventId ?? null,
       last_error: opts?.lastError ?? null,
-      metadata: opts?.metadata ?? {},
+      metadata: insertMetadata,
     })
     .onConflictDoUpdate({
       target: [
@@ -285,7 +313,7 @@ export async function touchAgentChannelConnection(
         last_seen_at: now,
         last_event_id: opts?.lastEventId ?? sql`${agentChannelConnections.last_event_id}`,
         last_error: opts?.lastError ?? null,
-        metadata: opts?.metadata ?? sql`${agentChannelConnections.metadata}`,
+        metadata: mergedMetadata,
         updated_at: now,
       },
     })

--- a/apps/api/src/lib/agent-onboarding-preflight.ts
+++ b/apps/api/src/lib/agent-onboarding-preflight.ts
@@ -1,0 +1,91 @@
+export type OnboardingPreflightCheck = {
+  key: string;
+  status: 'pass' | 'fail' | 'warning';
+  detail: string;
+};
+
+export type OnboardingPreflightResult = {
+  ready: boolean;
+  checked_at: string;
+  checks: OnboardingPreflightCheck[];
+};
+
+type ModuleRequirement = { module_id: string; access: 'read' | 'write' };
+type ModuleSnapshot = ModuleRequirement & { enabled: boolean };
+
+export function evaluateAgentOnboardingPreflight(input: {
+  employee: {
+    active: boolean;
+    unhealthy: boolean;
+    has_mcp_token: boolean;
+    has_channel_token: boolean;
+    trust_level: string;
+    max_daily_actions: number;
+  };
+  connection: {
+    status: string | null;
+    attestation?: {
+      ready?: boolean;
+      responses_api?: boolean;
+      skills_api?: boolean;
+      enabled_toolsets?: string[];
+    } | null;
+  } | null;
+  requirements: {
+    modules: ModuleRequirement[];
+    hermes_toolsets: string[];
+  };
+  modules: ModuleSnapshot[];
+  now?: Date;
+}): OnboardingPreflightResult {
+  const checks: OnboardingPreflightCheck[] = [];
+  const required = (key: string, pass: boolean, success: string, failure: string) => {
+    checks.push({ key, status: pass ? 'pass' : 'fail', detail: pass ? success : failure });
+  };
+
+  required('employee_active', input.employee.active && !input.employee.unhealthy,
+    'Employee is active and its circuit breaker is clear.',
+    input.employee.unhealthy ? 'Employee circuit breaker is open.' : 'Employee is paused or deleted.');
+  required('deft_credentials', input.employee.has_mcp_token && input.employee.has_channel_token,
+    'MCP and Agent Channel credentials are issued.',
+    'Issue both MCP and Agent Channel credentials.');
+  required('channel_compatibility', input.connection?.status === 'connected',
+    'The remote bridge is connected with the current Agent Channel contract.',
+    input.connection?.status === 'incompatible'
+      ? 'The remote bridge is incompatible with this Deft release.'
+      : 'The remote bridge is not connected and ready.');
+
+  const attestation = input.connection?.attestation;
+  required('hermes_runtime', attestation?.ready === true && attestation.responses_api === true,
+    'Hermes runtime and Responses API are reachable.',
+    'Hermes runtime preflight has not passed.');
+
+  for (const requirement of input.requirements.modules) {
+    const installed = input.modules.find((candidate) => candidate.module_id === requirement.module_id);
+    const accessRank = { read: 1, write: 2 } as const;
+    const allowed = Boolean(installed?.enabled)
+      && Boolean(installed && accessRank[installed.access] >= accessRank[requirement.access]);
+    required(`module:${requirement.module_id}:${requirement.access}`, allowed,
+      `${requirement.module_id} is enabled with ${installed?.access} agent access.`,
+      `${requirement.module_id} must be enabled with ${requirement.access} agent access.`);
+  }
+
+  const enabledToolsets = new Set(attestation?.enabled_toolsets ?? []);
+  for (const toolset of input.requirements.hermes_toolsets) {
+    required(`hermes_toolset:${toolset}`, enabledToolsets.has(toolset),
+      `Hermes reports the ${toolset} toolset enabled and configured.`,
+      `Configure the ${toolset} toolset in the remote Hermes runtime.`);
+  }
+
+  checks.push({
+    key: 'approval_guardrails',
+    status: 'pass',
+    detail: `Deft trust is ${input.employee.trust_level}; the daily action limit is ${input.employee.max_daily_actions}. External tools remain governed by the remote Hermes runtime.`,
+  });
+
+  return {
+    ready: checks.every((check) => check.status !== 'fail'),
+    checked_at: (input.now ?? new Date()).toISOString(),
+    checks,
+  };
+}

--- a/apps/api/src/lib/agent-runtime-recovery.ts
+++ b/apps/api/src/lib/agent-runtime-recovery.ts
@@ -1,5 +1,5 @@
 export type AgentRuntimeRecovery = {
-  state: 'healthy' | 'setup_required' | 'offline' | 'delivery_failed' | 'backlogged' | 'certifying';
+  state: 'ready' | 'setup_required' | 'offline' | 'incompatible' | 'degraded' | 'delivery_failed' | 'backlogged' | 'certifying';
   title: string;
   detail: string;
   action: 'none' | 'regenerate_channel_token' | 'send_channel_test' | 'inspect_queue';
@@ -22,11 +22,23 @@ export function describeAgentRuntimeRecovery(input: {
     detail: 'Generate a channel token, add it to the runtime, then send a test event.',
     action: 'regenerate_channel_token',
   };
+  if (input.connectionStatus === 'incompatible') return {
+    state: 'incompatible',
+    title: 'Runtime integration is incompatible',
+    detail: 'Install the Hermes integration bundle pinned to this Deft release, then restart the channel bridge.',
+    action: 'send_channel_test',
+  };
   if (input.failedDeliveries > 0) return {
     state: 'delivery_failed',
     title: `${input.failedDeliveries} delivery${input.failedDeliveries === 1 ? '' : 'ies'} need attention`,
     detail: 'Inspect the failed event below, retry it after the runtime is healthy, or cancel it if the work is obsolete.',
     action: 'inspect_queue',
+  };
+  if (input.connectionStatus === 'degraded') return {
+    state: 'degraded',
+    title: 'Runtime needs attention',
+    detail: 'The bridge is checking in, but its Hermes runtime preflight or recent work failed. Inspect the runtime health details before assigning more work.',
+    action: 'send_channel_test',
   };
   if (input.connectionStatus !== 'connected' || stale) return {
     state: 'offline',
@@ -47,7 +59,7 @@ export function describeAgentRuntimeRecovery(input: {
     action: 'inspect_queue',
   };
   return {
-    state: 'healthy',
+    state: 'ready',
     title: 'Runtime is ready',
     detail: 'The employee passed the end-to-end check, is connected, and has no delivery failures.',
     action: 'none',

--- a/apps/api/src/routes/agent-channel.ts
+++ b/apps/api/src/routes/agent-channel.ts
@@ -115,13 +115,26 @@ const reconcileSchema = z.object({
 });
 
 const statusSchema = z.object({
-  state: z.enum(['idle', 'typing', 'working', 'approval_pending', 'degraded', 'error']),
+  state: z.enum(['idle', 'typing', 'working', 'approval_pending', 'degraded', 'incompatible', 'error']),
   event_id: z.string().optional(),
   claim_token: z.string().min(1).optional(),
   lease_ms: z.number().int().positive().optional(),
   detail: z.string().max(2000).optional(),
+  worker_id: z.string().min(1).max(200).optional(),
+  attestation: z.object({
+    schema: z.literal('deft.hermes.runtime_attestation.v1'),
+    ready: z.boolean(),
+    checked_at: z.string().datetime(),
+    hermes_version: z.string().max(64).nullable().optional(),
+    configured_model: z.string().max(200).nullable().optional(),
+    available_models: z.array(z.string().max(200)).max(20).optional(),
+    responses_api: z.boolean().optional(),
+    skills_api: z.boolean().optional(),
+    enabled_toolsets: z.array(z.string().max(64)).max(50).optional(),
+    error_code: z.string().max(100).optional(),
+  }).strict().optional(),
   caller_employee_slug: z.string().optional(),
-});
+}).strict();
 
 function errorResponse(c: Context, status: 400 | 401 | 403 | 404 | 409 | 426 | 500, code: string, message: string) {
   return c.json({ error: message, code }, status);
@@ -330,10 +343,27 @@ agentChannelRoutes.get('/contract', (c) => c.json(channelContract()));
 agentChannelRoutes.get('/connect', async (c) => {
   const principal = await resolveChannelPrincipal(c, c.req.query('caller_employee_slug'));
   if (isResponse(principal)) return principal;
+  const workerId = c.req.query('worker_id')?.trim() ?? '';
+  if (!workerId || workerId.length > 200) {
+    return errorResponse(c, 400, 'VALIDATION_ERROR', 'worker_id is required and must be at most 200 characters');
+  }
   const compatibility = channelCompatibility(c);
-  if (isResponse(compatibility)) return compatibility;
+  if (isResponse(compatibility)) {
+    await touchAgentChannelConnection(principal, {
+      status: 'incompatible',
+      workerId,
+      lastError: 'Runtime protocol or capabilities are incompatible with this Deft release.',
+      metadata: {
+        adapter_version: c.req.query('adapter_version')?.trim() ?? null,
+        runtime_capabilities: (c.req.query('capabilities') ?? '').split(',').filter(Boolean),
+        compatibility_error: 'INCOMPATIBLE_CHANNEL',
+      },
+    });
+    return compatibility;
+  }
 
   const connection = await touchAgentChannelConnection(principal, {
+    workerId,
     metadata: {
       adapter_version: compatibility.adapterVersion,
       runtime_capabilities: compatibility.capabilities,
@@ -768,9 +798,11 @@ agentChannelRoutes.post('/status', async (c) => {
   const principal = await resolveChannelPrincipal(c, parsed.data.caller_employee_slug);
   if (isResponse(principal)) return principal;
 
-  const connectionStatus = parsed.data.state === 'error' || parsed.data.state === 'degraded'
-    ? 'degraded'
-    : 'connected';
+  const connectionStatus = parsed.data.state === 'incompatible'
+    ? 'incompatible'
+    : parsed.data.state === 'error' || parsed.data.state === 'degraded'
+      ? 'degraded'
+      : 'connected';
 
   if (parsed.data.event_id) {
     const event = await getEventForPrincipal(parsed.data.event_id, principal);
@@ -808,8 +840,12 @@ agentChannelRoutes.post('/status', async (c) => {
 
   const connection = await touchAgentChannelConnection(principal, {
     status: connectionStatus,
+    workerId: parsed.data.worker_id,
     lastEventId: parsed.data.event_id ?? null,
-    lastError: parsed.data.state === 'error' ? parsed.data.detail ?? 'Runtime reported error' : null,
+    lastError: ['error', 'degraded', 'incompatible'].includes(parsed.data.state)
+      ? parsed.data.detail ?? 'Runtime reported a degraded state'
+      : null,
+    metadata: parsed.data.attestation ? { runtime_attestation: parsed.data.attestation } : undefined,
   });
 
   return c.json({

--- a/apps/api/src/routes/agent-employees.ts
+++ b/apps/api/src/routes/agent-employees.ts
@@ -26,6 +26,7 @@ import {
   agentChannelTokens,
   projects,
   mcpConnections,
+  moduleInstallations,
 } from '@deft/db/schema';
 import type { SkillAgentConfig } from '../lib/skill-config.js';
 import {
@@ -42,6 +43,7 @@ import { summarizeAgentChannelLifecycle, summarizeAgentChannelMetrics } from '..
 import { loadAgentActivity } from '../lib/agent-activity.js';
 import { describeAgentRuntimeRecovery } from '../lib/agent-runtime-recovery.js';
 import { ensureAgentConversationSpace } from '../lib/ensure-agent-conversation-space.js';
+import { evaluateAgentOnboardingPreflight } from '../lib/agent-onboarding-preflight.js';
 
 export const agentEmployeeRoutes = new Hono();
 
@@ -609,6 +611,10 @@ type CertificationChallengeEvidence = {
   channelReplyNonceSeen: boolean;
   singleDelivery: boolean;
   runtimeSessionSeen: boolean;
+  baseCompleted: boolean;
+  restartDetected: boolean;
+  restartProofEventSeen: boolean;
+  restartProofCompleted: boolean;
   completed: boolean;
 };
 
@@ -623,6 +629,7 @@ function runtimeToolName(runtimeKind: string, tool: string): string {
 async function loadCertificationChallengeEvidence(params: {
   orgId: string;
   employeeId: string;
+  runtimeKind?: string | null;
   challenge: {
     id: string;
     nonce: string;
@@ -632,6 +639,7 @@ async function loadCertificationChallengeEvidence(params: {
   };
 }): Promise<CertificationChallengeEvidence> {
   const { orgId, employeeId, challenge } = params;
+  const requiresRestartProof = params.runtimeKind === 'hermes';
 
   // Certification evidence is scoped to the challenge and intentionally
   // independent of the bounded recent-activity lists rendered in diagnostics.
@@ -676,6 +684,7 @@ async function loadCertificationChallengeEvidence(params: {
       delivery_count: agentChannelEvents.delivery_count,
       runtime_session_key: agentChannelEvents.runtime_session_key,
       work_outcome: agentChannelEvents.work_outcome,
+      payload: agentChannelEvents.payload,
     })
     .from(agentChannelEvents)
     .where(and(
@@ -710,7 +719,7 @@ async function loadCertificationChallengeEvidence(params: {
   const channelReplyNonceSeen = persistedComplete || replyRows.length > 0;
   const singleDelivery = persistedComplete || channelEvent?.delivery_count === 1;
   const runtimeSessionSeen = persistedComplete || Boolean(channelEvent?.runtime_session_key);
-  const completed = persistedComplete || (
+  const baseCompleted = persistedComplete || (
     missingTools.length === 0
     && nonceSeen
     && channelEventSeen
@@ -719,6 +728,50 @@ async function loadCertificationChallengeEvidence(params: {
     && singleDelivery
     && runtimeSessionSeen
   );
+  const eventPayload = channelEvent?.payload && typeof channelEvent.payload === 'object'
+    ? channelEvent.payload as Record<string, unknown>
+    : {};
+  const baselineRestartCount = Number(eventPayload.baseline_restart_count ?? 0);
+  const [connection] = await db.select({ metadata: agentChannelConnections.metadata })
+    .from(agentChannelConnections)
+    .where(and(
+      eq(agentChannelConnections.org_id, orgId),
+      eq(agentChannelConnections.agent_employee_id, employeeId),
+    )).limit(1);
+  const currentRestartCount = Number((connection?.metadata as Record<string, unknown> | null)?.restart_count ?? 0);
+  const restartDetected = persistedComplete || !requiresRestartProof || currentRestartCount > baselineRestartCount;
+  const [restartProofEvent] = await db.select({
+    id: agentChannelEvents.id,
+    status: agentChannelEvents.status,
+    delivery_count: agentChannelEvents.delivery_count,
+    runtime_session_key: agentChannelEvents.runtime_session_key,
+    work_outcome: agentChannelEvents.work_outcome,
+  }).from(agentChannelEvents).where(and(
+    eq(agentChannelEvents.org_id, orgId),
+    eq(agentChannelEvents.agent_employee_id, employeeId),
+    eq(agentChannelEvents.kind, 'certification.restart_proof'),
+    eq(agentChannelEvents.source_kind, 'certification'),
+    eq(agentChannelEvents.source_id, challenge.id),
+    gte(agentChannelEvents.created_at, challenge.started_at),
+  )).orderBy(desc(agentChannelEvents.created_at)).limit(1);
+  const restartProofReplies = restartProofEvent ? await db.select({ id: agentChannelDeliveryAttempts.id })
+    .from(agentChannelDeliveryAttempts).where(and(
+      eq(agentChannelDeliveryAttempts.org_id, orgId),
+      eq(agentChannelDeliveryAttempts.agent_employee_id, employeeId),
+      eq(agentChannelDeliveryAttempts.event_id, restartProofEvent.id),
+      eq(agentChannelDeliveryAttempts.direction, 'inbound_reply'),
+      eq(agentChannelDeliveryAttempts.status, 'completed'),
+      sql`COALESCE(${agentChannelDeliveryAttempts.request_json}->>'content', '') ILIKE ${`%${challenge.nonce}%`}`,
+    )).limit(1) : [];
+  const restartProofEventSeen = persistedComplete || !requiresRestartProof || Boolean(restartProofEvent);
+  const restartProofCompleted = persistedComplete || !requiresRestartProof || Boolean(
+    restartProofEvent?.status === 'completed'
+      && restartProofEvent.work_outcome === 'completed'
+      && restartProofEvent.delivery_count === 1
+      && restartProofEvent.runtime_session_key
+      && restartProofReplies.length > 0
+  );
+  const completed = persistedComplete || (baseCompleted && restartDetected && restartProofCompleted);
 
   return {
     seenTools,
@@ -730,6 +783,10 @@ async function loadCertificationChallengeEvidence(params: {
     channelReplyNonceSeen,
     singleDelivery,
     runtimeSessionSeen,
+    baseCompleted,
+    restartDetected,
+    restartProofEventSeen,
+    restartProofCompleted,
     completed,
   };
 }
@@ -879,7 +936,7 @@ function buildRuntimeSetup(
       tool_server_name: 'deft',
       channel_protocol_version: AGENT_CHANNEL_PROTOCOL_VERSION,
       channel_capabilities: [...AGENT_CHANNEL_CAPABILITIES],
-      integration_version: '0.2.4',
+      integration_version: '0.3.0',
       integration_bundle_url: hermesIntegrationBundleUrl(),
       mcp_endpoint_url: endpoint,
       channel_endpoint_url: channelEndpoint,
@@ -1006,6 +1063,7 @@ function certificationInstructions(
     'For task_query, search for any active task or request a small list, and confirm returned tasks expose allowed_next_statuses. Do not mutate task state during certification.',
     'For module_list, request enabled modules. If one exists, call module_schema_get and inspect its create/update input schemas and collection examples. An empty list is valid; do not mutate module records during certification.',
     `For ping_alive, identify yourself naturally as ${employee.name}; do not prefix every future chat message with your name.`,
+    'After the first assignment passes, restart the channel bridge once. Deft will send a fresh assignment to prove reconnect persistence.',
     ...setup.troubleshooting.map((line) => `Troubleshooting: ${line}`),
   ].join('\n');
 }
@@ -1020,6 +1078,8 @@ function buildCertificationStages(params: {
   channelReplyNonceSeen: boolean;
   singleDelivery: boolean;
   runtimeSessionSeen: boolean;
+  restartDetected: boolean;
+  restartProofCompleted: boolean;
   completed: boolean;
 }): CertificationStage[] {
   const runtimeKind = runtimeKindOf(params.employee);
@@ -1084,6 +1144,22 @@ function buildCertificationStages(params: {
         : 'Waiting for a nonce-bearing reply through Agent Channel.',
     },
     {
+      key: 'runtime_restart_detected',
+      label: 'Runtime restart detected',
+      status: params.restartDetected ? 'pass' : 'pending',
+      detail: params.restartDetected
+        ? 'The remote bridge reconnected with a new worker identity.'
+        : 'Restart the Hermes channel bridge once to prove durable recovery.',
+    },
+    {
+      key: 'post_restart_assignment',
+      label: 'Post-restart assignment completed',
+      status: params.restartProofCompleted ? 'pass' : 'pending',
+      detail: params.restartProofCompleted
+        ? 'Hermes claimed and completed fresh work after reconnecting.'
+        : 'Waiting for Hermes to process the restart-proof assignment.',
+    },
+    {
       key: 'verified',
       label: 'Verified employee',
       status: params.completed ? 'pass' : 'pending',
@@ -1106,6 +1182,8 @@ function certificationFailureReason(params: {
   channelReplyNonceSeen: boolean;
   singleDelivery: boolean;
   runtimeSessionSeen: boolean;
+  restartDetected: boolean;
+  restartProofCompleted: boolean;
 }): string | null {
   if (
     params.missingTools.length === 0
@@ -1115,6 +1193,8 @@ function certificationFailureReason(params: {
     && params.channelReplyNonceSeen
     && params.singleDelivery
     && params.runtimeSessionSeen
+    && params.restartDetected
+    && params.restartProofCompleted
   ) return null;
   const runtimeKind = runtimeKindOf(params.employee);
   const mcpReachable = params.auditCount > 0 || Boolean(params.employee.last_mcp_call_at);
@@ -1132,6 +1212,8 @@ function certificationFailureReason(params: {
       : `The runtime has not called: ${params.missingTools.join(', ')}.`;
   }
   if (!params.channelReplyNonceSeen) return 'Hermes completed tool calls but did not reply through Agent Channel with the certification nonce.';
+  if (!params.restartDetected) return 'Restart the Hermes channel bridge once so Deft can prove reconnect persistence.';
+  if (!params.restartProofCompleted) return 'The bridge reconnected, but Hermes has not completed the post-restart proof assignment yet.';
   return 'Required tools were called, but the challenge nonce was not recorded in the cooperative log.';
 }
 
@@ -2145,6 +2227,84 @@ agentEmployeeRoutes.post('/:id/channel-events/:eventId/cancel', async (c) => {
 // agent's filesystem. A Defty-specific settings page (Defty's SOUL.md
 // lives inside Deft) can come back as its own focused feature if needed.
 
+const onboardingPreflightSchema = z.object({
+  modules: z.array(z.object({
+    module_id: z.string().trim().min(1).max(200),
+    access: z.enum(['read', 'write']),
+  }).strict()).max(50).default([]),
+  hermes_toolsets: z.array(z.string().trim().min(1).max(64)).max(50).default([]),
+}).strict();
+type OnboardingPreflightRequirements = z.infer<typeof onboardingPreflightSchema>;
+
+async function loadAgentOnboardingPreflight(
+  orgId: string,
+  employee: typeof agentEmployees.$inferSelect,
+  requirements: OnboardingPreflightRequirements,
+) {
+  const [[connection], [channelToken]] = await Promise.all([
+    db.select().from(agentChannelConnections)
+      .where(and(eq(agentChannelConnections.agent_employee_id, employee.id), eq(agentChannelConnections.org_id, orgId))).limit(1),
+    db.select({ id: agentChannelTokens.id }).from(agentChannelTokens).where(and(
+      eq(agentChannelTokens.agent_employee_id, employee.id),
+      eq(agentChannelTokens.org_id, orgId),
+      eq(agentChannelTokens.is_active, true),
+      isNull(agentChannelTokens.revoked_at),
+    )).limit(1),
+  ]);
+  const moduleIds = [...new Set(requirements.modules.map((requirement) => requirement.module_id))];
+  const installedModules = moduleIds.length === 0 ? [] : await db.select({
+    module_id: moduleInstallations.module_id,
+    access: moduleInstallations.agent_access,
+    enabled: moduleInstallations.is_enabled,
+  }).from(moduleInstallations).where(and(
+    eq(moduleInstallations.org_id, orgId),
+    eq(moduleInstallations.is_deleted, false),
+    inArray(moduleInstallations.module_id, moduleIds),
+  ));
+  const metadata = connection?.metadata && typeof connection.metadata === 'object'
+    ? connection.metadata as Record<string, unknown>
+    : {};
+  const attestation = metadata.runtime_attestation && typeof metadata.runtime_attestation === 'object'
+    ? metadata.runtime_attestation as any
+    : null;
+  return evaluateAgentOnboardingPreflight({
+    employee: {
+      active: employee.is_active && !employee.is_deleted,
+      unhealthy: employee.unhealthy,
+      has_mcp_token: Boolean(employee.mcp_token_hash),
+      has_channel_token: Boolean(channelToken),
+      trust_level: employee.trust_level,
+      max_daily_actions: employee.max_daily_actions,
+    },
+    connection: connection ? { status: connection.status, attestation } : null,
+    requirements,
+    modules: installedModules.filter((module) => module.access !== 'none') as Array<{
+      module_id: string;
+      access: 'read' | 'write';
+      enabled: boolean;
+    }>,
+  });
+}
+
+agentEmployeeRoutes.post('/:id/onboarding-preflight', async (c) => {
+  const authorizationError = await requireOwnerOrAdmin(c);
+  if (authorizationError) return authorizationError;
+  const user = c.get('user');
+  const id = c.req.param('id');
+  const parsed = onboardingPreflightSchema.safeParse(await c.req.json().catch(() => ({})));
+  if (!parsed.success) {
+    return c.json({ error: 'Invalid input', code: 'VALIDATION_ERROR', details: parsed.error.flatten() }, 400);
+  }
+
+  const [employee] = await db.select().from(agentEmployees)
+    .where(and(eq(agentEmployees.id, id), eq(agentEmployees.org_id, user.org_id))).limit(1);
+  if (!employee || employee.is_deleted) {
+    return c.json({ error: 'Agent employee not found', code: 'NOT_FOUND' }, 404);
+  }
+  const result = await loadAgentOnboardingPreflight(user.org_id, employee, parsed.data);
+  return c.json(result, result.ready ? 200 : 409);
+});
+
 // ─── GET /:id/developer  → BYOA connection credentials ───────────────
 //
 // Returns the MCP endpoint URL and a masked token placeholder so the
@@ -2265,6 +2425,7 @@ agentEmployeeRoutes.get('/:id/developer', async (c) => {
       ? await loadCertificationChallengeEvidence({
           orgId: user.org_id,
           employeeId: id,
+          runtimeKind: employee.runtime_kind,
           challenge: latestChallenge,
         })
       : null;
@@ -2306,6 +2467,8 @@ agentEmployeeRoutes.get('/:id/developer', async (c) => {
               channelReplyNonceSeen: challengeEvidence?.channelReplyNonceSeen ?? false,
               singleDelivery: challengeEvidence?.singleDelivery ?? false,
               runtimeSessionSeen: challengeEvidence?.runtimeSessionSeen ?? false,
+              restartDetected: challengeEvidence?.restartDetected ?? false,
+              restartProofCompleted: challengeEvidence?.restartProofCompleted ?? false,
               completed: challengeEvidence?.completed ?? false,
             }),
           }
@@ -2424,6 +2587,31 @@ agentEmployeeRoutes.post('/:id/certification/start', async (c) => {
       .limit(1);
     if (!employee) return c.json({ error: 'Agent employee not found', code: 'NOT_FOUND' }, 404);
 
+    const preflightInput = onboardingPreflightSchema.safeParse(await c.req.json().catch(() => ({})));
+    if (!preflightInput.success) {
+      return c.json({ error: 'Invalid input', code: 'VALIDATION_ERROR', details: preflightInput.error.flatten() }, 400);
+    }
+    const preflight = runtimeKindOf(employee) === 'hermes'
+      ? await loadAgentOnboardingPreflight(user.org_id, employee, preflightInput.data)
+      : null;
+    if (preflight && !preflight.ready) {
+      return c.json({
+        error: 'Hermes onboarding preflight failed. Resolve the failed checks before certification.',
+        code: 'ONBOARDING_PREFLIGHT_FAILED',
+        preflight,
+      }, 409);
+    }
+    const [currentConnection] = await db.select({ metadata: agentChannelConnections.metadata })
+      .from(agentChannelConnections)
+      .where(and(eq(agentChannelConnections.agent_employee_id, employee.id), eq(agentChannelConnections.org_id, user.org_id)))
+      .limit(1);
+    const connectionMetadata = currentConnection?.metadata && typeof currentConnection.metadata === 'object'
+      ? currentConnection.metadata as Record<string, unknown>
+      : {};
+    const baselineRestartCount = Number.isInteger(connectionMetadata.restart_count)
+      ? Number(connectionMetadata.restart_count)
+      : 0;
+
     await cancelPendingCertification(user.org_id, employee.id, 'Superseded by a new certification challenge');
     const nonce = `deft-cert-${employee.slug}-${crypto.randomBytes(6).toString('hex')}`;
     const [challenge] = await db
@@ -2461,6 +2649,8 @@ agentEmployeeRoutes.post('/:id/certification/start', async (c) => {
         parent_id: null,
         certification_prompt: buildCertificationPrompt(employee, nonce),
         expected_reply_contains: nonce,
+        onboarding_requirements: preflightInput.data,
+        baseline_restart_count: baselineRestartCount,
       },
     });
 
@@ -2475,6 +2665,7 @@ agentEmployeeRoutes.post('/:id/certification/start', async (c) => {
       conversation_id: challenge.id,
       instructions: certificationInstructions(employee, nonce),
       runtime_setup: buildRuntimeSetup(employee, nonce),
+      preflight,
       mcp_endpoint_url: mcpEndpointUrl(),
     }, 201);
   } catch (err) {
@@ -2509,6 +2700,7 @@ agentEmployeeRoutes.get('/:id/certification', async (c) => {
       ? await loadCertificationChallengeEvidence({
           orgId: user.org_id,
           employeeId: id,
+          runtimeKind: employee.runtime_kind,
           challenge,
         })
       : null;
@@ -2536,6 +2728,8 @@ agentEmployeeRoutes.get('/:id/certification', async (c) => {
               channelReplyNonceSeen: challengeEvidence?.channelReplyNonceSeen ?? false,
               singleDelivery: challengeEvidence?.singleDelivery ?? false,
               runtimeSessionSeen: challengeEvidence?.runtimeSessionSeen ?? false,
+              restartDetected: challengeEvidence?.restartDetected ?? false,
+              restartProofCompleted: challengeEvidence?.restartProofCompleted ?? false,
               completed: challengeEvidence?.completed ?? false,
             }),
           }
@@ -2576,6 +2770,7 @@ agentEmployeeRoutes.post('/:id/certification/check', async (c) => {
     const challengeEvidence = await loadCertificationChallengeEvidence({
       orgId: user.org_id,
       employeeId: id,
+      runtimeKind: employee.runtime_kind,
       challenge,
     });
     const {
@@ -2588,8 +2783,32 @@ agentEmployeeRoutes.post('/:id/certification/check', async (c) => {
       channelReplyNonceSeen,
       singleDelivery,
       runtimeSessionSeen,
+      baseCompleted,
+      restartDetected,
+      restartProofEventSeen,
+      restartProofCompleted,
       completed,
     } = challengeEvidence;
+    if (baseCompleted && restartDetected && !restartProofEventSeen) {
+      await publishAgentChannelEvent({
+        orgId: user.org_id,
+        employeeId: employee.id,
+        kind: 'certification.restart_proof',
+        sourceKind: 'certification',
+        sourceId: challenge.id,
+        spaceId: challenge.id,
+        actorUserId: user.id,
+        idempotencyKey: `employee-certification-restart:${challenge.id}`,
+        payload: {
+          nonce: challenge.nonce,
+          employee_slug: employee.slug,
+          is_dm: true,
+          parent_id: null,
+          certification_prompt: `This is the post-restart persistence check. Process this fresh assignment, call mcp_deft_ping_alive, and reply with the exact nonce ${challenge.nonce}.`,
+          expected_reply_contains: challenge.nonce,
+        },
+      });
+    }
     const stages = buildCertificationStages({
       employee,
       missingTools,
@@ -2600,6 +2819,8 @@ agentEmployeeRoutes.post('/:id/certification/check', async (c) => {
       channelReplyNonceSeen,
       singleDelivery,
       runtimeSessionSeen,
+      restartDetected,
+      restartProofCompleted,
       completed,
     });
     const failureReason = certificationFailureReason({
@@ -2612,6 +2833,8 @@ agentEmployeeRoutes.post('/:id/certification/check', async (c) => {
       channelReplyNonceSeen,
       singleDelivery,
       runtimeSessionSeen,
+      restartDetected,
+      restartProofCompleted,
     });
 
     if (completed) {
@@ -2641,6 +2864,9 @@ agentEmployeeRoutes.post('/:id/certification/check', async (c) => {
       channel_reply_nonce_seen: channelReplyNonceSeen,
       single_delivery: singleDelivery,
       runtime_session_seen: runtimeSessionSeen,
+      restart_detected: restartDetected,
+      restart_proof_event_seen: restartProofEventSeen,
+      restart_proof_completed: restartProofCompleted,
       seen_tools: Array.from(seenTools),
       required_tools: challenge.required_tools,
       instructions: certificationInstructions(employee, challenge.nonce),

--- a/apps/api/test/agent-certification-stability.test.ts
+++ b/apps/api/test/agent-certification-stability.test.ts
@@ -68,10 +68,10 @@ before(async () => {
     );
     await client.query(
       `INSERT INTO agent_employees
-         (id, org_id, user_id, name, slug, role, system_prompt, trust_level,
-          runtime_kind, certification_status, is_byoa, is_active, created_by)
+       (id, org_id, user_id, name, slug, role, system_prompt, trust_level,
+          runtime_kind, certification_status, is_byoa, is_active, mcp_token_hash, created_by)
        VALUES ($1, $2, $3, $4, $5, 'project_manager', 'test', 'standard',
-         'hermes', 'token_issued', true, true, $6)`,
+         'hermes', 'token_issued', true, true, 'test-mcp-hash', $6)`,
       [
         AUTH_EMPLOYEE_ID,
         ORG_ID,
@@ -80,6 +80,29 @@ before(async () => {
         AUTH_EMPLOYEE_SLUG,
         ADMIN_USER_ID,
       ],
+    );
+    await client.query(
+      `INSERT INTO agent_channel_tokens
+         (id, org_id, agent_employee_id, name, token_hash, token_prefix, scopes, is_active, created_by)
+       VALUES (gen_random_uuid()::text, $1, $2, 'Certification channel', 'test-channel-hash', 'deft_channel',
+         '["channel:read","channel:write"]'::jsonb, true, $3)`,
+      [ORG_ID, AUTH_EMPLOYEE_ID, ADMIN_USER_ID],
+    );
+    await client.query(
+      `INSERT INTO agent_channel_connections
+         (id, org_id, agent_employee_id, runtime_kind, status, protocol_version, last_seen_at, metadata)
+       VALUES (gen_random_uuid()::text, $1, $2, 'hermes', 'connected', 'deft.agent_channel.v2', now(), $3::jsonb)`,
+      [ORG_ID, AUTH_EMPLOYEE_ID, JSON.stringify({
+        worker_id: 'certification-worker-1',
+        restart_count: 0,
+        runtime_attestation: {
+          schema: 'deft.hermes.runtime_attestation.v1',
+          ready: true,
+          responses_api: true,
+          skills_api: true,
+          enabled_toolsets: [],
+        },
+      })],
     );
     await client.query(
       `INSERT INTO agent_certification_challenges
@@ -325,9 +348,57 @@ test('owner can use guarded routes without exposing a prompt-bearing shell comma
   );
   assert.equal(deepCheckResponse.status, 200);
   const deepCheckBody = await deepCheckResponse.json() as any;
-  assert.equal(deepCheckBody.completed, true);
+  assert.equal(deepCheckBody.completed, false, 'verification waits for a restart and fresh post-restart work');
   assert.equal(deepCheckBody.single_delivery, true);
   assert.equal(deepCheckBody.channel_reply_nonce_seen, true);
+
+  await withClient(async (client) => {
+    await client.query(
+      `UPDATE agent_channel_connections
+       SET metadata = metadata || '{"worker_id":"certification-worker-2","restart_count":1}'::jsonb,
+           last_seen_at = now()
+       WHERE agent_employee_id = $1`,
+      [AUTH_EMPLOYEE_ID],
+    );
+  });
+  const restartCheckResponse = await app().request(
+    `/api/agent-employees/${AUTH_EMPLOYEE_ID}/certification/check`,
+    { method: 'POST' },
+  );
+  const restartCheckBody = await restartCheckResponse.json() as any;
+  assert.equal(restartCheckBody.restart_detected, true);
+  assert.equal(restartCheckBody.restart_proof_event_seen, false);
+
+  await withClient(async (client) => {
+    const proof = await client.query(
+      `UPDATE agent_channel_events
+       SET status = 'completed', delivery_count = 1, delivered_at = now(), acked_at = now(),
+           completed_at = now(), work_outcome = 'completed', outcome_at = now(),
+           runtime_session_key = 'hermes:certification:restart'
+       WHERE agent_employee_id = $1 AND kind = 'certification.restart_proof'
+       RETURNING id`,
+      [AUTH_EMPLOYEE_ID],
+    );
+    await client.query(
+      `INSERT INTO agent_channel_delivery_attempts
+         (id, org_id, agent_employee_id, event_id, direction, idempotency_key, status, request_json)
+       VALUES (gen_random_uuid()::text, $1, $2, $3, 'inbound_reply', $4, 'completed', $5::jsonb)`,
+      [
+        ORG_ID,
+        AUTH_EMPLOYEE_ID,
+        proof.rows[0].id,
+        `certification-restart-reply-${startBody.challenge.id}`,
+        JSON.stringify({ content: `Restart proof ${startBody.challenge.nonce}` }),
+      ],
+    );
+  });
+  const finalCheckResponse = await app().request(
+    `/api/agent-employees/${AUTH_EMPLOYEE_ID}/certification/check`,
+    { method: 'POST' },
+  );
+  const finalCheckBody = await finalCheckResponse.json() as any;
+  assert.equal(finalCheckBody.completed, true);
+  assert.equal(finalCheckBody.restart_proof_completed, true);
 
   const resetResponse = await app().request(
     `/api/agent-employees/${AUTH_EMPLOYEE_ID}/certification/reset`,

--- a/apps/api/test/agent-channel.test.ts
+++ b/apps/api/test/agent-channel.test.ts
@@ -495,7 +495,8 @@ function channelCompatibilityQuery() {
   return new URLSearchParams({
     protocol_version: 'deft.agent_channel.v2',
     adapter_version: '0.2.0-test',
-    capabilities: 'single_flight_claims,renewable_leases,fencing_tokens,terminal_outcomes,identity_bound_mcp,wiki_memory_sync_v1,runtime_reconciliation_v1',
+    capabilities: 'single_flight_claims,renewable_leases,fencing_tokens,terminal_outcomes,identity_bound_mcp,wiki_memory_sync_v1,runtime_reconciliation_v1,runtime_attestation_v1',
+    worker_id: 'channel-test-worker',
   }).toString();
 }
 
@@ -532,10 +533,11 @@ test('GET /contract advertises the lease-safe public compatibility contract', as
   assert.ok(body.capabilities.includes('fencing_tokens'));
   assert.ok(body.required_runtime_capabilities.includes('terminal_outcomes'));
   assert.ok(body.required_runtime_capabilities.includes('runtime_reconciliation_v1'));
+  assert.ok(body.required_runtime_capabilities.includes('runtime_attestation_v1'));
 });
 
 test('GET /connect rejects a legacy runtime before recording it as connected', async () => {
-  const res = await app.request('/api/agent-channel/v1/connect?protocol_version=deft.agent_channel.v1&adapter_version=0.1.0&capabilities=terminal_outcomes', {
+  const res = await app.request('/api/agent-channel/v1/connect?protocol_version=deft.agent_channel.v1&adapter_version=0.1.0&capabilities=terminal_outcomes&worker_id=legacy-worker', {
     headers: { authorization: `Bearer ${bearer}` },
   });
   const body = await res.json() as any;
@@ -543,6 +545,46 @@ test('GET /connect rejects a legacy runtime before recording it as connected', a
   assert.equal(body.code, 'INCOMPATIBLE_CHANNEL');
   assert.equal(body.protocol_version, 'deft.agent_channel.v2');
   assert.ok(body.capabilities.includes('fencing_tokens'));
+
+  const [connection] = await db.select().from(agentChannelConnections)
+    .where(eq(agentChannelConnections.agent_employee_id, employeeId)).limit(1);
+  assert.equal(connection?.status, 'incompatible');
+});
+
+test('POST /status persists a bounded runtime attestation and reconnect count', async () => {
+  const reconnect = await app.request(`/api/agent-channel/v1/connect?${channelCompatibilityQuery().replace('channel-test-worker', 'replacement-worker')}`, {
+    headers: { authorization: `Bearer ${bearer}` },
+  });
+  assert.equal(reconnect.status, 200, await reconnect.text());
+
+  const res = await app.request('/api/agent-channel/v1/status', {
+    method: 'POST',
+    headers: { authorization: `Bearer ${bearer}`, 'content-type': 'application/json' },
+    body: JSON.stringify({
+      state: 'idle',
+      worker_id: 'replacement-worker',
+      attestation: {
+        schema: 'deft.hermes.runtime_attestation.v1',
+        ready: true,
+        checked_at: '2026-08-24T12:00:00.000Z',
+        hermes_version: '0.16.0',
+        configured_model: 'Maya',
+        available_models: ['Maya'],
+        responses_api: true,
+        skills_api: true,
+        enabled_toolsets: ['web'],
+      },
+    }),
+  });
+  assert.equal(res.status, 200, await res.text());
+
+  const [connection] = await db.select().from(agentChannelConnections)
+    .where(eq(agentChannelConnections.agent_employee_id, employeeId)).limit(1);
+  const metadata = connection?.metadata as Record<string, any>;
+  assert.equal(metadata.worker_id, 'replacement-worker');
+  assert.ok(metadata.restart_count >= 1);
+  assert.equal(metadata.runtime_attestation.hermes_version, '0.16.0');
+  assert.deepEqual(metadata.runtime_attestation.enabled_toolsets, ['web']);
 });
 
 test('GET /events returns pending events once and marks them delivered', async () => {

--- a/apps/api/test/agent-onboarding-preflight.test.ts
+++ b/apps/api/test/agent-onboarding-preflight.test.ts
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { evaluateAgentOnboardingPreflight } from '../src/lib/agent-onboarding-preflight.js';
+
+const base = {
+  employee: {
+    active: true,
+    unhealthy: false,
+    has_mcp_token: true,
+    has_channel_token: true,
+    trust_level: 'standard',
+    max_daily_actions: 50,
+  },
+  connection: {
+    status: 'connected',
+    attestation: {
+      ready: true,
+      responses_api: true,
+      skills_api: true,
+      enabled_toolsets: ['web'],
+    },
+  },
+  requirements: {
+    modules: [{ module_id: 'contacts', access: 'write' as const }],
+    hermes_toolsets: ['web'],
+  },
+  modules: [{ module_id: 'contacts', access: 'write' as const, enabled: true }],
+  now: new Date('2026-08-24T12:00:00.000Z'),
+};
+
+test('preflight passes Deft surfaces and remote Hermes toolsets without importing a tool catalog', () => {
+  const result = evaluateAgentOnboardingPreflight(base);
+  assert.equal(result.ready, true);
+  assert.ok(result.checks.some((check) => check.key === 'module:contacts:write' && check.status === 'pass'));
+  assert.ok(result.checks.some((check) => check.key === 'hermes_toolset:web' && check.status === 'pass'));
+});
+
+test('preflight names every missing dependency before certification', () => {
+  const result = evaluateAgentOnboardingPreflight({
+    ...base,
+    connection: { status: 'incompatible', attestation: null },
+    modules: [{ module_id: 'contacts', access: 'read', enabled: true }],
+  });
+  assert.equal(result.ready, false);
+  assert.deepEqual(result.checks.filter((check) => check.status === 'fail').map((check) => check.key), [
+    'channel_compatibility',
+    'hermes_runtime',
+    'module:contacts:write',
+    'hermes_toolset:web',
+  ]);
+});

--- a/apps/api/test/agent-runtime-recovery.test.ts
+++ b/apps/api/test/agent-runtime-recovery.test.ts
@@ -18,9 +18,15 @@ test('runtime recovery prioritizes setup, failures, offline state, and backlog',
   assert.equal(describeAgentRuntimeRecovery({ ...base, failedDeliveries: 2 }).action, 'inspect_queue');
   assert.equal(describeAgentRuntimeRecovery({ ...base, lastSeenAt: new Date(now.getTime() - 180_000) }).state, 'offline');
   assert.equal(describeAgentRuntimeRecovery({ ...base, pendingDeliveries: 6 }).state, 'backlogged');
-  assert.equal(describeAgentRuntimeRecovery(base).state, 'healthy');
+  assert.equal(describeAgentRuntimeRecovery(base).state, 'ready');
 });
 
 test('runtime recovery does not report an uncertified transport as healthy', () => {
   assert.equal(describeAgentRuntimeRecovery({ ...base, certificationStatus: 'challenge_issued' }).state, 'certifying');
+});
+
+test('runtime recovery distinguishes incompatible and degraded from offline and ready', () => {
+  assert.equal(describeAgentRuntimeRecovery({ ...base, connectionStatus: 'incompatible' }).state, 'incompatible');
+  assert.equal(describeAgentRuntimeRecovery({ ...base, connectionStatus: 'degraded' }).state, 'degraded');
+  assert.equal(describeAgentRuntimeRecovery(base).state, 'ready');
 });

--- a/apps/api/test/clone-agent.test.ts
+++ b/apps/api/test/clone-agent.test.ts
@@ -46,6 +46,10 @@ before(async () => {
   });
   if (!mem) {
     await db.insert(orgMembers).values({ id: crypto.randomUUID(), org_id: testOrgId, user_id: testUserId, role: 'admin' });
+  } else if (mem.role !== 'owner' && mem.role !== 'admin' || !mem.is_active) {
+    await db.update(orgMembers)
+      .set({ role: 'admin', is_active: true })
+      .where(and(eq(orgMembers.user_id, testUserId), eq(orgMembers.org_id, testOrgId)));
   }
 
   // Source employee with one attached skill

--- a/apps/web/src/app/(app)/settings/agent-employees/[id]/developer/page.tsx
+++ b/apps/web/src/app/(app)/settings/agent-employees/[id]/developer/page.tsx
@@ -122,6 +122,21 @@ type DeveloperPayload = {
       last_seen_at?: string | null;
       last_event_id?: string | null;
       last_error?: string | null;
+      metadata?: {
+        worker_id?: string;
+        restart_count?: number;
+        last_restart_at?: string | null;
+        runtime_attestation?: {
+          ready?: boolean;
+          hermes_version?: string | null;
+          configured_model?: string | null;
+          responses_api?: boolean;
+          skills_api?: boolean;
+          enabled_toolsets?: string[];
+          checked_at?: string;
+          error_code?: string;
+        };
+      };
     } | null;
     token: {
       token_prefix: string;
@@ -143,7 +158,7 @@ type DeveloperPayload = {
       oldest_open_age_ms: number | null;
     };
     recovery: {
-      state: 'healthy' | 'setup_required' | 'offline' | 'delivery_failed' | 'backlogged';
+      state: 'ready' | 'setup_required' | 'offline' | 'incompatible' | 'degraded' | 'delivery_failed' | 'backlogged' | 'certifying';
       title: string;
       detail: string;
       action: 'none' | 'regenerate_channel_token' | 'send_channel_test' | 'inspect_queue';
@@ -265,7 +280,17 @@ export default function DeveloperPage() {
     setError(null);
     try {
       const res = await api.post(`/api/agent-employees/${employeeId}/certification/${action}`);
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      if (!res.ok) {
+        const failure = await res.json().catch(() => null);
+        if (failure?.code === 'ONBOARDING_PREFLIGHT_FAILED') {
+          const failed = failure.preflight?.checks
+            ?.filter((check: { status: string }) => check.status === 'fail')
+            .map((check: { detail: string }) => check.detail)
+            .join(' ');
+          throw new Error(failed || failure.error);
+        }
+        throw new Error(failure?.error || `HTTP ${res.status}`);
+      }
       const payload = await res.json();
       if (action === 'check') {
         const missing = payload.missing_tools?.length ? ` Missing: ${payload.missing_tools.join(', ')}.` : '';
@@ -350,6 +375,15 @@ export default function DeveloperPage() {
     : data.channel.token
       ? 'Token issued, not connected yet'
       : 'No channel token issued';
+  const runtimeAttestation = data.channel.connection?.metadata?.runtime_attestation;
+  const runtimeAttestationLabel = runtimeAttestation
+    ? [
+        runtimeAttestation.ready ? 'ready' : `failed${runtimeAttestation.error_code ? ` (${runtimeAttestation.error_code})` : ''}`,
+        runtimeAttestation.hermes_version ? `Hermes ${runtimeAttestation.hermes_version}` : null,
+        runtimeAttestation.configured_model ? `model ${runtimeAttestation.configured_model}` : null,
+        runtimeAttestation.enabled_toolsets?.length ? `toolsets: ${runtimeAttestation.enabled_toolsets.join(', ')}` : null,
+      ].filter(Boolean).join(' · ')
+    : 'No runtime attestation received';
 
   const claudeDesktopConfig = JSON.stringify(
     {
@@ -409,7 +443,7 @@ export default function DeveloperPage() {
       )}
       {error && <div className="mb-3 rounded border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs">{error}</div>}
 
-      <div className={`mb-4 rounded border px-3 py-2 text-xs ${data.channel.recovery.state === 'healthy' ? 'border-emerald-500/25 bg-emerald-500/10' : 'border-amber-500/30 bg-amber-500/10'}`}>
+      <div className={`mb-4 rounded border px-3 py-2 text-xs ${data.channel.recovery.state === 'ready' ? 'border-emerald-500/25 bg-emerald-500/10' : 'border-amber-500/30 bg-amber-500/10'}`}>
         <div className="font-medium">{data.channel.recovery.title}</div>
         <div className="mt-0.5 text-muted-foreground">{data.channel.recovery.detail}</div>
         {data.channel.recovery.action === 'regenerate_channel_token' && (
@@ -433,6 +467,14 @@ export default function DeveloperPage() {
         <Field
           label="Runtime"
           value={`${data.employee.runtime_kind ?? 'custom_mcp'} / ${data.employee.wake_mode ?? 'manual'}`}
+        />
+        <Field
+          label="Runtime attestation"
+          value={runtimeAttestationLabel}
+        />
+        <Field
+          label="Bridge restart proof"
+          value={`${data.channel.connection?.metadata?.restart_count ?? 0} reconnect${(data.channel.connection?.metadata?.restart_count ?? 0) === 1 ? '' : 's'} recorded`}
         />
         <Field
           label="Job title"

--- a/integrations/hermes/integration-manifest.json
+++ b/integrations/hermes/integration-manifest.json
@@ -1,6 +1,6 @@
 {
   "schema": "deft.hermes.integration.v1",
-  "integration_version": "0.2.4",
+  "integration_version": "0.3.0",
   "deft_release": "0.3.0-preview.7",
   "deft_release_compatibility": "=0.3.0-preview.7",
   "agent_channel_protocols": ["deft.agent_channel.v2"],
@@ -11,7 +11,8 @@
     "terminal_outcomes",
     "identity_bound_mcp",
     "wiki_memory_sync_v1",
-    "runtime_reconciliation_v1"
+    "runtime_reconciliation_v1",
+    "runtime_attestation_v1"
   ],
   "hermes_compatibility": ">=0.16.0",
   "contents": [

--- a/scripts/hermes-agent-channel-bridge.mjs
+++ b/scripts/hermes-agent-channel-bridge.mjs
@@ -9,7 +9,7 @@ const DEFAULT_MAX_RETRIES = 5;
 const DEFAULT_RETRY_BASE_MS = 1000;
 const DEFAULT_HEARTBEAT_MS = 60000;
 const DEFAULT_LEASE_MS = 120000;
-export const HERMES_DEFT_ADAPTER_VERSION = '0.2.4';
+export const HERMES_DEFT_ADAPTER_VERSION = '0.3.0';
 export const AGENT_CHANNEL_PROTOCOL_VERSION = 'deft.agent_channel.v2';
 export const AGENT_CHANNEL_CAPABILITIES = [
   'single_flight_claims',
@@ -19,6 +19,7 @@ export const AGENT_CHANNEL_CAPABILITIES = [
   'identity_bound_mcp',
   'wiki_memory_sync_v1',
   'runtime_reconciliation_v1',
+  'runtime_attestation_v1',
 ];
 export const AGENT_CHANNEL_REQUIRED_SERVER_CAPABILITIES = [
   'single_flight_claims',
@@ -27,6 +28,7 @@ export const AGENT_CHANNEL_REQUIRED_SERVER_CAPABILITIES = [
   'terminal_outcomes',
   'identity_bound_mcp',
   'runtime_reconciliation_v1',
+  'runtime_attestation_v1',
 ];
 
 export class AgentChannelCompatibilityError extends Error {
@@ -316,13 +318,50 @@ export class HermesAgentChannelBridge {
   async connect() {
     const query = new URLSearchParams({
       caller_employee_slug: this.config.employeeSlug,
+      worker_id: this.config.workerId,
       ...this.compatibilityParams(),
     });
     const connection = await this.channel(`/connect?${query.toString()}`);
     return this.validateConnection(connection);
   }
 
-  async status(state, eventId = null, detail = null) {
+  async preflightHermesRuntime() {
+    const headers = { Authorization: `Bearer ${this.config.hermesApiKey}` };
+    const [health, models, capabilities, toolsets] = await Promise.all([
+      this.request(`${this.config.hermesApiUrl}/health`, {}, { retry: false }),
+      this.request(`${this.config.hermesApiUrl}/v1/models`, { headers }, { retry: false }),
+      this.request(`${this.config.hermesApiUrl}/v1/capabilities`, { headers }, { retry: false }),
+      this.request(`${this.config.hermesApiUrl}/v1/toolsets`, { headers }, { retry: false }),
+    ]);
+    const availableModels = [...new Set((Array.isArray(models?.data) ? models.data : [])
+      .map((model) => typeof model?.id === 'string' ? model.id.trim() : '')
+      .filter(Boolean))].slice(0, 20);
+    const enabledToolsets = [...new Set((Array.isArray(toolsets?.data) ? toolsets.data : [])
+      .filter((toolset) => toolset?.enabled === true && toolset?.configured === true)
+      .map((toolset) => typeof toolset?.name === 'string' ? toolset.name.trim().slice(0, 64) : '')
+      .filter(Boolean))].sort().slice(0, 50);
+    const responsesApi = capabilities?.features?.responses_api === true;
+    const skillsApi = capabilities?.features?.skills_api === true;
+    if (health?.status !== 'ok' || availableModels.length === 0 || !responsesApi || !skillsApi) {
+      const error = new Error('Hermes runtime is reachable but required health, model, Responses API, or skills capability is unavailable.');
+      error.code = 'HERMES_CAPABILITY_MISSING';
+      throw error;
+    }
+
+    return {
+      schema: 'deft.hermes.runtime_attestation.v1',
+      ready: true,
+      checked_at: new Date(this.now()).toISOString(),
+      hermes_version: typeof health?.version === 'string' ? health.version.slice(0, 64) : null,
+      configured_model: this.config.hermesModel,
+      available_models: availableModels,
+      responses_api: responsesApi,
+      skills_api: skillsApi,
+      enabled_toolsets: enabledToolsets,
+    };
+  }
+
+  async status(state, eventId = null, detail = null, options = {}) {
     return this.channel('/status', {
       method: 'POST',
       body: JSON.stringify({
@@ -331,6 +370,8 @@ export class HermesAgentChannelBridge {
         claim_token: eventId ? this.currentClaimToken : undefined,
         lease_ms: eventId ? this.config.leaseMs : undefined,
         detail,
+        worker_id: this.config.workerId,
+        attestation: options.attestation,
         caller_employee_slug: this.config.employeeSlug,
       }),
     });
@@ -575,7 +616,7 @@ export class HermesAgentChannelBridge {
       connection = await this.connect();
     } catch (error) {
       if (error?.code === 'INCOMPATIBLE_CHANNEL') {
-        await this.status('error', null, error instanceof Error ? error.message : String(error)).catch(() => {});
+        await this.status('incompatible', null, error instanceof Error ? error.message : String(error)).catch(() => {});
       }
       await this.writeHealth(error?.code === 'INCOMPATIBLE_CHANNEL' ? 'incompatible' : 'degraded', {
         last_error_code: error?.code ?? 'CONNECT_FAILED',
@@ -584,11 +625,28 @@ export class HermesAgentChannelBridge {
       throw error;
     }
     this.log.info?.(`[deft-channel] connected as ${connection.employee?.slug ?? this.config.employeeSlug}`);
+    let runtimeAttestation;
+    try {
+      runtimeAttestation = await this.preflightHermesRuntime();
+      await this.status('idle', null, 'Hermes runtime preflight passed.', { attestation: runtimeAttestation });
+    } catch (error) {
+      const detail = error instanceof Error ? error.message.slice(0, 500) : String(error).slice(0, 500);
+      runtimeAttestation = {
+        schema: 'deft.hermes.runtime_attestation.v1',
+        ready: false,
+        checked_at: new Date(this.now()).toISOString(),
+        error_code: error?.code ?? 'HERMES_PREFLIGHT_FAILED',
+      };
+      await this.status('degraded', null, detail, { attestation: runtimeAttestation }).catch(() => {});
+      await this.writeHealth('degraded', { last_error_code: runtimeAttestation.error_code, last_error: detail });
+      throw error;
+    }
     await this.writeHealth('healthy', {
       server_release: connection.server_release ?? null,
       server_commit: connection.server_commit ?? null,
       schema_head: connection.schema_head ?? null,
       last_success_at: new Date(this.now()).toISOString(),
+      runtime_attestation: runtimeAttestation,
     });
     do {
       try {

--- a/scripts/hermes-agent-channel-bridge.test.mjs
+++ b/scripts/hermes-agent-channel-bridge.test.mjs
@@ -59,6 +59,7 @@ const compatibleConnection = {
     'identity_bound_mcp',
     'wiki_memory_sync_v1',
     'runtime_reconciliation_v1',
+    'runtime_attestation_v1',
   ],
   employee: { slug: 'maya' },
 };
@@ -140,6 +141,41 @@ test('extractHermesText and parseHermesDecision accept Responses API output', ()
 
 test('conversationKey keeps a stable thread-scoped Hermes conversation', () => {
   assert.equal(conversationKey(event, 'maya'), 'deft:maya:thread-1');
+});
+
+test('runtime preflight reports Hermes reachability and only high-level toolset names', async () => {
+  const bridge = new HermesAgentChannelBridge(config(), {
+    fetchImpl: async (url) => {
+      if (url.endsWith('/health')) {
+        return jsonResponse({ status: 'ok', platform: 'hermes-agent', version: '0.16.0' });
+      }
+      if (url.endsWith('/v1/models')) {
+        return jsonResponse({ data: [{ id: 'Maya' }] });
+      }
+      if (url.endsWith('/v1/capabilities')) {
+        return jsonResponse({ features: { responses_api: true, skills_api: true } });
+      }
+      if (url.endsWith('/v1/toolsets')) {
+        return jsonResponse({
+          data: [
+            { name: 'web', enabled: true, configured: true, tools: ['browser', 'search'] },
+            { name: 'email', enabled: true, configured: false, tools: ['send_email'] },
+          ],
+        });
+      }
+      throw new Error(`unexpected URL ${url}`);
+    },
+    logger: { info() {}, warn() {}, error() {} },
+  });
+
+  const attestation = await bridge.preflightHermesRuntime();
+
+  assert.equal(attestation.ready, true);
+  assert.equal(attestation.hermes_version, '0.16.0');
+  assert.equal(attestation.configured_model, 'Maya');
+  assert.deepEqual(attestation.available_models, ['Maya']);
+  assert.deepEqual(attestation.enabled_toolsets, ['web']);
+  assert.equal(JSON.stringify(attestation).includes('browser'), false, 'Deft must not copy Hermes tool catalogs');
 });
 
 test('processEvent acks, marks working, invokes Hermes, replies once, and returns idle', async () => {


### PR DESCRIPTION
## Summary
- attest remote Hermes health, model, Responses API, skills, and configured high-level toolsets without copying Hermes tool catalogs
- persist compatible/incompatible/degraded/ready runtime state and atomic bridge restart counts
- gate Hermes certification on Deft credentials, module access, runtime capabilities, and requested native toolsets
- require a real bridge restart and successful fresh assignment before employee verification
- surface runtime attestation, reconnect proof, and actionable preflight failures in the Developer UI

## Validation
- pnpm lint
- pnpm build
- pnpm test:hermes-channel
- API typecheck and web typecheck
- agent-channel integration: 23/23
- certification stability: 4/4
- onboarding/recovery unit tests: 5/5
- clone fixture regression: 7/7
- full API suite: 989 passed, 44 skipped; four nondeterministic clone-fixture failures were corrected and the affected 7-test file reran green
- desktop 1440x900 and mobile responsive browser inspection