### PR TITLE
ci: certify Hermes employee release gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,10 +96,57 @@ jobs:
       - name: Run tests
         run: pnpm --filter @deft/api test
 
+  hermes-release-gate:
+    name: Hermes Employee Release Gate
+    runs-on: ubuntu-latest
+    needs: typecheck
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: deft_hermes_gate_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      DATABASE_URL: postgres://postgres:postgres@localhost:5432/deft_hermes_gate_test
+      DEFT_TEST_DATABASE_URL: postgres://postgres:postgres@localhost:5432/deft_hermes_gate_test
+      JWT_SECRET: ci-hermes-gate-jwt-not-for-prod
+      JWT_REFRESH_SECRET: ci-hermes-gate-refresh-not-for-prod
+      ANTHROPIC_API_KEY: sk-ant-ci-hermes-gate-dummy-not-real
+    steps:
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6.0.10
+        with:
+          version: 11.10.0
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: pnpm
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - run: pnpm install --frozen-lockfile
+      - name: Run two clean-state Hermes employee passes
+        run: pnpm test:hermes-employee-release-gate
+      - name: Retain certification evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: hermes-employee-release-gate
+          path: dist/hermes-employee-release-gate.json
+          if-no-files-found: warn
+
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: [typecheck, test]
+    needs: [typecheck, test, hermes-release-gate]
     steps:
       - uses: actions/checkout@v7
       - uses: pnpm/action-setup@v6.0.10
@@ -350,6 +397,11 @@ jobs:
           done
       - name: Install Chromium
         run: pnpm exec playwright install --with-deps chromium
+      - name: Run self-host Agent Channel and MCP smoke
+        env:
+          DEFT_API_URL: http://127.0.0.1:3001
+          DEFT_PUBLIC_URL: http://127.0.0.1:3001
+        run: pnpm selfhost:smoke
       - name: Run production browser smoke
         env:
           DEFT_WEB_URL: http://127.0.0.1:3000

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,9 +31,60 @@ env:
   IMAGE_NAME: maneek21/deft
 
 jobs:
+  certify:
+    name: Certify Hermes employee release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: deft_hermes_release_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      DATABASE_URL: postgres://postgres:postgres@localhost:5432/deft_hermes_release_test
+      DEFT_TEST_DATABASE_URL: postgres://postgres:postgres@localhost:5432/deft_hermes_release_test
+      JWT_SECRET: release-hermes-gate-jwt-not-for-prod
+      JWT_REFRESH_SECRET: release-hermes-gate-refresh-not-for-prod
+      ANTHROPIC_API_KEY: sk-ant-release-hermes-gate-dummy-not-real
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+          fetch-depth: 0
+      - uses: pnpm/action-setup@v6.0.10
+        with:
+          version: 11.10.0
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: pnpm
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - run: pnpm install --frozen-lockfile
+      - name: Run two clean-state Hermes employee passes
+        run: pnpm test:hermes-employee-release-gate
+      - name: Publish certification evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: hermes-employee-release-certification
+          path: dist/hermes-employee-release-gate.json
+          if-no-files-found: error
+
   publish:
     name: Publish release image
     runs-on: ubuntu-latest
+    needs: certify
     steps:
       - uses: actions/checkout@v7
         with:
@@ -56,6 +107,21 @@ jobs:
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "sha=$(git rev-parse "$tag^{commit}")" >> "$GITHUB_OUTPUT"
+
+      - name: Download Hermes employee certification
+        uses: actions/download-artifact@v4
+        with:
+          name: hermes-employee-release-certification
+          path: dist
+
+      - name: Verify certification matches release commit
+        shell: bash
+        run: |
+          certificate_commit="$(node -p "require('./dist/hermes-employee-release-gate.json').commit")"
+          [[ "$certificate_commit" == "${{ steps.release.outputs.sha }}" ]] || {
+            echo "Hermes employee certificate does not match the release commit" >&2
+            exit 1
+          }
 
       - uses: docker/setup-buildx-action@v4
 
