### PR TITLE
fix(agent-channel): recover reclaimed runtime attempts

### DIFF
--- a/apps/api/src/routes/agent-channel.ts
+++ b/apps/api/src/routes/agent-channel.ts
@@ -237,12 +237,18 @@ async function startRuntimeAttempt(params: {
         eq(agentChannelDeliveryAttempts.agent_employee_id, params.principal.employee_id),
         eq(agentChannelDeliveryAttempts.direction, 'outbound_runtime'),
         eq(agentChannelDeliveryAttempts.status, 'started'),
-        sql`NOT EXISTS (
-          SELECT 1 FROM agent_channel_events active_event
-          WHERE active_event.id = ${agentChannelDeliveryAttempts.event_id}
-            AND active_event.org_id = ${params.principal.org_id}
-            AND active_event.agent_employee_id = ${params.principal.employee_id}
-            AND active_event.lease_expires_at > now()
+        sql`(
+          (
+            ${agentChannelDeliveryAttempts.event_id} = ${params.event.id}
+            AND ${agentChannelDeliveryAttempts.idempotency_key} IS DISTINCT FROM ${params.runtimeRequestKey}
+          )
+          OR NOT EXISTS (
+            SELECT 1 FROM agent_channel_events active_event
+            WHERE active_event.id = ${agentChannelDeliveryAttempts.event_id}
+              AND active_event.org_id = ${params.principal.org_id}
+              AND active_event.agent_employee_id = ${params.principal.employee_id}
+              AND active_event.lease_expires_at > now()
+          )
         )`,
       ));
 

--- a/apps/api/test/agent-channel.test.ts
+++ b/apps/api/test/agent-channel.test.ts
@@ -704,6 +704,66 @@ test('expired owners are fenced after another worker reclaims the event', async 
   assert.equal(recorded?.lease_expires_at, null);
 });
 
+test('a reclaimed event abandons its stale runtime attempt before starting the next delivery attempt', async () => {
+  const event = await publishMessageEvent(`agent-channel-runtime-reclaim-${crypto.randomUUID()}`);
+  const firstClaim = await claimChannelEvent(event.id, 'runtime-reclaim-first');
+  const firstKey = `deft-channel:${event.id}:attempt:${firstClaim.delivery_count}`;
+  const first = await app.request('/api/agent-channel/v1/ack', {
+    method: 'POST',
+    headers: { authorization: `Bearer ${bearer}`, 'content-type': 'application/json' },
+    body: JSON.stringify({
+      event_id: event.id,
+      state: 'received',
+      claim_token: firstClaim.claim_token,
+      runtime_session_key: `deft:runtime-reclaim:${event.id}`,
+      runtime_request_key: firstKey,
+    }),
+  });
+  assert.equal(first.status, 200, await first.text());
+
+  await db.update(agentChannelEvents)
+    .set({ lease_expires_at: new Date(Date.now() - 1_000) })
+    .where(eq(agentChannelEvents.id, event.id));
+  const secondClaim = await claimChannelEvent(event.id, 'runtime-reclaim-second');
+  assert.equal(secondClaim.delivery_count, firstClaim.delivery_count + 1);
+  const secondKey = `deft-channel:${event.id}:attempt:${secondClaim.delivery_count}`;
+  const second = await app.request('/api/agent-channel/v1/ack', {
+    method: 'POST',
+    headers: { authorization: `Bearer ${bearer}`, 'content-type': 'application/json' },
+    body: JSON.stringify({
+      event_id: event.id,
+      state: 'received',
+      claim_token: secondClaim.claim_token,
+      runtime_session_key: `deft:runtime-reclaim:${event.id}`,
+      runtime_request_key: secondKey,
+    }),
+  });
+  assert.equal(second.status, 200, await second.text());
+
+  const attempts = await db.select({
+    key: agentChannelDeliveryAttempts.idempotency_key,
+    status: agentChannelDeliveryAttempts.status,
+  })
+    .from(agentChannelDeliveryAttempts)
+    .where(eq(agentChannelDeliveryAttempts.event_id, event.id));
+  assert.equal(attempts.find((attempt) => attempt.key === firstKey)?.status, 'abandoned');
+  assert.equal(attempts.find((attempt) => attempt.key === secondKey)?.status, 'started');
+
+  const settled = await app.request('/api/agent-channel/v1/ack', {
+    method: 'POST',
+    headers: { authorization: `Bearer ${bearer}`, 'content-type': 'application/json' },
+    body: JSON.stringify({
+      event_id: event.id,
+      state: 'failed',
+      claim_token: secondClaim.claim_token,
+      runtime_session_key: `deft:runtime-reclaim:${event.id}`,
+      runtime_request_key: secondKey,
+      error: 'Test cleanup',
+    }),
+  });
+  assert.equal(settled.status, 200, await settled.text());
+});
+
 test('POST /ack records received/completed state and cursor', async () => {
   const [fallbackAction] = await db.insert(agentActions).values({
     org_id: orgId,


### PR DESCRIPTION
## Summary
- abandon a stale runtime attempt when the same event is reclaimed under a newer fenced delivery
- preserve the existing one-employee single-flight guard across different events
- add a regression test for mid-delivery bridge restart recovery

## Evidence
- pnpm --filter @deft/api test -- test/agent-channel.test.ts (26/26)
- pnpm --filter @deft/api typecheck
- git diff --check

## Reproduction fixed
A bridge restart after eceived left attempt 1 in started. Reclaims incremented delivery count but could never start the next attempt because the active-event check treated the old attempt as current, producing repeated RUNTIME_REQUEST_KEY_CONFLICT.