### PR TITLE
Phase 3: add dormant governed App Run foundation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,6 +73,10 @@ NEXT_PUBLIC_FEATURE_HUDDLES=false
 DEFT_APPS_ENABLED=false
 NEXT_PUBLIC_FEATURE_APPS=false
 DEFT_APP_DEVELOPER_PAIRING_ENABLED=false
+# Governed App Runs are dormant unless both this exact opt-in and valid,
+# purpose-separated keyrings are supplied. See docs/self-hosting.md.
+DEFT_APP_RUNS_ENABLED=false
+DEFT_APP_RUN_KEYRINGS=
 API_PORT=3001
 
 # MCP connector network policy. HTTPS public origins are the default.

--- a/apps/api/src/lib/app-run-keyrings.ts
+++ b/apps/api/src/lib/app-run-keyrings.ts
@@ -1,0 +1,209 @@
+import { timingSafeEqual } from 'node:crypto';
+import { z } from 'zod';
+
+import { APP_RUN_CONTRACT_VERSIONS, APP_RUN_LIMITS } from '@deft/shared';
+
+export const APP_RUN_KEY_PURPOSES = [
+  'run_encryption',
+  'receipt_signing',
+  'fingerprint',
+] as const;
+
+export type AppRunKeyPurpose = (typeof APP_RUN_KEY_PURPOSES)[number];
+
+const KeyIdSchema = z
+  .string()
+  .min(1)
+  .max(APP_RUN_LIMITS.key_id_chars)
+  .regex(/^[A-Za-z0-9][A-Za-z0-9._-]*$/, 'Key id must use portable identifier characters');
+
+const KeyringSchema = z.object({
+  current: KeyIdSchema,
+  keys: z.record(KeyIdSchema, z.string()),
+}).strict();
+
+const KeyringDocumentSchema = z.object({
+  schema_version: z.literal(APP_RUN_CONTRACT_VERSIONS.keyring),
+  run_encryption: KeyringSchema,
+  receipt_signing: KeyringSchema,
+  fingerprint: KeyringSchema,
+}).strict();
+
+export class AppRunKeyringConfigError extends Error {
+  readonly code = 'APP_RUN_KEYRING_INVALID';
+
+  constructor() {
+    super('App Run keyring configuration is invalid');
+    this.name = 'AppRunKeyringConfigError';
+  }
+}
+
+export type AppRunKeyRef = Readonly<{
+  key_id: string;
+  key: Buffer;
+}>;
+
+export interface AppRunKeyProvider {
+  current(purpose: AppRunKeyPurpose): AppRunKeyRef;
+  read(purpose: AppRunKeyPurpose, keyId: string): AppRunKeyRef | null;
+  keyIds(purpose: AppRunKeyPurpose): readonly string[];
+}
+
+export type AppRunKeyReference = Readonly<{
+  purpose: AppRunKeyPurpose;
+  key_id: string;
+}>;
+
+export class AppRunKeyVersionUnavailableError extends Error {
+  readonly code = 'APP_RUN_KEY_VERSION_UNAVAILABLE';
+
+  constructor() {
+    super('A referenced App Run key version is unavailable');
+    this.name = 'AppRunKeyVersionUnavailableError';
+  }
+}
+
+type ParsedRing = {
+  current: string;
+  keys: Map<string, Buffer>;
+};
+
+const MAX_KEYRING_DOCUMENT_BYTES = 32 * 1024;
+
+function decodeCanonicalKey(value: string): Buffer {
+  if (!/^[A-Za-z0-9+/]{43}=$/.test(value)) throw new AppRunKeyringConfigError();
+  const decoded = Buffer.from(value, 'base64');
+  if (decoded.length !== 32 || decoded.toString('base64') !== value) {
+    decoded.fill(0);
+    throw new AppRunKeyringConfigError();
+  }
+  return decoded;
+}
+
+function parseRing(value: z.infer<typeof KeyringSchema>): ParsedRing {
+  const entries = Object.entries(value.keys);
+  if (
+    entries.length === 0
+    || entries.length > APP_RUN_LIMITS.keyring_entries
+    || !Object.prototype.hasOwnProperty.call(value.keys, value.current)
+  ) {
+    throw new AppRunKeyringConfigError();
+  }
+
+  const keys = new Map<string, Buffer>();
+  const seenMaterial: Buffer[] = [];
+  try {
+    for (const [keyId, encoded] of entries) {
+      const key = decodeCanonicalKey(encoded);
+      if (seenMaterial.some((candidate) => timingSafeEqual(candidate, key))) {
+        key.fill(0);
+        throw new AppRunKeyringConfigError();
+      }
+      keys.set(keyId, key);
+      seenMaterial.push(key);
+    }
+    return { current: value.current, keys };
+  } catch (error) {
+    for (const key of keys.values()) key.fill(0);
+    if (error instanceof AppRunKeyringConfigError) throw error;
+    throw new AppRunKeyringConfigError();
+  }
+}
+
+export class EnvironmentAppRunKeyProvider implements AppRunKeyProvider {
+  readonly #rings: Record<AppRunKeyPurpose, ParsedRing>;
+  #destroyed = false;
+
+  constructor(rings: Record<AppRunKeyPurpose, ParsedRing>) {
+    this.#rings = rings;
+  }
+
+  current(purpose: AppRunKeyPurpose): AppRunKeyRef {
+    this.#assertActive();
+    const ring = this.#rings[purpose];
+    const key = ring.keys.get(ring.current);
+    if (!key) throw new AppRunKeyringConfigError();
+    return { key_id: ring.current, key: Buffer.from(key) };
+  }
+
+  read(purpose: AppRunKeyPurpose, keyId: string): AppRunKeyRef | null {
+    this.#assertActive();
+    const key = this.#rings[purpose].keys.get(keyId);
+    return key ? { key_id: keyId, key: Buffer.from(key) } : null;
+  }
+
+  keyIds(purpose: AppRunKeyPurpose): readonly string[] {
+    this.#assertActive();
+    return Object.freeze([...this.#rings[purpose].keys.keys()]);
+  }
+
+  destroy(): void {
+    if (this.#destroyed) return;
+    for (const purpose of APP_RUN_KEY_PURPOSES) {
+      for (const key of this.#rings[purpose].keys.values()) key.fill(0);
+      this.#rings[purpose].keys.clear();
+    }
+    this.#destroyed = true;
+  }
+
+  #assertActive(): void {
+    if (this.#destroyed) throw new AppRunKeyringConfigError();
+  }
+}
+
+export function parseEnvironmentAppRunKeyrings(raw: string | undefined): EnvironmentAppRunKeyProvider {
+  if (!raw || Buffer.byteLength(raw, 'utf8') > MAX_KEYRING_DOCUMENT_BYTES) {
+    throw new AppRunKeyringConfigError();
+  }
+
+  let document: z.infer<typeof KeyringDocumentSchema>;
+  try {
+    document = KeyringDocumentSchema.parse(JSON.parse(raw));
+  } catch {
+    throw new AppRunKeyringConfigError();
+  }
+
+  const parsed = {} as Record<AppRunKeyPurpose, ParsedRing>;
+  const allMaterial: Buffer[] = [];
+  try {
+    for (const purpose of APP_RUN_KEY_PURPOSES) {
+      const ring = parseRing(document[purpose]);
+      parsed[purpose] = ring;
+      for (const key of ring.keys.values()) {
+        if (allMaterial.some((candidate) => timingSafeEqual(candidate, key))) {
+          throw new AppRunKeyringConfigError();
+        }
+        allMaterial.push(key);
+      }
+    }
+    return new EnvironmentAppRunKeyProvider(parsed);
+  } catch (error) {
+    for (const ring of Object.values(parsed)) {
+      for (const key of ring.keys.values()) key.fill(0);
+    }
+    if (error instanceof AppRunKeyringConfigError) throw error;
+    throw new AppRunKeyringConfigError();
+  }
+}
+
+export function validateAppRunKeyringEnvironment(
+  enabled: boolean,
+  raw: string | undefined,
+): void {
+  if (!enabled) return;
+  const provider = parseEnvironmentAppRunKeyrings(raw);
+  provider.destroy();
+}
+
+// Call this with the distinct key references inventoried from retained rows
+// before enabling execution or accepting a keyring retirement.
+export function assertAppRunReferencedKeysAvailable(
+  provider: AppRunKeyProvider,
+  references: readonly AppRunKeyReference[],
+): void {
+  for (const reference of references) {
+    const key = provider.read(reference.purpose, reference.key_id);
+    if (!key) throw new AppRunKeyVersionUnavailableError();
+    key.key.fill(0);
+  }
+}

--- a/apps/api/src/lib/app-run-secrets.ts
+++ b/apps/api/src/lib/app-run-secrets.ts
@@ -1,0 +1,302 @@
+import {
+  createCipheriv,
+  createDecipheriv,
+  createHmac,
+  randomBytes,
+  timingSafeEqual,
+} from 'node:crypto';
+import { z } from 'zod';
+
+import {
+  APP_RUN_CONTRACT_VERSIONS,
+  APP_RUN_LIMITS,
+  CapabilityJsonValueSchema,
+  assertCapabilityJsonWithinBudget,
+  canonicalCapabilityJson,
+  type CapabilityJsonValue,
+} from '@deft/shared';
+
+import {
+  type AppRunKeyProvider,
+  type AppRunKeyRef,
+} from './app-run-keyrings.js';
+
+const ALGORITHM = 'aes-256-gcm';
+const NONCE_BYTES = 12;
+const AUTH_TAG_BYTES = 16;
+
+const ExactContextIdSchema = z
+  .string()
+  .min(1)
+  .max(512)
+  .refine((value) => value === value.trim())
+  .refine((value) => !/[\u0000-\u001f\u007f]/u.test(value));
+
+export const AppRunSecretContextSchema = z.object({
+  org_id: ExactContextIdSchema,
+  run_id: ExactContextIdSchema,
+  payload_kind: z.enum(['input', 'output']),
+  attempt_id: ExactContextIdSchema.optional(),
+}).strict().superRefine((value, ctx) => {
+  if (value.payload_kind === 'input' && value.attempt_id !== undefined) {
+    ctx.addIssue({ code: 'custom', path: ['attempt_id'], message: 'Input payload cannot be attempt-scoped' });
+  }
+  if (value.payload_kind === 'output' && value.attempt_id === undefined) {
+    ctx.addIssue({ code: 'custom', path: ['attempt_id'], message: 'Output payload must be attempt-scoped' });
+  }
+});
+export type AppRunSecretContext = z.infer<typeof AppRunSecretContextSchema>;
+
+function canonicalBase64Schema(maxChars: number) {
+  return z.string().max(maxChars).refine((value) => {
+    if (!/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(value)) return false;
+    return Buffer.from(value, 'base64').toString('base64') === value;
+  }, 'Value must be canonical base64');
+}
+
+const MAX_CIPHERTEXT_BASE64_CHARS = 4 * Math.ceil(APP_RUN_LIMITS.output_bytes / 3);
+
+export const AppRunSecretEnvelopeSchema = z.object({
+  schema_version: z.literal(APP_RUN_CONTRACT_VERSIONS.secret_envelope),
+  algorithm: z.literal(ALGORITHM),
+  key_version: z.string()
+    .min(1)
+    .max(APP_RUN_LIMITS.key_id_chars)
+    .regex(/^[A-Za-z0-9][A-Za-z0-9._-]*$/),
+  nonce_b64: canonicalBase64Schema(16),
+  ciphertext_b64: canonicalBase64Schema(MAX_CIPHERTEXT_BASE64_CHARS),
+  auth_tag_b64: canonicalBase64Schema(24),
+}).strict().superRefine((value, ctx) => {
+  if (Buffer.from(value.nonce_b64, 'base64').length !== NONCE_BYTES) {
+    ctx.addIssue({ code: 'custom', path: ['nonce_b64'], message: 'Nonce must be 96 bits' });
+  }
+  if (Buffer.from(value.auth_tag_b64, 'base64').length !== AUTH_TAG_BYTES) {
+    ctx.addIssue({ code: 'custom', path: ['auth_tag_b64'], message: 'Authentication tag must be 128 bits' });
+  }
+});
+export type AppRunSecretEnvelope = z.infer<typeof AppRunSecretEnvelopeSchema>;
+
+export type AppRunSecretSafeProjection = Readonly<{
+  schema_version: typeof APP_RUN_CONTRACT_VERSIONS.secret_envelope;
+  algorithm: typeof ALGORITHM;
+  key_version: string;
+  ciphertext_bytes: number;
+}>;
+
+export type AppRunFingerprintPurpose = 'input' | 'idempotency';
+
+function aad(context: AppRunSecretContext): Buffer {
+  return Buffer.from(canonicalCapabilityJson([
+    APP_RUN_CONTRACT_VERSIONS.secret_aad,
+    context.org_id,
+    context.run_id,
+    context.payload_kind,
+    context.attempt_id ?? null,
+  ]), 'utf8');
+}
+
+function fingerprintDomain(purpose: AppRunFingerprintPurpose): Buffer {
+  return Buffer.from(`deft.app_run.fingerprint.v1\u0000${purpose}\u0000`, 'utf8');
+}
+
+function receiptDomain(): Buffer {
+  return Buffer.from(`${APP_RUN_CONTRACT_VERSIONS.receipt}\u0000`, 'utf8');
+}
+
+function hmac(key: Buffer, domain: Buffer, value: Buffer): string {
+  try {
+    return `hmac-sha256:${createHmac('sha256', key).update(domain).update(value).digest('hex')}`;
+  } finally {
+    key.fill(0);
+  }
+}
+
+function exactSignatureBytes(value: string): Buffer | null {
+  const match = /^hmac-sha256:([a-f0-9]{64})$/.exec(value);
+  return match ? Buffer.from(match[1]!, 'hex') : null;
+}
+
+export class AppRunSecretService {
+  constructor(private readonly keys: AppRunKeyProvider) {}
+
+  sealJson(value: unknown, rawContext: AppRunSecretContext): AppRunSecretEnvelope {
+    const context = AppRunSecretContextSchema.parse(rawContext);
+    const limit = context.payload_kind === 'input'
+      ? APP_RUN_LIMITS.input_bytes
+      : APP_RUN_LIMITS.output_bytes;
+    assertCapabilityJsonWithinBudget(value, limit);
+    const plaintext = Buffer.from(canonicalCapabilityJson(value), 'utf8');
+    const keyRef = this.keys.current('run_encryption');
+    const nonce = randomBytes(NONCE_BYTES);
+    let ciphertext: Buffer | null = null;
+    let authTag: Buffer | null = null;
+    try {
+      const cipher = createCipheriv(ALGORITHM, keyRef.key, nonce, { authTagLength: AUTH_TAG_BYTES });
+      cipher.setAAD(aad(context));
+      ciphertext = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+      authTag = cipher.getAuthTag();
+      const envelope = AppRunSecretEnvelopeSchema.parse({
+        schema_version: APP_RUN_CONTRACT_VERSIONS.secret_envelope,
+        algorithm: ALGORITHM,
+        key_version: keyRef.key_id,
+        nonce_b64: nonce.toString('base64'),
+        ciphertext_b64: ciphertext.toString('base64'),
+        auth_tag_b64: authTag.toString('base64'),
+      });
+      return Object.freeze(envelope);
+    } finally {
+      plaintext.fill(0);
+      keyRef.key.fill(0);
+      nonce.fill(0);
+      ciphertext?.fill(0);
+      authTag?.fill(0);
+    }
+  }
+
+  openJson(rawEnvelope: unknown, rawContext: AppRunSecretContext): CapabilityJsonValue {
+    const envelope = AppRunSecretEnvelopeSchema.parse(rawEnvelope);
+    const context = AppRunSecretContextSchema.parse(rawContext);
+    const keyRef = this.keys.read('run_encryption', envelope.key_version);
+    if (!keyRef) throw new Error('APP_RUN_KEY_VERSION_UNAVAILABLE');
+
+    const ciphertext = Buffer.from(envelope.ciphertext_b64, 'base64');
+    const nonce = Buffer.from(envelope.nonce_b64, 'base64');
+    const tag = Buffer.from(envelope.auth_tag_b64, 'base64');
+    let plaintext: Buffer | null = null;
+    try {
+      const decipher = createDecipheriv(ALGORITHM, keyRef.key, nonce, { authTagLength: AUTH_TAG_BYTES });
+      decipher.setAAD(aad(context));
+      decipher.setAuthTag(tag);
+      plaintext = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+      const value = CapabilityJsonValueSchema.parse(JSON.parse(plaintext.toString('utf8')));
+      const limit = context.payload_kind === 'input'
+        ? APP_RUN_LIMITS.input_bytes
+        : APP_RUN_LIMITS.output_bytes;
+      assertCapabilityJsonWithinBudget(value, limit);
+      return value;
+    } finally {
+      keyRef.key.fill(0);
+      ciphertext.fill(0);
+      nonce.fill(0);
+      tag.fill(0);
+      plaintext?.fill(0);
+    }
+  }
+
+  safeProjection(rawEnvelope: unknown): AppRunSecretSafeProjection {
+    const envelope = AppRunSecretEnvelopeSchema.parse(rawEnvelope);
+    const ciphertext = Buffer.from(envelope.ciphertext_b64, 'base64');
+    try {
+      return Object.freeze({
+        schema_version: envelope.schema_version,
+        algorithm: envelope.algorithm,
+        key_version: envelope.key_version,
+        ciphertext_bytes: ciphertext.length,
+      });
+    } finally {
+      ciphertext.fill(0);
+    }
+  }
+
+  fingerprintJson(purpose: AppRunFingerprintPurpose, value: unknown): Readonly<{
+    key_version: string;
+    fingerprint: string;
+  }> {
+    assertCapabilityJsonWithinBudget(value, APP_RUN_LIMITS.input_bytes);
+    const canonical = Buffer.from(canonicalCapabilityJson(value), 'utf8');
+    return this.#fingerprintWith(this.keys.current('fingerprint'), purpose, canonical);
+  }
+
+  fingerprintText(purpose: AppRunFingerprintPurpose, value: string): Readonly<{
+    key_version: string;
+    fingerprint: string;
+  }> {
+    const limit = purpose === 'idempotency'
+      ? APP_RUN_LIMITS.idempotency_key_bytes
+      : APP_RUN_LIMITS.input_bytes;
+    if (Buffer.byteLength(value, 'utf8') > limit) {
+      throw new TypeError(`App Run ${purpose} value exceeds ${limit} bytes`);
+    }
+    return this.#fingerprintWith(
+      this.keys.current('fingerprint'),
+      purpose,
+      Buffer.from(value, 'utf8'),
+    );
+  }
+
+  fingerprintTextCandidates(purpose: AppRunFingerprintPurpose, value: string): readonly Readonly<{
+    key_version: string;
+    fingerprint: string;
+  }>[] {
+    const limit = purpose === 'idempotency'
+      ? APP_RUN_LIMITS.idempotency_key_bytes
+      : APP_RUN_LIMITS.input_bytes;
+    if (Buffer.byteLength(value, 'utf8') > limit) {
+      throw new TypeError(`App Run ${purpose} value exceeds ${limit} bytes`);
+    }
+    return Object.freeze(this.keys.keyIds('fingerprint').map((keyId) => {
+      const keyRef = this.keys.read('fingerprint', keyId);
+      if (!keyRef) throw new Error('APP_RUN_KEY_VERSION_UNAVAILABLE');
+      return this.#fingerprintWith(keyRef, purpose, Buffer.from(value, 'utf8'));
+    }));
+  }
+
+  signReceipt(value: unknown): Readonly<{ key_version: string; signature_hmac: string }> {
+    assertCapabilityJsonWithinBudget(value, APP_RUN_LIMITS.safe_receipt_envelope_bytes);
+    const canonical = Buffer.from(canonicalCapabilityJson(value), 'utf8');
+    const keyRef = this.keys.current('receipt_signing');
+    try {
+      return Object.freeze({
+        key_version: keyRef.key_id,
+        signature_hmac: hmac(keyRef.key, receiptDomain(), canonical),
+      });
+    } finally {
+      canonical.fill(0);
+    }
+  }
+
+  verifyReceipt(value: unknown, keyVersion: string, signature: string): boolean {
+    try {
+      assertCapabilityJsonWithinBudget(value, APP_RUN_LIMITS.safe_receipt_envelope_bytes);
+      const keyRef = this.keys.read('receipt_signing', keyVersion);
+      if (!keyRef) return false;
+      const canonical = Buffer.from(canonicalCapabilityJson(value), 'utf8');
+      let expected: string;
+      try {
+        expected = hmac(keyRef.key, receiptDomain(), canonical);
+      } finally {
+        canonical.fill(0);
+      }
+      const expectedBytes = exactSignatureBytes(expected);
+      const actualBytes = exactSignatureBytes(signature);
+      try {
+        return Boolean(
+          expectedBytes
+          && actualBytes
+          && expectedBytes.length === actualBytes.length
+          && timingSafeEqual(expectedBytes, actualBytes),
+        );
+      } finally {
+        expectedBytes?.fill(0);
+        actualBytes?.fill(0);
+      }
+    } catch {
+      return false;
+    }
+  }
+
+  #fingerprintWith(
+    keyRef: AppRunKeyRef,
+    purpose: AppRunFingerprintPurpose,
+    value: Buffer,
+  ): Readonly<{ key_version: string; fingerprint: string }> {
+    try {
+      return Object.freeze({
+        key_version: keyRef.key_id,
+        fingerprint: hmac(keyRef.key, fingerprintDomain(purpose), value),
+      });
+    } finally {
+      value.fill(0);
+    }
+  }
+}

--- a/apps/api/src/lib/env.ts
+++ b/apps/api/src/lib/env.ts
@@ -2,6 +2,7 @@ import dotenv from 'dotenv';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { execFileSync } from 'node:child_process';
+import { validateAppRunKeyringEnvironment } from './app-run-keyrings.js';
 
 // Resolve .env from the repo root via the source file's location, NOT
 // process.cwd() — when this module loads under tsx / pnpm --filter / docker /
@@ -112,3 +113,9 @@ export const env = {
 export const APPS_ENABLED = process.env.DEFT_APPS_ENABLED === 'true';
 export const APP_DEVELOPER_PAIRING_ENABLED =
   APPS_ENABLED && process.env.DEFT_APP_DEVELOPER_PAIRING_ENABLED === 'true';
+
+// Governed App Runs remain a dormant, independent opt-in during Phase 3.
+// Exact "true" plus valid purpose-separated keyrings is required. A normal
+// legacy self-host boot never needs or parses the new secret document.
+export const APP_RUNS_ENABLED = process.env.DEFT_APP_RUNS_ENABLED === 'true';
+validateAppRunKeyringEnvironment(APP_RUNS_ENABLED, process.env.DEFT_APP_RUN_KEYRINGS);

--- a/apps/api/test/app-run-architecture.test.ts
+++ b/apps/api/test/app-run-architecture.test.ts
@@ -1,0 +1,50 @@
+import assert from 'node:assert/strict';
+import { readdir, readFile } from 'node:fs/promises';
+import { join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+const sourceRoot = fileURLToPath(new URL('../src/', import.meta.url));
+
+async function typescriptFiles(directory: string): Promise<string[]> {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const nested = await Promise.all(entries.map(async (entry) => {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) return typescriptFiles(path);
+    return entry.isFile() && entry.name.endsWith('.ts') ? [path] : [];
+  }));
+  return nested.flat();
+}
+
+test('only the App Run secret boundary handles ciphertext and signing material', async () => {
+  const allowed = new Set([
+    'lib/app-run-keyrings.ts',
+    'lib/app-run-secrets.ts',
+  ]);
+  const forbidden = /\b(?:ciphertext_b64|nonce_b64|auth_tag_b64|receipt_signing)\b/g;
+  const violations: string[] = [];
+
+  for (const path of await typescriptFiles(sourceRoot)) {
+    const sourcePath = relative(sourceRoot, path).replaceAll('\\', '/');
+    if (allowed.has(sourcePath)) continue;
+    const source = await readFile(path, 'utf8');
+    for (const match of source.matchAll(forbidden)) {
+      violations.push(`${sourcePath}:${match.index ?? 0}:${match[0]}`);
+    }
+  }
+
+  assert.deepEqual(violations, []);
+});
+
+test('the dormant foundation has no production execution consumer', async () => {
+  const consumers: string[] = [];
+  for (const path of await typescriptFiles(sourceRoot)) {
+    const sourcePath = relative(sourceRoot, path).replaceAll('\\', '/');
+    if (sourcePath.startsWith('lib/app-run-') || sourcePath === 'lib/env.ts') continue;
+    const source = await readFile(path, 'utf8');
+    if (/\b(?:AppRunSecretService|DEFT_APP_RUNS_ENABLED|APP_RUNS_ENABLED)\b/.test(source)) {
+      consumers.push(sourcePath);
+    }
+  }
+  assert.deepEqual(consumers, []);
+});

--- a/apps/api/test/app-run-secrets.test.ts
+++ b/apps/api/test/app-run-secrets.test.ts
@@ -1,0 +1,193 @@
+import assert from 'node:assert/strict';
+import { randomBytes } from 'node:crypto';
+import { describe, test } from 'node:test';
+
+import { APP_RUN_CONTRACT_VERSIONS, APP_RUN_LIMITS } from '@deft/shared';
+
+import {
+  AppRunKeyringConfigError,
+  AppRunKeyVersionUnavailableError,
+  assertAppRunReferencedKeysAvailable,
+  parseEnvironmentAppRunKeyrings,
+  validateAppRunKeyringEnvironment,
+} from '../src/lib/app-run-keyrings.js';
+import { AppRunSecretService } from '../src/lib/app-run-secrets.js';
+
+function key(byte: number): string {
+  return Buffer.alloc(32, byte).toString('base64');
+}
+
+function config(options: {
+  encryptionCurrent?: string;
+  encryptionKeys?: Record<string, string>;
+  signingKeys?: Record<string, string>;
+  fingerprintKeys?: Record<string, string>;
+} = {}): string {
+  return JSON.stringify({
+    schema_version: APP_RUN_CONTRACT_VERSIONS.keyring,
+    run_encryption: {
+      current: options.encryptionCurrent ?? 'enc-v1',
+      keys: options.encryptionKeys ?? { 'enc-v1': key(1) },
+    },
+    receipt_signing: {
+      current: 'sig-v1',
+      keys: options.signingKeys ?? { 'sig-v1': key(2) },
+    },
+    fingerprint: {
+      current: 'fp-v1',
+      keys: options.fingerprintKeys ?? { 'fp-v1': key(3) },
+    },
+  });
+}
+
+const inputContext = {
+  org_id: 'org-1',
+  run_id: 'run-1',
+  payload_kind: 'input' as const,
+};
+
+describe('App Run keyring configuration', () => {
+  test('is ignored while disabled and required while enabled', () => {
+    assert.doesNotThrow(() => validateAppRunKeyringEnvironment(false, undefined));
+    assert.throws(
+      () => validateAppRunKeyringEnvironment(true, undefined),
+      AppRunKeyringConfigError,
+    );
+    assert.doesNotThrow(() => validateAppRunKeyringEnvironment(true, config()));
+  });
+
+  test('rejects malformed, non-random-width, missing-current, duplicate, and cross-purpose key material', () => {
+    assert.throws(() => parseEnvironmentAppRunKeyrings('{'), AppRunKeyringConfigError);
+    assert.throws(() => parseEnvironmentAppRunKeyrings(config({
+      encryptionKeys: { 'enc-v1': Buffer.alloc(31, 1).toString('base64') },
+    })), AppRunKeyringConfigError);
+    assert.throws(() => parseEnvironmentAppRunKeyrings(config({
+      encryptionCurrent: 'missing',
+    })), AppRunKeyringConfigError);
+    assert.throws(() => parseEnvironmentAppRunKeyrings(config({
+      encryptionKeys: { 'enc-v1': key(1), 'enc-v2': key(1) },
+    })), AppRunKeyringConfigError);
+    assert.throws(() => parseEnvironmentAppRunKeyrings(config({
+      signingKeys: { 'sig-v1': key(1) },
+    })), AppRunKeyringConfigError);
+  });
+
+  test('refuses key retirement while retained references need the removed version', () => {
+    const provider = parseEnvironmentAppRunKeyrings(config());
+    assert.doesNotThrow(() => assertAppRunReferencedKeysAvailable(provider, [
+      { purpose: 'run_encryption', key_id: 'enc-v1' },
+      { purpose: 'receipt_signing', key_id: 'sig-v1' },
+      { purpose: 'fingerprint', key_id: 'fp-v1' },
+    ]));
+    assert.throws(() => assertAppRunReferencedKeysAvailable(provider, [
+      { purpose: 'run_encryption', key_id: 'removed' },
+    ]), AppRunKeyVersionUnavailableError);
+    provider.destroy();
+  });
+});
+
+describe('App Run Secret Service', () => {
+  test('round-trips canonical JSON with randomized 96-bit nonces and an explicit safe projection', () => {
+    const provider = parseEnvironmentAppRunKeyrings(config());
+    const service = new AppRunSecretService(provider);
+    const first = service.sealJson({ z: 1, nested: { b: 2, a: 'same' } }, inputContext);
+    const second = service.sealJson({ nested: { a: 'same', b: 2 }, z: 1 }, inputContext);
+
+    assert.notEqual(first.nonce_b64, second.nonce_b64);
+    assert.notEqual(first.ciphertext_b64, second.ciphertext_b64);
+    assert.deepEqual(service.openJson(first, inputContext), {
+      nested: { a: 'same', b: 2 },
+      z: 1,
+    });
+    assert.deepEqual(service.safeProjection(first), {
+      schema_version: APP_RUN_CONTRACT_VERSIONS.secret_envelope,
+      algorithm: 'aes-256-gcm',
+      key_version: 'enc-v1',
+      ciphertext_bytes: Buffer.from(first.ciphertext_b64, 'base64').length,
+    });
+    assert.equal('ciphertext_b64' in service.safeProjection(first), false);
+    provider.destroy();
+  });
+
+  test('binds ciphertext to tenant, Run, payload kind, and attempt', () => {
+    const provider = parseEnvironmentAppRunKeyrings(config());
+    const service = new AppRunSecretService(provider);
+    const envelope = service.sealJson({ secret: 'value' }, inputContext);
+    for (const context of [
+      { ...inputContext, org_id: 'other-org' },
+      { ...inputContext, run_id: 'other-run' },
+      { ...inputContext, payload_kind: 'output' as const, attempt_id: 'attempt-1' },
+    ]) {
+      assert.throws(() => service.openJson(envelope, context));
+    }
+    assert.throws(() => service.openJson({
+      ...envelope,
+      ciphertext_b64: Buffer.from(randomBytes(32)).toString('base64'),
+    }, inputContext));
+    assert.throws(() => service.openJson({ ...envelope, key_version: 'missing' }, inputContext),
+      /APP_RUN_KEY_VERSION_UNAVAILABLE/);
+    assert.throws(() => service.openJson({ ...envelope, nonce_b64: 'not-base64' }, inputContext));
+    assert.throws(() => service.openJson({
+      ...envelope,
+      ciphertext_b64: 'A'.repeat(4 * Math.ceil(APP_RUN_LIMITS.output_bytes / 3) + 4),
+    }, inputContext));
+    provider.destroy();
+  });
+
+  test('reads an older encryption key after rotation and writes only with current', () => {
+    const oldProvider = parseEnvironmentAppRunKeyrings(config());
+    const oldService = new AppRunSecretService(oldProvider);
+    const oldEnvelope = oldService.sealJson({ retained: true }, inputContext);
+    oldProvider.destroy();
+
+    const rotatedProvider = parseEnvironmentAppRunKeyrings(config({
+      encryptionCurrent: 'enc-v2',
+      encryptionKeys: { 'enc-v1': key(1), 'enc-v2': key(4) },
+    }));
+    const rotatedService = new AppRunSecretService(rotatedProvider);
+    assert.deepEqual(rotatedService.openJson(oldEnvelope, inputContext), { retained: true });
+    assert.equal(rotatedService.sealJson({ next: true }, inputContext).key_version, 'enc-v2');
+    rotatedProvider.destroy();
+  });
+
+  test('domain-separates input and idempotency fingerprints and supports rotation candidates', () => {
+    const provider = parseEnvironmentAppRunKeyrings(config({
+      fingerprintKeys: { 'fp-v1': key(3), 'fp-old': key(5) },
+    }));
+    const service = new AppRunSecretService(provider);
+    const input = service.fingerprintText('input', 'low-entropy');
+    const replay = service.fingerprintText('idempotency', 'low-entropy');
+    assert.notEqual(input.fingerprint, replay.fingerprint);
+    assert.deepEqual(
+      service.fingerprintTextCandidates('idempotency', 'low-entropy').map((item) => item.key_version),
+      ['fp-v1', 'fp-old'],
+    );
+    assert.doesNotMatch(JSON.stringify(replay), /low-entropy/);
+    assert.throws(
+      () => service.fingerprintText('idempotency', 'é'.repeat(APP_RUN_LIMITS.idempotency_key_bytes)),
+      /exceeds/,
+    );
+    provider.destroy();
+  });
+
+  test('signs safe receipts with a separate key and verifies in constant-shaped failure paths', () => {
+    const provider = parseEnvironmentAppRunKeyrings(config());
+    const service = new AppRunSecretService(provider);
+    const receipt = { run_id: 'run-1', state: 'succeeded', output_envelope_digest: 'sha256:abc' };
+    const signed = service.signReceipt(receipt);
+    assert.equal(service.verifyReceipt(receipt, signed.key_version, signed.signature_hmac), true);
+    assert.equal(service.verifyReceipt({ ...receipt, state: 'failed' }, signed.key_version, signed.signature_hmac), false);
+    assert.equal(service.verifyReceipt(receipt, 'missing', signed.signature_hmac), false);
+    assert.equal(service.verifyReceipt(receipt, signed.key_version, 'invalid'), false);
+    provider.destroy();
+  });
+
+  test('zeroes provider-owned material on destroy and fails closed afterwards', () => {
+    const provider = parseEnvironmentAppRunKeyrings(config());
+    const before = provider.current('run_encryption');
+    provider.destroy();
+    assert.throws(() => provider.current('run_encryption'), AppRunKeyringConfigError);
+    assert.notDeepEqual(before.key, Buffer.alloc(32));
+    before.key.fill(0);
+  });
+});

--- a/docs/decisions/2026-08-30-governed-app-runs-rollout.md
+++ b/docs/decisions/2026-08-30-governed-app-runs-rollout.md
@@ -1,6 +1,6 @@
 # ADR: Additive Governed App Runs and staged secret rollout
 
-- Status: Proposed; architecture-reviewed and rebased after Phase 2 merge
+- Status: Accepted; dormant foundation implementation begun after Phase 2 merge
 - Date: 2026-08-30
 - Depends on: Capability Service squash merge `9ba7b7c8` from PR #270
 - Supersedes: the big-bang sequencing implied by the earlier App Protocol v2

--- a/docs/decisions/2026-08-30-governed-app-runs-rollout.md
+++ b/docs/decisions/2026-08-30-governed-app-runs-rollout.md
@@ -1,0 +1,229 @@
+# ADR: Additive Governed App Runs and staged secret rollout
+
+- Status: Proposed; architecture-reviewed and rebased after Phase 2 merge
+- Date: 2026-08-30
+- Depends on: Capability Service squash merge `9ba7b7c8` from PR #270
+- Supersedes: the big-bang sequencing implied by the earlier App Protocol v2
+  specification where it conflicts
+
+## Context
+
+Phase 2 creates one internal Capability Service seam but deliberately preserves
+the two legacy execution lifecycles. The current approval ledger stores raw
+parameters in `agent_actions`; action receipts are signed with the same
+deployment secret used for encryption; provider credentials use one unversioned
+AES-GCM format; and a crash after an external effect begins cannot be represented
+uniformly as an unknown outcome.
+
+Phase 3 must add an actor-neutral, durable execution envelope without making
+existing Deft, Module, employee, or MCP behavior depend on an unfinished App
+grant model. It must remain straightforward to operate in an open-source
+self-host and leave a clean key-provider seam for a future hosted service.
+
+## Options considered
+
+### Extend `agent_actions` into the Run ledger
+
+This is the smallest schema change, but it retains an agent-specific source of
+truth, raw approval parameters, path-dependent retry semantics, and no adequate
+attempt or unknown-outcome model. App callers would inherit legacy constraints
+instead of receiving an actor-neutral contract. Rejected.
+
+### Replace legacy execution in one migration
+
+This produces the desired end state sooner on paper, but combines cryptography,
+schema, migration, approval, provider-call, receipt, worker, and rollback risk.
+An external-effect shadow comparison is unsafe, and a rollback could strand
+ciphertext an older image cannot read. Rejected.
+
+### Add a dormant Run subsystem and cut over behind a fail-closed flag
+
+Add new tables and a deep App Run service, preserve `agent_actions` as a linked
+approval adapter, and keep current execution active until parity and release
+gates pass. Versioned key readers land before existing ciphertext writers
+change. This is the selected option.
+
+An external workflow engine or mandatory KMS is not introduced. PostgreSQL and
+the existing queue remain the self-host baseline. A future hosted key provider
+may implement the same internal key-provider interface.
+
+## Decision
+
+### One source of truth
+
+`AppRunService` owns Run creation, idempotency, state transitions, attempts,
+retention, and sanitized projections. A reviewed Run may have exactly one linked
+`agent_actions` row of kind `app_run_invoke`; that row is an inbox/UI adapter,
+not the execution ledger. Its parameters contain identifiers and a bounded safe
+preview only.
+
+The caller-facing Capability Service remains the execution entrance. Governed
+requests submit to App Run service. A separate internal attempt executor is the
+only Run component allowed to dispatch to a capability provider adapter, which
+remains the only place allowed to call the low-level MCP client. Routes,
+resolvers, workers, and tests use the same caller-facing Run interface.
+
+No old/new provider shadow call is permitted.
+
+### Additive data boundary
+
+The exact columns are frozen in Loop 0, but the model has these responsibilities:
+
+- append-only, tenant-bound capability provider snapshots;
+- `app_runs` for actor, origin, policy, state, ancestry, pinned authorization
+  facts, safe preview, retention, and keyed fingerprints;
+- a one-to-one immutable secret-input row plus retention-bound encrypted attempt
+  output where exact replay requires it, separated from safe Run metadata so
+  ordinary Run selections cannot return ciphertext or full provider output;
+- attempts with claim/lease and provider-call boundary timestamps;
+- append-only sanitized events;
+- App-native sanitized receipts with signing-key version; and
+- one nullable, indexed `agent_actions.app_run_id` compatibility link.
+
+The Run row carries only a bounded sanitized outcome projection. Exact output may
+be returned to the authorized invocation caller and replayed while its encrypted
+payload is retained; generic inspection never returns it. After purge, replay
+returns the original terminal identity plus an explicit result-expired status and
+never calls the provider again.
+
+Existing generic Attention tables are reused with `source_type = app_run`; no
+parallel App-only inbox is created. New tables and old-table columns are
+additive so the rollback-floor image can ignore them.
+
+Database constraints and triggers enforce tenant-consistent references,
+immutable secret/snapshot identity fields, one approval adapter per Run, and
+legal state transitions. Only the App Run secret repository may reference the
+ciphertext table; an architecture test enforces this boundary.
+
+### State and effect semantics
+
+The Run lifecycle distinguishes pending, pending approval, running, waiting on
+an external system, succeeded, failed, cancelled/expired, and unknown outcome.
+Illegal transitions fail with a stable structured error. An unknown outcome is
+never automatically retried. Explicit operator reconciliation may resolve it to
+success or failure without another provider call and must append an event and
+receipt.
+
+Every provider call belongs to exactly one claimed attempt. Unsafe or unknown
+effects get at most one attempt. Safe or provider-idempotent effects may receive
+another attempt only under their host-owned retry classification and, for the
+idempotent class, the same provider idempotency key. Phase 3 does not claim
+exactly-once delivery to an external system.
+
+A process records and commits the attempt boundary before the provider call. If
+the provider result is known in-process, terminal persistence is retried without
+calling the provider again. Recovery of an expired lease with a started but
+unrecorded unsafe call becomes `unknown_outcome`.
+
+### Idempotency and ancestry
+
+Caller retry keys never appear in rows, logs, events, receipts, or responses.
+Versioned HMAC fingerprints are computed under a purpose-specific fingerprint
+keyring. A transaction-scoped PostgreSQL advisory lock uses a transient hash of
+the replay scope and raw key, then the service queries candidate fingerprints
+for every configured read key. Same replay key and same canonical input returns
+the original Run; different input fails with
+`APP_RUN_IDEMPOTENCY_CONFLICT`.
+
+Fingerprint-key removal is blocked while retained Runs reference that version.
+The raw key and transient lock digest are never persisted.
+
+Child Runs store root, parent, and bounded depth. Synchronous capability cycles
+are rejected before another effect. Children inherit the effective
+authorization ceiling and continue to consume the same actor/employee budgets;
+creating a child cannot reset limits.
+
+### Secret and key boundary
+
+Phase 3 adds three purpose-separated, versioned keyrings:
+
+1. authenticated encryption for Run secret payloads;
+2. App Run receipt signing; and
+3. input/idempotency fingerprints, with domain-separated purposes.
+
+Each envelope records an opaque key version and uses a random nonce plus AAD
+binding tenant, Run, payload kind, and envelope schema version. One key is
+current for writes; older configured keys are read/verify-only. Missing keys,
+wrong AAD, malformed envelopes, or fingerprint mismatch fail closed.
+
+The initial self-host format uses random 32-byte base64 key material,
+AES-256-GCM with a 96-bit nonce for envelope v1, and HMAC-SHA-256 for signing and
+fingerprints. Algorithm identifiers are versioned so a future format can be
+introduced without guessing from ciphertext shape. App-native receipts may bind
+to a digest of the randomized ciphertext envelope; they never publish a digest
+of low-entropy plaintext input or output.
+
+The initial self-host provider reads bounded keyring configuration from the
+environment and has no network dependency. Run execution remains disabled when
+its required keyrings are absent. A future SaaS KMS provider can replace this
+provider behind the same narrow interface.
+
+Existing `ENCRYPTION_KEY` ciphertext and action-receipt signatures keep their
+legacy write format during the first rollout. Readers may gain versioned-envelope
+support, but connectors are not re-encrypted in place. Existing writes can move
+to the new format only after a released rollback-floor image can read it and
+backup/restore plus key-rotation drills pass. Legacy retirement is a release
+milestone, not a same-PR cleanup.
+
+### Authority boundary
+
+Execution origin is a closed `core | legacy_connector | app` union. Phase 3 can
+exercise `core` and `legacy_connector`. `app` origin fails closed until Phase 5
+adds effective App grants and exact provider bindings; an App installation by
+itself is not authority.
+
+The effective policy is host-owned. Actor trust cannot bypass
+`review_requirement: always`. Membership, employee health and budget, token
+scope, connector, assignment, provider snapshot/schema, and every available
+authorization version are checked before approval and again immediately before
+the attempt.
+
+### Rollout
+
+Phase 3 is delivered as additive merge trains rather than one stacked PR:
+
+1. contracts, key readers, and dormant schema;
+2. Run lifecycle, attempts, and recovery using fake providers;
+3. approval and legacy compatibility behind `DEFT_APP_RUNS_ENABLED=false`;
+4. operations, retention, rotation, and release certification; and
+5. an explicit decision to widen opt-in after parity, never an implicit default.
+
+The Phase 2 PR remained unchanged while this plan was prepared. The Phase 3
+planning branch is now rebased onto the exact squash merge. The upgrade manifest
+ends at `0.3.0-preview.16` on that baseline, so `.17` is the current candidate;
+Loop 0 must re-confirm it immediately before the first schema implementation.
+
+## Consequences
+
+- Phase 3 is larger than a local refactor and may span more than one release.
+- Old and new execution can coexist in code, but exactly one is selected for an
+  invocation; they are never both called.
+- The linked legacy approval row remains temporarily necessary for native UI
+  compatibility.
+- New App Run tables can be rolled back by using an older image because that
+  image ignores them, but any change to existing ciphertext writers has a
+  separate rollback-floor gate.
+- Self-hosts gain explicit key configuration only when enabling App Runs;
+  existing deployments continue to boot with the legacy contract while the
+  feature is off.
+
+## Acceptance evidence
+
+- Migration tests prove fresh and supported-upgrade schemas, constraints,
+  checksums, old-image tolerance, and no ciphertext rewrite.
+- Crypto tests prove nonce uniqueness, AAD binding, purpose separation,
+  rotation, missing-key denial, low-entropy guessing resistance, and explicit
+  safe projections.
+- Concurrency and crash-point tests prove replay/conflict behavior, one provider
+  call per attempt, unsafe unknown-outcome handling, and no budget reset through
+  child Runs.
+- Approval tests prove sanitized parameters, source-of-truth ownership, live
+  authorization rechecks, and an unbypassable `always` floor.
+- Leakage tests cover generic/list API JSON, approval payloads, logs, errors,
+  events, receipts, metrics, Attention, and trace output. Separate tests prove
+  exact output is available only through the authorized invocation/result path
+  during its retention window.
+- Flag-off tests preserve every Phase 2 compatibility path; flag-on golden tests
+  certify legacy outcomes without external shadow execution.
+- Self-host, backup/restore, rotation, rollback-floor, image, browser approval,
+  security, and operator-recovery checks pass before opt-in is widened.

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -140,7 +140,8 @@ openssl rand -hex 32   # paste into JWT_SECRET
 openssl rand -hex 32   # paste into JWT_REFRESH_SECRET
 ```
 
-Replace `ENCRYPTION_KEY` before production. It must be exactly 32 characters.
+Replace `ENCRYPTION_KEY` before production. It must contain at least 32
+characters.
 
 Leave `OLLAMA_URL` commented unless an Ollama server is actually running.
 Otherwise Deft will correctly show AI features as off until a provider is
@@ -390,7 +391,9 @@ semi-autonomous runtime should show up as a shared coworker in Deft.
 | `POSTGRES_PASSWORD` | Yes | Database password for Compose Postgres | none |
 | `JWT_SECRET` | Yes | Signs access tokens | none |
 | `JWT_REFRESH_SECRET` | Yes | Signs refresh tokens | none |
-| `ENCRYPTION_KEY` | Production | Encrypts provider keys at rest; exactly 32 chars | dev value |
+| `ENCRYPTION_KEY` | Production | Encrypts provider keys at rest; at least 32 chars | dev value |
+| `DEFT_APP_RUNS_ENABLED` | No | Exact `true` enables the dormant Governed App Run foundation; invalid or missing keyrings then fail startup | `false` |
+| `DEFT_APP_RUN_KEYRINGS` | Only when App Runs enabled | Single-line versioned JSON document containing separate 32-byte base64 Run-encryption, receipt-signing, and fingerprint keyrings | none |
 | `DATABASE_URL` | No for Compose | External Postgres URL for non-Compose installs | derived |
 | `NEXT_PUBLIC_APP_URL` | Recommended | Public web URL and invite-link base | `http://localhost:3000` |
 | `NEXT_PUBLIC_API_URL` | Recommended | Public API URL seen by browser | `http://localhost:3001` |
@@ -407,6 +410,25 @@ semi-autonomous runtime should show up as a shared coworker in Deft.
 | `OLLAMA_URL` | No | Optional local Ollama endpoint; set only when running | none |
 | `R2_ENDPOINT` / `R2_ACCESS_KEY` / `R2_SECRET_KEY` / `R2_BUCKET` | No | Cloudflare R2 uploads | local uploads volume |
 | `METRICS_SCRAPE_TOKEN` | No | Bearer token for `/api/metrics` and `/health/queue`; unset disables detailed telemetry | none |
+
+### Dormant Governed App Run keyrings
+
+The App Run foundation has no production execution consumer in this release and
+stays off by default. Existing self-hosts do not need to set either App Run
+variable. If you are developing the later governed execution phases, generate
+three independent 32-byte keys with this Node.js command:
+
+```bash
+node -e "const c=require('node:crypto');const k=()=>c.randomBytes(32).toString('base64');console.log(JSON.stringify({schema_version:'deft.app_run_keyring.v1',run_encryption:{current:'enc-v1',keys:{'enc-v1':k()}},receipt_signing:{current:'sign-v1',keys:{'sign-v1':k()}},fingerprint:{current:'fp-v1',keys:{'fp-v1':k()}}}))"
+```
+
+Store the single-line output verbatim as `DEFT_APP_RUN_KEYRINGS`, then set
+`DEFT_APP_RUNS_ENABLED=true`. Add a new key ID and make it `current` to rotate;
+keep older entries configured for reads and verification. Back up this setting
+with the database. Removing a key that is still referenced by retained Run
+payloads, receipts, or fingerprints is unrecoverable data loss. The later
+execution rollout must add reference-inventory and retirement checks before this
+feature is exposed for normal use.
 
 ## Backups
 

--- a/docs/superpowers/plans/2026-08-29-full-surface-app-platform.md
+++ b/docs/superpowers/plans/2026-08-29-full-surface-app-platform.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |---|---|
-| **Status** | Phases 1–2 merged; Phase 3 additive Governed Run plan proposed and rebased onto `9ba7b7c8` |
+| **Status** | Phases 1–2 merged; Phase 3 dormant foundation (Loops 0–2) implemented for review on `9ba7b7c8` |
 | **Date** | 2026-08-29; Phase 2 rebaseline 2026-08-30 |
 | **Baseline inspected** | Phase 2 starts from `origin/master` at `bdb137ee`, the squash merge of Phase 1 PR #269 |
 | **North star** | A Deft user can ask Codex to build a useful application, install it into their Deft workspace, and have it participate natively in the human UI, search and knowledge, tasks and chat, Defty, employee agents, human MCP, automation, approvals, runs, receipts, and audit. |
@@ -770,6 +770,12 @@ known missing local pgvector extension was not retried.
 and the staged secret/rollback decision. Phase 3 is not one big-bang PR; migration
 identifiers must be re-confirmed at the implementation boundary even though the
 planning branch is now rebased onto the Phase 2 merge.
+
+**Foundation status (2026-08-30):** PR A implements the frozen contracts,
+purpose-separated versioned key readers and cryptographic service, and additive
+tenant-bound Run/attempt/secret/event/receipt schema at upgrade slot `.17`.
+The App origin and all production execution consumers remain disabled; existing
+execution and legacy ciphertext writes are unchanged.
 
 - [ ] Add a versioned Secret Service with random nonces, AAD-bound ciphertext, current and decrypt-only keys, rotation, and explicit safe projections.
 - [ ] Add minimum-input rules, strict Run payload/blob limits, retention classes, terminal-state purge, and sanitized audit residue; permission widening cannot silently extend retention.

--- a/docs/superpowers/plans/2026-08-29-full-surface-app-platform.md
+++ b/docs/superpowers/plans/2026-08-29-full-surface-app-platform.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |---|---|
-| **Status** | Phase 1 declarative alpha merged; Phase 2 Capability Service extraction complete; Phase 3 ready to plan |
+| **Status** | Phases 1–2 merged; Phase 3 additive Governed Run plan proposed and rebased onto `9ba7b7c8` |
 | **Date** | 2026-08-29; Phase 2 rebaseline 2026-08-30 |
 | **Baseline inspected** | Phase 2 starts from `origin/master` at `bdb137ee`, the squash merge of Phase 1 PR #269 |
 | **North star** | A Deft user can ask Codex to build a useful application, install it into their Deft workspace, and have it participate natively in the human UI, search and knowledge, tasks and chat, Defty, employee agents, human MCP, automation, approvals, runs, receipts, and audit. |
@@ -764,6 +764,12 @@ known missing local pgvector extension was not retried.
 ### Phase 3: Governed App Runs and Secret Service
 
 **Outcome:** every capability execution can use one actor-neutral, durable, approval-aware envelope.
+
+**Implementation sequence:** use the additive, fail-closed merge trains in
+[the Phase 3 loop plan](2026-08-30-app-platform-phase-3-governed-runs-loops.md)
+and the staged secret/rollback decision. Phase 3 is not one big-bang PR; migration
+identifiers must be re-confirmed at the implementation boundary even though the
+planning branch is now rebased onto the Phase 2 merge.
 
 - [ ] Add a versioned Secret Service with random nonces, AAD-bound ciphertext, current and decrypt-only keys, rotation, and explicit safe projections.
 - [ ] Add minimum-input rules, strict Run payload/blob limits, retention classes, terminal-state purge, and sanitized audit residue; permission widening cannot silently extend retention.

--- a/docs/superpowers/plans/2026-08-30-app-platform-phase-3-governed-runs-loops.md
+++ b/docs/superpowers/plans/2026-08-30-app-platform-phase-3-governed-runs-loops.md
@@ -1,11 +1,11 @@
 # App Platform Phase 3: Governed App Runs and Secret Service loops
 
-**Status:** proposed and architecture-reviewed; plan-only branch rebased onto
-Phase 2 squash merge `9ba7b7c8`
+**Status:** accepted and in progress; PR A implements the dormant Loops 0–2
+foundation on Phase 2 squash merge `9ba7b7c8`
 
 **Rebaseline record:** Phase 2 PR #270 merged with every required check green;
 the current upgrade manifest ends at `0.3.0-preview.16`, making `.17` the
-candidate first Phase 3 schema slot. Re-confirm immediately before Loop 2.
+candidate first Phase 3 schema slot. Loop 2 re-confirmed and selected `.17`.
 
 **Outcome:** Deft has an opt-in, actor-neutral, durable execution envelope with
 encrypted retained inputs, governed approvals, explicit attempts and unknown

--- a/docs/superpowers/plans/2026-08-30-app-platform-phase-3-governed-runs-loops.md
+++ b/docs/superpowers/plans/2026-08-30-app-platform-phase-3-governed-runs-loops.md
@@ -1,0 +1,409 @@
+# App Platform Phase 3: Governed App Runs and Secret Service loops
+
+**Status:** proposed and architecture-reviewed; plan-only branch rebased onto
+Phase 2 squash merge `9ba7b7c8`
+
+**Rebaseline record:** Phase 2 PR #270 merged with every required check green;
+the current upgrade manifest ends at `0.3.0-preview.16`, making `.17` the
+candidate first Phase 3 schema slot. Re-confirm immediately before Loop 2.
+
+**Outcome:** Deft has an opt-in, actor-neutral, durable execution envelope with
+encrypted retained inputs, governed approvals, explicit attempts and unknown
+outcomes, sanitized signed receipts, and no implicit App authority
+
+## Scope correction
+
+The roadmap outcome is sound, but completing it as one PR is not. Phase 3
+crosses cryptography, migrations, execution, approvals, workers, privacy,
+receipts, self-host configuration, and rollback compatibility. It therefore
+uses ten loops in four additive merge trains. Every train is reviewable and
+rollback-safe on its own. No implementation started before Phase 2 merged.
+
+Phase 3 does not add App manifest fields, App grants, capability bindings, App
+catalog UI, automation ingress, arbitrary code, a new queue, or a mandatory
+hosted dependency. Those remain later phases.
+
+## Completion model
+
+### Milestone A: dormant foundation
+
+Loops 0–2 land contracts, keyring readers, and additive schema with the feature
+off. Existing execution and existing ciphertext writes do not change.
+
+### Milestone B: governed engine
+
+Loops 3–4 implement lifecycle, idempotency, attempts, recovery, and retention
+against fake providers. There is still no production cutover.
+
+### Milestone C: compatibility integration
+
+Loops 5–7 integrate approvals, Capability Service, existing actors, receipts,
+Attention, ancestry, and operator inspection behind a fail-closed flag.
+
+### Milestone D: release certification
+
+Loops 8–9 prove key rotation, supported upgrades, rollback, self-host operation,
+parity, and leakage safety. Widening the flag remains a separate explicit
+decision.
+
+## Invariants
+
+- Every persisted row and reference is tenant-bound; actor and organization
+  identity come from authenticated context, never invocation input.
+- After request ingress, raw invocation inputs and retry keys never reappear in
+  approval rows, safe Run selections, events, receipts, logs, errors, metrics,
+  Attention, traces, or API responses. Full sensitive provider output appears
+  only in the authorized invocation/result response while its encrypted payload
+  is retained, never in generic Run APIs or observability surfaces.
+- App Run secret payloads are accessible only through the secret repository and
+  are always encrypted with versioned AEAD plus tenant/Run/purpose AAD.
+- One provider call belongs to one durable attempt. No route, approval resolver,
+  worker, or Run service calls the MCP client directly.
+- Unsafe/unknown attempts are never automatically retried after the call may
+  have started. Exactly-once external delivery is not claimed.
+- The App Run is the execution source of truth; `agent_actions` is only the
+  linked compatibility approval surface.
+- `review_requirement: always` cannot be bypassed by Autonomous trust.
+- App installations have no execution authority until later App grants and
+  bindings exist. `origin = app` therefore fails closed in Phase 3.
+- Current legacy behavior remains selected while the flag is off. The old and
+  new providers are never invoked for the same request.
+- Current connector ciphertext and legacy action-receipt writes are not changed
+  before their rollback-floor release gate.
+
+## Proposed internal flow
+
+```text
+caller
+  -> Capability Service governed entry
+    -> App Run submit/replay
+      -> immediate durable attempt OR linked approval adapter
+        -> shared attempt runner
+          -> internal capability provider executor
+            -> MCP provider adapter
+              -> low-level MCP client
+```
+
+The approval resolver and queue worker resume a Run through the same App Run
+service interface. They do not receive decrypted input or a provider callback.
+
+## Loop 0: Rebaseline and freeze the contract
+
+### Work
+
+- Rebase this plan onto the exact Phase 2 merge commit and rerun the architecture
+  inventory against current code, schema, upgrade manifest, CI, and release
+  docs.
+- Record the exact state machine, stable error codes, actor/origin unions,
+  retention classes, byte limits, retry classes, safe projections, AAD fields,
+  keyring configuration, and rollback-floor rules in shared contracts and an
+  accepted ADR.
+- Freeze the difference between Run state and attempt state. Define the exact
+  crash points that produce `failed`, `unknown_outcome`, or a retryable attempt.
+- Define the opt-in flag semantics. Absence, malformed keyrings, and every value
+  other than exact enablement fail closed without preventing a normal legacy
+  self-host boot.
+- Choose migration identifiers only after confirming the latest merged upgrade
+  manifest.
+
+### Exit evidence
+
+- Two independent reviewers can trace data, trust, retry, migration, and rollback
+  flows without an unresolved high-impact choice.
+- No code, schema, environment, or execution behavior changes in this loop.
+- The deletion test still justifies App Run service, the secret repository, and
+  the internal attempt executor as deep boundaries rather than pass-throughs.
+
+## Loop 1: Versioned Secret Service and key providers
+
+### Work
+
+- Add a narrow key-provider interface and a bounded environment-backed self-host
+  provider. Do not add KMS/network dependencies.
+- Add three purpose-separated versioned keyrings: Run AEAD, App Run receipt
+  signing, and domain-separated input/idempotency fingerprints.
+- Define a versioned envelope with random nonce, authenticated ciphertext,
+  opaque key version, algorithm/envelope version, and AAD covering tenant, Run,
+  payload kind, and schema version.
+- Make safe projections explicit and impossible to construct from a raw envelope
+  by object spreading.
+- Add read/verify-only keys, one current write key, key-reference inventory, and
+  refusal to remove a key still referenced inside the retention window.
+- Preserve legacy `ENCRYPTION_KEY` reads and writes. Versioned legacy readers may
+  be added, but no connector or existing receipt is rewritten.
+
+### Exit evidence
+
+- Random-nonce, wrong-AAD, wrong-tenant, wrong-purpose, tamper, malformed-envelope,
+  unknown-key, rotation, and constant-time verification tests pass.
+- Low-entropy retry/input values cannot be verified by an offline database-only
+  guessing attack.
+- Production startup fails only when App Runs are enabled without valid Run
+  keyrings; flag-off deployments retain the existing environment contract.
+- Architecture tests prove only the secret repository handles Run ciphertext and
+  only the signer handles signing key material.
+
+## Loop 2: Additive Run schema and supported upgrade
+
+### Work
+
+- Add tenant-bound immutable capability provider snapshots with deterministic
+  digests and no credentials, targets, effective policy, or raw provider object.
+- Add Run metadata, a separate immutable input payload and retention-bound
+  encrypted attempt-output storage, attempts, append-only events, and App-native
+  receipt tables.
+- Add a nullable `agent_actions.app_run_id` foreign key plus a uniqueness rule
+  that permits at most one reviewed compatibility action per Run.
+- Reuse generic Attention with `source_type = app_run`; do not create an App-only
+  attention/inbox table.
+- Add database constraints/triggers for tenant-consistent references, immutable
+  identity/ciphertext fields, bounded ancestry, legal state transitions, and
+  append-only event/receipt behavior.
+- Add the exact forward-only upgrade migration and fresh-schema representation.
+  Do not backfill legacy actions or rewrite existing ciphertext.
+
+### Exit evidence
+
+- `db:push-full` and `db:upgrade` converge on the same schema, indexes,
+  constraints, and triggers on pgvector-backed CI infrastructure.
+- Supported existing data upgrades without table rewrites or default-value locks
+  on hot legacy tables; the prior image can boot and ignore the additive schema.
+- Cross-org references, mutated immutable fields, duplicate approval links,
+  illegal transitions, and updates/deletes of append-only records fail.
+- Generic Run queries and serializers cannot select or expose ciphertext.
+
+## Loop 3: Run lifecycle, replay, and retention without effects
+
+### Work
+
+- Implement `AppRunService.submit`, safe lookup/inspection, transition, cancel,
+  expire, and explicit operator-reconciliation interfaces.
+- Canonicalize and validate input before encryption. Enforce minimum required
+  fields, strict byte/depth/count limits, retention class, terminal purge time,
+  and a bounded safe approval preview.
+- Claim idempotency under a transaction-scoped advisory lock. Query HMAC
+  fingerprints for all configured read key versions. Never persist the raw key
+  or transient lock digest.
+- Return the existing Run for same-key/same-input replay with no new event;
+  return `APP_RUN_IDEMPOTENCY_CONFLICT` for different input.
+- Add terminal secret purge and sanitized residue. Permission widening cannot
+  extend a previously chosen retention class.
+
+### Exit evidence
+
+- Concurrent same-key submissions create one Run; conflict, rotation overlap,
+  missing old key, and tenant/actor/provider scope cases fail deterministically.
+- State transitions and events commit atomically and illegal transitions have a
+  stable structured error.
+- Expired secrets are purged while the declared safe residue remains useful and
+  contains no raw input or retry key.
+- Logs/errors/API serialization/leak snapshots remain clean under injected
+  failures.
+
+## Loop 4: Attempt engine and crash recovery
+
+### Work
+
+- Implement a shared claimed-attempt runner usable synchronously and by the
+  PostgreSQL worker. Commit the attempt boundary before a provider call and do
+  not hold a transaction open across network I/O.
+- Start against a counting fake provider. Add the internal provider executor only
+  after state/recovery tests pass.
+- Persist a known provider result as bounded encrypted output plus a sanitized
+  terminal projection without another call even if event, receipt, metrics, or
+  Attention work needs repair.
+- Classify expired leases after call start: unsafe/unknown becomes
+  `unknown_outcome`; safe may retry; idempotent may retry only with the same
+  provider idempotency key. Each retry is a new attempt.
+- Make cancellation effective before call start and advisory after an external
+  call begins. Never report an external effect as cancelled when its outcome is
+  unknown.
+- Add idempotent repair jobs for terminal receipts/events/attention and bounded
+  stale-attempt reconciliation.
+
+### Exit evidence
+
+- Crash injection before claim, after claim, before call, during call, after
+  provider return, and during each terminal side effect produces the specified
+  state with no ungoverned retry.
+- Multi-worker and lease-expiry tests prove one call per attempt and no concurrent
+  claim reuse.
+- Unsafe attempts never call twice. Safe/idempotent retry tests show explicit
+  attempt ancestry and unchanged provider idempotency identity.
+- A provider success plus local post-call repair failure stays known success and
+  never re-enters the provider.
+- Exact result replay is available only to the live-authorized caller during the
+  result-retention window. After purge, replay returns terminal identity plus
+  `result_expired` and never calls the provider again.
+
+## Loop 5: Approval adapter and live authorization
+
+### Work
+
+- Add the `app_run_invoke` approval kind and one linked `agent_actions` adapter
+  containing only Run ID, capability/provider labels, resource identifiers, and
+  bounded safe preview.
+- Make approval creation and Run `pending_approval` transition atomic. Make
+  approval resolution claim and resume the Run through App Run service.
+- Recheck authenticated membership, initiating/execution actors, employee
+  health/budget, token scope, connector activity, assignment, provider snapshot
+  and schema, retry class, policy source, and bound authorization versions before
+  approval and immediately before attempt.
+- Implement the host-owned risk/review vocabulary from the accepted review-policy
+  ADR. App/provider metadata can never lower it; Autonomous cannot satisfy
+  `always`.
+- Keep existing approval API/UI response shapes where possible. The Run remains
+  source of truth if the compatibility action and Run disagree.
+
+### Exit evidence
+
+- Approval params, events, receipts, Attention, logs, and API responses contain no
+  raw input.
+- Approval/rejection/replay races resolve once and cannot create another Run or
+  provider attempt.
+- Revocation between proposal, approval, and attempt fails before the call.
+- `always` review is unbypassable under every current trust level.
+
+## Loop 6: Capability Service integration and legacy compatibility
+
+### Work
+
+- Split the caller-facing governed Capability Service entrance from the narrow
+  internal provider attempt executor so App Run execution cannot recurse.
+- Route selected `core` and `legacy_connector` invocations through App Runs only
+  when the exact fail-closed flag is enabled. Keep current direct behavior when
+  disabled.
+- Preserve Phase 2 discovery, target/credential materialization, policy/budget
+  ordering, exact provider result/error mapping, citations, timeouts, backoff,
+  and path-specific legacy receipts during compatibility certification.
+- Reserve `origin = app` but reject it until Phase 5 supplies an effective grant
+  and exact binding. An installation or manifest cannot fabricate authority.
+- Add architecture tests proving callers cannot bypass Capability Service, Run
+  attempts cannot bypass the internal executor, and only the MCP adapter calls
+  the low-level client.
+
+### Exit evidence
+
+- Flag-off tests are byte/state compatible with Phase 2.
+- Flag-on immediate, auto-direct, quick, full, replay, revocation, provider-error,
+  timeout, and unknown-outcome fixtures pass with one selected path and no shadow
+  call.
+- Existing explicit reapproval behavior is either preserved by the compatibility
+  adapter or changed only under a separately approved migration decision.
+- No App-origin invocation succeeds.
+
+## Loop 7: Ancestry, receipts, Attention, and operator inspection
+
+### Work
+
+- Add root/parent/depth handling, a small fixed maximum depth, synchronous
+  capability-cycle rejection, authorization-ceiling inheritance, and budget
+  continuity across child Runs.
+- Add App-native receipt envelopes over sanitized immutable facts, attempt and
+  outcome identity, actor attribution, reconciliation, and signing-key version.
+  Do not migrate legacy receipt rows in place.
+- Publish idempotent Run Attention events for approval, failure,
+  `unknown_outcome`, and repair gaps using the existing Attention service.
+- Add safe operator inspection and reconciliation surfaces plus bounded metrics.
+  Raw ciphertext and retry keys are never operator-list fields or metric labels.
+- Add reconciliation reports for missing terminal events/receipts/Attention.
+
+### Exit evidence
+
+- Cycles stop before a child call, depth is bounded, and child Runs cannot widen
+  authorization or reset budgets.
+- Receipt verification works across signing-key rotation and detects tampering;
+  key retirement is refused while retained receipts depend on it.
+- Operator resolution of unknown outcome performs no provider call and appends a
+  signed receipt/event.
+- Metrics and inspection stay tenant-scoped, bounded, and secret-free.
+
+## Loop 8: Release, rotation, rollback, and self-host gates
+
+### Work
+
+- Document and test key generation, addition, current-key rotation,
+  read/verify-only overlap, reference inventory, retirement refusal,
+  backup/restore, and disaster recovery for self-hosts.
+- Ship readers before changing any existing ciphertext writer. Record the exact
+  rollback-floor image that can read new envelopes.
+- Keep connector and legacy receipt writes legacy until that floor is proven.
+  Do not perform bulk in-place re-encryption during the compatibility window.
+- Test old-image tolerance of additive Run tables and new-image operation with
+  the flag off, misconfigured, and on.
+- Define the future hosted key-provider/KMS operational contract without adding
+  it as a Phase 3 runtime dependency.
+
+### Exit evidence
+
+- Fresh install, supported upgrade, backup/restore, rolling deployment, key
+  rotation, rollback-floor, and mixed-reader tests pass.
+- A missing decrypt/verify key is detected before effect execution and produces
+  actionable operator state without leaking material.
+- Legacy connector and receipt compatibility remains intact throughout the
+  window.
+- Self-host docs describe recoverable steps and explicitly warn that deleting a
+  referenced key is data loss.
+
+## Loop 9: Seal and certify Phase 3
+
+### Work
+
+- Run the consolidated contract, crypto, schema/upgrade, Run lifecycle,
+  concurrency, crash/recovery, provider, approval, trust, budget, connector,
+  receipt, Attention, leakage, architecture, API, worker, and repository checks.
+- Run one production image, self-host smoke, browser approval/inspection pass,
+  security workflows, and supported upgrade/rollback drill because Phase 3
+  touches those surfaces.
+- Inspect the final diff, generated artifacts, environment documentation,
+  migrations, safe projections, and every ciphertext/key reference.
+- Decide explicitly whether the feature remains developer-only, becomes self-host
+  opt-in, or can widen further. Never switch the default as a cleanup.
+- Update the roadmap and compatibility records with verified evidence and every
+  deferred release gate.
+
+### Exit evidence
+
+- The acceptance matrix passes on the immutable candidate revision.
+- No raw input, retry key, ciphertext, provider secret, full output, or
+  signing/fingerprint material appears in any generic/list or observability
+  surface; the exact result is confined to its explicitly authorized response.
+- Every flag-on governed provider effect has a Run and attempt; every reviewed
+  Run has one linked approval adapter; every terminal governed effect has a
+  receipt or a visible repair gap. Flag-off legacy execution remains explicitly
+  outside that claim.
+- Unknown outcomes are inspectable and never auto-retried.
+- The flag/default, rollback floor, key versions, unverified requirements, and
+  remaining legacy-encryption work are reported explicitly.
+
+## Pull request sequence
+
+1. **PR A — foundation:** Loops 0–2; contracts, key readers, dormant additive
+   schema, no execution cutover.
+2. **PR B — engine:** Loops 3–4; lifecycle, idempotency, retention, attempts, fake
+   providers, and recovery.
+3. **PR C — integration:** Loops 5–7; approval adapter, Capability Service flag,
+   compatibility, ancestry, receipts, Attention, and operator surfaces.
+4. **PR D — certification:** Loops 8–9; release/rotation/rollback evidence and the
+   explicit opt-in decision.
+
+Do not hold all four PRs for one final merge. Merge each independently green,
+then rebase the next train onto its merge commit. This preserves reviewability,
+forward-only migration order, and rollback diagnosis.
+
+## Stop conditions
+
+Stop and reopen the architecture gate if implementation would require:
+
+- raw input, retry keys, provider secrets, or ciphertext in an approval row,
+  event, receipt, log, metric, Attention item, trace, or API response;
+- treating `agent_actions` as the Run source of truth;
+- calling old and new external execution paths for comparison;
+- automatically retrying an unsafe or unknown effect;
+- promising exactly-once behavior from a provider that lacks idempotency;
+- changing existing ciphertext writes before the rollback-floor image is proven;
+- allowing an App installation or author metadata to create authority;
+- adding a mandatory KMS, Redis, workflow engine, or hosted dependency;
+- enabling App Runs by default before the immutable certification gate; or
+- selecting a migration identifier without re-confirming the current merged
+  upgrade manifest at the implementation boundary.

--- a/packages/db/scripts/apply-extras.ts
+++ b/packages/db/scripts/apply-extras.ts
@@ -43,6 +43,10 @@ async function main() {
     await client.query(readFileSync(resolve(upgradesDir, appsV0File), 'utf8'));
     console.log(`[apply-extras] applied ${appsV0File}`);
 
+    const appRunsFoundationFile = '0.3.0-preview.17-governed-app-runs-foundation.sql';
+    await client.query(readFileSync(resolve(upgradesDir, appRunsFoundationFile), 'utf8'));
+    console.log(`[apply-extras] applied ${appRunsFoundationFile}`);
+
     // Expression-based unique indexes can't be declared in schema.ts, so
     // `drizzle-kit push` silently drops them. Re-create the ones the app
     // depends on so pushed and migrated databases behave the same.
@@ -74,6 +78,19 @@ async function main() {
       'app_module_bindings_module_installation_fk',
       'app_module_bindings_module_version_fk',
       'app_developer_pairings_creator_member_fk',
+      'capability_provider_snapshots_org_id_id_unique',
+      'app_runs_org_id_id_unique',
+      'app_runs_org_provider_snapshot_fk',
+      'app_runs_org_root_run_fk',
+      'app_runs_org_parent_run_fk',
+      'app_run_attempts_org_run_fk',
+      'app_run_attempts_org_run_id_unique',
+      'app_run_secret_payloads_org_run_fk',
+      'app_run_secret_payloads_org_attempt_fk',
+      'app_run_events_org_run_fk',
+      'app_run_receipts_org_run_fk',
+      'app_run_receipts_org_attempt_fk',
+      'agent_actions_org_app_run_fk',
     ];
     const installedConstraints = await client.query<{ conname: string }>(
       `SELECT conname
@@ -104,6 +121,14 @@ async function main() {
       'app_module_bindings_owned_module_unique',
       'app_developer_pairings_code_hash_unique',
       'app_developer_pairings_session_hash_unique',
+      'capability_provider_snapshots_identity_digest_unique',
+      'app_runs_idempotency_unique',
+      'app_run_attempts_number_unique',
+      'app_run_secret_payloads_input_unique',
+      'app_run_secret_payloads_output_unique',
+      'app_run_events_sequence_unique',
+      'app_run_receipts_key_unique',
+      'agent_action_app_run_unique',
     ];
     const installedIndexes = await client.query<{ relname: string }>(
       `SELECT relname
@@ -131,6 +156,30 @@ async function main() {
       throw new Error('module_versions immutability trigger was not installed');
     }
     console.log('[apply-extras] verified module_versions_immutable_fields_trigger');
+
+    const requiredAppRunTriggers = [
+      'capability_provider_snapshots_append_only_trigger',
+      'app_runs_state_identity_trigger',
+      'app_run_attempts_state_identity_trigger',
+      'app_run_secret_payloads_append_only_trigger',
+      'app_run_events_append_only_trigger',
+      'app_run_receipts_append_only_trigger',
+    ];
+    const installedAppRunTriggers = await client.query<{ tgname: string }>(
+      `SELECT tgname
+         FROM pg_trigger
+        WHERE NOT tgisinternal
+          AND tgname = ANY($1::text[])`,
+      [requiredAppRunTriggers],
+    );
+    const installedAppRunTriggerNames = new Set(installedAppRunTriggers.rows.map((row) => row.tgname));
+    const missingAppRunTriggers = requiredAppRunTriggers.filter(
+      (name) => !installedAppRunTriggerNames.has(name),
+    );
+    if (missingAppRunTriggers.length > 0) {
+      throw new Error(`required App Run triggers are missing: ${missingAppRunTriggers.join(', ')}`);
+    }
+    console.log('[apply-extras] verified dormant App Run constraints, indexes, and triggers');
   } finally {
     await client.end();
   }

--- a/packages/db/scripts/upgrade.test.ts
+++ b/packages/db/scripts/upgrade.test.ts
@@ -17,7 +17,14 @@ import {
   agentChannelConnections,
   appInstallations,
   appModuleBindings,
+  appRunAttempts,
+  appRunEvents,
+  appRunReceipts,
+  appRuns,
+  appRunSecretPayloads,
   appVersions,
+  capabilityProviderSnapshots,
+  agentActions,
   moduleInstallations,
   moduleMutationReceipts,
   moduleRecordRelations,
@@ -72,6 +79,88 @@ test('App v0 supported upgrade contains the same tables and constraints as fresh
     assert.match(sql, new RegExp(constraint, 'i'));
   }
   assert.match(applyExtrasSource, /0\.3\.0-preview\.16-declarative-apps-v0\.sql/);
+});
+
+test('governed App Run fresh schema is tenant-bound and keeps ciphertext separate', () => {
+  const foreignKeyNames = (config: ReturnType<typeof getTableConfig>) =>
+    config.foreignKeys.map((key) => key.getName());
+  const run = getTableConfig(appRuns);
+  const attempt = getTableConfig(appRunAttempts);
+  const secret = getTableConfig(appRunSecretPayloads);
+  const event = getTableConfig(appRunEvents);
+  const receipt = getTableConfig(appRunReceipts);
+  const snapshot = getTableConfig(capabilityProviderSnapshots);
+  const action = getTableConfig(agentActions);
+
+  assert.ok(snapshot.uniqueConstraints.some(
+    (item) => item.name === 'capability_provider_snapshots_org_id_id_unique',
+  ));
+  assert.ok(run.uniqueConstraints.some((item) => item.name === 'app_runs_org_id_id_unique'));
+  assert.ok(foreignKeyNames(run).includes('app_runs_org_provider_snapshot_fk'));
+  assert.ok(foreignKeyNames(attempt).includes('app_run_attempts_org_run_fk'));
+  assert.deepEqual(
+    foreignKeyNames(secret).filter((name) => name.startsWith('app_run_secret_payloads_')).sort(),
+    ['app_run_secret_payloads_org_attempt_fk', 'app_run_secret_payloads_org_run_fk'],
+  );
+  assert.ok(foreignKeyNames(event).includes('app_run_events_org_run_fk'));
+  assert.deepEqual(
+    foreignKeyNames(receipt).filter((name) => name.startsWith('app_run_receipts_')).sort(),
+    ['app_run_receipts_org_attempt_fk', 'app_run_receipts_org_run_fk'],
+  );
+  assert.ok(foreignKeyNames(action).includes('agent_actions_org_app_run_fk'));
+  assert.ok(action.indexes.some((item) => item.config.name === 'agent_action_app_run_unique'));
+
+  const safeRunColumnNames = new Set(run.columns.map((column) => column.name));
+  for (const secretColumn of ['nonce_b64', 'ciphertext_b64', 'auth_tag_b64']) {
+    assert.equal(safeRunColumnNames.has(secretColumn), false);
+  }
+  const secretColumnNames = new Set(secret.columns.map((column) => column.name));
+  assert.ok(secretColumnNames.has('ciphertext_b64'));
+});
+
+test('governed App Run supported upgrade preserves dormant and immutable boundaries', () => {
+  const migration = upgradeManifest.migrations.find((item) => item.version === '0.3.0-preview.17');
+  assert.ok(migration);
+  const scriptsDir = dirname(fileURLToPath(import.meta.url));
+  const sql = readFileSync(resolve(scriptsDir, '..', 'upgrades', migration.file), 'utf8');
+  const applyExtrasSource = readFileSync(resolve(scriptsDir, 'apply-extras.ts'), 'utf8');
+
+  for (const table of [
+    'capability_provider_snapshots',
+    'app_runs',
+    'app_run_attempts',
+    'app_run_secret_payloads',
+    'app_run_events',
+    'app_run_receipts',
+  ]) {
+    assert.match(sql, new RegExp(`CREATE TABLE IF NOT EXISTS ${table}`, 'i'));
+  }
+  for (const boundary of [
+    'app_runs_org_root_run_fk',
+    'app_runs_org_parent_run_fk',
+    'agent_actions_org_app_run_fk',
+    'agent_action_app_run_unique',
+    'app_runs_app_origin_disabled_check',
+    'app_runs_contract_version_check',
+    'app_runs_state_identity_trigger',
+    'app_run_attempts_state_identity_trigger',
+    'app_run_secret_payloads_append_only_trigger',
+    'app_run_secret_payloads_size_check',
+    'app_run_events_version_check',
+    'app_run_events_type_check',
+    'app_run_receipts_version_check',
+    'app_run_events_append_only_trigger',
+    'app_run_receipts_append_only_trigger',
+    'APP_RUN_ILLEGAL_TRANSITION',
+    'APP_RUN_IMMUTABLE_FIELD',
+    'APP_RUN_APPEND_ONLY',
+  ]) {
+    assert.match(sql, new RegExp(boundary, 'i'));
+  }
+  assert.match(sql, /ALTER TABLE agent_actions ADD COLUMN IF NOT EXISTS app_run_id text/i);
+  assert.doesNotMatch(sql, /UPDATE\s+agent_actions/i);
+  assert.doesNotMatch(sql, /^\s*UPDATE\s+/im);
+  assert.match(applyExtrasSource, /0\.3\.0-preview\.17-governed-app-runs-foundation\.sql/);
 });
 
 test('parseUpgradeArgs recognizes status and dry run', () => {

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -628,6 +628,327 @@ export const favorites = pgTable('favorites', {
   uniqueIndex('favorite_unique').on(t.user_id, t.entity_type, t.entity_id),
 ]);
 
+// ═══ GOVERNED APP RUNS (DORMANT PHASE 3 FOUNDATION) ═══
+// These tables are additive and have no execution consumer until a later,
+// separately certified phase. Secret payload ciphertext is intentionally split
+// from safe Run metadata so ordinary app_runs selections cannot expose it.
+export const capabilityProviderSnapshots = pgTable('capability_provider_snapshots', {
+  ...id(),
+  org_id: text('org_id').notNull().references(() => orgs.id, { onDelete: 'cascade' }),
+  provider_kind: text('provider_kind').$type<'mcp'>().notNull(),
+  provider_instance_id: text('provider_instance_id').notNull(),
+  adapter_contract_version: text('adapter_contract_version').notNull(),
+  snapshot_digest: text('snapshot_digest').notNull(),
+  safe_snapshot: jsonb('safe_snapshot').$type<Record<string, unknown>>().notNull(),
+  captured_at: timestamp('captured_at').notNull(),
+  created_at: timestamp('created_at').defaultNow().notNull(),
+}, (t) => [
+  unique('capability_provider_snapshots_org_id_id_unique').on(t.org_id, t.id),
+  uniqueIndex('capability_provider_snapshots_identity_digest_unique')
+    .on(t.org_id, t.provider_kind, t.provider_instance_id, t.snapshot_digest),
+  index('capability_provider_snapshots_provider_idx')
+    .on(t.org_id, t.provider_kind, t.provider_instance_id, t.captured_at),
+  check('capability_provider_snapshots_kind_check', sql`${t.provider_kind} IN ('mcp')`),
+  check('capability_provider_snapshots_digest_check', sql`${t.snapshot_digest} ~ '^sha256:[a-f0-9]{64}$'`),
+  check('capability_provider_snapshots_json_check', sql`jsonb_typeof(${t.safe_snapshot}) = 'object'`),
+  check('capability_provider_snapshots_size_check', sql`octet_length(${t.safe_snapshot}::text) <= 1048576`),
+]);
+
+export const appRuns = pgTable('app_runs', {
+  ...id(),
+  org_id: text('org_id').notNull().references(() => orgs.id, { onDelete: 'cascade' }),
+  contract_version: text('contract_version').$type<'deft.app_run.v1'>().notNull(),
+  origin_kind: text('origin_kind').$type<'core' | 'legacy_connector' | 'app'>().notNull(),
+  initiating_actor_type: text('initiating_actor_type')
+    .$type<'human' | 'agent_employee' | 'system' | 'automation'>()
+    .notNull(),
+  initiating_actor_id: text('initiating_actor_id').notNull(),
+  execution_actor_type: text('execution_actor_type')
+    .$type<'human' | 'agent_employee' | 'system' | 'automation'>()
+    .notNull(),
+  execution_actor_id: text('execution_actor_id').notNull(),
+  provider_kind: text('provider_kind').$type<'mcp'>().notNull(),
+  provider_instance_id: text('provider_instance_id').notNull(),
+  operation_name: text('operation_name').notNull(),
+  provider_snapshot_id: text('provider_snapshot_id').notNull(),
+  state: text('state').$type<
+    | 'pending'
+    | 'pending_approval'
+    | 'running'
+    | 'waiting_external'
+    | 'succeeded'
+    | 'failed'
+    | 'cancelled'
+    | 'expired'
+    | 'unknown_outcome'
+  >().default('pending').notNull(),
+  risk_class: text('risk_class')
+    .$type<'read' | 'internal_write' | 'external_write' | 'destructive' | 'privileged'>()
+    .notNull(),
+  review_requirement: text('review_requirement').$type<'policy' | 'always'>().notNull(),
+  review_scope: text('review_scope')
+    .$type<'per_invocation' | 'immutable_batch' | 'approved_automation_definition' | 'forbidden_in_automation'>()
+    .notNull(),
+  retry_class: text('retry_class').$type<'safe' | 'idempotent_with_key' | 'unsafe_or_unknown'>().notNull(),
+  retention_class: text('retention_class').$type<'ephemeral' | 'standard' | 'extended'>().notNull(),
+  idempotency_key_version: text('idempotency_key_version').notNull(),
+  idempotency_fingerprint: text('idempotency_fingerprint').notNull(),
+  input_fingerprint_key_version: text('input_fingerprint_key_version').notNull(),
+  input_fingerprint: text('input_fingerprint').notNull(),
+  authorization_snapshot: jsonb('authorization_snapshot').$type<Record<string, unknown>>().notNull(),
+  safe_preview: jsonb('safe_preview').$type<Record<string, unknown>>().notNull(),
+  safe_outcome: jsonb('safe_outcome').$type<Record<string, unknown> | null>(),
+  root_run_id: text('root_run_id').notNull(),
+  parent_run_id: text('parent_run_id'),
+  depth: integer('depth').default(0).notNull(),
+  input_expires_at: timestamp('input_expires_at').notNull(),
+  result_expires_at: timestamp('result_expires_at').notNull(),
+  input_purged_at: timestamp('input_purged_at'),
+  result_purged_at: timestamp('result_purged_at'),
+  started_at: timestamp('started_at'),
+  terminal_at: timestamp('terminal_at'),
+  unknown_outcome_at: timestamp('unknown_outcome_at'),
+  reconciled_at: timestamp('reconciled_at'),
+  cancelled_at: timestamp('cancelled_at'),
+  ...timestamps(),
+}, (t) => [
+  unique('app_runs_org_id_id_unique').on(t.org_id, t.id),
+  foreignKey({
+    columns: [t.org_id, t.provider_snapshot_id],
+    foreignColumns: [capabilityProviderSnapshots.org_id, capabilityProviderSnapshots.id],
+    name: 'app_runs_org_provider_snapshot_fk',
+  }).onDelete('no action'),
+  uniqueIndex('app_runs_idempotency_unique').on(
+    t.org_id,
+    t.initiating_actor_type,
+    t.initiating_actor_id,
+    t.provider_kind,
+    t.provider_instance_id,
+    t.operation_name,
+    t.idempotency_key_version,
+    t.idempotency_fingerprint,
+  ),
+  index('app_runs_org_state_idx').on(t.org_id, t.state, t.created_at),
+  index('app_runs_root_idx').on(t.org_id, t.root_run_id, t.created_at),
+  index('app_runs_parent_idx').on(t.org_id, t.parent_run_id),
+  index('app_runs_secret_expiry_idx').on(t.state, t.input_expires_at, t.result_expires_at),
+  check('app_runs_origin_check', sql`${t.origin_kind} IN ('core', 'legacy_connector', 'app')`),
+  check('app_runs_contract_version_check', sql`${t.contract_version} = 'deft.app_run.v1'`),
+  // App origin is reserved but cannot persist until connected App grants exist.
+  check('app_runs_app_origin_disabled_check', sql`${t.origin_kind} <> 'app'`),
+  check('app_runs_actor_type_check', sql`
+    ${t.initiating_actor_type} IN ('human', 'agent_employee', 'system', 'automation')
+    AND ${t.execution_actor_type} IN ('human', 'agent_employee', 'system', 'automation')
+  `),
+  check('app_runs_provider_kind_check', sql`${t.provider_kind} IN ('mcp')`),
+  check('app_runs_state_check', sql`${t.state} IN (
+    'pending', 'pending_approval', 'running', 'waiting_external', 'succeeded',
+    'failed', 'cancelled', 'expired', 'unknown_outcome'
+  )`),
+  check('app_runs_risk_check', sql`${t.risk_class} IN ('read', 'internal_write', 'external_write', 'destructive', 'privileged')`),
+  check('app_runs_review_requirement_check', sql`${t.review_requirement} IN ('policy', 'always')`),
+  check('app_runs_review_scope_check', sql`${t.review_scope} IN ('per_invocation', 'immutable_batch', 'approved_automation_definition', 'forbidden_in_automation')`),
+  check('app_runs_retry_class_check', sql`${t.retry_class} IN ('safe', 'idempotent_with_key', 'unsafe_or_unknown')`),
+  check('app_runs_retention_class_check', sql`${t.retention_class} IN ('ephemeral', 'standard', 'extended')`),
+  check('app_runs_fingerprint_check', sql`
+    ${t.idempotency_fingerprint} ~ '^hmac-sha256:[a-f0-9]{64}$'
+    AND ${t.input_fingerprint} ~ '^hmac-sha256:[a-f0-9]{64}$'
+  `),
+  check('app_runs_key_version_check', sql`
+    ${t.idempotency_key_version} ~ '^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$'
+    AND ${t.input_fingerprint_key_version} ~ '^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$'
+  `),
+  check('app_runs_json_check', sql`
+    jsonb_typeof(${t.authorization_snapshot}) = 'object'
+    AND jsonb_typeof(${t.safe_preview}) = 'object'
+    AND (${t.safe_outcome} IS NULL OR jsonb_typeof(${t.safe_outcome}) = 'object')
+  `),
+  check('app_runs_json_size_check', sql`
+    octet_length(${t.authorization_snapshot}::text) <= 65536
+    AND octet_length(${t.safe_preview}::text) <= 16384
+    AND (${t.safe_outcome} IS NULL OR octet_length(${t.safe_outcome}::text) <= 32768)
+  `),
+  check('app_runs_ancestry_check', sql`
+    ${t.depth} >= 0 AND ${t.depth} <= 8
+    AND (
+      (${t.depth} = 0 AND ${t.parent_run_id} IS NULL AND ${t.root_run_id} = ${t.id})
+      OR (${t.depth} > 0 AND ${t.parent_run_id} IS NOT NULL)
+    )
+  `),
+  check('app_runs_expiry_check', sql`${t.result_expires_at} >= ${t.input_expires_at}`),
+]);
+
+export const appRunAttempts = pgTable('app_run_attempts', {
+  ...id(),
+  ...orgId(),
+  run_id: text('run_id').notNull(),
+  attempt_number: integer('attempt_number').notNull(),
+  state: text('state').$type<
+    'pending' | 'claimed' | 'provider_call_started' | 'succeeded' | 'failed' | 'cancelled' | 'unknown_outcome'
+  >().default('pending').notNull(),
+  claim_owner: text('claim_owner'),
+  claim_token: text('claim_token'),
+  claimed_at: timestamp('claimed_at'),
+  lease_expires_at: timestamp('lease_expires_at'),
+  provider_call_started_at: timestamp('provider_call_started_at'),
+  provider_call_finished_at: timestamp('provider_call_finished_at'),
+  provider_idempotency_key_version: text('provider_idempotency_key_version'),
+  provider_idempotency_fingerprint: text('provider_idempotency_fingerprint'),
+  safe_outcome: jsonb('safe_outcome').$type<Record<string, unknown> | null>(),
+  error_code: text('error_code'),
+  ...timestamps(),
+}, (t) => [
+  foreignKey({
+    columns: [t.org_id, t.run_id],
+    foreignColumns: [appRuns.org_id, appRuns.id],
+    name: 'app_run_attempts_org_run_fk',
+  }).onDelete('cascade'),
+  unique('app_run_attempts_org_run_id_unique').on(t.org_id, t.run_id, t.id),
+  uniqueIndex('app_run_attempts_number_unique').on(t.org_id, t.run_id, t.attempt_number),
+  index('app_run_attempts_lease_idx').on(t.state, t.lease_expires_at),
+  check('app_run_attempts_number_check', sql`${t.attempt_number} >= 1`),
+  check('app_run_attempts_state_check', sql`${t.state} IN ('pending', 'claimed', 'provider_call_started', 'succeeded', 'failed', 'cancelled', 'unknown_outcome')`),
+  check('app_run_attempts_claim_shape_check', sql`
+    (${t.claim_owner} IS NULL AND ${t.claim_token} IS NULL AND ${t.claimed_at} IS NULL AND ${t.lease_expires_at} IS NULL)
+    OR (${t.claim_owner} IS NOT NULL AND ${t.claim_token} IS NOT NULL AND ${t.claimed_at} IS NOT NULL AND ${t.lease_expires_at} IS NOT NULL)
+  `),
+  check('app_run_attempts_provider_call_time_check', sql`
+    ${t.provider_call_finished_at} IS NULL
+    OR (${t.provider_call_started_at} IS NOT NULL AND ${t.provider_call_finished_at} >= ${t.provider_call_started_at})
+  `),
+  check('app_run_attempts_idempotency_shape_check', sql`
+    (${t.provider_idempotency_key_version} IS NULL AND ${t.provider_idempotency_fingerprint} IS NULL)
+    OR (
+      ${t.provider_idempotency_key_version} ~ '^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$'
+      AND ${t.provider_idempotency_fingerprint} ~ '^hmac-sha256:[a-f0-9]{64}$'
+    )
+  `),
+  check('app_run_attempts_safe_outcome_check', sql`
+    ${t.safe_outcome} IS NULL
+    OR (jsonb_typeof(${t.safe_outcome}) = 'object' AND octet_length(${t.safe_outcome}::text) <= 32768)
+  `),
+]);
+
+export const appRunSecretPayloads = pgTable('app_run_secret_payloads', {
+  ...id(),
+  ...orgId(),
+  run_id: text('run_id').notNull(),
+  attempt_id: text('attempt_id'),
+  payload_kind: text('payload_kind').$type<'input' | 'output'>().notNull(),
+  envelope_version: text('envelope_version').notNull(),
+  algorithm: text('algorithm').$type<'aes-256-gcm'>().notNull(),
+  key_version: text('key_version').notNull(),
+  nonce_b64: text('nonce_b64').notNull(),
+  ciphertext_b64: text('ciphertext_b64').notNull(),
+  auth_tag_b64: text('auth_tag_b64').notNull(),
+  payload_bytes: integer('payload_bytes').notNull(),
+  expires_at: timestamp('expires_at').notNull(),
+  created_at: timestamp('created_at').defaultNow().notNull(),
+}, (t) => [
+  foreignKey({
+    columns: [t.org_id, t.run_id],
+    foreignColumns: [appRuns.org_id, appRuns.id],
+    name: 'app_run_secret_payloads_org_run_fk',
+  }).onDelete('cascade'),
+  foreignKey({
+    columns: [t.org_id, t.run_id, t.attempt_id],
+    foreignColumns: [appRunAttempts.org_id, appRunAttempts.run_id, appRunAttempts.id],
+    name: 'app_run_secret_payloads_org_attempt_fk',
+  }).onDelete('cascade'),
+  uniqueIndex('app_run_secret_payloads_input_unique')
+    .on(t.org_id, t.run_id, t.payload_kind)
+    .where(sql`${t.payload_kind} = 'input'`),
+  uniqueIndex('app_run_secret_payloads_output_unique')
+    .on(t.org_id, t.attempt_id, t.payload_kind)
+    .where(sql`${t.payload_kind} = 'output'`),
+  index('app_run_secret_payloads_expiry_idx').on(t.expires_at),
+  check('app_run_secret_payloads_kind_shape_check', sql`
+    (${t.payload_kind} = 'input' AND ${t.attempt_id} IS NULL AND ${t.payload_bytes} BETWEEN 1 AND 262144)
+    OR (${t.payload_kind} = 'output' AND ${t.attempt_id} IS NOT NULL AND ${t.payload_bytes} BETWEEN 1 AND 1048576)
+  `),
+  check('app_run_secret_payloads_envelope_check', sql`
+    ${t.envelope_version} = 'deft.secret.v1'
+    AND ${t.algorithm} = 'aes-256-gcm'
+    AND ${t.key_version} ~ '^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$'
+    AND ${t.nonce_b64} ~ '^[A-Za-z0-9+/]{16}$'
+    AND ${t.auth_tag_b64} ~ '^[A-Za-z0-9+/]{22}==$'
+    AND ${t.ciphertext_b64} ~ '^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$'
+  `),
+  check('app_run_secret_payloads_size_check', sql`
+    octet_length(decode(${t.ciphertext_b64}, 'base64')) = ${t.payload_bytes}
+  `),
+]);
+
+export const appRunEvents = pgTable('app_run_events', {
+  ...id(),
+  ...orgId(),
+  run_id: text('run_id').notNull(),
+  event_version: text('event_version').$type<'deft.app_run_event.v1'>()
+    .default('deft.app_run_event.v1').notNull(),
+  sequence: integer('sequence').notNull(),
+  event_type: text('event_type').notNull(),
+  actor_type: text('actor_type'),
+  actor_id: text('actor_id'),
+  payload: jsonb('payload').$type<Record<string, unknown>>().notNull().default({}),
+  created_at: timestamp('created_at').defaultNow().notNull(),
+}, (t) => [
+  foreignKey({
+    columns: [t.org_id, t.run_id],
+    foreignColumns: [appRuns.org_id, appRuns.id],
+    name: 'app_run_events_org_run_fk',
+  }).onDelete('cascade'),
+  uniqueIndex('app_run_events_sequence_unique').on(t.org_id, t.run_id, t.sequence),
+  index('app_run_events_run_idx').on(t.org_id, t.run_id, t.created_at),
+  check('app_run_events_sequence_check', sql`${t.sequence} >= 1`),
+  check('app_run_events_version_check', sql`${t.event_version} = 'deft.app_run_event.v1'`),
+  check('app_run_events_type_check', sql`${t.event_type} IN (
+    'run_created', 'approval_requested', 'approval_resolved', 'attempt_created',
+    'attempt_claimed', 'provider_call_started', 'attempt_terminal', 'run_transitioned',
+    'secrets_purged', 'reconciliation_recorded', 'repair_gap'
+  )`),
+  check('app_run_events_actor_shape_check', sql`
+    (${t.actor_type} IS NULL AND ${t.actor_id} IS NULL)
+    OR (${t.actor_type} IN ('human', 'agent_employee', 'system', 'automation') AND ${t.actor_id} IS NOT NULL)
+  `),
+  check('app_run_events_payload_check', sql`jsonb_typeof(${t.payload}) = 'object' AND octet_length(${t.payload}::text) <= 32768`),
+]);
+
+export const appRunReceipts = pgTable('app_run_receipts', {
+  ...id(),
+  ...orgId(),
+  run_id: text('run_id').notNull(),
+  attempt_id: text('attempt_id'),
+  receipt_version: text('receipt_version').$type<'deft.app_run_receipt.v1'>()
+    .default('deft.app_run_receipt.v1').notNull(),
+  receipt_key: text('receipt_key').notNull(),
+  receipt_kind: text('receipt_kind').$type<'approval' | 'attempt_terminal' | 'reconciliation' | 'repair'>().notNull(),
+  envelope: jsonb('envelope').$type<Record<string, unknown>>().notNull(),
+  envelope_digest: text('envelope_digest').notNull(),
+  signing_key_version: text('signing_key_version').notNull(),
+  signature_hmac: text('signature_hmac').notNull(),
+  signed_at: timestamp('signed_at').defaultNow().notNull(),
+  created_at: timestamp('created_at').defaultNow().notNull(),
+}, (t) => [
+  foreignKey({
+    columns: [t.org_id, t.run_id],
+    foreignColumns: [appRuns.org_id, appRuns.id],
+    name: 'app_run_receipts_org_run_fk',
+  }).onDelete('cascade'),
+  foreignKey({
+    columns: [t.org_id, t.run_id, t.attempt_id],
+    foreignColumns: [appRunAttempts.org_id, appRunAttempts.run_id, appRunAttempts.id],
+    name: 'app_run_receipts_org_attempt_fk',
+  }).onDelete('cascade'),
+  uniqueIndex('app_run_receipts_key_unique').on(t.org_id, t.run_id, t.receipt_key),
+  index('app_run_receipts_run_idx').on(t.org_id, t.run_id, t.signed_at),
+  check('app_run_receipts_kind_check', sql`${t.receipt_kind} IN ('approval', 'attempt_terminal', 'reconciliation', 'repair')`),
+  check('app_run_receipts_version_check', sql`${t.receipt_version} = 'deft.app_run_receipt.v1'`),
+  check('app_run_receipts_envelope_check', sql`jsonb_typeof(${t.envelope}) = 'object' AND octet_length(${t.envelope}::text) <= 32768`),
+  check('app_run_receipts_digest_check', sql`${t.envelope_digest} ~ '^sha256:[a-f0-9]{64}$'`),
+  check('app_run_receipts_signature_check', sql`${t.signature_hmac} ~ '^hmac-sha256:[a-f0-9]{64}$'`),
+  check('app_run_receipts_key_version_check', sql`${t.signing_key_version} ~ '^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$'`),
+]);
+
 // ═══ AGENT: ACTIONS LOG ═══
 // Note: agent_conversations and agent_messages were dropped in migration 0065
 // (Phase 2 agent-chat unification). Conversation IDs are now space IDs in the
@@ -641,6 +962,9 @@ export const agentActions = pgTable('agent_actions', {
   agent_employee_id: text('agent_employee_id'),
   tool_use_id: text('tool_use_id'), // Anthropic tool_use block id (toolu_*)
   source: text('source').default('native'),
+  // Nullable compatibility link only. App Runs are dormant and never created
+  // by the current action paths in the foundation phase.
+  app_run_id: text('app_run_id'),
   mcp_connection_id: text('mcp_connection_id'),
   plan_id: text('plan_id'),
   plan_step_id: text('plan_step_id'),
@@ -660,9 +984,17 @@ export const agentActions = pgTable('agent_actions', {
   undone_at: timestamp('undone_at'),
   ...timestamps(),
 }, (t) => [
+  foreignKey({
+    columns: [t.org_id, t.app_run_id],
+    foreignColumns: [appRuns.org_id, appRuns.id],
+    name: 'agent_actions_org_app_run_fk',
+  }).onDelete('restrict'),
   index('agent_action_org_idx').on(t.org_id),
   index('agent_action_user_idx').on(t.user_id),
   index('agent_action_runtime_request_idx').on(t.org_id, t.agent_employee_id, t.runtime_request_key),
+  uniqueIndex('agent_action_app_run_unique')
+    .on(t.org_id, t.app_run_id)
+    .where(sql`${t.app_run_id} IS NOT NULL`),
 ]);
 
 // ═══ ATTENTION + DELIVERY ═══

--- a/packages/db/upgrades/0.3.0-preview.17-governed-app-runs-foundation.sql
+++ b/packages/db/upgrades/0.3.0-preview.17-governed-app-runs-foundation.sql
@@ -1,0 +1,437 @@
+-- Dormant governed App Run foundation. This migration is additive: it does not
+-- backfill legacy actions, alter current execution, or rewrite ciphertext.
+
+CREATE TABLE IF NOT EXISTS capability_provider_snapshots (
+  id text PRIMARY KEY,
+  org_id text NOT NULL REFERENCES orgs(id) ON DELETE CASCADE,
+  provider_kind text NOT NULL,
+  provider_instance_id text NOT NULL,
+  adapter_contract_version text NOT NULL,
+  snapshot_digest text NOT NULL,
+  safe_snapshot jsonb NOT NULL,
+  captured_at timestamp NOT NULL,
+  created_at timestamp NOT NULL DEFAULT now(),
+  CONSTRAINT capability_provider_snapshots_org_id_id_unique UNIQUE (org_id, id),
+  CONSTRAINT capability_provider_snapshots_kind_check CHECK (provider_kind IN ('mcp')),
+  CONSTRAINT capability_provider_snapshots_digest_check CHECK (snapshot_digest ~ '^sha256:[a-f0-9]{64}$'),
+  CONSTRAINT capability_provider_snapshots_json_check CHECK (jsonb_typeof(safe_snapshot) = 'object'),
+  CONSTRAINT capability_provider_snapshots_size_check CHECK (octet_length(safe_snapshot::text) <= 1048576)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS capability_provider_snapshots_identity_digest_unique
+  ON capability_provider_snapshots(org_id, provider_kind, provider_instance_id, snapshot_digest);
+CREATE INDEX IF NOT EXISTS capability_provider_snapshots_provider_idx
+  ON capability_provider_snapshots(org_id, provider_kind, provider_instance_id, captured_at);
+
+CREATE TABLE IF NOT EXISTS app_runs (
+  id text PRIMARY KEY,
+  org_id text NOT NULL REFERENCES orgs(id) ON DELETE CASCADE,
+  contract_version text NOT NULL,
+  origin_kind text NOT NULL,
+  initiating_actor_type text NOT NULL,
+  initiating_actor_id text NOT NULL,
+  execution_actor_type text NOT NULL,
+  execution_actor_id text NOT NULL,
+  provider_kind text NOT NULL,
+  provider_instance_id text NOT NULL,
+  operation_name text NOT NULL,
+  provider_snapshot_id text NOT NULL,
+  state text NOT NULL DEFAULT 'pending',
+  risk_class text NOT NULL,
+  review_requirement text NOT NULL,
+  review_scope text NOT NULL,
+  retry_class text NOT NULL,
+  retention_class text NOT NULL,
+  idempotency_key_version text NOT NULL,
+  idempotency_fingerprint text NOT NULL,
+  input_fingerprint_key_version text NOT NULL,
+  input_fingerprint text NOT NULL,
+  authorization_snapshot jsonb NOT NULL,
+  safe_preview jsonb NOT NULL,
+  safe_outcome jsonb,
+  root_run_id text NOT NULL,
+  parent_run_id text,
+  depth integer NOT NULL DEFAULT 0,
+  input_expires_at timestamp NOT NULL,
+  result_expires_at timestamp NOT NULL,
+  input_purged_at timestamp,
+  result_purged_at timestamp,
+  started_at timestamp,
+  terminal_at timestamp,
+  unknown_outcome_at timestamp,
+  reconciled_at timestamp,
+  cancelled_at timestamp,
+  created_at timestamp NOT NULL DEFAULT now(),
+  updated_at timestamp NOT NULL DEFAULT now(),
+  CONSTRAINT app_runs_org_id_id_unique UNIQUE (org_id, id),
+  CONSTRAINT app_runs_org_provider_snapshot_fk FOREIGN KEY (org_id, provider_snapshot_id)
+    REFERENCES capability_provider_snapshots(org_id, id) ON DELETE NO ACTION
+    DEFERRABLE INITIALLY DEFERRED,
+  CONSTRAINT app_runs_contract_version_check CHECK (contract_version = 'deft.app_run.v1'),
+  CONSTRAINT app_runs_origin_check CHECK (origin_kind IN ('core', 'legacy_connector', 'app')),
+  CONSTRAINT app_runs_app_origin_disabled_check CHECK (origin_kind <> 'app'),
+  CONSTRAINT app_runs_actor_type_check CHECK (
+    initiating_actor_type IN ('human', 'agent_employee', 'system', 'automation')
+    AND execution_actor_type IN ('human', 'agent_employee', 'system', 'automation')
+  ),
+  CONSTRAINT app_runs_provider_kind_check CHECK (provider_kind IN ('mcp')),
+  CONSTRAINT app_runs_state_check CHECK (state IN (
+    'pending', 'pending_approval', 'running', 'waiting_external', 'succeeded',
+    'failed', 'cancelled', 'expired', 'unknown_outcome'
+  )),
+  CONSTRAINT app_runs_risk_check CHECK (risk_class IN (
+    'read', 'internal_write', 'external_write', 'destructive', 'privileged'
+  )),
+  CONSTRAINT app_runs_review_requirement_check CHECK (review_requirement IN ('policy', 'always')),
+  CONSTRAINT app_runs_review_scope_check CHECK (review_scope IN (
+    'per_invocation', 'immutable_batch', 'approved_automation_definition', 'forbidden_in_automation'
+  )),
+  CONSTRAINT app_runs_retry_class_check CHECK (retry_class IN ('safe', 'idempotent_with_key', 'unsafe_or_unknown')),
+  CONSTRAINT app_runs_retention_class_check CHECK (retention_class IN ('ephemeral', 'standard', 'extended')),
+  CONSTRAINT app_runs_fingerprint_check CHECK (
+    idempotency_fingerprint ~ '^hmac-sha256:[a-f0-9]{64}$'
+    AND input_fingerprint ~ '^hmac-sha256:[a-f0-9]{64}$'
+  ),
+  CONSTRAINT app_runs_key_version_check CHECK (
+    idempotency_key_version ~ '^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$'
+    AND input_fingerprint_key_version ~ '^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$'
+  ),
+  CONSTRAINT app_runs_json_check CHECK (
+    jsonb_typeof(authorization_snapshot) = 'object'
+    AND jsonb_typeof(safe_preview) = 'object'
+    AND (safe_outcome IS NULL OR jsonb_typeof(safe_outcome) = 'object')
+  ),
+  CONSTRAINT app_runs_json_size_check CHECK (
+    octet_length(authorization_snapshot::text) <= 65536
+    AND octet_length(safe_preview::text) <= 16384
+    AND (safe_outcome IS NULL OR octet_length(safe_outcome::text) <= 32768)
+  ),
+  CONSTRAINT app_runs_ancestry_check CHECK (
+    depth >= 0 AND depth <= 8
+    AND (
+      (depth = 0 AND parent_run_id IS NULL AND root_run_id = id)
+      OR (depth > 0 AND parent_run_id IS NOT NULL)
+    )
+  ),
+  CONSTRAINT app_runs_expiry_check CHECK (result_expires_at >= input_expires_at)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS app_runs_idempotency_unique ON app_runs(
+  org_id, initiating_actor_type, initiating_actor_id, provider_kind,
+  provider_instance_id, operation_name, idempotency_key_version, idempotency_fingerprint
+);
+CREATE INDEX IF NOT EXISTS app_runs_org_state_idx ON app_runs(org_id, state, created_at);
+CREATE INDEX IF NOT EXISTS app_runs_root_idx ON app_runs(org_id, root_run_id, created_at);
+CREATE INDEX IF NOT EXISTS app_runs_parent_idx ON app_runs(org_id, parent_run_id);
+CREATE INDEX IF NOT EXISTS app_runs_secret_expiry_idx ON app_runs(state, input_expires_at, result_expires_at);
+
+ALTER TABLE app_runs
+  ALTER CONSTRAINT app_runs_org_provider_snapshot_fk DEFERRABLE INITIALLY DEFERRED;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'app_runs_org_root_run_fk') THEN
+    ALTER TABLE app_runs ADD CONSTRAINT app_runs_org_root_run_fk
+      FOREIGN KEY (org_id, root_run_id) REFERENCES app_runs(org_id, id) ON DELETE NO ACTION
+      DEFERRABLE INITIALLY DEFERRED;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'app_runs_org_parent_run_fk') THEN
+    ALTER TABLE app_runs ADD CONSTRAINT app_runs_org_parent_run_fk
+      FOREIGN KEY (org_id, parent_run_id) REFERENCES app_runs(org_id, id) ON DELETE NO ACTION
+      DEFERRABLE INITIALLY DEFERRED;
+  END IF;
+END $$;
+
+CREATE TABLE IF NOT EXISTS app_run_attempts (
+  id text PRIMARY KEY,
+  org_id text NOT NULL,
+  run_id text NOT NULL,
+  attempt_number integer NOT NULL,
+  state text NOT NULL DEFAULT 'pending',
+  claim_owner text,
+  claim_token text,
+  claimed_at timestamp,
+  lease_expires_at timestamp,
+  provider_call_started_at timestamp,
+  provider_call_finished_at timestamp,
+  provider_idempotency_key_version text,
+  provider_idempotency_fingerprint text,
+  safe_outcome jsonb,
+  error_code text,
+  created_at timestamp NOT NULL DEFAULT now(),
+  updated_at timestamp NOT NULL DEFAULT now(),
+  CONSTRAINT app_run_attempts_org_run_fk FOREIGN KEY (org_id, run_id)
+    REFERENCES app_runs(org_id, id) ON DELETE CASCADE,
+  CONSTRAINT app_run_attempts_org_run_id_unique UNIQUE (org_id, run_id, id),
+  CONSTRAINT app_run_attempts_number_check CHECK (attempt_number >= 1),
+  CONSTRAINT app_run_attempts_state_check CHECK (state IN (
+    'pending', 'claimed', 'provider_call_started', 'succeeded', 'failed', 'cancelled', 'unknown_outcome'
+  )),
+  CONSTRAINT app_run_attempts_claim_shape_check CHECK (
+    (claim_owner IS NULL AND claim_token IS NULL AND claimed_at IS NULL AND lease_expires_at IS NULL)
+    OR (claim_owner IS NOT NULL AND claim_token IS NOT NULL AND claimed_at IS NOT NULL AND lease_expires_at IS NOT NULL)
+  ),
+  CONSTRAINT app_run_attempts_provider_call_time_check CHECK (
+    provider_call_finished_at IS NULL
+    OR (provider_call_started_at IS NOT NULL AND provider_call_finished_at >= provider_call_started_at)
+  ),
+  CONSTRAINT app_run_attempts_idempotency_shape_check CHECK (
+    (provider_idempotency_key_version IS NULL AND provider_idempotency_fingerprint IS NULL)
+    OR (
+      provider_idempotency_key_version ~ '^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$'
+      AND provider_idempotency_fingerprint ~ '^hmac-sha256:[a-f0-9]{64}$'
+    )
+  ),
+  CONSTRAINT app_run_attempts_safe_outcome_check CHECK (
+    safe_outcome IS NULL
+    OR (jsonb_typeof(safe_outcome) = 'object' AND octet_length(safe_outcome::text) <= 32768)
+  )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS app_run_attempts_number_unique
+  ON app_run_attempts(org_id, run_id, attempt_number);
+CREATE INDEX IF NOT EXISTS app_run_attempts_lease_idx
+  ON app_run_attempts(state, lease_expires_at);
+
+CREATE TABLE IF NOT EXISTS app_run_secret_payloads (
+  id text PRIMARY KEY,
+  org_id text NOT NULL,
+  run_id text NOT NULL,
+  attempt_id text,
+  payload_kind text NOT NULL,
+  envelope_version text NOT NULL,
+  algorithm text NOT NULL,
+  key_version text NOT NULL,
+  nonce_b64 text NOT NULL,
+  ciphertext_b64 text NOT NULL,
+  auth_tag_b64 text NOT NULL,
+  payload_bytes integer NOT NULL,
+  expires_at timestamp NOT NULL,
+  created_at timestamp NOT NULL DEFAULT now(),
+  CONSTRAINT app_run_secret_payloads_org_run_fk FOREIGN KEY (org_id, run_id)
+    REFERENCES app_runs(org_id, id) ON DELETE CASCADE,
+  CONSTRAINT app_run_secret_payloads_org_attempt_fk FOREIGN KEY (org_id, run_id, attempt_id)
+    REFERENCES app_run_attempts(org_id, run_id, id) ON DELETE CASCADE,
+  CONSTRAINT app_run_secret_payloads_kind_shape_check CHECK (
+    (payload_kind = 'input' AND attempt_id IS NULL AND payload_bytes BETWEEN 1 AND 262144)
+    OR (payload_kind = 'output' AND attempt_id IS NOT NULL AND payload_bytes BETWEEN 1 AND 1048576)
+  ),
+  CONSTRAINT app_run_secret_payloads_envelope_check CHECK (
+    envelope_version = 'deft.secret.v1'
+    AND algorithm = 'aes-256-gcm'
+    AND key_version ~ '^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$'
+    AND nonce_b64 ~ '^[A-Za-z0-9+/]{16}$'
+    AND auth_tag_b64 ~ '^[A-Za-z0-9+/]{22}==$'
+    AND ciphertext_b64 ~ '^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$'
+  ),
+  CONSTRAINT app_run_secret_payloads_size_check CHECK (
+    octet_length(decode(ciphertext_b64, 'base64')) = payload_bytes
+  )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS app_run_secret_payloads_input_unique
+  ON app_run_secret_payloads(org_id, run_id, payload_kind) WHERE payload_kind = 'input';
+CREATE UNIQUE INDEX IF NOT EXISTS app_run_secret_payloads_output_unique
+  ON app_run_secret_payloads(org_id, attempt_id, payload_kind) WHERE payload_kind = 'output';
+CREATE INDEX IF NOT EXISTS app_run_secret_payloads_expiry_idx ON app_run_secret_payloads(expires_at);
+
+CREATE TABLE IF NOT EXISTS app_run_events (
+  id text PRIMARY KEY,
+  org_id text NOT NULL,
+  run_id text NOT NULL,
+  event_version text NOT NULL DEFAULT 'deft.app_run_event.v1',
+  sequence integer NOT NULL,
+  event_type text NOT NULL,
+  actor_type text,
+  actor_id text,
+  payload jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamp NOT NULL DEFAULT now(),
+  CONSTRAINT app_run_events_org_run_fk FOREIGN KEY (org_id, run_id)
+    REFERENCES app_runs(org_id, id) ON DELETE CASCADE,
+  CONSTRAINT app_run_events_sequence_check CHECK (sequence >= 1),
+  CONSTRAINT app_run_events_version_check CHECK (event_version = 'deft.app_run_event.v1'),
+  CONSTRAINT app_run_events_type_check CHECK (event_type IN (
+    'run_created', 'approval_requested', 'approval_resolved', 'attempt_created',
+    'attempt_claimed', 'provider_call_started', 'attempt_terminal', 'run_transitioned',
+    'secrets_purged', 'reconciliation_recorded', 'repair_gap'
+  )),
+  CONSTRAINT app_run_events_actor_shape_check CHECK (
+    (actor_type IS NULL AND actor_id IS NULL)
+    OR (actor_type IN ('human', 'agent_employee', 'system', 'automation') AND actor_id IS NOT NULL)
+  ),
+  CONSTRAINT app_run_events_payload_check CHECK (
+    jsonb_typeof(payload) = 'object' AND octet_length(payload::text) <= 32768
+  )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS app_run_events_sequence_unique
+  ON app_run_events(org_id, run_id, sequence);
+CREATE INDEX IF NOT EXISTS app_run_events_run_idx ON app_run_events(org_id, run_id, created_at);
+
+CREATE TABLE IF NOT EXISTS app_run_receipts (
+  id text PRIMARY KEY,
+  org_id text NOT NULL,
+  run_id text NOT NULL,
+  attempt_id text,
+  receipt_version text NOT NULL DEFAULT 'deft.app_run_receipt.v1',
+  receipt_key text NOT NULL,
+  receipt_kind text NOT NULL,
+  envelope jsonb NOT NULL,
+  envelope_digest text NOT NULL,
+  signing_key_version text NOT NULL,
+  signature_hmac text NOT NULL,
+  signed_at timestamp NOT NULL DEFAULT now(),
+  created_at timestamp NOT NULL DEFAULT now(),
+  CONSTRAINT app_run_receipts_org_run_fk FOREIGN KEY (org_id, run_id)
+    REFERENCES app_runs(org_id, id) ON DELETE CASCADE,
+  CONSTRAINT app_run_receipts_org_attempt_fk FOREIGN KEY (org_id, run_id, attempt_id)
+    REFERENCES app_run_attempts(org_id, run_id, id) ON DELETE CASCADE,
+  CONSTRAINT app_run_receipts_version_check CHECK (receipt_version = 'deft.app_run_receipt.v1'),
+  CONSTRAINT app_run_receipts_kind_check CHECK (receipt_kind IN (
+    'approval', 'attempt_terminal', 'reconciliation', 'repair'
+  )),
+  CONSTRAINT app_run_receipts_envelope_check CHECK (
+    jsonb_typeof(envelope) = 'object' AND octet_length(envelope::text) <= 32768
+  ),
+  CONSTRAINT app_run_receipts_digest_check CHECK (envelope_digest ~ '^sha256:[a-f0-9]{64}$'),
+  CONSTRAINT app_run_receipts_signature_check CHECK (signature_hmac ~ '^hmac-sha256:[a-f0-9]{64}$'),
+  CONSTRAINT app_run_receipts_key_version_check CHECK (
+    signing_key_version ~ '^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$'
+  )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS app_run_receipts_key_unique
+  ON app_run_receipts(org_id, run_id, receipt_key);
+CREATE INDEX IF NOT EXISTS app_run_receipts_run_idx ON app_run_receipts(org_id, run_id, signed_at);
+
+ALTER TABLE agent_actions ADD COLUMN IF NOT EXISTS app_run_id text;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'agent_actions_org_app_run_fk') THEN
+    ALTER TABLE agent_actions ADD CONSTRAINT agent_actions_org_app_run_fk
+      FOREIGN KEY (org_id, app_run_id) REFERENCES app_runs(org_id, id) ON DELETE RESTRICT;
+  END IF;
+END $$;
+
+CREATE UNIQUE INDEX IF NOT EXISTS agent_action_app_run_unique
+  ON agent_actions(org_id, app_run_id) WHERE app_run_id IS NOT NULL;
+
+-- A nested FK cascade (for example organization deletion) remains possible.
+-- Direct deletion is reserved for a bounded maintenance transaction which uses
+-- SET LOCAL deft.app_run_maintenance = 'on'.
+CREATE OR REPLACE FUNCTION enforce_app_run_append_only() RETURNS trigger AS $$
+BEGIN
+  IF TG_OP = 'DELETE' AND (
+    pg_trigger_depth() > 1
+    OR current_setting('deft.app_run_maintenance', true) = 'on'
+  ) THEN
+    RETURN OLD;
+  END IF;
+  RAISE EXCEPTION 'APP_RUN_APPEND_ONLY' USING ERRCODE = '55000';
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION enforce_app_run_state_and_identity() RETURNS trigger AS $$
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    IF pg_trigger_depth() > 1 OR current_setting('deft.app_run_maintenance', true) = 'on' THEN
+      RETURN OLD;
+    END IF;
+    RAISE EXCEPTION 'APP_RUN_APPEND_ONLY' USING ERRCODE = '55000';
+  END IF;
+
+  IF (NEW.org_id, NEW.contract_version, NEW.origin_kind, NEW.initiating_actor_type, NEW.initiating_actor_id,
+      NEW.execution_actor_type, NEW.execution_actor_id, NEW.provider_kind,
+      NEW.provider_instance_id, NEW.operation_name, NEW.provider_snapshot_id,
+      NEW.risk_class, NEW.review_requirement, NEW.review_scope, NEW.retry_class,
+      NEW.retention_class, NEW.idempotency_key_version, NEW.idempotency_fingerprint,
+      NEW.input_fingerprint_key_version, NEW.input_fingerprint, NEW.authorization_snapshot,
+      NEW.safe_preview, NEW.root_run_id, NEW.depth, NEW.input_expires_at, NEW.result_expires_at)
+    IS DISTINCT FROM
+     (OLD.org_id, OLD.contract_version, OLD.origin_kind, OLD.initiating_actor_type, OLD.initiating_actor_id,
+      OLD.execution_actor_type, OLD.execution_actor_id, OLD.provider_kind,
+      OLD.provider_instance_id, OLD.operation_name, OLD.provider_snapshot_id,
+      OLD.risk_class, OLD.review_requirement, OLD.review_scope, OLD.retry_class,
+      OLD.retention_class, OLD.idempotency_key_version, OLD.idempotency_fingerprint,
+      OLD.input_fingerprint_key_version, OLD.input_fingerprint, OLD.authorization_snapshot,
+      OLD.safe_preview, OLD.root_run_id, OLD.depth, OLD.input_expires_at, OLD.result_expires_at)
+  THEN
+    RAISE EXCEPTION 'APP_RUN_IMMUTABLE_FIELD' USING ERRCODE = '55000';
+  END IF;
+
+  IF NEW.parent_run_id IS DISTINCT FROM OLD.parent_run_id THEN
+    RAISE EXCEPTION 'APP_RUN_IMMUTABLE_FIELD' USING ERRCODE = '55000';
+  END IF;
+
+  IF NEW.state <> OLD.state AND NOT (
+    (OLD.state = 'pending' AND NEW.state IN ('pending_approval', 'running', 'cancelled', 'expired'))
+    OR (OLD.state = 'pending_approval' AND NEW.state IN ('running', 'cancelled', 'expired'))
+    OR (OLD.state = 'running' AND NEW.state IN ('waiting_external', 'succeeded', 'failed', 'unknown_outcome'))
+    OR (OLD.state = 'waiting_external' AND NEW.state IN ('running', 'succeeded', 'failed', 'cancelled', 'unknown_outcome'))
+    OR (OLD.state = 'unknown_outcome' AND NEW.state IN ('succeeded', 'failed'))
+  ) THEN
+    RAISE EXCEPTION 'APP_RUN_ILLEGAL_TRANSITION' USING ERRCODE = '55000';
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION enforce_app_run_attempt_state_and_identity() RETURNS trigger AS $$
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    IF pg_trigger_depth() > 1 OR current_setting('deft.app_run_maintenance', true) = 'on' THEN
+      RETURN OLD;
+    END IF;
+    RAISE EXCEPTION 'APP_RUN_APPEND_ONLY' USING ERRCODE = '55000';
+  END IF;
+
+  IF (NEW.org_id, NEW.run_id, NEW.attempt_number,
+      NEW.provider_idempotency_key_version, NEW.provider_idempotency_fingerprint)
+    IS DISTINCT FROM
+     (OLD.org_id, OLD.run_id, OLD.attempt_number,
+      OLD.provider_idempotency_key_version, OLD.provider_idempotency_fingerprint)
+  THEN
+    RAISE EXCEPTION 'APP_RUN_IMMUTABLE_FIELD' USING ERRCODE = '55000';
+  END IF;
+
+  IF NEW.state <> OLD.state AND NOT (
+    (OLD.state = 'pending' AND NEW.state IN ('claimed', 'cancelled'))
+    OR (OLD.state = 'claimed' AND NEW.state IN ('provider_call_started', 'failed', 'cancelled'))
+    OR (OLD.state = 'provider_call_started' AND NEW.state IN ('succeeded', 'failed', 'cancelled', 'unknown_outcome'))
+  ) THEN
+    RAISE EXCEPTION 'APP_RUN_ILLEGAL_TRANSITION' USING ERRCODE = '55000';
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS capability_provider_snapshots_append_only_trigger ON capability_provider_snapshots;
+CREATE TRIGGER capability_provider_snapshots_append_only_trigger
+  BEFORE UPDATE OR DELETE ON capability_provider_snapshots
+  FOR EACH ROW EXECUTE FUNCTION enforce_app_run_append_only();
+
+DROP TRIGGER IF EXISTS app_runs_state_identity_trigger ON app_runs;
+CREATE TRIGGER app_runs_state_identity_trigger
+  BEFORE UPDATE OR DELETE ON app_runs
+  FOR EACH ROW EXECUTE FUNCTION enforce_app_run_state_and_identity();
+
+DROP TRIGGER IF EXISTS app_run_attempts_state_identity_trigger ON app_run_attempts;
+CREATE TRIGGER app_run_attempts_state_identity_trigger
+  BEFORE UPDATE OR DELETE ON app_run_attempts
+  FOR EACH ROW EXECUTE FUNCTION enforce_app_run_attempt_state_and_identity();
+
+DROP TRIGGER IF EXISTS app_run_secret_payloads_append_only_trigger ON app_run_secret_payloads;
+CREATE TRIGGER app_run_secret_payloads_append_only_trigger
+  BEFORE UPDATE OR DELETE ON app_run_secret_payloads
+  FOR EACH ROW EXECUTE FUNCTION enforce_app_run_append_only();
+
+DROP TRIGGER IF EXISTS app_run_events_append_only_trigger ON app_run_events;
+CREATE TRIGGER app_run_events_append_only_trigger
+  BEFORE UPDATE OR DELETE ON app_run_events
+  FOR EACH ROW EXECUTE FUNCTION enforce_app_run_append_only();
+
+DROP TRIGGER IF EXISTS app_run_receipts_append_only_trigger ON app_run_receipts;
+CREATE TRIGGER app_run_receipts_append_only_trigger
+  BEFORE UPDATE OR DELETE ON app_run_receipts
+  FOR EACH ROW EXECUTE FUNCTION enforce_app_run_append_only();

--- a/packages/db/upgrades/manifest.ts
+++ b/packages/db/upgrades/manifest.ts
@@ -102,6 +102,11 @@ export const upgradeManifest = {
       file: '0.3.0-preview.16-declarative-apps-v0.sql',
       description: 'Add declarative App v0 installations, immutable versions, and owned Module bindings',
     },
+    {
+      version: '0.3.0-preview.17',
+      file: '0.3.0-preview.17-governed-app-runs-foundation.sql',
+      description: 'Add dormant governed App Run metadata, encrypted payload, attempt, event, and receipt boundaries',
+    },
   ] satisfies UpgradeMigration[],
 } as const;
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -5,7 +5,7 @@
   "license": "AGPL-3.0-only",
   "type": "module",
   "scripts": {
-    "test": "tsx --test test/modules.test.ts test/capabilities.test.ts",
+    "test": "tsx --test test/modules.test.ts test/capabilities.test.ts test/app-runs.test.ts",
     "typecheck": "tsc --noEmit"
   },
   "exports": {

--- a/packages/shared/src/app-runs.ts
+++ b/packages/shared/src/app-runs.ts
@@ -1,0 +1,478 @@
+import { z } from 'zod';
+
+import {
+  CapabilityJsonObjectSchema,
+  CapabilityProviderOperationIdentitySchema,
+  assertCapabilityJsonWithinBudget,
+  type CapabilityJsonValue,
+} from './capabilities';
+
+export const APP_RUN_CONTRACT_VERSIONS = {
+  run: 'deft.app_run.v1',
+  event: 'deft.app_run_event.v1',
+  receipt: 'deft.app_run_receipt.v1',
+  secret_envelope: 'deft.secret.v1',
+  secret_aad: 'deft.app_run_aad.v1',
+  keyring: 'deft.app_run_keyring.v1',
+} as const;
+
+export const APP_RUN_LIMITS = {
+  input_bytes: 256 * 1024,
+  output_bytes: 1024 * 1024,
+  authorization_snapshot_bytes: 64 * 1024,
+  safe_preview_bytes: 16 * 1024,
+  safe_event_payload_bytes: 32 * 1024,
+  safe_receipt_envelope_bytes: 32 * 1024,
+  idempotency_key_bytes: 256,
+  keyring_entries: 16,
+  key_id_chars: 64,
+  max_child_depth: 8,
+  resource_refs_per_preview: 32,
+} as const;
+
+export const APP_RUN_SECRET_RETENTION_MS = {
+  ephemeral: 60 * 60 * 1000,
+  standard: 7 * 24 * 60 * 60 * 1000,
+  extended: 30 * 24 * 60 * 60 * 1000,
+} as const;
+
+const ExactIdentitySchema = z
+  .string()
+  .min(1)
+  .max(512)
+  .refine((value) => value === value.trim(), 'Identity must not have surrounding whitespace')
+  .refine((value) => !/[\u0000-\u001f\u007f]/u.test(value), 'Identity must not contain control characters');
+
+const APP_RUN_FORBIDDEN_SAFE_KEYS = new Set([
+  'input',
+  'output',
+  'raw_input',
+  'raw_output',
+  'params',
+  'idempotency_key',
+  'retry_key',
+  'ciphertext',
+  'ciphertext_b64',
+  'nonce_b64',
+  'auth_tag_b64',
+  'credential',
+  'credentials',
+  'secret',
+  'password',
+  'access_token',
+  'refresh_token',
+  'api_key',
+  'private_key',
+  'signature_hmac',
+]);
+
+function findForbiddenSafeKey(value: CapabilityJsonValue, path: readonly string[] = []): readonly string[] | null {
+  if (Array.isArray(value)) {
+    for (const [index, item] of value.entries()) {
+      const found = findForbiddenSafeKey(item, [...path, String(index)]);
+      if (found) return found;
+    }
+    return null;
+  }
+  if (value && typeof value === 'object') {
+    for (const [key, item] of Object.entries(value)) {
+      const next = [...path, key];
+      if (APP_RUN_FORBIDDEN_SAFE_KEYS.has(key.toLowerCase())) return next;
+      const found = findForbiddenSafeKey(item, next);
+      if (found) return found;
+    }
+  }
+  return null;
+}
+
+export const AppRunSafeMetadataSchema = CapabilityJsonObjectSchema.superRefine((value, ctx) => {
+  const forbiddenPath = findForbiddenSafeKey(value);
+  if (forbiddenPath) {
+    ctx.addIssue({
+      code: 'custom',
+      path: [...forbiddenPath],
+      message: 'Safe App Run metadata cannot contain secret-bearing fields',
+    });
+  }
+});
+export type AppRunSafeMetadata = z.infer<typeof AppRunSafeMetadataSchema>;
+
+export const AppRunStateSchema = z.enum([
+  'pending',
+  'pending_approval',
+  'running',
+  'waiting_external',
+  'succeeded',
+  'failed',
+  'cancelled',
+  'expired',
+  'unknown_outcome',
+]);
+export type AppRunState = z.infer<typeof AppRunStateSchema>;
+
+export const APP_RUN_TERMINAL_STATES = [
+  'succeeded',
+  'failed',
+  'cancelled',
+  'expired',
+] as const satisfies readonly AppRunState[];
+
+export const APP_RUN_STATE_TRANSITIONS = {
+  pending: ['pending_approval', 'running', 'cancelled', 'expired'],
+  pending_approval: ['running', 'cancelled', 'expired'],
+  running: ['waiting_external', 'succeeded', 'failed', 'unknown_outcome'],
+  waiting_external: ['running', 'succeeded', 'failed', 'cancelled', 'unknown_outcome'],
+  succeeded: [],
+  failed: [],
+  cancelled: [],
+  expired: [],
+  unknown_outcome: ['succeeded', 'failed'],
+} as const satisfies Record<AppRunState, readonly AppRunState[]>;
+
+export function isAppRunStateTransitionAllowed(from: AppRunState, to: AppRunState): boolean {
+  return from === to || (APP_RUN_STATE_TRANSITIONS[from] as readonly AppRunState[]).includes(to);
+}
+
+export const AppRunAttemptStateSchema = z.enum([
+  'pending',
+  'claimed',
+  'provider_call_started',
+  'succeeded',
+  'failed',
+  'cancelled',
+  'unknown_outcome',
+]);
+export type AppRunAttemptState = z.infer<typeof AppRunAttemptStateSchema>;
+
+export const APP_RUN_ATTEMPT_STATE_TRANSITIONS = {
+  pending: ['claimed', 'cancelled'],
+  claimed: ['provider_call_started', 'failed', 'cancelled'],
+  provider_call_started: ['succeeded', 'failed', 'cancelled', 'unknown_outcome'],
+  succeeded: [],
+  failed: [],
+  cancelled: [],
+  unknown_outcome: [],
+} as const satisfies Record<AppRunAttemptState, readonly AppRunAttemptState[]>;
+
+export function isAppRunAttemptStateTransitionAllowed(
+  from: AppRunAttemptState,
+  to: AppRunAttemptState,
+): boolean {
+  return from === to
+    || (APP_RUN_ATTEMPT_STATE_TRANSITIONS[from] as readonly AppRunAttemptState[]).includes(to);
+}
+
+export const AppRunOriginKindSchema = z.enum(['core', 'legacy_connector', 'app']);
+export type AppRunOriginKind = z.infer<typeof AppRunOriginKindSchema>;
+
+export const AppRunActorSchema = z.discriminatedUnion('actor_type', [
+  z.object({ actor_type: z.literal('human'), user_id: ExactIdentitySchema }).strict(),
+  z.object({
+    actor_type: z.literal('agent_employee'),
+    agent_employee_id: ExactIdentitySchema,
+    user_id: ExactIdentitySchema.optional(),
+  }).strict(),
+  z.object({ actor_type: z.literal('system'), system_id: ExactIdentitySchema }).strict(),
+  z.object({
+    actor_type: z.literal('automation'),
+    automation_id: ExactIdentitySchema,
+    user_id: ExactIdentitySchema.optional(),
+  }).strict(),
+]);
+export type AppRunActor = z.infer<typeof AppRunActorSchema>;
+
+export const AppRunOriginSchema = z.discriminatedUnion('origin_kind', [
+  z.object({ origin_kind: z.literal('core') }).strict(),
+  z.object({
+    origin_kind: z.literal('legacy_connector'),
+    connection_id: ExactIdentitySchema,
+  }).strict(),
+  z.object({
+    origin_kind: z.literal('app'),
+    installation_id: ExactIdentitySchema,
+    app_version_id: ExactIdentitySchema,
+    binding_key: ExactIdentitySchema,
+    grant_snapshot_id: ExactIdentitySchema,
+  }).strict(),
+]);
+export type AppRunOrigin = z.infer<typeof AppRunOriginSchema>;
+
+export const AppRunRiskClassSchema = z.enum([
+  'read',
+  'internal_write',
+  'external_write',
+  'destructive',
+  'privileged',
+]);
+export type AppRunRiskClass = z.infer<typeof AppRunRiskClassSchema>;
+
+export const AppRunReviewRequirementSchema = z.enum(['policy', 'always']);
+export type AppRunReviewRequirement = z.infer<typeof AppRunReviewRequirementSchema>;
+
+export const AppRunReviewScopeSchema = z.enum([
+  'per_invocation',
+  'immutable_batch',
+  'approved_automation_definition',
+  'forbidden_in_automation',
+]);
+export type AppRunReviewScope = z.infer<typeof AppRunReviewScopeSchema>;
+
+export const AppRunRetryClassSchema = z.enum(['safe', 'idempotent_with_key', 'unsafe_or_unknown']);
+export type AppRunRetryClass = z.infer<typeof AppRunRetryClassSchema>;
+
+export const AppRunRetentionClassSchema = z.enum(['ephemeral', 'standard', 'extended']);
+export type AppRunRetentionClass = z.infer<typeof AppRunRetentionClassSchema>;
+
+export const AppRunErrorCodeSchema = z.enum([
+  'APP_RUNS_DISABLED',
+  'APP_RUN_KEYRING_INVALID',
+  'APP_RUN_KEY_VERSION_UNAVAILABLE',
+  'APP_RUN_INPUT_INVALID',
+  'APP_RUN_INPUT_TOO_LARGE',
+  'APP_RUN_OUTPUT_TOO_LARGE',
+  'APP_RUN_IDEMPOTENCY_CONFLICT',
+  'APP_RUN_ILLEGAL_TRANSITION',
+  'APP_RUN_ACCESS_DENIED',
+  'APP_RUN_AUTHORIZATION_STALE',
+  'APP_RUN_PROVIDER_UNAVAILABLE',
+  'APP_RUN_PROVIDER_ERROR',
+  'APP_RUN_PROVIDER_TIMEOUT',
+  'APP_RUN_APPROVAL_REJECTED',
+  'APP_RUN_APPROVAL_EXPIRED',
+  'APP_RUN_CANCELLED',
+  'APP_RUN_EXPIRED',
+  'APP_RUN_UNKNOWN_OUTCOME',
+  'APP_RUN_RESULT_EXPIRED',
+  'APP_RUN_REPAIR_REQUIRED',
+  'APP_RUN_ANCESTRY_LIMIT',
+  'APP_RUN_CAPABILITY_CYCLE',
+]);
+export type AppRunErrorCode = z.infer<typeof AppRunErrorCodeSchema>;
+
+export type AppRunCrashRecoveryDecision =
+  | 'persist_known_result'
+  | 'create_retry_attempt'
+  | 'unknown_outcome';
+
+export function classifyAppRunCrashRecovery(input: Readonly<{
+  retry_class: AppRunRetryClass;
+  provider_call_started: boolean;
+  provider_result_known: boolean;
+  provider_idempotency_key_bound: boolean;
+}>): AppRunCrashRecoveryDecision {
+  if (input.provider_result_known) return 'persist_known_result';
+  if (!input.provider_call_started) return 'create_retry_attempt';
+  if (input.retry_class === 'safe') return 'create_retry_attempt';
+  if (input.retry_class === 'idempotent_with_key' && input.provider_idempotency_key_bound) {
+    return 'create_retry_attempt';
+  }
+  return 'unknown_outcome';
+}
+
+export const AppRunPolicySnapshotSchema = z.object({
+  risk_class: AppRunRiskClassSchema,
+  review_requirement: AppRunReviewRequirementSchema,
+  review_scope: AppRunReviewScopeSchema,
+  retry_class: AppRunRetryClassSchema,
+}).strict();
+export type AppRunPolicySnapshot = z.infer<typeof AppRunPolicySnapshotSchema>;
+
+export const AppRunAuthorityRefSchema = z.object({
+  authority_kind: z.enum([
+    'membership',
+    'token_scope',
+    'employee_health',
+    'employee_budget',
+    'assignment',
+    'connector',
+    'provider_schema',
+    'policy',
+  ]),
+  authority_id: ExactIdentitySchema,
+  version: ExactIdentitySchema,
+}).strict();
+
+export const AppRunAuthorizationSnapshotSchema = z.object({
+  schema_version: z.literal(APP_RUN_CONTRACT_VERSIONS.run),
+  authenticated_subject: AppRunActorSchema,
+  authority_refs: z.array(AppRunAuthorityRefSchema).min(1).max(32),
+}).strict().superRefine((value, ctx) => {
+  const identities = new Set<string>();
+  for (const [index, ref] of value.authority_refs.entries()) {
+    const identity = `${ref.authority_kind}\u0000${ref.authority_id}`;
+    if (identities.has(identity)) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['authority_refs', index],
+        message: 'Authorization authority identity must be unique',
+      });
+    }
+    identities.add(identity);
+  }
+});
+export type AppRunAuthorizationSnapshot = z.infer<typeof AppRunAuthorizationSnapshotSchema>;
+
+export const AppRunSafeResourceRefSchema = z.object({
+  resource_kind: ExactIdentitySchema,
+  resource_id: ExactIdentitySchema,
+  label: z.string().min(1).max(200).optional(),
+}).strict();
+
+export const AppRunSafePreviewSchema = z.object({
+  schema_version: z.literal(APP_RUN_CONTRACT_VERSIONS.run),
+  title: z.string().min(1).max(200),
+  summary: z.string().max(1_000).optional(),
+  resource_refs: z.array(AppRunSafeResourceRefSchema)
+    .max(APP_RUN_LIMITS.resource_refs_per_preview)
+    .default([]),
+  fields: AppRunSafeMetadataSchema.optional(),
+}).strict();
+export type AppRunSafePreview = z.infer<typeof AppRunSafePreviewSchema>;
+
+export const AppRunSafeOutcomeSchema = z.object({
+  success: z.boolean(),
+  provider_call_attempted: z.boolean(),
+  result_status: z.enum(['retained', 'expired', 'unavailable']),
+  summary: z.string().max(1_000).optional(),
+  error_code: AppRunErrorCodeSchema.optional(),
+}).strict().superRefine((value, ctx) => {
+  if (value.success && value.error_code !== undefined) {
+    ctx.addIssue({ code: 'custom', path: ['error_code'], message: 'Successful outcomes cannot include an error code' });
+  }
+  if (!value.success && value.error_code === undefined) {
+    ctx.addIssue({ code: 'custom', path: ['error_code'], message: 'Failed outcomes require an error code' });
+  }
+});
+export type AppRunSafeOutcome = z.infer<typeof AppRunSafeOutcomeSchema>;
+
+export const AppRunEventTypeSchema = z.enum([
+  'run_created',
+  'approval_requested',
+  'approval_resolved',
+  'attempt_created',
+  'attempt_claimed',
+  'provider_call_started',
+  'attempt_terminal',
+  'run_transitioned',
+  'secrets_purged',
+  'reconciliation_recorded',
+  'repair_gap',
+]);
+
+export const AppRunEventSchema = z.object({
+  schema_version: z.literal(APP_RUN_CONTRACT_VERSIONS.event),
+  event_id: ExactIdentitySchema,
+  org_id: ExactIdentitySchema,
+  run_id: ExactIdentitySchema,
+  sequence: z.number().int().positive(),
+  event_type: AppRunEventTypeSchema,
+  actor: AppRunActorSchema.optional(),
+  payload: AppRunSafeMetadataSchema.default({}),
+  occurred_at: z.string().datetime({ offset: true }),
+}).strict();
+export type AppRunEvent = z.infer<typeof AppRunEventSchema>;
+
+export const AppRunReceiptKindSchema = z.enum([
+  'approval',
+  'attempt_terminal',
+  'reconciliation',
+  'repair',
+]);
+
+export const AppRunReceiptEnvelopeSchema = z.object({
+  schema_version: z.literal(APP_RUN_CONTRACT_VERSIONS.receipt),
+  receipt_id: ExactIdentitySchema,
+  receipt_kind: AppRunReceiptKindSchema,
+  org_id: ExactIdentitySchema,
+  run_id: ExactIdentitySchema,
+  attempt_id: ExactIdentitySchema.optional(),
+  run_state: AppRunStateSchema,
+  actor: AppRunActorSchema.optional(),
+  operation: CapabilityProviderOperationIdentitySchema,
+  policy: AppRunPolicySnapshotSchema,
+  input_fingerprint: z.object({
+    key_version: ExactIdentitySchema,
+    fingerprint: z.string().regex(/^hmac-sha256:[a-f0-9]{64}$/),
+  }).strict(),
+  output_envelope_digest: z.string().regex(/^sha256:[a-f0-9]{64}$/).optional(),
+  facts: AppRunSafeMetadataSchema.default({}),
+  occurred_at: z.string().datetime({ offset: true }),
+}).strict().superRefine((value, ctx) => {
+  if (value.receipt_kind === 'attempt_terminal' && value.attempt_id === undefined) {
+    ctx.addIssue({
+      code: 'custom',
+      path: ['attempt_id'],
+      message: 'Attempt terminal receipts require an attempt identity',
+    });
+  }
+  if (value.operation.provider.org_id !== value.org_id) {
+    ctx.addIssue({
+      code: 'custom',
+      path: ['operation', 'provider', 'org_id'],
+      message: 'Receipt provider organization must match receipt organization',
+    });
+  }
+});
+export type AppRunReceiptEnvelope = z.infer<typeof AppRunReceiptEnvelopeSchema>;
+
+export const AppRunSubmissionSchema = z.object({
+  schema_version: z.literal(APP_RUN_CONTRACT_VERSIONS.run),
+  org_id: ExactIdentitySchema,
+  initiating_actor: AppRunActorSchema,
+  execution_actor: AppRunActorSchema,
+  origin: AppRunOriginSchema,
+  operation: CapabilityProviderOperationIdentitySchema,
+  provider_snapshot_digest: z.string().regex(/^sha256:[a-f0-9]{64}$/),
+  policy: AppRunPolicySnapshotSchema,
+  retention_class: AppRunRetentionClassSchema,
+  idempotency_key: z.string().min(1),
+  input: CapabilityJsonObjectSchema,
+  authorization_snapshot: AppRunAuthorizationSnapshotSchema,
+  safe_preview: AppRunSafePreviewSchema,
+}).strict().superRefine((value, ctx) => {
+  if (value.operation.provider.org_id !== value.org_id) {
+    ctx.addIssue({ code: 'custom', path: ['operation', 'provider', 'org_id'], message: 'Provider organization must match Run organization' });
+  }
+});
+export type AppRunSubmission = z.infer<typeof AppRunSubmissionSchema>;
+
+function utf8Bytes(value: string): number {
+  return new TextEncoder().encode(value).byteLength;
+}
+
+export function parseAppRunSubmission(value: unknown): AppRunSubmission {
+  const parsed = AppRunSubmissionSchema.parse(value);
+  if (utf8Bytes(parsed.idempotency_key) > APP_RUN_LIMITS.idempotency_key_bytes) {
+    throw new TypeError(`App Run idempotency key exceeds ${APP_RUN_LIMITS.idempotency_key_bytes} bytes`);
+  }
+  assertCapabilityJsonWithinBudget(parsed.input, APP_RUN_LIMITS.input_bytes);
+  assertCapabilityJsonWithinBudget(
+    parsed.authorization_snapshot,
+    APP_RUN_LIMITS.authorization_snapshot_bytes,
+  );
+  assertCapabilityJsonWithinBudget(parsed.safe_preview, APP_RUN_LIMITS.safe_preview_bytes);
+  return parsed;
+}
+
+export function assertAppRunOutputWithinBudget(value: unknown): asserts value is CapabilityJsonValue {
+  assertCapabilityJsonWithinBudget(value, APP_RUN_LIMITS.output_bytes);
+}
+
+export function parseAppRunEvent(value: unknown): AppRunEvent {
+  const parsed = AppRunEventSchema.parse(value);
+  assertCapabilityJsonWithinBudget(parsed.payload, APP_RUN_LIMITS.safe_event_payload_bytes);
+  return parsed;
+}
+
+export function parseAppRunReceiptEnvelope(value: unknown): AppRunReceiptEnvelope {
+  const parsed = AppRunReceiptEnvelopeSchema.parse(value);
+  assertCapabilityJsonWithinBudget(parsed, APP_RUN_LIMITS.safe_receipt_envelope_bytes);
+  return parsed;
+}
+
+export function retentionDeadline(
+  retentionClass: AppRunRetentionClass,
+  from: Date,
+): Date {
+  return new Date(from.getTime() + APP_RUN_SECRET_RETENTION_MS[retentionClass]);
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,4 +1,5 @@
 export const APP_NAME = 'Deft';
 
+export * from './app-runs';
 export * from './capabilities';
 export * from './modules';

--- a/packages/shared/test/app-runs.test.ts
+++ b/packages/shared/test/app-runs.test.ts
@@ -1,0 +1,248 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+
+import {
+  APP_RUN_CONTRACT_VERSIONS,
+  APP_RUN_LIMITS,
+  APP_RUN_SECRET_RETENTION_MS,
+  AppRunSafeOutcomeSchema,
+  AppRunAttemptStateSchema,
+  AppRunStateSchema,
+  isAppRunAttemptStateTransitionAllowed,
+  classifyAppRunCrashRecovery,
+  isAppRunStateTransitionAllowed,
+  parseAppRunSubmission,
+  parseAppRunEvent,
+  parseAppRunReceiptEnvelope,
+  retentionDeadline,
+} from '../src/app-runs';
+
+const digest = `sha256:${'a'.repeat(64)}`;
+
+function submission(overrides: Record<string, unknown> = {}) {
+  return {
+    schema_version: APP_RUN_CONTRACT_VERSIONS.run,
+    org_id: 'org-1',
+    initiating_actor: { actor_type: 'human', user_id: 'user-1' },
+    execution_actor: { actor_type: 'agent_employee', agent_employee_id: 'employee-1' },
+    origin: { origin_kind: 'legacy_connector', connection_id: 'connection-1' },
+    operation: {
+      provider: {
+        org_id: 'org-1',
+        provider_kind: 'mcp',
+        provider_instance_id: 'connection-1',
+      },
+      operation_name: 'send_email',
+    },
+    provider_snapshot_digest: digest,
+    policy: {
+      risk_class: 'external_write',
+      review_requirement: 'always',
+      review_scope: 'per_invocation',
+      retry_class: 'unsafe_or_unknown',
+    },
+    retention_class: 'standard',
+    idempotency_key: 'caller-key',
+    input: { recipient: 'person@example.com', body: 'hello' },
+    authorization_snapshot: {
+      schema_version: APP_RUN_CONTRACT_VERSIONS.run,
+      authenticated_subject: { actor_type: 'human', user_id: 'user-1' },
+      authority_refs: [
+        { authority_kind: 'membership', authority_id: 'membership-1', version: '3' },
+        { authority_kind: 'connector', authority_id: 'connection-1', version: '5' },
+      ],
+    },
+    safe_preview: {
+      schema_version: APP_RUN_CONTRACT_VERSIONS.run,
+      title: 'Send one email',
+      resource_refs: [{ resource_kind: 'contact', resource_id: 'contact-1', label: 'Recipient' }],
+    },
+    ...overrides,
+  };
+}
+
+describe('App Run contract', () => {
+  test('keeps origin, actor, policy, and provider identity closed and tenant-bound', () => {
+    const parsed = parseAppRunSubmission(submission());
+    assert.equal(parsed.origin.origin_kind, 'legacy_connector');
+    assert.equal(parsed.policy.review_requirement, 'always');
+
+    assert.throws(() => parseAppRunSubmission(submission({
+      operation: {
+        provider: {
+          org_id: 'other-org',
+          provider_kind: 'mcp',
+          provider_instance_id: 'connection-1',
+        },
+        operation_name: 'send_email',
+      },
+    })), /must match Run organization/);
+
+    assert.throws(() => parseAppRunSubmission(submission({
+      origin: { origin_kind: 'plugin', plugin_id: 'unsafe' },
+    })));
+  });
+
+  test('enforces byte budgets for opaque replay keys and retained JSON', () => {
+    assert.throws(() => parseAppRunSubmission(submission({
+      idempotency_key: 'é'.repeat(APP_RUN_LIMITS.idempotency_key_bytes),
+    })), /idempotency key exceeds/);
+
+    assert.throws(() => parseAppRunSubmission(submission({
+      input: { value: 'x'.repeat(APP_RUN_LIMITS.input_bytes) },
+    })), /exceeds/);
+  });
+
+  test('allows only the frozen Run transitions and explicit unknown reconciliation', () => {
+    for (const state of AppRunStateSchema.options) {
+      assert.equal(isAppRunStateTransitionAllowed(state, state), true);
+    }
+    assert.equal(isAppRunStateTransitionAllowed('pending', 'pending_approval'), true);
+    assert.equal(isAppRunStateTransitionAllowed('running', 'unknown_outcome'), true);
+    assert.equal(isAppRunStateTransitionAllowed('unknown_outcome', 'succeeded'), true);
+    assert.equal(isAppRunStateTransitionAllowed('succeeded', 'running'), false);
+    assert.equal(isAppRunStateTransitionAllowed('failed', 'pending'), false);
+  });
+
+  test('keeps attempt transitions distinct from Run reconciliation', () => {
+    for (const state of AppRunAttemptStateSchema.options) {
+      assert.equal(isAppRunAttemptStateTransitionAllowed(state, state), true);
+    }
+    assert.equal(isAppRunAttemptStateTransitionAllowed('pending', 'claimed'), true);
+    assert.equal(isAppRunAttemptStateTransitionAllowed('claimed', 'provider_call_started'), true);
+    assert.equal(isAppRunAttemptStateTransitionAllowed('provider_call_started', 'unknown_outcome'), true);
+    assert.equal(isAppRunAttemptStateTransitionAllowed('unknown_outcome', 'succeeded'), false);
+    assert.equal(isAppRunAttemptStateTransitionAllowed('failed', 'claimed'), false);
+  });
+
+  test('freezes crash recovery without retrying a possibly-started unsafe effect', () => {
+    assert.equal(classifyAppRunCrashRecovery({
+      retry_class: 'unsafe_or_unknown',
+      provider_call_started: true,
+      provider_result_known: false,
+      provider_idempotency_key_bound: false,
+    }), 'unknown_outcome');
+    assert.equal(classifyAppRunCrashRecovery({
+      retry_class: 'idempotent_with_key',
+      provider_call_started: true,
+      provider_result_known: false,
+      provider_idempotency_key_bound: true,
+    }), 'create_retry_attempt');
+    assert.equal(classifyAppRunCrashRecovery({
+      retry_class: 'unsafe_or_unknown',
+      provider_call_started: true,
+      provider_result_known: true,
+      provider_idempotency_key_bound: false,
+    }), 'persist_known_result');
+    assert.equal(classifyAppRunCrashRecovery({
+      retry_class: 'unsafe_or_unknown',
+      provider_call_started: false,
+      provider_result_known: false,
+      provider_idempotency_key_bound: false,
+    }), 'create_retry_attempt');
+  });
+
+  test('rejects opaque authorization blobs and duplicate authority versions', () => {
+    assert.throws(() => parseAppRunSubmission(submission({
+      authorization_snapshot: { membership_version: 3, connector_version: 5 },
+    })));
+    assert.throws(() => parseAppRunSubmission(submission({
+      authorization_snapshot: {
+        schema_version: APP_RUN_CONTRACT_VERSIONS.run,
+        authenticated_subject: { actor_type: 'human', user_id: 'user-1' },
+        authority_refs: [
+          { authority_kind: 'membership', authority_id: 'membership-1', version: '3' },
+          { authority_kind: 'membership', authority_id: 'membership-1', version: '4' },
+        ],
+      },
+    })), /must be unique/);
+  });
+
+  test('keeps safe outcomes result-free and coherent', () => {
+    assert.deepEqual(AppRunSafeOutcomeSchema.parse({
+      success: true,
+      provider_call_attempted: true,
+      result_status: 'retained',
+      summary: 'Sent',
+    }), {
+      success: true,
+      provider_call_attempted: true,
+      result_status: 'retained',
+      summary: 'Sent',
+    });
+    assert.throws(() => AppRunSafeOutcomeSchema.parse({
+      success: true,
+      provider_call_attempted: true,
+      result_status: 'retained',
+      output: { secret: true },
+    }));
+    assert.throws(() => AppRunSafeOutcomeSchema.parse({
+      success: false,
+      provider_call_attempted: false,
+      result_status: 'unavailable',
+    }), /require an error code/);
+  });
+
+  test('freezes safe event and receipt envelopes without secret-bearing metadata', () => {
+    const event = {
+      schema_version: APP_RUN_CONTRACT_VERSIONS.event,
+      event_id: 'event-1',
+      org_id: 'org-1',
+      run_id: 'run-1',
+      sequence: 1,
+      event_type: 'run_created',
+      payload: { summary: 'Created' },
+      occurred_at: '2026-08-30T00:00:00.000Z',
+    };
+    assert.equal(parseAppRunEvent(event).event_type, 'run_created');
+    assert.throws(() => parseAppRunEvent({
+      ...event,
+      payload: { nested: { ciphertext_b64: 'not-safe' } },
+    }), /secret-bearing/);
+
+    const receipt = {
+      schema_version: APP_RUN_CONTRACT_VERSIONS.receipt,
+      receipt_id: 'receipt-1',
+      receipt_kind: 'attempt_terminal',
+      org_id: 'org-1',
+      run_id: 'run-1',
+      attempt_id: 'attempt-1',
+      run_state: 'succeeded',
+      operation: {
+        provider: { org_id: 'org-1', provider_kind: 'mcp', provider_instance_id: 'provider-1' },
+        operation_name: 'send_email',
+      },
+      policy: {
+        risk_class: 'external_write',
+        review_requirement: 'always',
+        review_scope: 'per_invocation',
+        retry_class: 'unsafe_or_unknown',
+      },
+      input_fingerprint: {
+        key_version: 'fp-v1',
+        fingerprint: `hmac-sha256:${'a'.repeat(64)}`,
+      },
+      output_envelope_digest: digest,
+      facts: { result_status: 'retained' },
+      occurred_at: '2026-08-30T00:00:01.000Z',
+    };
+    assert.equal(parseAppRunReceiptEnvelope(receipt).receipt_kind, 'attempt_terminal');
+    assert.throws(() => parseAppRunReceiptEnvelope({ ...receipt, attempt_id: undefined }));
+    assert.throws(() => parseAppRunReceiptEnvelope({
+      ...receipt,
+      facts: { output: { recipient: 'person@example.com' } },
+    }), /secret-bearing/);
+  });
+
+  test('uses fixed retention ceilings independent of later permission changes', () => {
+    const from = new Date('2026-08-30T00:00:00.000Z');
+    assert.equal(
+      retentionDeadline('ephemeral', from).getTime() - from.getTime(),
+      APP_RUN_SECRET_RETENTION_MS.ephemeral,
+    );
+    assert.equal(
+      retentionDeadline('extended', from).getTime() - from.getTime(),
+      APP_RUN_SECRET_RETENTION_MS.extended,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- freeze the actor-neutral Governed App Run, attempt, crash-recovery, safe event, receipt, retention, and authorization contracts
- add purpose-separated versioned self-host keyrings plus AES-256-GCM Run payload encryption, HMAC fingerprints, receipt signing, rotation readers, retirement guards, and fail-closed opt-in validation
- add dormant tenant-bound Run/snapshot/attempt/secret/event/receipt storage and supported upgrade `0.3.0-preview.17`, with immutable fields, legal transitions, append-only guards, bounded ancestry, and one nullable approval compatibility link
- document the disabled-by-default self-host keyring contract and update the accepted Phase 3 rollout record

## Safety boundary
- no production execution consumer or provider call was added
- `origin_kind = app` is reserved but rejected by the database
- existing Capability Service behavior, `agent_actions` writes, approvals, and legacy ciphertext writers are unchanged
- generic Run rows do not contain ciphertext or full provider output

## Local evidence
- shared contract suite: 54/54
- focused App Run crypto/keyring suite: 11/11; App Run architecture guards: 2/2
- focused Capability Service and architecture compatibility suite: 14/14
- database upgrade suite: 19/19
- disposable PostgreSQL 16 probe: final `.17` SQL applied twice; tenant, transition, immutability, append-only, version/size, one-action-link, and organization-cascade probes passed; server and data directory removed
- repository typecheck passed
- repository lint passed
- API production compile passed
- `git diff --check` passed

## CI evidence
- Type Check, Versioned Upgrade, Test API, Build, Hermes Employee Release Gate, and Production Image + Browser Smoke passed
- CodeQL, Dependency Review, and Dependency Audit passed
- the pgvector-backed Versioned Upgrade job certifies the fresh/supported schema path unavailable in the local PostgreSQL installation

## Deferred by Phase 3 sequencing
- Full key backup/restore, rollback-floor, and rotation drills remain Phase 3 PR D.
- The feature remains dormant and disabled by default; widening it is a separate explicit decision.