### PR TITLE
chore(release): v0.3.0-preview.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ env vars. Patch versions (`0.X.Y`) are non-breaking fixes only.
 
 ## [Unreleased]
 
+## [0.3.0-preview.12] — 2026-08-25
+
+### Fixed
+
+- The Windows Hermes Agent Channel service installer now keeps its long-running
+  supervisor persistent. It no longer adds a duration-bound repeating task
+  trigger that could terminate a healthy bridge and cause repeated event
+  reclaims.
+
 ## [0.3.0-preview.11] — 2026-08-25
 
 ### Fixed
@@ -345,7 +354,8 @@ The `0.1.0-alpha` tag was originally published under BSL 1.1. The current
 codebase has since been relicensed under [GNU AGPL v3.0 only](LICENSE); consult
 the license file present in the exact revision you use.
 
-[Unreleased]: https://github.com/Maneek21/Deft/compare/v0.3.0-preview.11...HEAD
+[Unreleased]: https://github.com/Maneek21/Deft/compare/v0.3.0-preview.12...HEAD
+[0.3.0-preview.12]: https://github.com/Maneek21/Deft/releases/tag/v0.3.0-preview.12
 [0.3.0-preview.11]: https://github.com/Maneek21/Deft/releases/tag/v0.3.0-preview.11
 [0.3.0-preview.10]: https://github.com/Maneek21/Deft/releases/tag/v0.3.0-preview.10
 [0.3.0-preview.9]: https://github.com/Maneek21/Deft/releases/tag/v0.3.0-preview.9

--- a/apps/api/src/lib/agent-channel.ts
+++ b/apps/api/src/lib/agent-channel.ts
@@ -31,9 +31,9 @@ export const AGENT_CHANNEL_REQUIRED_RUNTIME_CAPABILITIES = [
   'runtime_reconciliation_v1',
   'runtime_attestation_v1',
 ] as const;
-export const DEFT_RELEASE_VERSION = process.env.DEFT_RELEASE_VERSION || '0.3.0-preview.11';
+export const DEFT_RELEASE_VERSION = process.env.DEFT_RELEASE_VERSION || '0.3.0-preview.12';
 export const DEFT_BUILD_COMMIT = process.env.DEFT_BUILD_COMMIT || process.env.VCS_REF || 'unknown';
-export const DEFT_SCHEMA_HEAD = '0.3.0-preview.11';
+export const DEFT_SCHEMA_HEAD = '0.3.0-preview.12';
 export const AGENT_CHANNEL_DEFAULT_LEASE_MS = 120_000;
 export const AGENT_CHANNEL_MIN_LEASE_MS = 30_000;
 export const AGENT_CHANNEL_MAX_LEASE_MS = 600_000;

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -66,7 +66,7 @@ upgrade baseline. Release-tagged images are signed by the release workflow and
 carry GitHub build provenance. Verify the digest before deploying it:
 
 ```bash
-export TAG=v0.3.0-preview.11
+export TAG=v0.3.0-preview.12
 export VERSION="${TAG#v}"
 export IMAGE=ghcr.io/maneek21/deft
 export DIGEST="$(docker buildx imagetools inspect "$IMAGE:$VERSION" --format '{{json .Manifest.Digest}}' | tr -d '"')"

--- a/integrations/hermes/integration-manifest.json
+++ b/integrations/hermes/integration-manifest.json
@@ -1,8 +1,8 @@
 {
   "schema": "deft.hermes.integration.v1",
   "integration_version": "0.3.0",
-  "deft_release": "0.3.0-preview.11",
-  "deft_release_compatibility": "=0.3.0-preview.11",
+  "deft_release": "0.3.0-preview.12",
+  "deft_release_compatibility": "=0.3.0-preview.12",
   "agent_channel_protocols": ["deft.agent_channel.v2"],
   "required_channel_capabilities": [
     "single_flight_claims",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deft",
-  "version": "0.3.0-preview.11",
+  "version": "0.3.0-preview.12",
   "private": true,
   "license": "AGPL-3.0-only",
   "repository": {


### PR DESCRIPTION
## Summary
- prepare v0.3.0-preview.12
- bind the release and Hermes bundle to the persistent Windows bridge supervisor fix from #253

## Validation
- pnpm test:release-workflow (6/6)
- pnpm --filter @deft/api typecheck
- node --test scripts/hermes-channel-service.test.mjs (3/3)