### PR TITLE
fix(hermes): keep Windows bridge supervisor persistent

### DIFF
--- a/scripts/hermes-channel-service.ps1
+++ b/scripts/hermes-channel-service.ps1
@@ -123,14 +123,12 @@ switch ($Action) {
       '-NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "{0}" -ServiceRoot "{1}"' -f $runnerTarget, $ServiceRoot
     )
     $logonTrigger = New-ScheduledTaskTrigger -AtLogOn -User $env:USERNAME
-    $watchdogTrigger = New-ScheduledTaskTrigger -Once -At (Get-Date).AddMinutes(1) `
-      -RepetitionInterval (New-TimeSpan -Minutes 5)
     $settings = New-ScheduledTaskSettingsSet -RestartCount 999 -RestartInterval (New-TimeSpan -Minutes 1) `
       -ExecutionTimeLimit (New-TimeSpan -Days 3650) -MultipleInstances IgnoreNew -StartWhenAvailable `
       -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries
     $principal = New-ScheduledTaskPrincipal -UserId ([Security.Principal.WindowsIdentity]::GetCurrent().Name) `
       -LogonType Interactive -RunLevel Limited
-    Register-ScheduledTask -TaskName $TaskName -Action $taskAction -Trigger @($logonTrigger, $watchdogTrigger) `
+    Register-ScheduledTask -TaskName $TaskName -Action $taskAction -Trigger $logonTrigger `
       -Settings $settings -Principal $principal -Description 'Runs the Deft Hermes Agent Channel bridge.' -Force | Out-Null
     Start-ScheduledTask -TaskName $TaskName
     Write-Output "Installed and started '$TaskName'."

--- a/scripts/hermes-channel-service.test.mjs
+++ b/scripts/hermes-channel-service.test.mjs
@@ -27,3 +27,12 @@ test('Windows service health compares bridge timestamps as UTC instants', async 
   assert.match(installer, /\[DateTimeOffset\]::UtcNow/);
   assert.doesNotMatch(installer, /\(Get-Date\) - \[datetime\]\$health\.checked_at/);
 });
+
+test('Windows service installer does not add a duration-bound repeating trigger', async () => {
+  const installer = await readFile(installerUrl, 'utf8');
+
+  assert.match(installer, /New-ScheduledTaskTrigger -AtLogOn/);
+  assert.match(installer, /-Trigger \$logonTrigger/);
+  assert.doesNotMatch(installer, /-RepetitionInterval/);
+  assert.doesNotMatch(installer, /\$watchdogTrigger/);
+});


### PR DESCRIPTION
## Summary
- remove the duration-bound repeating Scheduled Task trigger that can terminate a healthy long-running Hermes bridge
- keep the logon trigger plus the existing in-process and Scheduled Task failure restart behavior
- add regression coverage for the trigger shape

## Evidence
- reproduced on the Rita preview.11 pilot: Windows terminated the bridge with 0xC000013A and repeatedly reclaimed the active event
- node --test scripts/hermes-channel-service.test.mjs (3/3)
- pnpm test:release-workflow (6/6)
- clean restart boundary completed with exactly two deliveries after applying the persistent-trigger shape