### PR TITLE
fix: isolate Windows Hermes channel services

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "agent:hermes-channel": "node scripts/hermes-agent-channel-bridge.mjs",
     "agent:hermes-bundle": "node scripts/build-hermes-integration-bundle.mjs",
     "test:hermes-channel": "node --test scripts/hermes-agent-channel-bridge.test.mjs",
+    "test:hermes-channel-service": "node --test scripts/hermes-channel-service.test.mjs",
     "test:hermes-employee-release-gate": "pnpm --filter @deft/api exec tsx src/scripts/hermes-employee-release-gate.ts",
     "chat:certify": "tsx scripts/reports/chat-ui-certification.ts",
     "certify:60-person": "node scripts/certify-60-person.mjs",

--- a/scripts/hermes-channel-service.ps1
+++ b/scripts/hermes-channel-service.ps1
@@ -50,6 +50,26 @@ function Protect-Config([string]$Path) {
   if ($LASTEXITCODE -ne 0) { throw "Could not protect service config: $Path" }
 }
 
+function Get-UtcAgeSeconds([object]$Timestamp) {
+  if (-not $Timestamp) { return $null }
+  try {
+    $parsed = if ($Timestamp -is [DateTimeOffset]) {
+      $Timestamp
+    } elseif ($Timestamp -is [datetime]) {
+      [DateTimeOffset]$Timestamp
+    } else {
+      [DateTimeOffset]::Parse(
+        [string]$Timestamp,
+        [Globalization.CultureInfo]::InvariantCulture,
+        [Globalization.DateTimeStyles]::RoundtripKind
+      )
+    }
+    return [Math]::Max(0, [Math]::Round(([DateTimeOffset]::UtcNow - $parsed.ToUniversalTime()).TotalSeconds))
+  } catch {
+    return $null
+  }
+}
+
 function Get-ServiceProcess {
   Get-CimInstance Win32_Process | Where-Object {
     $_.Name -eq 'node.exe' -and $_.CommandLine -like "*$bridgeTarget*"
@@ -139,10 +159,8 @@ switch ($Action) {
     $logAgeSeconds = if ($logItem) {
       [Math]::Round(((Get-Date) - $logItem.LastWriteTime).TotalSeconds)
     } else { $null }
-    $healthAgeSeconds = if ($health -and $health.checked_at) {
-      [Math]::Round(((Get-Date) - [datetime]$health.checked_at).TotalSeconds)
-    } else { $null }
-    $semanticallyHealthy = $health -and $health.state -eq 'healthy' -and $healthAgeSeconds -le 180
+    $healthAgeSeconds = if ($health) { Get-UtcAgeSeconds $health.checked_at } else { $null }
+    $semanticallyHealthy = $health -and $health.state -eq 'healthy' -and $null -ne $healthAgeSeconds -and $healthAgeSeconds -le 180
     [pscustomobject]@{
       Installed = [bool]$task
       Healthy = [bool]($task -and $taskState -eq 'Running' -and $processes.Count -eq 1 -and $semanticallyHealthy)
@@ -171,7 +189,8 @@ switch ($Action) {
     $health = if (Test-Path -LiteralPath $healthPath) {
       try { Get-Content -LiteralPath $healthPath -Raw | ConvertFrom-Json } catch { $null }
     } else { $null }
-    $healthIsFresh = $health -and $health.state -eq 'healthy' -and ((Get-Date) - [datetime]$health.checked_at).TotalSeconds -le 180
+    $healthAgeSeconds = if ($health) { Get-UtcAgeSeconds $health.checked_at } else { $null }
+    $healthIsFresh = $health -and $health.state -eq 'healthy' -and $null -ne $healthAgeSeconds -and $healthAgeSeconds -le 180
     if ([string]$task.State -ne 'Running' -or @(Get-ServiceProcess).Count -ne 1 -or -not $healthIsFresh) {
       Stop-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
       Stop-ServiceProcesses

--- a/scripts/hermes-channel-service.test.mjs
+++ b/scripts/hermes-channel-service.test.mjs
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+const runnerUrl = new URL('./run-hermes-channel-service.ps1', import.meta.url);
+const installerUrl = new URL('./hermes-channel-service.ps1', import.meta.url);
+
+test('Windows Hermes channel runners isolate their mutex by service root', async () => {
+  const runner = await readFile(runnerUrl, 'utf8');
+
+  assert.match(runner, /\[string\]\$MutexName\s*\r?\n/);
+  assert.match(runner, /GetFullPath\(\$ServiceRoot\)/);
+  assert.match(runner, /SHA256\]::Create\(\)/);
+  assert.match(runner, /Local\\DeftHermesAgentChannel-\$serviceInstanceHash/);
+  assert.doesNotMatch(
+    runner,
+    /\[string\]\$MutexName\s*=\s*'Local\\DeftHermesAgentChannel'/,
+  );
+});
+
+test('Windows service health compares bridge timestamps as UTC instants', async () => {
+  const installer = await readFile(installerUrl, 'utf8');
+
+  assert.match(installer, /function Get-UtcAgeSeconds/);
+  assert.match(installer, /\$Timestamp -is \[datetime\]/);
+  assert.match(installer, /\[DateTimeOffset\]::Parse/);
+  assert.match(installer, /\[DateTimeOffset\]::UtcNow/);
+  assert.doesNotMatch(installer, /\(Get-Date\) - \[datetime\]\$health\.checked_at/);
+});

--- a/scripts/run-hermes-channel-service.ps1
+++ b/scripts/run-hermes-channel-service.ps1
@@ -3,10 +3,22 @@ param(
   [string]$ServiceRoot = (Join-Path $env:LOCALAPPDATA 'Deft\hermes-channel'),
   [int]$RestartDelaySeconds = 5,
   [int]$MaxLogSizeMB = 10,
-  [string]$MutexName = 'Local\DeftHermesAgentChannel'
+  [string]$MutexName
 )
 
 $ErrorActionPreference = 'Stop'
+$resolvedServiceRoot = [IO.Path]::GetFullPath($ServiceRoot).TrimEnd('\', '/')
+if (-not $MutexName) {
+  $normalizedServiceRoot = $resolvedServiceRoot.ToLowerInvariant()
+  $sha256 = [Security.Cryptography.SHA256]::Create()
+  try {
+    $hashBytes = $sha256.ComputeHash([Text.Encoding]::UTF8.GetBytes($normalizedServiceRoot))
+  } finally {
+    $sha256.Dispose()
+  }
+  $serviceInstanceHash = ([BitConverter]::ToString($hashBytes)).Replace('-', '').Substring(0, 16)
+  $MutexName = "Local\DeftHermesAgentChannel-$serviceInstanceHash"
+}
 $configPath = Join-Path $ServiceRoot 'service.env'
 $bridgePath = Join-Path $ServiceRoot 'hermes-agent-channel-bridge.mjs'
 $logPath = Join-Path $ServiceRoot 'service.log'


### PR DESCRIPTION
## What changed
- derive the runner mutex from the service root so multiple employee bridges can coexist on Windows
- evaluate bridge health timestamps as UTC instants so non-UTC hosts do not restart healthy employees
- add focused regression tests

## Reproduction
A second service with a distinct task name and service root exited 0 without a process or health file while the first service held the global mutex. After bypassing that, a fresh UTC health timestamp appeared ~19,800 seconds old on an Asia/Kolkata host.

## Evidence
- pnpm test:hermes-channel-service
- pnpm test:hermes-channel
- pnpm test:release-workflow
- real Windows pilot: two service roots coexist; pilot status reports Healthy=true and a single-digit health age