### PR TITLE
chore(release): v0.3.0-preview.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ env vars. Patch versions (`0.X.Y`) are non-breaking fixes only.
 
 ## [Unreleased]
 
+## [0.3.0-preview.10] — 2026-08-24
+
+### Fixed
+
+- Multiple independently installed Hermes employee channel services can now
+  run side by side on Windows; each service root receives its own stable mutex
+  instead of silently exiting behind the first employee's global mutex.
+- Windows service health and repair checks now compare bridge timestamps as UTC
+  instants, preventing healthy employees from appearing stale or being
+  restarted on hosts outside UTC.
+
 ## [0.3.0-preview.9] — 2026-08-24
 
 ### Fixed
@@ -325,7 +336,8 @@ The `0.1.0-alpha` tag was originally published under BSL 1.1. The current
 codebase has since been relicensed under [GNU AGPL v3.0 only](LICENSE); consult
 the license file present in the exact revision you use.
 
-[Unreleased]: https://github.com/Maneek21/Deft/compare/v0.3.0-preview.9...HEAD
+[Unreleased]: https://github.com/Maneek21/Deft/compare/v0.3.0-preview.10...HEAD
+[0.3.0-preview.10]: https://github.com/Maneek21/Deft/releases/tag/v0.3.0-preview.10
 [0.3.0-preview.9]: https://github.com/Maneek21/Deft/releases/tag/v0.3.0-preview.9
 [0.3.0-preview.8]: https://github.com/Maneek21/Deft/releases/tag/v0.3.0-preview.8
 [0.3.0-preview.7]: https://github.com/Maneek21/Deft/releases/tag/v0.3.0-preview.7

--- a/apps/api/src/lib/agent-channel.ts
+++ b/apps/api/src/lib/agent-channel.ts
@@ -31,9 +31,9 @@ export const AGENT_CHANNEL_REQUIRED_RUNTIME_CAPABILITIES = [
   'runtime_reconciliation_v1',
   'runtime_attestation_v1',
 ] as const;
-export const DEFT_RELEASE_VERSION = process.env.DEFT_RELEASE_VERSION || '0.3.0-preview.9';
+export const DEFT_RELEASE_VERSION = process.env.DEFT_RELEASE_VERSION || '0.3.0-preview.10';
 export const DEFT_BUILD_COMMIT = process.env.DEFT_BUILD_COMMIT || process.env.VCS_REF || 'unknown';
-export const DEFT_SCHEMA_HEAD = '0.3.0-preview.9';
+export const DEFT_SCHEMA_HEAD = '0.3.0-preview.10';
 export const AGENT_CHANNEL_DEFAULT_LEASE_MS = 120_000;
 export const AGENT_CHANNEL_MIN_LEASE_MS = 30_000;
 export const AGENT_CHANNEL_MAX_LEASE_MS = 600_000;

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -66,7 +66,7 @@ upgrade baseline. Release-tagged images are signed by the release workflow and
 carry GitHub build provenance. Verify the digest before deploying it:
 
 ```bash
-export TAG=v0.3.0-preview.9
+export TAG=v0.3.0-preview.10
 export VERSION="${TAG#v}"
 export IMAGE=ghcr.io/maneek21/deft
 export DIGEST="$(docker buildx imagetools inspect "$IMAGE:$VERSION" --format '{{json .Manifest.Digest}}' | tr -d '"')"

--- a/integrations/hermes/integration-manifest.json
+++ b/integrations/hermes/integration-manifest.json
@@ -1,8 +1,8 @@
 {
   "schema": "deft.hermes.integration.v1",
   "integration_version": "0.3.0",
-  "deft_release": "0.3.0-preview.9",
-  "deft_release_compatibility": "=0.3.0-preview.9",
+  "deft_release": "0.3.0-preview.10",
+  "deft_release_compatibility": "=0.3.0-preview.10",
   "agent_channel_protocols": ["deft.agent_channel.v2"],
   "required_channel_capabilities": [
     "single_flight_claims",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deft",
-  "version": "0.3.0-preview.9",
+  "version": "0.3.0-preview.10",
   "private": true,
   "license": "AGPL-3.0-only",
   "repository": {


### PR DESCRIPTION
## Release delta
- Windows Hermes employee services use per-service-root mutexes
- service health and repair use UTC-safe timestamps
- bundle manifest and self-hosting defaults target preview.10

## Local evidence
- pnpm test:hermes-channel-service
- pnpm test:hermes-channel
- pnpm test:release-workflow
- pnpm agent:hermes-bundle