@@ -186,7 +252,8 @@ jobs:
             "platforms": ["linux/amd64"],
             "upgrade_support": "versioned-from-v0.2.0-preview.1",
             "agent_channel_protocol": "deft.agent_channel.v2",
-            "hermes_integration": "deft-hermes-integration-${{ steps.release.outputs.version }}.tar.gz"
+            "hermes_integration": "deft-hermes-integration-${{ steps.release.outputs.version }}.tar.gz",
+            "hermes_employee_certification": "hermes-employee-release-gate.json"
           }
           JSON
 

--- a/apps/api/src/scripts/hermes-employee-release-gate.ts
+++ b/apps/api/src/scripts/hermes-employee-release-gate.ts
@@ -1,0 +1,165 @@
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Client } from 'pg';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '..', '..', '..', '..');
+const certificatePath = resolve(repoRoot, 'dist', 'hermes-employee-release-gate.json');
+const requiredPasses = Number.parseInt(process.env.DEFT_HERMES_GATE_PASSES ?? '2', 10);
+const databaseUrl = process.env.DEFT_TEST_DATABASE_URL ?? process.env.DATABASE_URL;
+const pnpmCli = process.env.npm_execpath;
+
+const apiSuites = [
+  'test/agent-channel.test.ts',
+  'test/agent-certification-stability.test.ts',
+  'test/agent-approval-resolver.test.ts',
+  'test/agent-untrusted-context.test.ts',
+  'test/direct-route-privacy.test.ts',
+  'test/identity-hardening.test.ts',
+  'test/mcp-connector-safety.test.ts',
+  'test/mcp-human-context-packets.test.ts',
+  'test/mcp-message-privacy.test.ts',
+  'test/mcp-server.test.ts',
+  'test/mcp-tool-trust-boundary.test.ts',
+  'test/mcp-write-tools.test.ts',
+  'test/modules-contacts-acceptance.test.ts',
+  'test/modules-mcp-adapter.test.ts',
+  'test/phase8-heartbeat-budget.test.ts',
+  'test/receipts.test.ts',
+] as const;
+
+const scenarioCoverage = {
+  conversation_locality: ['agent-channel', 'mcp-human-context-packets', 'mcp-message-privacy'],
+  explicit_and_implicit_knowledge: ['deft-memory plugin', 'mcp-human-context-packets', 'mcp-server'],
+  generic_module_and_contacts_writes: ['modules-contacts-acceptance', 'modules-mcp-adapter'],
+  approved_external_outreach: ['deft-employee plugin'],
+  destructive_and_identity_boundaries: ['deft-employee plugin', 'identity-hardening', 'mcp-connector-safety'],
+  approval_delay_and_rejection: ['agent-approval-resolver', 'modules-mcp-adapter'],
+  duplicate_delivery: ['agent-channel', 'Hermes bridge'],
+  bridge_and_runtime_restart: ['agent-channel', 'agent-certification-stability', 'Hermes bridge'],
+  credential_revocation: ['agent-channel', 'identity-hardening'],
+  memory_correction_and_fresh_reuse: ['agent-channel', 'deft-memory plugin'],
+  action_budget_exhaustion: ['deft-employee plugin', 'phase8-heartbeat-budget', 'modules-mcp-adapter'],
+  delegated_partial_failure: ['deft-employee plugin'],
+  injection_resistance: ['agent-untrusted-context', 'mcp-tool-trust-boundary', 'deft-memory plugin'],
+  privacy: ['direct-route-privacy', 'mcp-message-privacy'],
+  secret_redaction: ['deft-employee plugin', 'mcp-connector-safety', 'receipts'],
+  progress_and_truthful_outcomes: ['agent-channel', 'agent-certification-stability', 'Hermes bridge'],
+} as const;
+
+function fail(message: string): never {
+  console.error(`[hermes-release-gate] ${message}`);
+  process.exit(1);
+}
+
+if (!databaseUrl) fail('DEFT_TEST_DATABASE_URL or DATABASE_URL is required');
+if (!pnpmCli) fail('Run this gate through pnpm so npm_execpath is available');
+if (!Number.isSafeInteger(requiredPasses) || requiredPasses < 2 || requiredPasses > 5) {
+  fail('DEFT_HERMES_GATE_PASSES must be an integer from 2 through 5');
+}
+
+const parsedDatabaseUrl = new URL(databaseUrl);
+const databaseName = decodeURIComponent(parsedDatabaseUrl.pathname.replace(/^\//, ''));
+if (!/(?:test|ci|acceptance|gauntlet)/i.test(databaseName)) {
+  fail(`refusing to reset database "${databaseName}"; its name must contain test, ci, acceptance, or gauntlet`);
+}
+
+const childEnv = {
+  ...process.env,
+  CI: 'true',
+  DATABASE_URL: databaseUrl,
+  DEFT_TEST_DATABASE_URL: databaseUrl,
+  JWT_SECRET: process.env.JWT_SECRET ?? 'hermes-release-gate-jwt-not-for-production',
+  JWT_REFRESH_SECRET: process.env.JWT_REFRESH_SECRET ?? 'hermes-release-gate-refresh-not-for-production',
+  ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY ?? 'sk-ant-hermes-release-gate-dummy-not-real',
+};
+
+function run(label: string, args: string[]) {
+  console.log(`[hermes-release-gate] ${label}`);
+  const result = spawnSync(process.execPath, [pnpmCli!, ...args], {
+    cwd: repoRoot,
+    env: childEnv,
+    stdio: 'inherit',
+    timeout: Number(process.env.DEFT_HERMES_GATE_TIMEOUT_MS ?? 20 * 60 * 1000),
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) throw new Error(`${label} exited with status ${result.status ?? 'unknown'}`);
+}
+
+function runPython(label: string, path: string) {
+  const candidates = process.platform === 'win32' ? ['python', 'py'] : ['python3', 'python'];
+  for (const command of candidates) {
+    const args = command === 'py' ? ['-3', path] : [path];
+    const result = spawnSync(command, args, { cwd: repoRoot, env: childEnv, stdio: 'inherit' });
+    if (result.error && (result.error as NodeJS.ErrnoException).code === 'ENOENT') continue;
+    if (result.error) throw result.error;
+    if (result.status !== 0) throw new Error(`${label} exited with status ${result.status ?? 'unknown'}`);
+    return;
+  }
+  throw new Error(`${label} requires Python 3`);
+}
+
+function currentCommit(): string {
+  const result = spawnSync('git', ['rev-parse', 'HEAD'], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) throw new Error('could not resolve the certified Git commit');
+  const commit = result.stdout.trim();
+  if (!/^[a-f0-9]{40}$/.test(commit)) throw new Error('certified Git commit is invalid');
+  return commit;
+}
+
+async function resetDisposableDatabase(pass: number) {
+  console.log(`[hermes-release-gate] pass ${pass}/${requiredPasses}: reset disposable database ${databaseName}`);
+  const client = new Client({ connectionString: databaseUrl });
+  await client.connect();
+  try {
+    await client.query('DROP SCHEMA public CASCADE');
+    await client.query('CREATE SCHEMA public AUTHORIZATION CURRENT_USER');
+  } finally {
+    await client.end();
+  }
+}
+
+async function main() {
+  const startedAt = new Date();
+  const passes: Array<{ pass: number; completed_at: string }> = [];
+
+  for (let pass = 1; pass <= requiredPasses; pass += 1) {
+    await resetDisposableDatabase(pass);
+    run(`pass ${pass}: install fresh schema`, ['db:push-full']);
+    run(`pass ${pass}: seed fresh organization`, ['db:seed:demo']);
+    run(`pass ${pass}: Deft employee boundary matrix`, [
+      '--filter', '@deft/api', 'test', '--', ...apiSuites,
+    ]);
+    run(`pass ${pass}: Agent Channel bridge recovery`, ['test:hermes-channel']);
+    runPython(`pass ${pass}: Hermes employee hook`, 'integrations/hermes/deft-employee/test_deft_employee.py');
+    runPython(`pass ${pass}: Hermes memory provider`, 'integrations/hermes/deft-memory/test_deft_memory.py');
+    run(`pass ${pass}: matched integration bundle`, ['agent:hermes-bundle']);
+    passes.push({ pass, completed_at: new Date().toISOString() });
+  }
+
+  mkdirSync(dirname(certificatePath), { recursive: true });
+  const certificate = {
+    schema: 'deft.hermes.employee.release_gate.v1',
+    result: 'passed',
+    clean_state: true,
+    consecutive_passes: passes.length,
+    started_at: startedAt.toISOString(),
+    completed_at: new Date().toISOString(),
+    commit: currentCommit(),
+    database_name: databaseName,
+    scenario_coverage: scenarioCoverage,
+    api_suites: apiSuites,
+    passes,
+  };
+  writeFileSync(certificatePath, `${JSON.stringify(certificate, null, 2)}\n`, 'utf8');
+  console.log(`[hermes-release-gate] PASSED ${passes.length} consecutive clean-state runs`);
+  console.log(`[hermes-release-gate] certificate: ${certificatePath}`);
+}
+
+main().catch((error) => fail(error instanceof Error ? error.message : String(error)));

--- a/apps/api/test/agent-channel.test.ts
+++ b/apps/api/test/agent-channel.test.ts
@@ -1347,3 +1347,35 @@ test('POST /reply keeps a top-level DM response inline', async () => {
     .limit(1);
   assert.equal(reply?.parent_id, null);
 });
+
+test('regenerating a channel credential revokes the old runtime immediately', async () => {
+  const oldBearer = bearer;
+  const rotated = await operatorApp.request(`/api/agent-employees/${employeeId}/regenerate-channel-token`, {
+    method: 'POST',
+  });
+  const rotatedBody = await rotated.json() as any;
+  assert.equal(rotated.status, 200, JSON.stringify(rotatedBody));
+  assert.equal(typeof rotatedBody.channel_key, 'string');
+  assert.notEqual(rotatedBody.channel_key, oldBearer);
+
+  const denied = await app.request(`/api/agent-channel/v1/connect?${channelCompatibilityQuery()}`, {
+    headers: { authorization: `Bearer ${oldBearer}` },
+  });
+  assert.equal(denied.status, 401, await denied.text());
+
+  bearer = rotatedBody.channel_key;
+  const accepted = await app.request(`/api/agent-channel/v1/connect?${channelCompatibilityQuery()}`, {
+    headers: { authorization: `Bearer ${bearer}` },
+  });
+  assert.equal(accepted.status, 200, await accepted.text());
+
+  const activeTokens = await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(agentChannelTokens)
+    .where(and(
+      eq(agentChannelTokens.agent_employee_id, employeeId),
+      eq(agentChannelTokens.is_active, true),
+      sql`${agentChannelTokens.revoked_at} IS NULL`,
+    ));
+  assert.equal(activeTokens[0]?.count, 1);
+});

--- a/apps/api/test/mcp-connector-safety.test.ts
+++ b/apps/api/test/mcp-connector-safety.test.ts
@@ -144,6 +144,20 @@ test('three consecutive connection failures trigger a persistent backoff', async
   assert.equal(connectionAttempts, 3);
 });
 
+test('a backoff timestamp ending in .401 is not mistaken for an HTTP auth failure', async (t) => {
+  const manager = new MCPClientManager();
+  t.after(() => manager.shutdown());
+  const backoffMessage = 'Connection conn-test is in backoff until 2026-08-24T12:00:00.401Z';
+
+  (manager as unknown as { connect: () => Promise<never> }).connect = async () => {
+    throw new Error(backoffMessage);
+  };
+
+  const result = await manager.executeTool(connectionConfig, 'read_record', {});
+  assert.equal(result.success, false);
+  assert.equal(result.error, backoffMessage);
+});
+
 test('tool discovery explicitly bypasses the SDK response cache', async (t) => {
   const manager = new MCPClientManager();
   t.after(() => manager.shutdown());

--- a/docs/superpowers/plans/2026-08-23-deft-hermes-agent-employee-roadmap.md
+++ b/docs/superpowers/plans/2026-08-23-deft-hermes-agent-employee-roadmap.md
@@ -60,7 +60,10 @@ The first five minimum-work packages are merged:
   bridge-restart proof without placing Hermes on the Deft VPS; and
 - PR #244 completes governed employee-private memory writeback, promotion,
   correction/deletion fencing, secret and instruction rejection, and fresh
-  session reuse certification.
+  session reuse certification; and
+- PR #245 completes durable task milestones, quiet long-run heartbeats,
+  artifact-oriented outcome cards, immutable employee attribution, and the
+  matched Hermes progress/reporting contract.
 
 The executable-contract package established this employee boundary:
 
@@ -76,9 +79,12 @@ The executable-contract package established this employee boundary:
 - employee certification probes task-transition discovery and generic module
   discovery without requiring Contacts—or any module—to be installed.
 
-This still does not make the ideal-employee claim. The employee progress and
-business-outcome package is in validation; the clean-state release gauntlet and
-two consecutive matched demo runs remain in the delivery order below.
+This still does not make the ideal-employee claim. The deterministic release
+gate now rebuilds and seeds a disposable Deft database, exercises the complete
+employee recovery/security matrix and matched Hermes bundle twice, and emits a
+commit-bound certificate required by release publication. Two consecutive
+matched live demo runs from newly onboarded external Hermes profiles remain in
+the delivery order below.
 
 ## Executive summary
 

--- a/integrations/hermes/deft-employee/test_deft_employee.py
+++ b/integrations/hermes/deft-employee/test_deft_employee.py
@@ -16,6 +16,20 @@ class DeftEmployeeHookTests(unittest.TestCase):
         decision = hooks.pre_tool_call(tool_name="gmail_send_email", args={"to": "a@example.com"})
         self.assertEqual(decision["action"], "block")
 
+    def test_approved_external_write_is_available_to_the_runtime(self):
+        hooks = MOD.DeftEmployeeHooks()
+        hooks.policy = {"allow_external_writes": True}
+        decision = hooks.pre_tool_call(tool_name="gmail_send_email", args={"to": "a@example.com"})
+        self.assertIsNone(decision)
+
+    def test_tool_budget_exhaustion_requests_human_assistance(self):
+        hooks = MOD.DeftEmployeeHooks()
+        hooks.policy = {"budgets": {"max_tool_calls": 1}}
+        self.assertIsNone(hooks.pre_tool_call(tool_name="browser", args={"url": "https://example.com"}))
+        decision = hooks.pre_tool_call(tool_name="browser", args={"url": "https://example.org"})
+        self.assertEqual(decision["action"], "block")
+        self.assertIn("human assistance", decision["message"])
+
     def test_model_visible_deft_write_is_governed_by_deft(self):
         hooks = MOD.DeftEmployeeHooks()
         decision = hooks.pre_tool_call(

--- a/integrations/hermes/deft-memory/test_deft_memory.py
+++ b/integrations/hermes/deft-memory/test_deft_memory.py
@@ -1,7 +1,26 @@
 import importlib.util
 import json
 import pathlib
+import sys
+import types
 import unittest
+
+
+try:
+    from agent.memory_provider import MemoryProvider as _HermesMemoryProvider
+except ModuleNotFoundError as exc:
+    if exc.name not in {"agent", "agent.memory_provider"}:
+        raise
+    agent_package = types.ModuleType("agent")
+    agent_package.__path__ = []
+    memory_provider_module = types.ModuleType("agent.memory_provider")
+
+    class _HermesMemoryProvider:
+        pass
+
+    memory_provider_module.MemoryProvider = _HermesMemoryProvider
+    sys.modules["agent"] = agent_package
+    sys.modules["agent.memory_provider"] = memory_provider_module
 
 
 MODULE = pathlib.Path(__file__).with_name("__init__.py")

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "agent:hermes-channel": "node scripts/hermes-agent-channel-bridge.mjs",
     "agent:hermes-bundle": "node scripts/build-hermes-integration-bundle.mjs",
     "test:hermes-channel": "node --test scripts/hermes-agent-channel-bridge.test.mjs",
+    "test:hermes-employee-release-gate": "pnpm --filter @deft/api exec tsx src/scripts/hermes-employee-release-gate.ts",
     "chat:certify": "tsx scripts/reports/chat-ui-certification.ts",
     "certify:60-person": "node scripts/certify-60-person.mjs",
     "selfhost:backup": "tsx scripts/selfhost-backup.ts",

--- a/packages/mcp/src/client.ts
+++ b/packages/mcp/src/client.ts
@@ -178,7 +178,7 @@ export function clientOptionsForTransport(
 function isAuthenticationError(message: string): boolean {
   const normalized = message.toLowerCase();
   return (
-    normalized.includes("401") ||
+    /\b401\b/.test(normalized) ||
     normalized.includes("unauthorized") ||
     normalized.includes("authentication") ||
     normalized.includes("invalid token")

--- a/scripts/release-workflow.test.mjs
+++ b/scripts/release-workflow.test.mjs
@@ -47,3 +47,15 @@ test('release couples the image, package version, and Hermes integration bundle'
   assert.match(workflow, /deft-hermes-integration-\$\{\{ steps\.release\.outputs\.version \}\}\.tar\.gz/);
   assert.match(workflow, /"agent_channel_protocol": "deft\.agent_channel\.v2"/);
 });
+
+test('release publication is blocked on a two-pass clean-state Hermes employee certificate', () => {
+  assert.match(workflow, /certify:\s*[\s\S]*?pnpm test:hermes-employee-release-gate/);
+  assert.match(workflow, /publish:\s*[\s\S]*?needs: certify/);
+  assert.match(workflow, /name: hermes-employee-release-certification/);
+  assert.match(workflow, /certificate_commit[\s\S]*?steps\.release\.outputs\.sha/);
+  assert.match(workflow, /"hermes_employee_certification": "hermes-employee-release-gate\.json"/);
+
+  const certification = position('certify:');
+  const publication = position('publish:');
+  assert.ok(certification < publication);
+});

--- a/scripts/selfhost-smoke.ts
+++ b/scripts/selfhost-smoke.ts
@@ -18,6 +18,8 @@ const REDIRECT_URI = process.env.DEFT_SMOKE_REDIRECT_URI || 'http://localhost:39
 const REQUESTED_SCOPE = process.env.DEFT_SMOKE_SCOPE || 'read:workspace read:wiki read:tasks read:messages read:calendar';
 const OPTIONAL_BEARER = process.env.DEFT_MCP_BEARER_TOKEN || process.env.DEFT_SMOKE_MCP_TOKEN || '';
 const REQUIRE_AUTH = args.has('--require-auth') || process.env.DEFT_REQUIRE_AUTH_SMOKE === '1';
+const REQUIRE_HERMES_EMPLOYEE = args.has('--require-hermes-employee') || process.env.DEFT_REQUIRE_HERMES_EMPLOYEE_SMOKE === '1';
+const REQUIRED_EMPLOYEE_TOOLS = ['platform_context', 'memory_recall', 'memory_write', 'record_progress', 'task_query', 'module_schema_get'];
 
 function mark(check: Check) {
   const icon = check.ok ? (check.warn ? 'WARN' : 'OK') : 'FAIL';
@@ -77,7 +79,16 @@ async function checkReadiness(): Promise<Check> {
 async function checkAgentChannelContract(): Promise<Check> {
   const res = await fetchJson(`${API_URL}/api/agent-channel/v1/contract`);
   const body = res.json as any;
-  const required = ['single_flight_claims', 'renewable_leases', 'fencing_tokens', 'terminal_outcomes', 'identity_bound_mcp'];
+  const required = [
+    'single_flight_claims',
+    'renewable_leases',
+    'fencing_tokens',
+    'terminal_outcomes',
+    'identity_bound_mcp',
+    'wiki_memory_sync_v1',
+    'runtime_reconciliation_v1',
+    'runtime_attestation_v1',
+  ];
   const ok = res.status === 200
     && body?.protocol_version === 'deft.agent_channel.v2'
     && required.every((capability) => body?.capabilities?.includes(capability));
@@ -182,10 +193,10 @@ async function checkOptionalBearerToolsList(): Promise<Check> {
   if (!OPTIONAL_BEARER) {
     return {
       name: 'Optional bearer MCP flow',
-      ok: !REQUIRE_AUTH,
-      warn: !REQUIRE_AUTH,
-      detail: REQUIRE_AUTH
-        ? 'DEFT_MCP_BEARER_TOKEN not set; authenticated tools/list smoke is required'
+      ok: !REQUIRE_AUTH && !REQUIRE_HERMES_EMPLOYEE,
+      warn: !REQUIRE_AUTH && !REQUIRE_HERMES_EMPLOYEE,
+      detail: REQUIRE_AUTH || REQUIRE_HERMES_EMPLOYEE
+        ? 'DEFT_MCP_BEARER_TOKEN not set; authenticated employee tools/list smoke is required'
         : 'DEFT_MCP_BEARER_TOKEN not set; skipped authenticated tools/list smoke. Set DEFT_REQUIRE_AUTH_SMOKE=1 or pass --require-auth to make this a failure.',
     };
   }
@@ -196,11 +207,21 @@ async function checkOptionalBearerToolsList(): Promise<Check> {
   });
   const body = res.json as any;
   const tools = body?.result?.tools;
-  const ok = res.status === 200 && Array.isArray(tools) && tools.length > 0;
+  const toolNames = Array.isArray(tools)
+    ? new Set(tools.map((tool: any) => tool?.name).filter((name: unknown): name is string => typeof name === 'string'))
+    : new Set<string>();
+  const missingEmployeeTools = REQUIRE_HERMES_EMPLOYEE
+    ? REQUIRED_EMPLOYEE_TOOLS.filter((name) => !toolNames.has(name))
+    : [];
+  const ok = res.status === 200 && Array.isArray(tools) && tools.length > 0 && missingEmployeeTools.length === 0;
   return {
     name: 'Optional bearer MCP flow',
     ok,
-    detail: ok ? `authenticated tools/list returned ${tools.length} tool(s)` : `authenticated tools/list returned ${res.status}: ${res.text.slice(0, 180)}`,
+    detail: ok
+      ? `authenticated tools/list returned ${tools.length} tool(s)${REQUIRE_HERMES_EMPLOYEE ? '; required Hermes employee contract is present' : ''}`
+      : missingEmployeeTools.length > 0
+        ? `authenticated tools/list is missing employee tools: ${missingEmployeeTools.join(', ')}`
+        : `authenticated tools/list returned ${res.status}: ${res.text.slice(0, 180)}`,
   };
 }
 
@@ -210,6 +231,7 @@ async function main() {
   console.log(`  public api: ${PUBLIC_API_URL}`);
   console.log(`  mcp: ${MCP_URL}`);
   console.log(`  authenticated tools/list: ${REQUIRE_AUTH ? 'required' : 'optional'}`);
+  console.log(`  Hermes employee contract: ${REQUIRE_HERMES_EMPLOYEE ? 'required' : 'optional'}`);
   console.log('');
 
   const checks = [


### PR DESCRIPTION
## Outcome

Blocks CI builds and release publication unless the Hermes employee contract passes twice consecutively from a freshly rebuilt and seeded disposable database.

## What changed

- adds a guarded two-pass release-gate orchestrator and commit-bound JSON certificate
- covers conversation locality, knowledge/memory, Contacts and generic modules, approvals, delivery recovery, credential rotation, budgets, delegation, privacy, injection, redaction, progress, and outcomes
- makes release publication depend on the exact commit's certificate
- extends production self-host smoke coverage for Agent Channel v2 and the authenticated employee tool contract
- adds explicit channel-token rotation, approved external-write, and budget-exhaustion assertions
- fixes a flaky production bug where an ISO timestamp ending in `.401Z` was misclassified as an HTTP 401 auth failure

## Evidence

- two clean-state passes: 172 API/security + 17 bridge + 16 Hermes plugin assertions per pass
- connector safety regression: 5 consecutive focused passes
- root typecheck and lint
- release workflow contract: 5/5
- current-code self-host smoke: health, readiness, Agent Channel v2, OAuth metadata/DCR, MCP initialize and auth challenge all green
- workflow YAML parse and `git diff --check`