### PR TITLE
feat(apps): add governed App Run engine

### DIFF
--- a/apps/api/src/lib/app-run-attempt-runner.ts
+++ b/apps/api/src/lib/app-run-attempt-runner.ts
@@ -1,0 +1,445 @@
+import { createHash } from 'node:crypto';
+import { and, asc, desc, eq, inArray, lte, sql } from 'drizzle-orm';
+import { appRunAttempts } from '@deft/db/schema';
+import {
+  AppRunSafeOutcomeSchema,
+  assertAppRunOutputWithinBudget,
+  classifyAppRunCrashRecovery,
+  type AppRunSafeOutcome,
+} from '@deft/shared';
+import { db } from './db.js';
+import { AppRunError } from './app-run-errors.js';
+import type { AppRunProviderExecutor, AppRunProviderExecutionResult } from './app-run-provider-executor.js';
+import { PostgresAppRunRepository, type AppRunSafeView, type AppRunTransaction } from './app-run-repository.js';
+import { AppRunSecretRepository } from './app-run-secret-repository.js';
+import type { AppRunSecretService } from './app-run-secrets.js';
+
+type ClaimedAttempt = Readonly<{
+  run: AppRunSafeView;
+  attempt: typeof appRunAttempts.$inferSelect;
+}>;
+
+function providerIdempotencyKey(runId: string): string {
+  return createHash('sha256')
+    .update('deft.app_run.provider_idempotency.v1\0')
+    .update(runId)
+    .digest('base64url');
+}
+
+function boundedLeaseMs(value: number): number {
+  return Math.max(1_000, Math.min(value, 15 * 60_000));
+}
+
+export class AppRunAttemptRunner {
+  constructor(
+    private readonly repository: PostgresAppRunRepository,
+    private readonly secretRepository: AppRunSecretRepository,
+    private readonly secrets: AppRunSecretService,
+    private readonly executor: AppRunProviderExecutor,
+    private readonly now: () => Date = () => new Date(),
+    private readonly leaseMs = 60_000,
+  ) {}
+
+  async run(orgId: string, runId: string, workerId: string, signal?: AbortSignal): Promise<AppRunSafeView> {
+    await this.recoverRun(orgId, runId);
+    const claimed = await this.#claim(orgId, runId, workerId);
+    if (!claimed) return this.repository.inspect(orgId, runId).then((run) => {
+      if (!run) throw new AppRunError('APP_RUN_ACCESS_DENIED');
+      return run;
+    });
+
+    const input = await this.secretRepository.readInput(orgId, runId);
+    if (input === null) {
+      await this.#settleBeforeCallFailure(claimed, 'APP_RUN_EXPIRED');
+      return this.repository.inspect(orgId, runId).then((run) => run!);
+    }
+    const boundaryCommitted = await this.#markProviderCallStarted(claimed);
+    if (!boundaryCommitted) return this.repository.inspect(orgId, runId).then((run) => run!);
+
+    const stableProviderKey = claimed.run.retry_class === 'idempotent_with_key'
+      ? providerIdempotencyKey(runId)
+      : undefined;
+    let result: AppRunProviderExecutionResult;
+    try {
+      result = await this.executor.execute({
+        org_id: orgId,
+        provider_kind: claimed.run.provider_kind,
+        provider_instance_id: claimed.run.provider_instance_id,
+        operation_name: claimed.run.operation_name,
+        input,
+        provider_idempotency_key: stableProviderKey,
+        signal,
+      });
+    } catch {
+      result = { status: 'indeterminate' };
+    }
+
+    if (result.status === 'indeterminate') {
+      await this.#settleIndeterminate(orgId, runId, claimed.attempt.id);
+      return this.repository.inspect(orgId, runId).then((run) => run!);
+    }
+
+    const known = await this.#knownOutcome(claimed.run, result);
+    await this.#persistKnownResult(orgId, runId, claimed.attempt.id, result, known);
+    await this.#finalizeKnownResult(orgId, runId, claimed.attempt.id);
+    return this.repository.inspect(orgId, runId).then((run) => run!);
+  }
+
+  async renewLease(orgId: string, attemptId: string, claimToken: string): Promise<boolean> {
+    const now = this.now();
+    const [identity] = await db.select({ run_id: appRunAttempts.run_id }).from(appRunAttempts).where(and(
+      eq(appRunAttempts.org_id, orgId), eq(appRunAttempts.id, attemptId),
+    )).limit(1);
+    if (!identity) return false;
+    return this.repository.transaction(async (tx) => {
+      if (!await this.repository.lockRun(tx, orgId, identity.run_id)) return false;
+      await tx.execute(sql`SELECT id FROM app_run_attempts
+        WHERE org_id = ${orgId} AND id = ${attemptId} FOR UPDATE`);
+      const [current] = await tx.select().from(appRunAttempts).where(and(
+        eq(appRunAttempts.org_id, orgId), eq(appRunAttempts.id, attemptId),
+      )).limit(1);
+      if (
+        !current
+        || current.claim_token !== claimToken
+        || !current.lease_expires_at
+        || current.lease_expires_at <= now
+        || (current.state !== 'claimed' && current.state !== 'provider_call_started')
+      ) return false;
+      const [renewed] = await tx.update(appRunAttempts).set({
+        lease_expires_at: new Date(now.getTime() + boundedLeaseMs(this.leaseMs)),
+        updated_at: now,
+      }).where(and(
+        eq(appRunAttempts.org_id, orgId),
+        eq(appRunAttempts.id, attemptId),
+        eq(appRunAttempts.claim_token, claimToken),
+      )).returning({ id: appRunAttempts.id });
+      return Boolean(renewed);
+    });
+  }
+
+  async recoverStale(limit = 100): Promise<number> {
+    const now = this.now();
+    const rows = await db.select({
+      org_id: appRunAttempts.org_id,
+      run_id: appRunAttempts.run_id,
+    }).from(appRunAttempts).where(and(
+      inArray(appRunAttempts.state, ['claimed', 'provider_call_started']),
+      lte(appRunAttempts.lease_expires_at, now),
+    )).orderBy(asc(appRunAttempts.lease_expires_at)).limit(Math.max(1, Math.min(limit, 500)));
+    let recovered = 0;
+    for (const row of rows) recovered += await this.recoverRun(row.org_id, row.run_id);
+    return recovered;
+  }
+
+  async recoverRun(orgId: string, runId: string): Promise<number> {
+    const now = this.now();
+    return this.repository.transaction(async (tx) => {
+      const run = await this.repository.lockRun(tx, orgId, runId);
+      if (!run) return 0;
+      const [attempt] = await tx.select().from(appRunAttempts).where(and(
+        eq(appRunAttempts.org_id, orgId),
+        eq(appRunAttempts.run_id, runId),
+        inArray(appRunAttempts.state, ['claimed', 'provider_call_started']),
+        lte(appRunAttempts.lease_expires_at, now),
+      )).orderBy(asc(appRunAttempts.attempt_number)).limit(1);
+      if (!attempt) return 0;
+      await tx.execute(sql`SELECT id FROM app_run_attempts WHERE org_id = ${orgId} AND id = ${attempt.id} FOR UPDATE`);
+      if (attempt.state === 'provider_call_started' && attempt.provider_call_finished_at && attempt.safe_outcome) {
+        await this.#finalizeKnownInTransaction(tx, run, attempt, now);
+        return 1;
+      }
+      await this.#recoverUnknownInTransaction(tx, run, attempt, now);
+      return 1;
+    });
+  }
+
+  async #claim(orgId: string, runId: string, workerId: string): Promise<ClaimedAttempt | null> {
+    const now = this.now();
+    return this.repository.transaction(async (tx) => {
+      let run = await this.repository.lockRun(tx, orgId, runId);
+      if (!run || ['succeeded', 'failed', 'cancelled', 'expired', 'unknown_outcome'].includes(run.state)) return null;
+      if (run.input_expires_at <= now) {
+        run = await this.repository.transition(tx, {
+          run, state: 'expired', now, error_code: 'APP_RUN_EXPIRED',
+          safe_outcome: AppRunSafeOutcomeSchema.parse({
+            success: false, provider_call_attempted: false,
+            result_status: 'unavailable', error_code: 'APP_RUN_EXPIRED',
+          }),
+        });
+        return null;
+      }
+      const [existingAttempt] = await tx.select().from(appRunAttempts).where(and(
+        eq(appRunAttempts.org_id, orgId),
+        eq(appRunAttempts.run_id, runId),
+        inArray(appRunAttempts.state, ['pending', 'claimed', 'provider_call_started']),
+      )).orderBy(asc(appRunAttempts.attempt_number)).limit(1);
+      let attempt: typeof appRunAttempts.$inferSelect | null | undefined = existingAttempt;
+      if (!attempt) attempt = await this.#createAttempt(tx, run, now);
+      if (!attempt || attempt.state !== 'pending') return null;
+      const claimToken = crypto.randomUUID();
+      const [claimed] = await tx.update(appRunAttempts).set({
+        state: 'claimed',
+        claim_owner: workerId,
+        claim_token: claimToken,
+        claimed_at: now,
+        lease_expires_at: new Date(now.getTime() + boundedLeaseMs(this.leaseMs)),
+        updated_at: now,
+      }).where(and(
+        eq(appRunAttempts.org_id, orgId),
+        eq(appRunAttempts.id, attempt.id),
+        eq(appRunAttempts.state, 'pending'),
+      )).returning();
+      if (!claimed) return null;
+      await this.repository.appendEvent(tx, {
+        id: crypto.randomUUID(), org_id: orgId, run_id: runId,
+        event_type: 'attempt_claimed', payload: { attempt_id: claimed.id }, now,
+      });
+      return { run, attempt: claimed };
+    });
+  }
+
+  async #createAttempt(
+    tx: AppRunTransaction,
+    run: AppRunSafeView,
+    now: Date,
+  ): Promise<typeof appRunAttempts.$inferSelect | null> {
+    const [last] = await tx.select().from(appRunAttempts).where(and(
+      eq(appRunAttempts.org_id, run.org_id), eq(appRunAttempts.run_id, run.id),
+    )).orderBy(desc(appRunAttempts.attempt_number)).limit(1);
+    const attemptNumber = (last?.attempt_number ?? 0) + 1;
+    if (attemptNumber > run.attempt_limit) return null;
+    const providerKey = run.retry_class === 'idempotent_with_key'
+      ? providerIdempotencyKey(run.id)
+      : null;
+    const providerFingerprint = providerKey
+      ? this.secrets.fingerprintText('idempotency', providerKey)
+      : null;
+    const [attempt] = await tx.insert(appRunAttempts).values({
+      id: crypto.randomUUID(), org_id: run.org_id, run_id: run.id,
+      attempt_number: attemptNumber,
+      retry_of_attempt_id: last?.id ?? null,
+      state: 'pending',
+      provider_idempotency_key_version: providerFingerprint?.key_version ?? null,
+      provider_idempotency_fingerprint: providerFingerprint?.fingerprint ?? null,
+      created_at: now, updated_at: now,
+    }).returning();
+    if (!attempt) return null;
+    await this.repository.appendEvent(tx, {
+      id: crypto.randomUUID(), org_id: run.org_id, run_id: run.id,
+      event_type: 'attempt_created', payload: { attempt_id: attempt.id, attempt_number: attemptNumber }, now,
+    });
+    return attempt;
+  }
+
+  async #markProviderCallStarted(claimed: ClaimedAttempt): Promise<boolean> {
+    const now = this.now();
+    return this.repository.transaction(async (tx) => {
+      let run = await this.repository.lockRun(tx, claimed.run.org_id, claimed.run.id);
+      if (!run || run.state === 'cancelled') return false;
+      await tx.execute(sql`SELECT id FROM app_run_attempts
+        WHERE org_id = ${claimed.run.org_id} AND id = ${claimed.attempt.id} FOR UPDATE`);
+      const [current] = await tx.select().from(appRunAttempts).where(and(
+        eq(appRunAttempts.org_id, claimed.run.org_id),
+        eq(appRunAttempts.id, claimed.attempt.id),
+      )).limit(1);
+      if (
+        !current
+        || current.state !== 'claimed'
+        || current.claim_token !== claimed.attempt.claim_token
+        || !current.lease_expires_at
+        || current.lease_expires_at <= now
+      ) return false;
+      const [attempt] = await tx.update(appRunAttempts).set({
+        state: 'provider_call_started', provider_call_started_at: now, updated_at: now,
+      }).where(and(
+        eq(appRunAttempts.org_id, claimed.run.org_id),
+        eq(appRunAttempts.id, claimed.attempt.id),
+        eq(appRunAttempts.state, 'claimed'),
+        eq(appRunAttempts.claim_token, claimed.attempt.claim_token!),
+      )).returning();
+      if (!attempt) return false;
+      if (run.state === 'pending' || run.state === 'pending_approval') {
+        run = await this.repository.transition(tx, { run, state: 'running', now });
+      }
+      await this.repository.appendEvent(tx, {
+        id: crypto.randomUUID(), org_id: run.org_id, run_id: run.id,
+        event_type: 'provider_call_started', payload: { attempt_id: attempt.id }, now,
+      });
+      return true;
+    });
+  }
+
+  async #knownOutcome(run: AppRunSafeView, result: Exclude<AppRunProviderExecutionResult, { status: 'indeterminate' }>): Promise<AppRunSafeOutcome> {
+    if (result.status === 'failed') {
+      return AppRunSafeOutcomeSchema.parse({
+        success: false, provider_call_attempted: true,
+        result_status: 'unavailable', error_code: 'APP_RUN_PROVIDER_ERROR',
+      });
+    }
+    let retained = run.result_expires_at > this.now();
+    if (retained) {
+      try {
+        assertAppRunOutputWithinBudget(result.output);
+      } catch {
+        retained = false;
+      }
+    }
+    return AppRunSafeOutcomeSchema.parse({
+      success: true, provider_call_attempted: true,
+      result_status: retained ? 'retained' : 'unavailable',
+    });
+  }
+
+  async #persistKnownResult(
+    orgId: string,
+    runId: string,
+    attemptId: string,
+    result: Exclude<AppRunProviderExecutionResult, { status: 'indeterminate' }>,
+    outcome: AppRunSafeOutcome,
+  ): Promise<void> {
+    let lastError: unknown;
+    for (let retry = 0; retry < 3; retry += 1) {
+      try {
+        await this.repository.transaction(async (tx) => {
+          const run = await this.repository.lockRun(tx, orgId, runId);
+          if (!run) throw new AppRunError('APP_RUN_ACCESS_DENIED');
+          await tx.execute(sql`SELECT id FROM app_run_attempts WHERE org_id = ${orgId} AND id = ${attemptId} FOR UPDATE`);
+          const [attempt] = await tx.select().from(appRunAttempts).where(and(
+            eq(appRunAttempts.org_id, orgId), eq(appRunAttempts.id, attemptId),
+          )).limit(1);
+          if (!attempt || attempt.state !== 'provider_call_started') return;
+          if (attempt.provider_call_finished_at && attempt.safe_outcome) return;
+          if (result.status === 'succeeded' && outcome.result_status === 'retained') {
+            await this.secretRepository.insertOutput(tx, {
+              org_id: orgId, run_id: runId, attempt_id: attemptId,
+              value: result.output, expires_at: run.result_expires_at,
+            });
+          }
+          await tx.update(appRunAttempts).set({
+            provider_call_finished_at: this.now(), safe_outcome: outcome, updated_at: this.now(),
+          }).where(and(eq(appRunAttempts.org_id, orgId), eq(appRunAttempts.id, attemptId)));
+        });
+        return;
+      } catch (error) {
+        lastError = error;
+      }
+    }
+    throw lastError;
+  }
+
+  async #finalizeKnownResult(orgId: string, runId: string, attemptId: string): Promise<void> {
+    await this.repository.transaction(async (tx) => {
+      const run = await this.repository.lockRun(tx, orgId, runId);
+      if (!run) return;
+      await tx.execute(sql`SELECT id FROM app_run_attempts WHERE org_id = ${orgId} AND id = ${attemptId} FOR UPDATE`);
+      const [attempt] = await tx.select().from(appRunAttempts).where(and(
+        eq(appRunAttempts.org_id, orgId), eq(appRunAttempts.id, attemptId),
+      )).limit(1);
+      if (!attempt || attempt.state !== 'provider_call_started' || !attempt.safe_outcome) return;
+      await this.#finalizeKnownInTransaction(tx, run, attempt, this.now());
+    });
+  }
+
+  async #finalizeKnownInTransaction(
+    tx: AppRunTransaction,
+    run: AppRunSafeView,
+    attempt: typeof appRunAttempts.$inferSelect,
+    now: Date,
+  ): Promise<void> {
+    const outcome = AppRunSafeOutcomeSchema.parse(attempt.safe_outcome);
+    const attemptState = outcome.success ? 'succeeded' : 'failed';
+    await tx.update(appRunAttempts).set({
+      state: attemptState,
+      error_code: outcome.error_code ?? null,
+      updated_at: now,
+    }).where(and(eq(appRunAttempts.org_id, run.org_id), eq(appRunAttempts.id, attempt.id)));
+    await this.repository.appendEvent(tx, {
+      id: crypto.randomUUID(), org_id: run.org_id, run_id: run.id,
+      event_type: 'attempt_terminal', payload: { attempt_id: attempt.id, state: attemptState }, now,
+    });
+    await this.repository.transition(tx, {
+      run, state: outcome.success ? 'succeeded' : 'failed', safe_outcome: outcome,
+      error_code: outcome.error_code, now,
+    });
+  }
+
+  async #settleBeforeCallFailure(claimed: ClaimedAttempt, code: 'APP_RUN_EXPIRED'): Promise<void> {
+    const now = this.now();
+    await this.repository.transaction(async (tx) => {
+      const run = await this.repository.lockRun(tx, claimed.run.org_id, claimed.run.id);
+      if (!run) return;
+      await tx.update(appRunAttempts).set({ state: 'failed', error_code: code, updated_at: now })
+        .where(and(eq(appRunAttempts.org_id, run.org_id), eq(appRunAttempts.id, claimed.attempt.id)));
+      await this.repository.transition(tx, {
+        run, state: 'expired', now, error_code: code,
+        safe_outcome: AppRunSafeOutcomeSchema.parse({
+          success: false, provider_call_attempted: false,
+          result_status: 'unavailable', error_code: code,
+        }),
+      });
+    });
+  }
+
+  async #settleIndeterminate(orgId: string, runId: string, attemptId: string): Promise<void> {
+    await this.repository.transaction(async (tx) => {
+      const run = await this.repository.lockRun(tx, orgId, runId);
+      if (!run) return;
+      await tx.execute(sql`SELECT id FROM app_run_attempts WHERE org_id = ${orgId} AND id = ${attemptId} FOR UPDATE`);
+      const [attempt] = await tx.select().from(appRunAttempts).where(and(
+        eq(appRunAttempts.org_id, orgId), eq(appRunAttempts.id, attemptId),
+      )).limit(1);
+      if (!attempt || attempt.state !== 'provider_call_started') return;
+      await this.#recoverUnknownInTransaction(tx, run, attempt, this.now());
+    });
+  }
+
+  async #recoverUnknownInTransaction(
+    tx: AppRunTransaction,
+    run: AppRunSafeView,
+    attempt: typeof appRunAttempts.$inferSelect,
+    now: Date,
+  ): Promise<void> {
+    const decision = classifyAppRunCrashRecovery({
+      retry_class: run.retry_class,
+      provider_call_started: attempt.state === 'provider_call_started',
+      provider_result_known: Boolean(attempt.provider_call_finished_at && attempt.safe_outcome),
+      provider_idempotency_key_bound: Boolean(attempt.provider_idempotency_fingerprint),
+    });
+    const terminalAttemptState = attempt.state === 'claimed' ? 'failed' : 'unknown_outcome';
+    await tx.update(appRunAttempts).set({
+      state: terminalAttemptState,
+      error_code: terminalAttemptState === 'unknown_outcome'
+        ? 'APP_RUN_UNKNOWN_OUTCOME'
+        : 'APP_RUN_PROVIDER_UNAVAILABLE',
+      updated_at: now,
+    }).where(and(eq(appRunAttempts.org_id, run.org_id), eq(appRunAttempts.id, attempt.id)));
+    await this.repository.appendEvent(tx, {
+      id: crypto.randomUUID(), org_id: run.org_id, run_id: run.id,
+      event_type: 'attempt_terminal',
+      payload: { attempt_id: attempt.id, state: terminalAttemptState }, now,
+    });
+    if (decision === 'create_retry_attempt' && attempt.attempt_number < run.attempt_limit && run.input_expires_at > now) {
+      await this.#createAttempt(tx, run, now);
+      return;
+    }
+    if (attempt.state === 'claimed') {
+      await this.repository.transition(tx, {
+        run, state: 'failed', now, error_code: 'APP_RUN_PROVIDER_UNAVAILABLE',
+        safe_outcome: AppRunSafeOutcomeSchema.parse({
+          success: false, provider_call_attempted: false,
+          result_status: 'unavailable', error_code: 'APP_RUN_PROVIDER_UNAVAILABLE',
+        }),
+      });
+      return;
+    }
+    await this.repository.transition(tx, {
+      run, state: 'unknown_outcome', now, error_code: 'APP_RUN_UNKNOWN_OUTCOME',
+      safe_outcome: AppRunSafeOutcomeSchema.parse({
+        success: false,
+        provider_call_attempted: attempt.state === 'provider_call_started',
+        result_status: 'unavailable',
+        error_code: 'APP_RUN_UNKNOWN_OUTCOME',
+      }),
+    });
+  }
+}

--- a/apps/api/src/lib/app-run-authorization.ts
+++ b/apps/api/src/lib/app-run-authorization.ts
@@ -1,0 +1,19 @@
+import type { AppRunActor } from '@deft/shared';
+import type { AppRunSafeView } from './app-run-repository.js';
+
+export type AppRunAccessAction = 'inspect' | 'result' | 'cancel' | 'reconcile';
+
+export interface AppRunAuthorizer {
+  authorize(input: Readonly<{
+    action: AppRunAccessAction;
+    org_id: string;
+    actor: AppRunActor;
+    run: AppRunSafeView;
+  }>): Promise<boolean>;
+}
+
+export const denyAllAppRunAuthorizer: AppRunAuthorizer = Object.freeze({
+  async authorize() {
+    return false;
+  },
+});

--- a/apps/api/src/lib/app-run-errors.ts
+++ b/apps/api/src/lib/app-run-errors.ts
@@ -1,0 +1,40 @@
+import { AppRunErrorCodeSchema, type AppRunErrorCode } from '@deft/shared';
+
+const SAFE_MESSAGES: Record<AppRunErrorCode, string> = {
+  APP_RUNS_DISABLED: 'App Run execution is disabled',
+  APP_RUN_KEYRING_INVALID: 'App Run key configuration is invalid',
+  APP_RUN_KEY_VERSION_UNAVAILABLE: 'A required App Run key version is unavailable',
+  APP_RUN_INPUT_INVALID: 'App Run input is invalid',
+  APP_RUN_INPUT_TOO_LARGE: 'App Run input exceeds its limit',
+  APP_RUN_OUTPUT_TOO_LARGE: 'App Run output exceeds its limit',
+  APP_RUN_IDEMPOTENCY_CONFLICT: 'The App Run idempotency key conflicts with an existing Run',
+  APP_RUN_ILLEGAL_TRANSITION: 'The App Run state transition is not allowed',
+  APP_RUN_ACCESS_DENIED: 'Access to the App Run is denied',
+  APP_RUN_AUTHORIZATION_STALE: 'App Run authorization is no longer current',
+  APP_RUN_PROVIDER_UNAVAILABLE: 'The App Run provider is unavailable',
+  APP_RUN_PROVIDER_ERROR: 'The App Run provider returned an error',
+  APP_RUN_PROVIDER_TIMEOUT: 'The App Run provider timed out',
+  APP_RUN_APPROVAL_REJECTED: 'App Run approval was rejected',
+  APP_RUN_APPROVAL_EXPIRED: 'App Run approval expired',
+  APP_RUN_CANCELLED: 'The App Run was cancelled',
+  APP_RUN_EXPIRED: 'The App Run expired',
+  APP_RUN_UNKNOWN_OUTCOME: 'The App Run outcome is unknown',
+  APP_RUN_RESULT_EXPIRED: 'The exact App Run result is no longer retained',
+  APP_RUN_REPAIR_REQUIRED: 'The App Run requires local repair',
+  APP_RUN_ANCESTRY_LIMIT: 'The App Run ancestry limit was reached',
+  APP_RUN_CAPABILITY_CYCLE: 'The App Run capability cycle was rejected',
+};
+
+export class AppRunError extends Error {
+  constructor(readonly code: AppRunErrorCode) {
+    super(SAFE_MESSAGES[code]);
+    this.name = 'AppRunError';
+  }
+}
+
+export function asAppRunError(error: unknown): AppRunError {
+  if (error instanceof AppRunError) return error;
+  const parsed = error instanceof Error ? AppRunErrorCodeSchema.safeParse(error.message) : null;
+  const code = parsed?.success ? parsed.data : 'APP_RUN_INPUT_INVALID';
+  return new AppRunError(code);
+}

--- a/apps/api/src/lib/app-run-provider-executor.ts
+++ b/apps/api/src/lib/app-run-provider-executor.ts
@@ -1,0 +1,20 @@
+import type { CapabilityJsonValue } from '@deft/shared';
+
+export type AppRunProviderExecutionRequest = Readonly<{
+  org_id: string;
+  provider_kind: 'mcp';
+  provider_instance_id: string;
+  operation_name: string;
+  input: CapabilityJsonValue;
+  provider_idempotency_key?: string;
+  signal?: AbortSignal;
+}>;
+
+export type AppRunProviderExecutionResult =
+  | Readonly<{ status: 'succeeded'; output: unknown }>
+  | Readonly<{ status: 'failed'; no_effect: true }>
+  | Readonly<{ status: 'indeterminate' }>;
+
+export interface AppRunProviderExecutor {
+  execute(request: AppRunProviderExecutionRequest): Promise<AppRunProviderExecutionResult>;
+}

--- a/apps/api/src/lib/app-run-repository.ts
+++ b/apps/api/src/lib/app-run-repository.ts
@@ -1,0 +1,313 @@
+import { and, asc, eq, gt, inArray, or, sql } from 'drizzle-orm';
+import {
+  appRunAttempts,
+  appRunEvents,
+  appRuns,
+  capabilityProviderSnapshots,
+} from '@deft/db/schema';
+import type {
+  AppRunActor,
+  AppRunErrorCode,
+  AppRunSafeOutcome,
+  AppRunState,
+  AppRunSubmission,
+} from '@deft/shared';
+import { db } from './db.js';
+
+export type AppRunTransaction = Parameters<Parameters<typeof db.transaction>[0]>[0];
+
+const safeRunSelection = {
+  id: appRuns.id,
+  org_id: appRuns.org_id,
+  contract_version: appRuns.contract_version,
+  origin_kind: appRuns.origin_kind,
+  initiating_actor_type: appRuns.initiating_actor_type,
+  initiating_actor_id: appRuns.initiating_actor_id,
+  execution_actor_type: appRuns.execution_actor_type,
+  execution_actor_id: appRuns.execution_actor_id,
+  provider_kind: appRuns.provider_kind,
+  provider_instance_id: appRuns.provider_instance_id,
+  operation_name: appRuns.operation_name,
+  state: appRuns.state,
+  risk_class: appRuns.risk_class,
+  review_requirement: appRuns.review_requirement,
+  review_scope: appRuns.review_scope,
+  retry_class: appRuns.retry_class,
+  retention_class: appRuns.retention_class,
+  safe_preview: appRuns.safe_preview,
+  safe_outcome: appRuns.safe_outcome,
+  root_run_id: appRuns.root_run_id,
+  parent_run_id: appRuns.parent_run_id,
+  depth: appRuns.depth,
+  input_expires_at: appRuns.input_expires_at,
+  result_expires_at: appRuns.result_expires_at,
+  idempotency_expires_at: appRuns.idempotency_expires_at,
+  attempt_limit: appRuns.attempt_limit,
+  input_purged_at: appRuns.input_purged_at,
+  result_purged_at: appRuns.result_purged_at,
+  started_at: appRuns.started_at,
+  terminal_at: appRuns.terminal_at,
+  unknown_outcome_at: appRuns.unknown_outcome_at,
+  reconciled_at: appRuns.reconciled_at,
+  cancelled_at: appRuns.cancelled_at,
+  cancel_requested_at: appRuns.cancel_requested_at,
+  created_at: appRuns.created_at,
+  updated_at: appRuns.updated_at,
+};
+
+export type AppRunSafeView = Pick<typeof appRuns.$inferSelect, keyof typeof safeRunSelection>;
+
+export function appRunActorId(actor: AppRunActor): string {
+  switch (actor.actor_type) {
+    case 'human': return actor.user_id;
+    case 'agent_employee': return actor.agent_employee_id;
+    case 'system': return actor.system_id;
+    case 'automation': return actor.automation_id;
+  }
+}
+
+function actorColumns(actor: AppRunActor) {
+  return { type: actor.actor_type, id: appRunActorId(actor) };
+}
+
+export type FingerprintCandidate = Readonly<{ key_version: string; fingerprint: string }>;
+
+export class PostgresAppRunRepository {
+  async transaction<T>(work: (tx: AppRunTransaction) => Promise<T>): Promise<T> {
+    return db.transaction(work);
+  }
+
+  async acquireSubmissionLock(tx: AppRunTransaction, derivedLock: string): Promise<void> {
+    await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtextextended(${derivedLock}, 0))`);
+  }
+
+  async findProviderSnapshot(tx: AppRunTransaction, submission: AppRunSubmission) {
+    const [snapshot] = await tx.select().from(capabilityProviderSnapshots).where(and(
+      eq(capabilityProviderSnapshots.org_id, submission.org_id),
+      eq(capabilityProviderSnapshots.provider_kind, submission.operation.provider.provider_kind),
+      eq(capabilityProviderSnapshots.provider_instance_id, submission.operation.provider.provider_instance_id),
+      eq(capabilityProviderSnapshots.snapshot_digest, submission.provider_snapshot_digest),
+    )).limit(1);
+    return snapshot ?? null;
+  }
+
+  async findReplay(
+    tx: AppRunTransaction,
+    submission: AppRunSubmission,
+    candidates: readonly FingerprintCandidate[],
+    now: Date,
+  ): Promise<(AppRunSafeView & {
+    input_fingerprint_key_version: string;
+    input_fingerprint: string;
+  }) | null> {
+    const actor = actorColumns(submission.initiating_actor);
+    const candidateFilters = candidates.map((candidate) => and(
+      eq(appRuns.idempotency_key_version, candidate.key_version),
+      eq(appRuns.idempotency_fingerprint, candidate.fingerprint),
+    ));
+    const [row] = await tx.select({
+      ...safeRunSelection,
+      input_fingerprint_key_version: appRuns.input_fingerprint_key_version,
+      input_fingerprint: appRuns.input_fingerprint,
+    }).from(appRuns).where(and(
+      eq(appRuns.org_id, submission.org_id),
+      eq(appRuns.initiating_actor_type, actor.type),
+      eq(appRuns.initiating_actor_id, actor.id),
+      eq(appRuns.provider_kind, submission.operation.provider.provider_kind),
+      eq(appRuns.provider_instance_id, submission.operation.provider.provider_instance_id),
+      eq(appRuns.operation_name, submission.operation.operation_name),
+      gt(appRuns.idempotency_expires_at, now),
+      or(...candidateFilters),
+    )).limit(1);
+    return row ?? null;
+  }
+
+  async insertRun(
+    tx: AppRunTransaction,
+    input: Readonly<{
+      id: string;
+      submission: AppRunSubmission;
+      provider_snapshot_id: string;
+      idempotency: FingerprintCandidate;
+      input_fingerprint: FingerprintCandidate;
+      input_expires_at: Date;
+      result_expires_at: Date;
+      idempotency_expires_at: Date;
+      attempt_limit: number;
+      now: Date;
+    }>,
+  ): Promise<AppRunSafeView> {
+    const initiating = actorColumns(input.submission.initiating_actor);
+    const execution = actorColumns(input.submission.execution_actor);
+    const [run] = await tx.insert(appRuns).values({
+      id: input.id,
+      org_id: input.submission.org_id,
+      contract_version: input.submission.schema_version,
+      origin_kind: input.submission.origin.origin_kind,
+      initiating_actor_type: initiating.type,
+      initiating_actor_id: initiating.id,
+      execution_actor_type: execution.type,
+      execution_actor_id: execution.id,
+      provider_kind: input.submission.operation.provider.provider_kind,
+      provider_instance_id: input.submission.operation.provider.provider_instance_id,
+      operation_name: input.submission.operation.operation_name,
+      provider_snapshot_id: input.provider_snapshot_id,
+      state: 'pending',
+      risk_class: input.submission.policy.risk_class,
+      review_requirement: input.submission.policy.review_requirement,
+      review_scope: input.submission.policy.review_scope,
+      retry_class: input.submission.policy.retry_class,
+      retention_class: input.submission.retention_class,
+      idempotency_key_version: input.idempotency.key_version,
+      idempotency_fingerprint: input.idempotency.fingerprint,
+      input_fingerprint_key_version: input.input_fingerprint.key_version,
+      input_fingerprint: input.input_fingerprint.fingerprint,
+      authorization_snapshot: input.submission.authorization_snapshot,
+      safe_preview: input.submission.safe_preview,
+      root_run_id: input.id,
+      depth: 0,
+      input_expires_at: input.input_expires_at,
+      result_expires_at: input.result_expires_at,
+      idempotency_expires_at: input.idempotency_expires_at,
+      attempt_limit: input.attempt_limit,
+      created_at: input.now,
+      updated_at: input.now,
+    }).returning(safeRunSelection);
+    if (!run) throw new Error('APP_RUN_INPUT_INVALID');
+    return run;
+  }
+
+  async appendEvent(
+    tx: AppRunTransaction,
+    input: Readonly<{
+      id: string;
+      org_id: string;
+      run_id: string;
+      event_type: string;
+      actor?: AppRunActor;
+      payload?: Record<string, unknown>;
+      now: Date;
+    }>,
+  ): Promise<void> {
+    const [sequenceRow] = await tx.select({
+      next: sql<number>`COALESCE(MAX(${appRunEvents.sequence}), 0)::int + 1`,
+    }).from(appRunEvents).where(and(
+      eq(appRunEvents.org_id, input.org_id),
+      eq(appRunEvents.run_id, input.run_id),
+    ));
+    const actor = input.actor ? actorColumns(input.actor) : null;
+    await tx.insert(appRunEvents).values({
+      id: input.id,
+      org_id: input.org_id,
+      run_id: input.run_id,
+      sequence: sequenceRow?.next ?? 1,
+      event_type: input.event_type,
+      actor_type: actor?.type ?? null,
+      actor_id: actor?.id ?? null,
+      payload: input.payload ?? {},
+      created_at: input.now,
+    });
+  }
+
+  async inspect(orgId: string, runId: string): Promise<AppRunSafeView | null> {
+    const [run] = await db.select(safeRunSelection).from(appRuns).where(and(
+      eq(appRuns.org_id, orgId),
+      eq(appRuns.id, runId),
+    )).limit(1);
+    return run ?? null;
+  }
+
+  async lockRun(tx: AppRunTransaction, orgId: string, runId: string): Promise<AppRunSafeView | null> {
+    await tx.execute(sql`SELECT id FROM app_runs WHERE org_id = ${orgId} AND id = ${runId} FOR UPDATE`);
+    const [run] = await tx.select(safeRunSelection).from(appRuns).where(and(
+      eq(appRuns.org_id, orgId),
+      eq(appRuns.id, runId),
+    )).limit(1);
+    return run ?? null;
+  }
+
+  async transition(
+    tx: AppRunTransaction,
+    input: Readonly<{
+      run: AppRunSafeView;
+      state: AppRunState;
+      actor?: AppRunActor;
+      safe_outcome?: AppRunSafeOutcome;
+      error_code?: AppRunErrorCode;
+      now: Date;
+      event_type?: string;
+    }>,
+  ): Promise<AppRunSafeView> {
+    if (input.run.state === input.state) return input.run;
+    const terminal = ['succeeded', 'failed', 'cancelled', 'expired'].includes(input.state);
+    const [updated] = await tx.update(appRuns).set({
+      state: input.state,
+      safe_outcome: input.safe_outcome ?? input.run.safe_outcome,
+      started_at: input.state === 'running' ? (input.run.started_at ?? input.now) : input.run.started_at,
+      terminal_at: terminal ? (input.run.terminal_at ?? input.now) : input.run.terminal_at,
+      unknown_outcome_at: input.state === 'unknown_outcome'
+        ? (input.run.unknown_outcome_at ?? input.now)
+        : input.run.unknown_outcome_at,
+      reconciled_at: input.run.state === 'unknown_outcome' ? input.now : input.run.reconciled_at,
+      cancelled_at: input.state === 'cancelled' ? (input.run.cancelled_at ?? input.now) : input.run.cancelled_at,
+      updated_at: input.now,
+    }).where(and(eq(appRuns.org_id, input.run.org_id), eq(appRuns.id, input.run.id)))
+      .returning(safeRunSelection);
+    if (!updated) throw new Error('APP_RUN_ILLEGAL_TRANSITION');
+    await this.appendEvent(tx, {
+      id: crypto.randomUUID(),
+      org_id: input.run.org_id,
+      run_id: input.run.id,
+      event_type: input.event_type ?? 'run_transitioned',
+      actor: input.actor,
+      payload: { from_state: input.run.state, to_state: input.state, ...(input.error_code ? { error_code: input.error_code } : {}) },
+      now: input.now,
+    });
+    return updated;
+  }
+
+  async requestCancellation(
+    tx: AppRunTransaction,
+    run: AppRunSafeView,
+    actor: AppRunActor,
+    now: Date,
+  ): Promise<AppRunSafeView> {
+    if (run.cancel_requested_at) return run;
+    const [updated] = await tx.update(appRuns).set({ cancel_requested_at: now, updated_at: now })
+      .where(and(eq(appRuns.org_id, run.org_id), eq(appRuns.id, run.id)))
+      .returning(safeRunSelection);
+    if (!updated) throw new Error('APP_RUN_ILLEGAL_TRANSITION');
+    await this.appendEvent(tx, {
+      id: crypto.randomUUID(), org_id: run.org_id, run_id: run.id,
+      event_type: 'cancellation_requested', actor, payload: {}, now,
+    });
+    return updated;
+  }
+
+  async activeKeyReferences(now: Date): Promise<readonly { purpose: 'fingerprint'; key_id: string }[]> {
+    const rows = await db.select({
+      idempotency: appRuns.idempotency_key_version,
+      input: appRuns.input_fingerprint_key_version,
+    }).from(appRuns).where(gt(appRuns.idempotency_expires_at, now));
+    const ids = new Set(rows.flatMap((row) => [row.idempotency, row.input]));
+    return [...ids].map((key_id) => ({ purpose: 'fingerprint' as const, key_id }));
+  }
+
+  async pendingAttemptIds(orgId: string, runId: string): Promise<readonly string[]> {
+    const rows = await db.select({ id: appRunAttempts.id }).from(appRunAttempts).where(and(
+      eq(appRunAttempts.org_id, orgId),
+      eq(appRunAttempts.run_id, runId),
+      inArray(appRunAttempts.state, ['pending', 'claimed', 'provider_call_started']),
+    )).orderBy(asc(appRunAttempts.attempt_number));
+    return rows.map((row) => row.id);
+  }
+
+  async latestSuccessfulAttemptId(orgId: string, runId: string): Promise<string | null> {
+    const [row] = await db.select({ id: appRunAttempts.id }).from(appRunAttempts).where(and(
+      eq(appRunAttempts.org_id, orgId),
+      eq(appRunAttempts.run_id, runId),
+      eq(appRunAttempts.state, 'succeeded'),
+    )).orderBy(sql`${appRunAttempts.attempt_number} DESC`).limit(1);
+    return row?.id ?? null;
+  }
+}

--- a/apps/api/src/lib/app-run-secret-repository.ts
+++ b/apps/api/src/lib/app-run-secret-repository.ts
@@ -1,0 +1,197 @@
+import { and, asc, eq, lte, sql } from 'drizzle-orm';
+import { appRunEvents, appRuns, appRunSecretPayloads } from '@deft/db/schema';
+import type { CapabilityJsonValue } from '@deft/shared';
+import { db } from './db.js';
+import type { AppRunTransaction } from './app-run-repository.js';
+import {
+  AppRunSecretService,
+  type AppRunSecretEnvelope,
+} from './app-run-secrets.js';
+
+function payloadBytes(envelope: AppRunSecretEnvelope): number {
+  const bytes = Buffer.from(envelope.ciphertext_b64, 'base64');
+  try {
+    return bytes.length;
+  } finally {
+    bytes.fill(0);
+  }
+}
+
+function envelopeFromRow(row: typeof appRunSecretPayloads.$inferSelect): AppRunSecretEnvelope {
+  return {
+    schema_version: row.envelope_version as AppRunSecretEnvelope['schema_version'],
+    algorithm: row.algorithm,
+    key_version: row.key_version,
+    nonce_b64: row.nonce_b64,
+    ciphertext_b64: row.ciphertext_b64,
+    auth_tag_b64: row.auth_tag_b64,
+  };
+}
+
+export class AppRunSecretRepository {
+  constructor(private readonly secrets: AppRunSecretService) {}
+
+  async insertInput(
+    tx: AppRunTransaction,
+    input: Readonly<{ org_id: string; run_id: string; value: unknown; expires_at: Date }>,
+  ): Promise<void> {
+    const envelope = this.secrets.sealJson(input.value, {
+      org_id: input.org_id,
+      run_id: input.run_id,
+      payload_kind: 'input',
+    });
+    await tx.insert(appRunSecretPayloads).values({
+      id: crypto.randomUUID(),
+      org_id: input.org_id,
+      run_id: input.run_id,
+      payload_kind: 'input',
+      envelope_version: envelope.schema_version,
+      algorithm: envelope.algorithm,
+      key_version: envelope.key_version,
+      nonce_b64: envelope.nonce_b64,
+      ciphertext_b64: envelope.ciphertext_b64,
+      auth_tag_b64: envelope.auth_tag_b64,
+      payload_bytes: payloadBytes(envelope),
+      expires_at: input.expires_at,
+    });
+  }
+
+  async insertOutput(
+    tx: AppRunTransaction,
+    input: Readonly<{
+      org_id: string;
+      run_id: string;
+      attempt_id: string;
+      value: unknown;
+      expires_at: Date;
+    }>,
+  ): Promise<void> {
+    const envelope = this.secrets.sealJson(input.value, {
+      org_id: input.org_id,
+      run_id: input.run_id,
+      attempt_id: input.attempt_id,
+      payload_kind: 'output',
+    });
+    await tx.insert(appRunSecretPayloads).values({
+      id: crypto.randomUUID(),
+      org_id: input.org_id,
+      run_id: input.run_id,
+      attempt_id: input.attempt_id,
+      payload_kind: 'output',
+      envelope_version: envelope.schema_version,
+      algorithm: envelope.algorithm,
+      key_version: envelope.key_version,
+      nonce_b64: envelope.nonce_b64,
+      ciphertext_b64: envelope.ciphertext_b64,
+      auth_tag_b64: envelope.auth_tag_b64,
+      payload_bytes: payloadBytes(envelope),
+      expires_at: input.expires_at,
+    });
+  }
+
+  async readInput(orgId: string, runId: string): Promise<CapabilityJsonValue | null> {
+    const [row] = await db.select().from(appRunSecretPayloads).where(and(
+      eq(appRunSecretPayloads.org_id, orgId),
+      eq(appRunSecretPayloads.run_id, runId),
+      eq(appRunSecretPayloads.payload_kind, 'input'),
+    )).limit(1);
+    if (!row) return null;
+    return this.secrets.openJson(envelopeFromRow(row), {
+      org_id: orgId,
+      run_id: runId,
+      payload_kind: 'input',
+    });
+  }
+
+  async readOutput(orgId: string, runId: string, attemptId: string): Promise<CapabilityJsonValue | null> {
+    const [row] = await db.select().from(appRunSecretPayloads).where(and(
+      eq(appRunSecretPayloads.org_id, orgId),
+      eq(appRunSecretPayloads.run_id, runId),
+      eq(appRunSecretPayloads.attempt_id, attemptId),
+      eq(appRunSecretPayloads.payload_kind, 'output'),
+    )).limit(1);
+    if (!row) return null;
+    return this.secrets.openJson(envelopeFromRow(row), {
+      org_id: orgId,
+      run_id: runId,
+      attempt_id: attemptId,
+      payload_kind: 'output',
+    });
+  }
+
+  async retainedKeyReferences(now: Date): Promise<readonly { purpose: 'run_encryption'; key_id: string }[]> {
+    const rows = await db.selectDistinct({ key_id: appRunSecretPayloads.key_version })
+      .from(appRunSecretPayloads)
+      .where(sql`${appRunSecretPayloads.expires_at} > ${now}`);
+    return rows.map((row) => ({ purpose: 'run_encryption' as const, key_id: row.key_id }));
+  }
+
+  async purgeExpiredBatch(now = new Date(), limit = 100): Promise<number> {
+    const candidates = await db.select({
+      org_id: appRunSecretPayloads.org_id,
+      run_id: appRunSecretPayloads.run_id,
+    }).from(appRunSecretPayloads)
+      .where(lte(appRunSecretPayloads.expires_at, now))
+      .groupBy(appRunSecretPayloads.org_id, appRunSecretPayloads.run_id)
+      .orderBy(asc(appRunSecretPayloads.run_id))
+      .limit(Math.max(1, Math.min(limit, 500)));
+    let purged = 0;
+    for (const candidate of candidates) {
+      purged += await this.#purgeRun(candidate.org_id, candidate.run_id, now);
+    }
+    return purged;
+  }
+
+  async #purgeRun(orgId: string, runId: string, now: Date): Promise<number> {
+    return db.transaction(async (tx) => {
+      await tx.execute(sql`SELECT id FROM app_runs WHERE org_id = ${orgId} AND id = ${runId} FOR UPDATE`);
+      const expired = await tx.select({
+        id: appRunSecretPayloads.id,
+        payload_kind: appRunSecretPayloads.payload_kind,
+      }).from(appRunSecretPayloads).where(and(
+        eq(appRunSecretPayloads.org_id, orgId),
+        eq(appRunSecretPayloads.run_id, runId),
+        lte(appRunSecretPayloads.expires_at, now),
+      ));
+      if (expired.length === 0) return 0;
+
+      await tx.execute(sql`SELECT set_config('deft.app_run_maintenance', 'on', true)`);
+      await tx.delete(appRunSecretPayloads).where(and(
+        eq(appRunSecretPayloads.org_id, orgId),
+        eq(appRunSecretPayloads.run_id, runId),
+        lte(appRunSecretPayloads.expires_at, now),
+      ));
+
+      const purgedInput = expired.some((row) => row.payload_kind === 'input');
+      const purgedOutput = expired.some((row) => row.payload_kind === 'output');
+      const [run] = await tx.select({ state: appRuns.state, safe_outcome: appRuns.safe_outcome })
+        .from(appRuns).where(and(eq(appRuns.org_id, orgId), eq(appRuns.id, runId))).limit(1);
+      const shouldExpire = purgedInput && (run?.state === 'pending' || run?.state === 'pending_approval');
+      const safeOutcome = purgedOutput && run?.safe_outcome
+        ? { ...run.safe_outcome, result_status: 'expired' }
+        : run?.safe_outcome;
+      await tx.update(appRuns).set({
+        state: shouldExpire ? 'expired' : run?.state,
+        safe_outcome: safeOutcome,
+        input_purged_at: purgedInput ? now : undefined,
+        result_purged_at: purgedOutput ? now : undefined,
+        terminal_at: shouldExpire ? now : undefined,
+        updated_at: now,
+      }).where(and(eq(appRuns.org_id, orgId), eq(appRuns.id, runId)));
+
+      const [sequenceRow] = await tx.select({
+        next: sql<number>`COALESCE(MAX(${appRunEvents.sequence}), 0)::int + 1`,
+      }).from(appRunEvents).where(and(
+        eq(appRunEvents.org_id, orgId), eq(appRunEvents.run_id, runId),
+      ));
+      await tx.insert(appRunEvents).values({
+        id: crypto.randomUUID(), org_id: orgId, run_id: runId,
+        sequence: sequenceRow?.next ?? 1,
+        event_type: 'secrets_purged',
+        payload: { input_purged: purgedInput, result_purged: purgedOutput },
+        created_at: now,
+      });
+      return expired.length;
+    });
+  }
+}

--- a/apps/api/src/lib/app-run-secrets.ts
+++ b/apps/api/src/lib/app-run-secrets.ts
@@ -207,6 +207,19 @@ export class AppRunSecretService {
     return this.#fingerprintWith(this.keys.current('fingerprint'), purpose, canonical);
   }
 
+  fingerprintJsonCandidates(purpose: AppRunFingerprintPurpose, value: unknown): readonly Readonly<{
+    key_version: string;
+    fingerprint: string;
+  }>[] {
+    assertCapabilityJsonWithinBudget(value, APP_RUN_LIMITS.input_bytes);
+    const canonical = canonicalCapabilityJson(value);
+    return Object.freeze(this.keys.keyIds('fingerprint').map((keyId) => {
+      const keyRef = this.keys.read('fingerprint', keyId);
+      if (!keyRef) throw new Error('APP_RUN_KEY_VERSION_UNAVAILABLE');
+      return this.#fingerprintWith(keyRef, purpose, Buffer.from(canonical, 'utf8'));
+    }));
+  }
+
   fingerprintText(purpose: AppRunFingerprintPurpose, value: string): Readonly<{
     key_version: string;
     fingerprint: string;

--- a/apps/api/src/lib/app-run-service.ts
+++ b/apps/api/src/lib/app-run-service.ts
@@ -1,0 +1,264 @@
+import { createHash } from 'node:crypto';
+import {
+  APP_RUN_DEFAULT_ATTEMPT_LIMIT,
+  AppRunSafeOutcomeSchema,
+  idempotencyDeadline,
+  parseAppRunSubmission,
+  retentionDeadline,
+  type AppRunActor,
+  type AppRunErrorCode,
+  type AppRunSubmission,
+} from '@deft/shared';
+import {
+  assertAppRunReferencedKeysAvailable,
+  type AppRunKeyProvider,
+} from './app-run-keyrings.js';
+import type { AppRunSecretService } from './app-run-secrets.js';
+import {
+  denyAllAppRunAuthorizer,
+  type AppRunAccessAction,
+  type AppRunAuthorizer,
+} from './app-run-authorization.js';
+import { AppRunError, asAppRunError } from './app-run-errors.js';
+import {
+  PostgresAppRunRepository,
+  appRunActorId,
+  type AppRunSafeView,
+} from './app-run-repository.js';
+import { AppRunSecretRepository } from './app-run-secret-repository.js';
+
+export type AppRunTrustedContext = Readonly<{
+  org_id: string;
+  initiating_actor: AppRunActor;
+  execution_actor: AppRunActor;
+}>;
+
+function sameActor(left: AppRunActor, right: AppRunActor): boolean {
+  return left.actor_type === right.actor_type && appRunActorId(left) === appRunActorId(right);
+}
+
+function derivedSubmissionLock(submission: AppRunSubmission): string {
+  const actor = appRunActorId(submission.initiating_actor);
+  const digest = createHash('sha256');
+  digest.update('deft.app_run.submit_lock.v1\0');
+  for (const value of [
+    submission.org_id,
+    submission.initiating_actor.actor_type,
+    actor,
+    submission.operation.provider.provider_kind,
+    submission.operation.provider.provider_instance_id,
+    submission.operation.operation_name,
+    submission.idempotency_key,
+  ]) {
+    digest.update(value);
+    digest.update('\0');
+  }
+  return digest.digest('hex');
+}
+
+function replayExecutionMatches(run: AppRunSafeView, submission: AppRunSubmission): boolean {
+  return run.execution_actor_type === submission.execution_actor.actor_type
+    && run.execution_actor_id === appRunActorId(submission.execution_actor)
+    && run.origin_kind === submission.origin.origin_kind;
+}
+
+export class AppRunService {
+  constructor(
+    private readonly repository: PostgresAppRunRepository,
+    private readonly secretRepository: AppRunSecretRepository,
+    private readonly secrets: AppRunSecretService,
+    private readonly keys: AppRunKeyProvider,
+    private readonly authorizer: AppRunAuthorizer = denyAllAppRunAuthorizer,
+    private readonly now: () => Date = () => new Date(),
+  ) {}
+
+  async submit(context: AppRunTrustedContext, rawSubmission: unknown): Promise<AppRunSafeView> {
+    let submission: AppRunSubmission;
+    try {
+      submission = parseAppRunSubmission(rawSubmission);
+    } catch (error) {
+      throw asAppRunError(error);
+    }
+    if (
+      context.org_id !== submission.org_id
+      || !sameActor(context.initiating_actor, submission.initiating_actor)
+      || !sameActor(context.execution_actor, submission.execution_actor)
+      || !sameActor(context.initiating_actor, submission.authorization_snapshot.authenticated_subject)
+      || submission.origin.origin_kind === 'app'
+      || (submission.origin.origin_kind === 'legacy_connector'
+        && submission.origin.connection_id !== submission.operation.provider.provider_instance_id)
+    ) {
+      throw new AppRunError('APP_RUN_ACCESS_DENIED');
+    }
+
+    const now = this.now();
+    await this.assertReferencedKeysAvailable(now);
+    const idempotency = this.secrets.fingerprintText('idempotency', submission.idempotency_key);
+    const replayCandidates = this.secrets.fingerprintTextCandidates('idempotency', submission.idempotency_key);
+    const inputFingerprint = this.secrets.fingerprintJson('input', submission.input);
+    const inputCandidates = this.secrets.fingerprintJsonCandidates('input', submission.input);
+    const lock = derivedSubmissionLock(submission);
+    const runId = crypto.randomUUID();
+    const inputExpiresAt = retentionDeadline(submission.retention_class, now);
+    const resultExpiresAt = retentionDeadline(submission.retention_class, now);
+    const idempotencyExpiresAt = idempotencyDeadline(submission.retention_class, now);
+
+    return this.repository.transaction(async (tx) => {
+      await this.repository.acquireSubmissionLock(tx, lock);
+      const replay = await this.repository.findReplay(tx, submission, replayCandidates, now);
+      if (replay) {
+        const sameInput = inputCandidates.some((candidate) =>
+          candidate.key_version === replay.input_fingerprint_key_version
+          && candidate.fingerprint === replay.input_fingerprint);
+        if (!sameInput || !replayExecutionMatches(replay, submission)) {
+          throw new AppRunError('APP_RUN_IDEMPOTENCY_CONFLICT');
+        }
+        const { input_fingerprint: _fingerprint, input_fingerprint_key_version: _version, ...safe } = replay;
+        return safe;
+      }
+      const snapshot = await this.repository.findProviderSnapshot(tx, submission);
+      if (!snapshot) throw new AppRunError('APP_RUN_PROVIDER_UNAVAILABLE');
+      const run = await this.repository.insertRun(tx, {
+        id: runId,
+        submission,
+        provider_snapshot_id: snapshot.id,
+        idempotency,
+        input_fingerprint: inputFingerprint,
+        input_expires_at: inputExpiresAt,
+        result_expires_at: resultExpiresAt,
+        idempotency_expires_at: idempotencyExpiresAt,
+        attempt_limit: APP_RUN_DEFAULT_ATTEMPT_LIMIT,
+        now,
+      });
+      await this.secretRepository.insertInput(tx, {
+        org_id: submission.org_id,
+        run_id: runId,
+        value: submission.input,
+        expires_at: inputExpiresAt,
+      });
+      await this.repository.appendEvent(tx, {
+        id: crypto.randomUUID(), org_id: submission.org_id, run_id: runId,
+        event_type: 'run_created', actor: submission.initiating_actor,
+        payload: { state: 'pending' }, now,
+      });
+      return run;
+    });
+  }
+
+  async inspect(orgId: string, runId: string, actor: AppRunActor): Promise<AppRunSafeView> {
+    const run = await this.requiredRun(orgId, runId);
+    await this.assertAuthorized('inspect', orgId, actor, run);
+    return run;
+  }
+
+  async cancel(orgId: string, runId: string, actor: AppRunActor): Promise<AppRunSafeView> {
+    const visible = await this.requiredRun(orgId, runId);
+    await this.assertAuthorized('cancel', orgId, actor, visible);
+    return this.repository.transaction(async (tx) => {
+      const run = await this.repository.lockRun(tx, orgId, runId);
+      if (!run) throw new AppRunError('APP_RUN_ACCESS_DENIED');
+      if (run.state === 'pending' || run.state === 'pending_approval') {
+        return this.repository.transition(tx, {
+          run, state: 'cancelled', actor, now: this.now(), error_code: 'APP_RUN_CANCELLED',
+          safe_outcome: AppRunSafeOutcomeSchema.parse({
+            success: false, provider_call_attempted: false,
+            result_status: 'unavailable', error_code: 'APP_RUN_CANCELLED',
+          }),
+        });
+      }
+      if (run.state === 'running' || run.state === 'waiting_external') {
+        return this.repository.requestCancellation(tx, run, actor, this.now());
+      }
+      return run;
+    });
+  }
+
+  async expire(orgId: string, runId: string): Promise<AppRunSafeView> {
+    return this.repository.transaction(async (tx) => {
+      const run = await this.repository.lockRun(tx, orgId, runId);
+      if (!run) throw new AppRunError('APP_RUN_ACCESS_DENIED');
+      if (run.state !== 'pending' && run.state !== 'pending_approval') return run;
+      return this.repository.transition(tx, {
+        run, state: 'expired', now: this.now(), error_code: 'APP_RUN_EXPIRED',
+        safe_outcome: AppRunSafeOutcomeSchema.parse({
+          success: false, provider_call_attempted: false,
+          result_status: 'unavailable', error_code: 'APP_RUN_EXPIRED',
+        }),
+      });
+    });
+  }
+
+  async reconcileUnknown(
+    orgId: string,
+    runId: string,
+    actor: AppRunActor,
+    resolution: 'succeeded' | 'failed',
+  ): Promise<AppRunSafeView> {
+    const visible = await this.requiredRun(orgId, runId);
+    await this.assertAuthorized('reconcile', orgId, actor, visible);
+    return this.repository.transaction(async (tx) => {
+      const run = await this.repository.lockRun(tx, orgId, runId);
+      if (!run || run.state !== 'unknown_outcome') {
+        throw new AppRunError('APP_RUN_ILLEGAL_TRANSITION');
+      }
+      const errorCode: AppRunErrorCode | undefined = resolution === 'failed'
+        ? 'APP_RUN_PROVIDER_ERROR'
+        : undefined;
+      return this.repository.transition(tx, {
+        run, state: resolution, actor, now: this.now(), error_code: errorCode,
+        event_type: 'reconciliation_recorded',
+        safe_outcome: AppRunSafeOutcomeSchema.parse({
+          success: resolution === 'succeeded',
+          provider_call_attempted: true,
+          result_status: 'unavailable',
+          ...(errorCode ? { error_code: errorCode } : {}),
+        }),
+      });
+    });
+  }
+
+  async result(orgId: string, runId: string, actor: AppRunActor): Promise<Readonly<{
+    run: AppRunSafeView;
+    value: unknown;
+  }>> {
+    const run = await this.requiredRun(orgId, runId);
+    await this.assertAuthorized('result', orgId, actor, run);
+    if (run.result_purged_at || run.result_expires_at <= this.now()) {
+      throw new AppRunError('APP_RUN_RESULT_EXPIRED');
+    }
+    const attemptId = await this.repository.latestSuccessfulAttemptId(orgId, runId);
+    if (!attemptId) throw new AppRunError('APP_RUN_RESULT_EXPIRED');
+    const value = await this.secretRepository.readOutput(orgId, runId, attemptId);
+    if (value === null) throw new AppRunError('APP_RUN_RESULT_EXPIRED');
+    return Object.freeze({ run, value });
+  }
+
+  async purgeExpiredSecrets(now = this.now(), limit = 100): Promise<number> {
+    return this.secretRepository.purgeExpiredBatch(now, limit);
+  }
+
+  async assertReferencedKeysAvailable(now = this.now()): Promise<void> {
+    const references = [
+      ...await this.repository.activeKeyReferences(now),
+      ...await this.secretRepository.retainedKeyReferences(now),
+    ];
+    assertAppRunReferencedKeysAvailable(this.keys, references);
+  }
+
+  async requiredRun(orgId: string, runId: string): Promise<AppRunSafeView> {
+    const run = await this.repository.inspect(orgId, runId);
+    if (!run) throw new AppRunError('APP_RUN_ACCESS_DENIED');
+    return run;
+  }
+
+  async assertAuthorized(
+    action: AppRunAccessAction,
+    orgId: string,
+    actor: AppRunActor,
+    run: AppRunSafeView,
+  ): Promise<void> {
+    if (!await this.authorizer.authorize({ action, org_id: orgId, actor, run })) {
+      throw new AppRunError('APP_RUN_ACCESS_DENIED');
+    }
+  }
+}

--- a/apps/api/src/lib/app-run-worker-handler.ts
+++ b/apps/api/src/lib/app-run-worker-handler.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod';
+import type { JobHandler } from '../workers/types.js';
+import type { AppRunAttemptRunner } from './app-run-attempt-runner.js';
+
+const AppRunJobSchema = z.object({
+  orgId: z.string().min(1).max(512),
+  runId: z.string().min(1).max(512),
+}).strict();
+
+// PR B deliberately exports an injectable factory without registering it in
+// the production worker registry. PR C owns the cutover decision.
+export function createAppRunAttemptJobHandler(runner: AppRunAttemptRunner): JobHandler {
+  return async (job) => {
+    const payload = AppRunJobSchema.parse(job.data);
+    await runner.run(payload.orgId, payload.runId, `job:${job.id}`, job.signal);
+  };
+}

--- a/apps/api/test/app-run-architecture.test.ts
+++ b/apps/api/test/app-run-architecture.test.ts
@@ -20,6 +20,7 @@ test('only the App Run secret boundary handles ciphertext and signing material',
   const allowed = new Set([
     'lib/app-run-keyrings.ts',
     'lib/app-run-secrets.ts',
+    'lib/app-run-secret-repository.ts',
   ]);
   const forbidden = /\b(?:ciphertext_b64|nonce_b64|auth_tag_b64|receipt_signing)\b/g;
   const violations: string[] = [];
@@ -47,4 +48,16 @@ test('the dormant foundation has no production execution consumer', async () => 
     }
   }
   assert.deepEqual(consumers, []);
+});
+
+test('the governed engine stays unwired from production entrances', async () => {
+  const protectedEntrances = [
+    'lib/capability-service.ts',
+    'lib/capability-providers/mcp.ts',
+    'workers/index.ts',
+  ];
+  for (const sourcePath of protectedEntrances) {
+    const source = await readFile(join(sourceRoot, sourcePath), 'utf8');
+    assert.doesNotMatch(source, /\b(?:AppRunService|AppRunAttemptRunner|createAppRunAttemptJobHandler)\b/);
+  }
 });

--- a/apps/api/test/app-run-engine-db.test.ts
+++ b/apps/api/test/app-run-engine-db.test.ts
@@ -1,0 +1,462 @@
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import test, { after, before } from 'node:test';
+import pg from 'pg';
+import { APP_RUN_CONTRACT_VERSIONS } from '@deft/shared';
+import { AppRunAttemptRunner } from '../src/lib/app-run-attempt-runner.js';
+import type {
+  AppRunProviderExecutionRequest,
+  AppRunProviderExecutionResult,
+  AppRunProviderExecutor,
+} from '../src/lib/app-run-provider-executor.js';
+import { PostgresAppRunRepository } from '../src/lib/app-run-repository.js';
+import { AppRunSecretRepository } from '../src/lib/app-run-secret-repository.js';
+import { AppRunSecretService } from '../src/lib/app-run-secrets.js';
+import { AppRunService } from '../src/lib/app-run-service.js';
+import { createAppRunAttemptJobHandler } from '../src/lib/app-run-worker-handler.js';
+import { parseEnvironmentAppRunKeyrings, type EnvironmentAppRunKeyProvider } from '../src/lib/app-run-keyrings.js';
+import { closeDb } from '../src/lib/db.js';
+
+const DATABASE_URL = process.env.DEFT_TEST_DATABASE_URL
+  ?? (process.env.CI === 'true' ? process.env.DATABASE_URL : undefined);
+if (!DATABASE_URL) throw new Error('App Run engine DB tests require DEFT_TEST_DATABASE_URL');
+if (process.env.CI !== 'true' && !/phase3|test|ci|acceptance/i.test(new URL(DATABASE_URL).pathname)) {
+  throw new Error('App Run engine DB tests require an explicitly disposable database');
+}
+
+const suffix = randomUUID().replaceAll('-', '').slice(0, 12);
+const ORG_ID = `app-run-org-${suffix}`;
+const SNAPSHOT_ID = `app-run-snapshot-${suffix}`;
+const PROVIDER_ID = `app-run-provider-${suffix}`;
+const USER_ID = `app-run-user-${suffix}`;
+const digest = `sha256:${'a'.repeat(64)}`;
+const { Client } = pg;
+let client: pg.Client;
+const providers: EnvironmentAppRunKeyProvider[] = [];
+
+function key(seed: number): string {
+  return Buffer.alloc(32, seed).toString('base64');
+}
+
+function keyProvider(
+  fingerprintCurrent: 'fp-v1' | 'fp-old' = 'fp-v1',
+  includeOld = true,
+): EnvironmentAppRunKeyProvider {
+  const provider = parseEnvironmentAppRunKeyrings(JSON.stringify({
+    schema_version: APP_RUN_CONTRACT_VERSIONS.keyring,
+    run_encryption: { current: 'enc-v1', keys: { 'enc-v1': key(1) } },
+    receipt_signing: { current: 'sig-v1', keys: { 'sig-v1': key(2) } },
+    fingerprint: {
+      current: fingerprintCurrent,
+      keys: includeOld ? { 'fp-v1': key(3), 'fp-old': key(4) } : { 'fp-v1': key(3) },
+    },
+  }));
+  providers.push(provider);
+  return provider;
+}
+
+const allowAll = { async authorize() { return true; } };
+
+function service(
+  now: () => Date = () => new Date(),
+  allow = allowAll,
+  keyOptions: Readonly<{ current?: 'fp-v1' | 'fp-old'; includeOld?: boolean }> = {},
+) {
+  const keys = keyProvider(keyOptions.current, keyOptions.includeOld);
+  const secrets = new AppRunSecretService(keys);
+  const repository = new PostgresAppRunRepository();
+  const secretRepository = new AppRunSecretRepository(secrets);
+  return {
+    service: new AppRunService(repository, secretRepository, secrets, keys, allow, now),
+    repository,
+    secretRepository,
+    secrets,
+  };
+}
+
+function submission(overrides: Record<string, unknown> = {}) {
+  return {
+    schema_version: APP_RUN_CONTRACT_VERSIONS.run,
+    org_id: ORG_ID,
+    initiating_actor: { actor_type: 'human', user_id: USER_ID },
+    execution_actor: { actor_type: 'human', user_id: USER_ID },
+    origin: { origin_kind: 'legacy_connector', connection_id: PROVIDER_ID },
+    operation: {
+      provider: { org_id: ORG_ID, provider_kind: 'mcp', provider_instance_id: PROVIDER_ID },
+      operation_name: 'send_email',
+    },
+    provider_snapshot_digest: digest,
+    policy: {
+      risk_class: 'external_write',
+      review_requirement: 'always',
+      review_scope: 'per_invocation',
+      retry_class: 'unsafe_or_unknown',
+    },
+    retention_class: 'standard',
+    idempotency_key: `retry-${suffix}`,
+    input: { body: `raw-marker-${suffix}`, recipient: 'person@example.test' },
+    authorization_snapshot: {
+      schema_version: APP_RUN_CONTRACT_VERSIONS.run,
+      authenticated_subject: { actor_type: 'human', user_id: USER_ID },
+      authority_refs: [
+        { authority_kind: 'membership', authority_id: USER_ID, version: '1' },
+        { authority_kind: 'connector', authority_id: PROVIDER_ID, version: '1' },
+      ],
+    },
+    safe_preview: {
+      schema_version: APP_RUN_CONTRACT_VERSIONS.run,
+      title: 'Send one email',
+      resource_refs: [],
+    },
+    ...overrides,
+  };
+}
+
+const trusted = {
+  org_id: ORG_ID,
+  initiating_actor: { actor_type: 'human' as const, user_id: USER_ID },
+  execution_actor: { actor_type: 'human' as const, user_id: USER_ID },
+};
+
+before(async () => {
+  client = new Client({ connectionString: DATABASE_URL });
+  await client.connect();
+  await client.query('INSERT INTO orgs (id, name, slug) VALUES ($1, $2, $3)', [ORG_ID, 'App Run Test', ORG_ID]);
+  await client.query(
+    `INSERT INTO capability_provider_snapshots
+      (id, org_id, provider_kind, provider_instance_id, adapter_contract_version,
+       snapshot_digest, safe_snapshot, captured_at)
+     VALUES ($1, $2, 'mcp', $3, 'deft.capability.v1', $4, $5::jsonb, now())`,
+    [SNAPSHOT_ID, ORG_ID, PROVIDER_ID, digest, JSON.stringify({ operation: 'send_email' })],
+  );
+});
+
+after(async () => {
+  if (client) {
+    await client.query('DELETE FROM orgs WHERE id = $1', [ORG_ID]);
+    await client.end();
+  }
+  for (const provider of providers) provider.destroy();
+  await closeDb();
+});
+
+test('submission is atomic, rotation-safe, tenant-scoped, and replay-conflict aware', async () => {
+  const { service: runs } = service();
+  const parallel = await Promise.all(Array.from({ length: 20 }, () => runs.submit(trusted, submission())));
+  assert.equal(new Set(parallel.map((run) => run.id)).size, 1);
+  const runId = parallel[0]!.id;
+
+  const counts = await client.query<{
+    runs: string; inputs: string; created_events: string;
+  }>(
+    `SELECT
+       (SELECT count(*) FROM app_runs WHERE org_id = $1 AND id = $2) AS runs,
+       (SELECT count(*) FROM app_run_secret_payloads WHERE org_id = $1 AND run_id = $2 AND payload_kind = 'input') AS inputs,
+       (SELECT count(*) FROM app_run_events WHERE org_id = $1 AND run_id = $2 AND event_type = 'run_created') AS created_events`,
+    [ORG_ID, runId],
+  );
+  assert.deepEqual(counts.rows[0], { runs: '1', inputs: '1', created_events: '1' });
+
+  await assert.rejects(
+    runs.submit(trusted, submission({ input: { body: 'different', recipient: 'person@example.test' } })),
+    (error: any) => error?.code === 'APP_RUN_IDEMPOTENCY_CONFLICT',
+  );
+  const residue = await client.query<{ row: string }>(
+    `SELECT row_to_json(safe)::text AS row FROM (
+       SELECT id, org_id, state, safe_preview, safe_outcome, idempotency_fingerprint, input_fingerprint
+       FROM app_runs WHERE id = $1
+     ) safe`,
+    [runId],
+  );
+  assert.doesNotMatch(residue.rows[0]!.row, new RegExp(`raw-marker-${suffix}|retry-${suffix}`));
+
+  const cancelled = await runs.cancel(ORG_ID, runId, trusted.initiating_actor);
+  assert.equal(cancelled.state, 'cancelled');
+  assert.equal((await runs.cancel(ORG_ID, runId, trusted.initiating_actor)).state, 'cancelled');
+
+  const oldKeys = service(() => new Date(), allowAll, { current: 'fp-old' });
+  const rotationSubmission = submission({ idempotency_key: `rotation-${suffix}` });
+  const beforeRotation = await oldKeys.service.submit(trusted, rotationSubmission);
+  const rotated = service();
+  assert.equal((await rotated.service.submit(trusted, rotationSubmission)).id, beforeRotation.id);
+  const missingOld = service(() => new Date(), allowAll, { includeOld: false });
+  await assert.rejects(
+    missingOld.service.assertReferencedKeysAvailable(),
+    (error: any) => error?.code === 'APP_RUN_KEY_VERSION_UNAVAILABLE',
+  );
+});
+
+class CountingExecutor implements AppRunProviderExecutor {
+  calls: AppRunProviderExecutionRequest[] = [];
+  results: AppRunProviderExecutionResult[] = [];
+  entered: (() => void) | null = null;
+  wait: Promise<void> | null = null;
+
+  async execute(request: AppRunProviderExecutionRequest): Promise<AppRunProviderExecutionResult> {
+    this.calls.push(request);
+    this.entered?.();
+    if (this.wait) await this.wait;
+    return this.results.shift() ?? { status: 'succeeded', output: { message_id: 'message-1' } };
+  }
+}
+
+test('concurrent runners call once, commit the call boundary, and replay retained output with authorization', async () => {
+  const setup = service();
+  const created = await setup.service.submit(trusted, submission({ idempotency_key: `runner-${suffix}` }));
+  const executor = new CountingExecutor();
+  let release!: () => void;
+  executor.wait = new Promise<void>((resolve) => { release = resolve; });
+  const entered = new Promise<void>((resolve) => { executor.entered = resolve; });
+  const runner = new AppRunAttemptRunner(
+    setup.repository, setup.secretRepository, setup.secrets, executor,
+  );
+
+  const firstExecution = runner.run(ORG_ID, created.id, 'worker-0');
+  await entered;
+  const competitors = Array.from({ length: 15 }, (_, index) =>
+    runner.run(ORG_ID, created.id, `worker-${index + 1}`));
+  await Promise.all(competitors);
+  const boundary = await client.query<{ state: string; run_state: string }>(
+    `SELECT a.state, r.state AS run_state
+       FROM app_run_attempts a JOIN app_runs r ON r.org_id = a.org_id AND r.id = a.run_id
+      WHERE a.org_id = $1 AND a.run_id = $2`,
+    [ORG_ID, created.id],
+  );
+  assert.deepEqual(boundary.rows[0], { state: 'provider_call_started', run_state: 'running' });
+  assert.equal(executor.calls.length, 1);
+  const claim = await client.query<{ id: string; claim_token: string }>(
+    'SELECT id, claim_token FROM app_run_attempts WHERE org_id = $1 AND run_id = $2',
+    [ORG_ID, created.id],
+  );
+  assert.equal(await runner.renewLease(ORG_ID, claim.rows[0]!.id, randomUUID()), false);
+  assert.equal(await runner.renewLease(ORG_ID, claim.rows[0]!.id, claim.rows[0]!.claim_token), true);
+  const requested = await setup.service.cancel(ORG_ID, created.id, trusted.initiating_actor);
+  assert.equal(requested.state, 'running');
+  assert.ok(requested.cancel_requested_at);
+  release();
+  await firstExecution;
+
+  const finished = await setup.service.inspect(ORG_ID, created.id, trusted.initiating_actor);
+  assert.equal(finished.state, 'succeeded');
+  assert.deepEqual((await setup.service.result(ORG_ID, created.id, trusted.initiating_actor)).value, {
+    message_id: 'message-1',
+  });
+  const attemptCounts = await client.query<{ attempts: string; outputs: string }>(
+    `SELECT
+       (SELECT count(*) FROM app_run_attempts WHERE org_id = $1 AND run_id = $2) AS attempts,
+       (SELECT count(*) FROM app_run_secret_payloads WHERE org_id = $1 AND run_id = $2 AND payload_kind = 'output') AS outputs`,
+    [ORG_ID, created.id],
+  );
+  assert.deepEqual(attemptCounts.rows[0], { attempts: '1', outputs: '1' });
+
+  const denied = service(() => new Date(), { async authorize() { return false; } });
+  let touchedSecret = false;
+  denied.secretRepository.readOutput = async () => {
+    touchedSecret = true;
+    throw new Error('secret read should not happen');
+  };
+  await assert.rejects(
+    denied.service.result(ORG_ID, created.id, trusted.initiating_actor),
+    (error: any) => error?.code === 'APP_RUN_ACCESS_DENIED',
+  );
+  assert.equal(touchedSecret, false);
+});
+
+test('unsafe indeterminate effects never retry while safe and idempotent effects use new attempts', async () => {
+  const unsafeSetup = service();
+  const unsafe = await unsafeSetup.service.submit(trusted, submission({ idempotency_key: `unsafe-${suffix}` }));
+  const unsafeExecutor = new CountingExecutor();
+  unsafeExecutor.results.push({ status: 'indeterminate' });
+  const unsafeRunner = new AppRunAttemptRunner(
+    unsafeSetup.repository, unsafeSetup.secretRepository, unsafeSetup.secrets, unsafeExecutor,
+  );
+  assert.equal((await unsafeRunner.run(ORG_ID, unsafe.id, 'unsafe-1')).state, 'unknown_outcome');
+  await unsafeRunner.run(ORG_ID, unsafe.id, 'unsafe-2');
+  assert.equal(unsafeExecutor.calls.length, 1);
+
+  const idempotentSetup = service();
+  const idempotent = await idempotentSetup.service.submit(trusted, submission({
+    idempotency_key: `idempotent-${suffix}`,
+    policy: {
+      risk_class: 'external_write', review_requirement: 'always',
+      review_scope: 'per_invocation', retry_class: 'idempotent_with_key',
+    },
+  }));
+  const idempotentExecutor = new CountingExecutor();
+  idempotentExecutor.results.push(
+    { status: 'indeterminate' },
+    { status: 'succeeded', output: { delivered: true } },
+  );
+  const idempotentRunner = new AppRunAttemptRunner(
+    idempotentSetup.repository, idempotentSetup.secretRepository, idempotentSetup.secrets,
+    idempotentExecutor,
+  );
+  assert.equal((await idempotentRunner.run(ORG_ID, idempotent.id, 'idempotent-1')).state, 'running');
+  assert.equal((await idempotentRunner.run(ORG_ID, idempotent.id, 'idempotent-2')).state, 'succeeded');
+  assert.equal(idempotentExecutor.calls.length, 2);
+  assert.equal(idempotentExecutor.calls[0]!.provider_idempotency_key, idempotentExecutor.calls[1]!.provider_idempotency_key);
+  const attempts = await client.query<{ attempt_number: number; retry_of_attempt_id: string | null }>(
+    `SELECT attempt_number, retry_of_attempt_id FROM app_run_attempts
+      WHERE org_id = $1 AND run_id = $2 ORDER BY attempt_number`,
+    [ORG_ID, idempotent.id],
+  );
+  assert.equal(attempts.rows.length, 2);
+  assert.equal(attempts.rows[0]!.retry_of_attempt_id, null);
+  assert.ok(attempts.rows[1]!.retry_of_attempt_id);
+});
+
+test('retention purge is one-way, audited, and leaves only safe terminal residue', async () => {
+  const past = new Date('2020-01-01T00:00:00.000Z');
+  const setup = service(() => past);
+  const created = await setup.service.submit(trusted, submission({ idempotency_key: `expired-${suffix}` }));
+  assert.equal(await setup.service.purgeExpiredSecrets(new Date('2021-01-01T00:00:00.000Z')), 1);
+  const rows = await client.query<{ secrets: string; state: string; input_purged_at: Date | null; events: string }>(
+    `SELECT
+       (SELECT count(*) FROM app_run_secret_payloads WHERE org_id = $1 AND run_id = $2) AS secrets,
+       r.state, r.input_purged_at,
+       (SELECT count(*) FROM app_run_events WHERE org_id = $1 AND run_id = $2 AND event_type = 'secrets_purged') AS events
+     FROM app_runs r WHERE r.org_id = $1 AND r.id = $2`,
+    [ORG_ID, created.id],
+  );
+  assert.equal(rows.rows[0]!.secrets, '0');
+  assert.equal(rows.rows[0]!.state, 'expired');
+  assert.ok(rows.rows[0]!.input_purged_at);
+  assert.equal(rows.rows[0]!.events, '1');
+  assert.equal(await setup.service.purgeExpiredSecrets(new Date('2021-01-01T00:00:00.000Z')), 0);
+});
+
+test('a hard crash after the call boundary recovers unsafe work as unknown and fences the late result', async () => {
+  const setup = service();
+  const created = await setup.service.submit(trusted, submission({ idempotency_key: `hard-crash-${suffix}` }));
+  const executor = new CountingExecutor();
+  let release!: () => void;
+  executor.wait = new Promise<void>((resolve) => { release = resolve; });
+  const entered = new Promise<void>((resolve) => { executor.entered = resolve; });
+  let clock = new Date();
+  const runner = new AppRunAttemptRunner(
+    setup.repository, setup.secretRepository, setup.secrets, executor, () => clock, 1_000,
+  );
+  const inFlight = runner.run(ORG_ID, created.id, 'crash-worker');
+  await entered;
+  clock = new Date(clock.getTime() + 2_000);
+  assert.equal(await runner.recoverRun(ORG_ID, created.id), 1);
+  assert.equal((await setup.repository.inspect(ORG_ID, created.id))?.state, 'unknown_outcome');
+  release();
+  await inFlight;
+  assert.equal((await setup.repository.inspect(ORG_ID, created.id))?.state, 'unknown_outcome');
+  assert.equal(executor.calls.length, 1);
+});
+
+test('a durable known result survives finalization failure and repair never recalls the provider', async () => {
+  const setup = service();
+  const created = await setup.service.submit(trusted, submission({ idempotency_key: `repair-${suffix}` }));
+  const executor = new CountingExecutor();
+  const originalTransition = setup.repository.transition.bind(setup.repository);
+  let failFinalization = true;
+  setup.repository.transition = async (tx, input) => {
+    if (failFinalization && input.state === 'succeeded') {
+      failFinalization = false;
+      throw new Error('injected finalization failure');
+    }
+    return originalTransition(tx, input);
+  };
+  const runner = new AppRunAttemptRunner(
+    setup.repository, setup.secretRepository, setup.secrets, executor,
+  );
+  await assert.rejects(runner.run(ORG_ID, created.id, 'repair-worker'), /injected finalization failure/);
+  assert.equal(executor.calls.length, 1);
+  const marker = await client.query<{ state: string; provider_call_finished_at: Date | null }>(
+    'SELECT state, provider_call_finished_at FROM app_run_attempts WHERE org_id = $1 AND run_id = $2',
+    [ORG_ID, created.id],
+  );
+  assert.equal(marker.rows[0]!.state, 'provider_call_started');
+  assert.ok(marker.rows[0]!.provider_call_finished_at);
+
+  setup.repository.transition = originalTransition;
+  const repairExecutor: AppRunProviderExecutor = {
+    async execute() { throw new Error('provider must not be recalled'); },
+  };
+  const future = new Date(Date.now() + 2 * 60_000);
+  const repairRunner = new AppRunAttemptRunner(
+    setup.repository, setup.secretRepository, setup.secrets, repairExecutor, () => future,
+  );
+  assert.equal(await repairRunner.recoverRun(ORG_ID, created.id), 1);
+  assert.equal((await setup.repository.inspect(ORG_ID, created.id))?.state, 'succeeded');
+  assert.equal(executor.calls.length, 1);
+});
+
+test('oversized post-effect output remains known success without exact result or a second call', async () => {
+  const setup = service();
+  const created = await setup.service.submit(trusted, submission({ idempotency_key: `oversized-${suffix}` }));
+  const executor = new CountingExecutor();
+  executor.results.push({ status: 'succeeded', output: { value: 'x'.repeat(1024 * 1024 + 1) } });
+  const runner = new AppRunAttemptRunner(
+    setup.repository, setup.secretRepository, setup.secrets, executor,
+  );
+  const finished = await runner.run(ORG_ID, created.id, 'oversized-worker');
+  assert.equal(finished.state, 'succeeded');
+  assert.equal(finished.safe_outcome?.result_status, 'unavailable');
+  await runner.run(ORG_ID, created.id, 'oversized-worker-2');
+  assert.equal(executor.calls.length, 1);
+  await assert.rejects(
+    setup.service.result(ORG_ID, created.id, trusted.initiating_actor),
+    (error: any) => error?.code === 'APP_RUN_RESULT_EXPIRED',
+  );
+});
+
+test('database fencing rejects a second active attempt and mutable ownership', async () => {
+  const setup = service();
+  const created = await setup.service.submit(trusted, submission({ idempotency_key: `fencing-${suffix}` }));
+  const attemptId = randomUUID();
+  await client.query(
+    `INSERT INTO app_run_attempts
+      (id, org_id, run_id, attempt_number, state)
+     VALUES ($1, $2, $3, 1, 'pending')`,
+    [attemptId, ORG_ID, created.id],
+  );
+  await assert.rejects(
+    client.query(
+      `UPDATE app_run_attempts SET claim_owner = 'owner-0', claim_token = $1,
+         claimed_at = now(), lease_expires_at = now() + interval '1 minute'
+       WHERE id = $2`,
+      [randomUUID(), attemptId],
+    ),
+    /APP_RUN_ILLEGAL_TRANSITION/,
+  );
+  await client.query(
+    `UPDATE app_run_attempts SET state = 'claimed', claim_owner = 'owner-1',
+       claim_token = $1, claimed_at = now(), lease_expires_at = now() + interval '1 minute'
+     WHERE id = $2`,
+    [randomUUID(), attemptId],
+  );
+  await assert.rejects(
+    client.query('UPDATE app_run_attempts SET claim_owner = $1 WHERE id = $2', ['owner-2', attemptId]),
+    /APP_RUN_IMMUTABLE_FIELD/,
+  );
+  await assert.rejects(
+    client.query(
+      `INSERT INTO app_run_attempts
+        (id, org_id, run_id, attempt_number, retry_of_attempt_id, state)
+       VALUES ($1, $2, $3, 2, $4, 'pending')`,
+      [randomUUID(), ORG_ID, created.id, attemptId],
+    ),
+    /app_run_attempts_one_active_unique/,
+  );
+});
+
+test('the worker adapter accepts ID-only jobs and remains dependency injected', async () => {
+  const calls: unknown[] = [];
+  const runner = {
+    async run(orgId: string, runId: string, workerId: string, signal?: AbortSignal) {
+      calls.push({ orgId, runId, workerId, signal });
+      return {} as never;
+    },
+  } as AppRunAttemptRunner;
+  const handler = createAppRunAttemptJobHandler(runner);
+  const signal = new AbortController().signal;
+  await handler({ id: 'job-1', name: 'app-run-attempt', data: { orgId: ORG_ID, runId: 'run-1' }, attempts: 1, signal });
+  assert.deepEqual(calls, [{ orgId: ORG_ID, runId: 'run-1', workerId: 'job:job-1', signal }]);
+  await assert.rejects(
+    handler({ id: 'job-2', name: 'app-run-attempt', data: { orgId: ORG_ID, runId: 'run-1', input: 'secret' }, attempts: 1 }),
+  );
+});

--- a/apps/api/test/app-run-secrets.test.ts
+++ b/apps/api/test/app-run-secrets.test.ts
@@ -162,6 +162,15 @@ describe('App Run Secret Service', () => {
       service.fingerprintTextCandidates('idempotency', 'low-entropy').map((item) => item.key_version),
       ['fp-v1', 'fp-old'],
     );
+    assert.deepEqual(
+      service.fingerprintJsonCandidates('input', { nested: { b: 2, a: 1 } })
+        .map((item) => item.key_version),
+      ['fp-v1', 'fp-old'],
+    );
+    assert.deepEqual(
+      service.fingerprintJsonCandidates('input', { b: 2, a: 1 }),
+      service.fingerprintJsonCandidates('input', { a: 1, b: 2 }),
+    );
     assert.doesNotMatch(JSON.stringify(replay), /low-entropy/);
     assert.throws(
       () => service.fingerprintText('idempotency', 'é'.repeat(APP_RUN_LIMITS.idempotency_key_bytes)),

--- a/docs/superpowers/plans/2026-08-30-app-platform-phase-3-governed-runs-loops.md
+++ b/docs/superpowers/plans/2026-08-30-app-platform-phase-3-governed-runs-loops.md
@@ -186,6 +186,10 @@ service interface. They do not receive decrypted input or a provider callback.
   or transient lock digest.
 - Return the existing Run for same-key/same-input replay with no new event;
   return `APP_RUN_IDEMPOTENCY_CONFLICT` for different input.
+- Pin a host-owned idempotency horizon at submission: 7 days for ephemeral,
+  30 days for standard, and 90 days for extended Runs. Active rows block
+  fingerprint-key retirement; after the horizon callers must use a new key.
+  Apps and later permission changes cannot widen this window.
 - Add terminal secret purge and sanitized residue. Permission widening cannot
   extend a previously chosen retention class.
 
@@ -207,8 +211,9 @@ service interface. They do not receive decrypted input or a provider callback.
 - Implement a shared claimed-attempt runner usable synchronously and by the
   PostgreSQL worker. Commit the attempt boundary before a provider call and do
   not hold a transaction open across network I/O.
-- Start against a counting fake provider. Add the internal provider executor only
-  after state/recovery tests pass.
+- Start against a counting fake provider and freeze a narrow injected executor
+  port after state/recovery tests pass. The real internal provider executor and
+  production worker registration remain Loop 6 cutover work.
 - Persist a known provider result as bounded encrypted output plus a sanitized
   terminal projection without another call even if event, receipt, metrics, or
   Attention work needs repair.
@@ -218,8 +223,9 @@ service interface. They do not receive decrypted input or a provider callback.
 - Make cancellation effective before call start and advisory after an external
   call begins. Never report an external effect as cancelled when its outcome is
   unknown.
-- Add idempotent repair jobs for terminal receipts/events/attention and bounded
-  stale-attempt reconciliation.
+- Add bounded stale-attempt reconciliation and idempotent repair for
+  engine-owned terminal state/events. Concrete receipt and Attention repair
+  remains Loop 7 work, after those projections exist.
 
 ### Exit evidence
 
@@ -234,7 +240,8 @@ service interface. They do not receive decrypted input or a provider callback.
   never re-enters the provider.
 - Exact result replay is available only to the live-authorized caller during the
   result-retention window. After purge, replay returns terminal identity plus
-  `result_expired` and never calls the provider again.
+  `result_expired` and never calls the provider again during the pinned
+  idempotency horizon.
 
 ## Loop 5: Approval adapter and live authorization
 

--- a/packages/db/scripts/apply-extras.ts
+++ b/packages/db/scripts/apply-extras.ts
@@ -47,6 +47,10 @@ async function main() {
     await client.query(readFileSync(resolve(upgradesDir, appRunsFoundationFile), 'utf8'));
     console.log(`[apply-extras] applied ${appRunsFoundationFile}`);
 
+    const appRunEngineHardeningFile = '0.3.0-preview.18-governed-app-run-engine-hardening.sql';
+    await client.query(readFileSync(resolve(upgradesDir, appRunEngineHardeningFile), 'utf8'));
+    console.log(`[apply-extras] applied ${appRunEngineHardeningFile}`);
+
     // Expression-based unique indexes can't be declared in schema.ts, so
     // `drizzle-kit push` silently drops them. Re-create the ones the app
     // depends on so pushed and migrated databases behave the same.
@@ -85,6 +89,11 @@ async function main() {
       'app_runs_org_parent_run_fk',
       'app_run_attempts_org_run_fk',
       'app_run_attempts_org_run_id_unique',
+      'app_run_attempts_retry_of_fk',
+      'app_runs_idempotency_expiry_check',
+      'app_runs_attempt_limit_check',
+      'app_runs_cancel_request_check',
+      'app_run_attempts_retry_shape_check',
       'app_run_secret_payloads_org_run_fk',
       'app_run_secret_payloads_org_attempt_fk',
       'app_run_events_org_run_fk',
@@ -124,6 +133,8 @@ async function main() {
       'capability_provider_snapshots_identity_digest_unique',
       'app_runs_idempotency_unique',
       'app_run_attempts_number_unique',
+      'app_run_attempts_one_active_unique',
+      'app_runs_idempotency_expiry_idx',
       'app_run_secret_payloads_input_unique',
       'app_run_secret_payloads_output_unique',
       'app_run_events_sequence_unique',

--- a/packages/db/scripts/upgrade.test.ts
+++ b/packages/db/scripts/upgrade.test.ts
@@ -98,6 +98,7 @@ test('governed App Run fresh schema is tenant-bound and keeps ciphertext separat
   assert.ok(run.uniqueConstraints.some((item) => item.name === 'app_runs_org_id_id_unique'));
   assert.ok(foreignKeyNames(run).includes('app_runs_org_provider_snapshot_fk'));
   assert.ok(foreignKeyNames(attempt).includes('app_run_attempts_org_run_fk'));
+  assert.ok(attempt.indexes.some((item) => item.config.name === 'app_run_attempts_one_active_unique'));
   assert.deepEqual(
     foreignKeyNames(secret).filter((name) => name.startsWith('app_run_secret_payloads_')).sort(),
     ['app_run_secret_payloads_org_attempt_fk', 'app_run_secret_payloads_org_run_fk'],
@@ -161,6 +162,31 @@ test('governed App Run supported upgrade preserves dormant and immutable boundar
   assert.doesNotMatch(sql, /UPDATE\s+agent_actions/i);
   assert.doesNotMatch(sql, /^\s*UPDATE\s+/im);
   assert.match(applyExtrasSource, /0\.3\.0-preview\.17-governed-app-runs-foundation\.sql/);
+});
+
+test('governed App Run engine hardening is additive and fences replay and attempts', () => {
+  const migration = upgradeManifest.migrations.find((item) => item.version === '0.3.0-preview.18');
+  assert.ok(migration);
+  const scriptsDir = dirname(fileURLToPath(import.meta.url));
+  const sql = readFileSync(resolve(scriptsDir, '..', 'upgrades', migration.file), 'utf8');
+  const applyExtrasSource = readFileSync(resolve(scriptsDir, 'apply-extras.ts'), 'utf8');
+
+  for (const boundary of [
+    'idempotency_expires_at',
+    'attempt_limit',
+    'cancel_requested_at',
+    'retry_of_attempt_id',
+    'app_run_attempts_retry_of_fk',
+    'app_run_attempts_one_active_unique',
+    'app_runs_idempotency_expiry_check',
+    'app_run_attempts_retry_shape_check',
+    'cancellation_requested',
+    'APP_RUN_IMMUTABLE_FIELD',
+  ]) {
+    assert.match(sql, new RegExp(boundary, 'i'));
+  }
+  assert.doesNotMatch(sql, /ALTER TABLE agent_actions/i);
+  assert.match(applyExtrasSource, /0\.3\.0-preview\.18-governed-app-run-engine-hardening\.sql/);
 });
 
 test('parseUpgradeArgs recognizes status and dry run', () => {

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -703,6 +703,8 @@ export const appRuns = pgTable('app_runs', {
   depth: integer('depth').default(0).notNull(),
   input_expires_at: timestamp('input_expires_at').notNull(),
   result_expires_at: timestamp('result_expires_at').notNull(),
+  idempotency_expires_at: timestamp('idempotency_expires_at').notNull(),
+  attempt_limit: integer('attempt_limit').notNull(),
   input_purged_at: timestamp('input_purged_at'),
   result_purged_at: timestamp('result_purged_at'),
   started_at: timestamp('started_at'),
@@ -710,6 +712,7 @@ export const appRuns = pgTable('app_runs', {
   unknown_outcome_at: timestamp('unknown_outcome_at'),
   reconciled_at: timestamp('reconciled_at'),
   cancelled_at: timestamp('cancelled_at'),
+  cancel_requested_at: timestamp('cancel_requested_at'),
   ...timestamps(),
 }, (t) => [
   unique('app_runs_org_id_id_unique').on(t.org_id, t.id),
@@ -732,6 +735,7 @@ export const appRuns = pgTable('app_runs', {
   index('app_runs_root_idx').on(t.org_id, t.root_run_id, t.created_at),
   index('app_runs_parent_idx').on(t.org_id, t.parent_run_id),
   index('app_runs_secret_expiry_idx').on(t.state, t.input_expires_at, t.result_expires_at),
+  index('app_runs_idempotency_expiry_idx').on(t.idempotency_expires_at),
   check('app_runs_origin_check', sql`${t.origin_kind} IN ('core', 'legacy_connector', 'app')`),
   check('app_runs_contract_version_check', sql`${t.contract_version} = 'deft.app_run.v1'`),
   // App origin is reserved but cannot persist until connected App grants exist.
@@ -776,6 +780,9 @@ export const appRuns = pgTable('app_runs', {
     )
   `),
   check('app_runs_expiry_check', sql`${t.result_expires_at} >= ${t.input_expires_at}`),
+  check('app_runs_idempotency_expiry_check', sql`${t.idempotency_expires_at} >= ${t.result_expires_at}`),
+  check('app_runs_attempt_limit_check', sql`${t.attempt_limit} BETWEEN 1 AND 10`),
+  check('app_runs_cancel_request_check', sql`${t.cancel_requested_at} IS NULL OR ${t.started_at} IS NOT NULL`),
 ]);
 
 export const appRunAttempts = pgTable('app_run_attempts', {
@@ -783,6 +790,7 @@ export const appRunAttempts = pgTable('app_run_attempts', {
   ...orgId(),
   run_id: text('run_id').notNull(),
   attempt_number: integer('attempt_number').notNull(),
+  retry_of_attempt_id: text('retry_of_attempt_id'),
   state: text('state').$type<
     'pending' | 'claimed' | 'provider_call_started' | 'succeeded' | 'failed' | 'cancelled' | 'unknown_outcome'
   >().default('pending').notNull(),
@@ -805,8 +813,15 @@ export const appRunAttempts = pgTable('app_run_attempts', {
   }).onDelete('cascade'),
   unique('app_run_attempts_org_run_id_unique').on(t.org_id, t.run_id, t.id),
   uniqueIndex('app_run_attempts_number_unique').on(t.org_id, t.run_id, t.attempt_number),
+  uniqueIndex('app_run_attempts_one_active_unique')
+    .on(t.org_id, t.run_id)
+    .where(sql`${t.state} IN ('pending', 'claimed', 'provider_call_started')`),
   index('app_run_attempts_lease_idx').on(t.state, t.lease_expires_at),
   check('app_run_attempts_number_check', sql`${t.attempt_number} >= 1`),
+  check('app_run_attempts_retry_shape_check', sql`
+    (${t.attempt_number} = 1 AND ${t.retry_of_attempt_id} IS NULL)
+    OR (${t.attempt_number} > 1 AND ${t.retry_of_attempt_id} IS NOT NULL)
+  `),
   check('app_run_attempts_state_check', sql`${t.state} IN ('pending', 'claimed', 'provider_call_started', 'succeeded', 'failed', 'cancelled', 'unknown_outcome')`),
   check('app_run_attempts_claim_shape_check', sql`
     (${t.claim_owner} IS NULL AND ${t.claim_token} IS NULL AND ${t.claimed_at} IS NULL AND ${t.lease_expires_at} IS NULL)
@@ -903,7 +918,7 @@ export const appRunEvents = pgTable('app_run_events', {
   check('app_run_events_version_check', sql`${t.event_version} = 'deft.app_run_event.v1'`),
   check('app_run_events_type_check', sql`${t.event_type} IN (
     'run_created', 'approval_requested', 'approval_resolved', 'attempt_created',
-    'attempt_claimed', 'provider_call_started', 'attempt_terminal', 'run_transitioned',
+    'attempt_claimed', 'provider_call_started', 'cancellation_requested', 'attempt_terminal', 'run_transitioned',
     'secrets_purged', 'reconciliation_recorded', 'repair_gap'
   )`),
   check('app_run_events_actor_shape_check', sql`

--- a/packages/db/upgrades/0.3.0-preview.18-governed-app-run-engine-hardening.sql
+++ b/packages/db/upgrades/0.3.0-preview.18-governed-app-run-engine-hardening.sql
@@ -1,0 +1,198 @@
+-- Forward-only hardening for the still-dormant governed App Run engine.
+-- This adds no execution consumer and does not modify legacy action paths.
+
+ALTER TABLE app_runs
+  ADD COLUMN IF NOT EXISTS idempotency_expires_at timestamp,
+  ADD COLUMN IF NOT EXISTS attempt_limit integer,
+  ADD COLUMN IF NOT EXISTS cancel_requested_at timestamp;
+
+UPDATE app_runs
+SET idempotency_expires_at = created_at + CASE retention_class
+      WHEN 'ephemeral' THEN interval '7 days'
+      WHEN 'standard' THEN interval '30 days'
+      WHEN 'extended' THEN interval '90 days'
+    END,
+    attempt_limit = COALESCE(attempt_limit, 3)
+WHERE idempotency_expires_at IS NULL OR attempt_limit IS NULL;
+
+ALTER TABLE app_runs
+  ALTER COLUMN idempotency_expires_at SET NOT NULL,
+  ALTER COLUMN attempt_limit SET NOT NULL;
+
+ALTER TABLE app_run_attempts
+  ADD COLUMN IF NOT EXISTS retry_of_attempt_id text;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'app_runs_idempotency_expiry_check') THEN
+    ALTER TABLE app_runs ADD CONSTRAINT app_runs_idempotency_expiry_check
+      CHECK (idempotency_expires_at >= result_expires_at);
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'app_runs_attempt_limit_check') THEN
+    ALTER TABLE app_runs ADD CONSTRAINT app_runs_attempt_limit_check
+      CHECK (attempt_limit BETWEEN 1 AND 10);
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'app_runs_cancel_request_check') THEN
+    ALTER TABLE app_runs ADD CONSTRAINT app_runs_cancel_request_check
+      CHECK (cancel_requested_at IS NULL OR started_at IS NOT NULL);
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'app_run_attempts_retry_shape_check') THEN
+    ALTER TABLE app_run_attempts ADD CONSTRAINT app_run_attempts_retry_shape_check
+      CHECK (
+        (attempt_number = 1 AND retry_of_attempt_id IS NULL)
+        OR (attempt_number > 1 AND retry_of_attempt_id IS NOT NULL)
+      );
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'app_run_attempts_retry_of_fk') THEN
+    ALTER TABLE app_run_attempts ADD CONSTRAINT app_run_attempts_retry_of_fk
+      FOREIGN KEY (org_id, run_id, retry_of_attempt_id)
+      REFERENCES app_run_attempts(org_id, run_id, id) ON DELETE NO ACTION
+      DEFERRABLE INITIALLY DEFERRED;
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS app_runs_idempotency_expiry_idx
+  ON app_runs(idempotency_expires_at);
+
+CREATE UNIQUE INDEX IF NOT EXISTS app_run_attempts_one_active_unique
+  ON app_run_attempts(org_id, run_id)
+  WHERE state IN ('pending', 'claimed', 'provider_call_started');
+
+ALTER TABLE app_run_events DROP CONSTRAINT IF EXISTS app_run_events_type_check;
+ALTER TABLE app_run_events ADD CONSTRAINT app_run_events_type_check CHECK (event_type IN (
+  'run_created', 'approval_requested', 'approval_resolved', 'attempt_created',
+  'attempt_claimed', 'provider_call_started', 'cancellation_requested',
+  'attempt_terminal', 'run_transitioned', 'secrets_purged',
+  'reconciliation_recorded', 'repair_gap'
+));
+
+CREATE OR REPLACE FUNCTION enforce_app_run_state_and_identity() RETURNS trigger AS $$
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    IF pg_trigger_depth() > 1 OR current_setting('deft.app_run_maintenance', true) = 'on' THEN
+      RETURN OLD;
+    END IF;
+    RAISE EXCEPTION 'APP_RUN_APPEND_ONLY' USING ERRCODE = '55000';
+  END IF;
+
+  IF (NEW.org_id, NEW.contract_version, NEW.origin_kind, NEW.initiating_actor_type, NEW.initiating_actor_id,
+      NEW.execution_actor_type, NEW.execution_actor_id, NEW.provider_kind,
+      NEW.provider_instance_id, NEW.operation_name, NEW.provider_snapshot_id,
+      NEW.risk_class, NEW.review_requirement, NEW.review_scope, NEW.retry_class,
+      NEW.retention_class, NEW.idempotency_key_version, NEW.idempotency_fingerprint,
+      NEW.input_fingerprint_key_version, NEW.input_fingerprint, NEW.authorization_snapshot,
+      NEW.safe_preview, NEW.root_run_id, NEW.parent_run_id, NEW.depth,
+      NEW.input_expires_at, NEW.result_expires_at, NEW.idempotency_expires_at, NEW.attempt_limit)
+    IS DISTINCT FROM
+     (OLD.org_id, OLD.contract_version, OLD.origin_kind, OLD.initiating_actor_type, OLD.initiating_actor_id,
+      OLD.execution_actor_type, OLD.execution_actor_id, OLD.provider_kind,
+      OLD.provider_instance_id, OLD.operation_name, OLD.provider_snapshot_id,
+      OLD.risk_class, OLD.review_requirement, OLD.review_scope, OLD.retry_class,
+      OLD.retention_class, OLD.idempotency_key_version, OLD.idempotency_fingerprint,
+      OLD.input_fingerprint_key_version, OLD.input_fingerprint, OLD.authorization_snapshot,
+      OLD.safe_preview, OLD.root_run_id, OLD.parent_run_id, OLD.depth,
+      OLD.input_expires_at, OLD.result_expires_at, OLD.idempotency_expires_at, OLD.attempt_limit)
+  THEN
+    RAISE EXCEPTION 'APP_RUN_IMMUTABLE_FIELD' USING ERRCODE = '55000';
+  END IF;
+
+  IF (OLD.started_at IS NOT NULL AND NEW.started_at IS DISTINCT FROM OLD.started_at)
+    OR (OLD.terminal_at IS NOT NULL AND NEW.terminal_at IS DISTINCT FROM OLD.terminal_at)
+    OR (OLD.unknown_outcome_at IS NOT NULL AND NEW.unknown_outcome_at IS DISTINCT FROM OLD.unknown_outcome_at)
+    OR (OLD.reconciled_at IS NOT NULL AND NEW.reconciled_at IS DISTINCT FROM OLD.reconciled_at)
+    OR (OLD.cancelled_at IS NOT NULL AND NEW.cancelled_at IS DISTINCT FROM OLD.cancelled_at)
+    OR (OLD.cancel_requested_at IS NOT NULL AND NEW.cancel_requested_at IS DISTINCT FROM OLD.cancel_requested_at)
+    OR (OLD.input_purged_at IS NOT NULL AND NEW.input_purged_at IS DISTINCT FROM OLD.input_purged_at)
+    OR (OLD.result_purged_at IS NOT NULL AND NEW.result_purged_at IS DISTINCT FROM OLD.result_purged_at)
+    OR (OLD.safe_outcome IS NOT NULL AND NEW.safe_outcome IS NULL)
+  THEN
+    RAISE EXCEPTION 'APP_RUN_IMMUTABLE_FIELD' USING ERRCODE = '55000';
+  END IF;
+
+  IF OLD.cancel_requested_at IS NULL AND NEW.cancel_requested_at IS NOT NULL
+     AND OLD.state NOT IN ('running', 'waiting_external') THEN
+    RAISE EXCEPTION 'APP_RUN_ILLEGAL_TRANSITION' USING ERRCODE = '55000';
+  END IF;
+
+  IF NEW.state <> OLD.state AND NOT (
+    (OLD.state = 'pending' AND NEW.state IN ('pending_approval', 'running', 'cancelled', 'expired'))
+    OR (OLD.state = 'pending_approval' AND NEW.state IN ('running', 'cancelled', 'expired'))
+    OR (OLD.state = 'running' AND NEW.state IN ('waiting_external', 'succeeded', 'failed', 'unknown_outcome'))
+    OR (OLD.state = 'waiting_external' AND NEW.state IN ('running', 'succeeded', 'failed', 'cancelled', 'unknown_outcome'))
+    OR (OLD.state = 'unknown_outcome' AND NEW.state IN ('succeeded', 'failed'))
+  ) THEN
+    RAISE EXCEPTION 'APP_RUN_ILLEGAL_TRANSITION' USING ERRCODE = '55000';
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION enforce_app_run_attempt_state_and_identity() RETURNS trigger AS $$
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    IF pg_trigger_depth() > 1 OR current_setting('deft.app_run_maintenance', true) = 'on' THEN
+      RETURN OLD;
+    END IF;
+    RAISE EXCEPTION 'APP_RUN_APPEND_ONLY' USING ERRCODE = '55000';
+  END IF;
+
+  IF (NEW.org_id, NEW.run_id, NEW.attempt_number, NEW.retry_of_attempt_id,
+      NEW.provider_idempotency_key_version, NEW.provider_idempotency_fingerprint)
+    IS DISTINCT FROM
+     (OLD.org_id, OLD.run_id, OLD.attempt_number, OLD.retry_of_attempt_id,
+      OLD.provider_idempotency_key_version, OLD.provider_idempotency_fingerprint)
+  THEN
+    RAISE EXCEPTION 'APP_RUN_IMMUTABLE_FIELD' USING ERRCODE = '55000';
+  END IF;
+
+  IF OLD.claim_token IS NOT NULL AND (
+    NEW.claim_owner IS DISTINCT FROM OLD.claim_owner
+    OR NEW.claim_token IS DISTINCT FROM OLD.claim_token
+    OR NEW.claimed_at IS DISTINCT FROM OLD.claimed_at
+  ) THEN
+    RAISE EXCEPTION 'APP_RUN_IMMUTABLE_FIELD' USING ERRCODE = '55000';
+  END IF;
+  IF OLD.claim_token IS NULL AND NEW.claim_token IS NOT NULL
+     AND NOT (OLD.state = 'pending' AND NEW.state = 'claimed') THEN
+    RAISE EXCEPTION 'APP_RUN_ILLEGAL_TRANSITION' USING ERRCODE = '55000';
+  END IF;
+  IF OLD.lease_expires_at IS NOT NULL AND NEW.lease_expires_at < OLD.lease_expires_at THEN
+    RAISE EXCEPTION 'APP_RUN_IMMUTABLE_FIELD' USING ERRCODE = '55000';
+  END IF;
+  IF OLD.provider_call_started_at IS NOT NULL
+     AND NEW.provider_call_started_at IS DISTINCT FROM OLD.provider_call_started_at THEN
+    RAISE EXCEPTION 'APP_RUN_IMMUTABLE_FIELD' USING ERRCODE = '55000';
+  END IF;
+  IF OLD.provider_call_started_at IS NULL AND NEW.provider_call_started_at IS NOT NULL
+     AND NOT (OLD.state = 'claimed' AND NEW.state = 'provider_call_started') THEN
+    RAISE EXCEPTION 'APP_RUN_ILLEGAL_TRANSITION' USING ERRCODE = '55000';
+  END IF;
+  IF OLD.provider_call_finished_at IS NOT NULL
+     AND NEW.provider_call_finished_at IS DISTINCT FROM OLD.provider_call_finished_at THEN
+    RAISE EXCEPTION 'APP_RUN_IMMUTABLE_FIELD' USING ERRCODE = '55000';
+  END IF;
+  IF OLD.provider_call_finished_at IS NULL AND NEW.provider_call_finished_at IS NOT NULL
+     AND OLD.state <> 'provider_call_started' THEN
+    RAISE EXCEPTION 'APP_RUN_ILLEGAL_TRANSITION' USING ERRCODE = '55000';
+  END IF;
+  IF OLD.safe_outcome IS NOT NULL AND NEW.safe_outcome IS DISTINCT FROM OLD.safe_outcome THEN
+    RAISE EXCEPTION 'APP_RUN_IMMUTABLE_FIELD' USING ERRCODE = '55000';
+  END IF;
+  IF OLD.safe_outcome IS NULL AND NEW.safe_outcome IS NOT NULL
+     AND (OLD.state <> 'provider_call_started' OR NEW.provider_call_finished_at IS NULL) THEN
+    RAISE EXCEPTION 'APP_RUN_ILLEGAL_TRANSITION' USING ERRCODE = '55000';
+  END IF;
+  IF OLD.error_code IS NOT NULL AND NEW.error_code IS DISTINCT FROM OLD.error_code THEN
+    RAISE EXCEPTION 'APP_RUN_IMMUTABLE_FIELD' USING ERRCODE = '55000';
+  END IF;
+
+  IF NEW.state <> OLD.state AND NOT (
+    (OLD.state = 'pending' AND NEW.state IN ('claimed', 'cancelled'))
+    OR (OLD.state = 'claimed' AND NEW.state IN ('provider_call_started', 'failed', 'cancelled'))
+    OR (OLD.state = 'provider_call_started' AND NEW.state IN ('succeeded', 'failed', 'cancelled', 'unknown_outcome'))
+  ) THEN
+    RAISE EXCEPTION 'APP_RUN_ILLEGAL_TRANSITION' USING ERRCODE = '55000';
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;

--- a/packages/db/upgrades/manifest.ts
+++ b/packages/db/upgrades/manifest.ts
@@ -107,6 +107,11 @@ export const upgradeManifest = {
       file: '0.3.0-preview.17-governed-app-runs-foundation.sql',
       description: 'Add dormant governed App Run metadata, encrypted payload, attempt, event, and receipt boundaries',
     },
+    {
+      version: '0.3.0-preview.18',
+      file: '0.3.0-preview.18-governed-app-run-engine-hardening.sql',
+      description: 'Harden dormant App Run replay, cancellation, retry ancestry, and attempt fencing',
+    },
   ] satisfies UpgradeMigration[],
 } as const;
 

--- a/packages/shared/src/app-runs.ts
+++ b/packages/shared/src/app-runs.ts
@@ -36,6 +36,17 @@ export const APP_RUN_SECRET_RETENTION_MS = {
   extended: 30 * 24 * 60 * 60 * 1000,
 } as const;
 
+// Caller idempotency outlives exact input/result retention, but it is bounded
+// so self-hosted operators and the hosted service can eventually retire old
+// fingerprint keys. Apps cannot widen this host-owned policy.
+export const APP_RUN_IDEMPOTENCY_RETENTION_MS = {
+  ephemeral: 7 * 24 * 60 * 60 * 1000,
+  standard: 30 * 24 * 60 * 60 * 1000,
+  extended: 90 * 24 * 60 * 60 * 1000,
+} as const;
+
+export const APP_RUN_DEFAULT_ATTEMPT_LIMIT = 3;
+
 const ExactIdentitySchema = z
   .string()
   .min(1)
@@ -352,6 +363,7 @@ export const AppRunEventTypeSchema = z.enum([
   'attempt_created',
   'attempt_claimed',
   'provider_call_started',
+  'cancellation_requested',
   'attempt_terminal',
   'run_transitioned',
   'secrets_purged',
@@ -441,6 +453,13 @@ function utf8Bytes(value: string): number {
 }
 
 export function parseAppRunSubmission(value: unknown): AppRunSubmission {
+  // Bound adversarial recursive input before Zod walks it.
+  if (value !== null && typeof value === 'object' && !Array.isArray(value) && 'input' in value) {
+    assertCapabilityJsonWithinBudget(
+      (value as { input?: unknown }).input,
+      APP_RUN_LIMITS.input_bytes,
+    );
+  }
   const parsed = AppRunSubmissionSchema.parse(value);
   if (utf8Bytes(parsed.idempotency_key) > APP_RUN_LIMITS.idempotency_key_bytes) {
     throw new TypeError(`App Run idempotency key exceeds ${APP_RUN_LIMITS.idempotency_key_bytes} bytes`);
@@ -475,4 +494,11 @@ export function retentionDeadline(
   from: Date,
 ): Date {
   return new Date(from.getTime() + APP_RUN_SECRET_RETENTION_MS[retentionClass]);
+}
+
+export function idempotencyDeadline(
+  retentionClass: AppRunRetentionClass,
+  from = new Date(),
+): Date {
+  return new Date(from.getTime() + APP_RUN_IDEMPOTENCY_RETENTION_MS[retentionClass]);
 }

--- a/packages/shared/test/app-runs.test.ts
+++ b/packages/shared/test/app-runs.test.ts
@@ -5,6 +5,7 @@ import {
   APP_RUN_CONTRACT_VERSIONS,
   APP_RUN_LIMITS,
   APP_RUN_SECRET_RETENTION_MS,
+  APP_RUN_IDEMPOTENCY_RETENTION_MS,
   AppRunSafeOutcomeSchema,
   AppRunAttemptStateSchema,
   AppRunStateSchema,
@@ -15,6 +16,7 @@ import {
   parseAppRunEvent,
   parseAppRunReceiptEnvelope,
   retentionDeadline,
+  idempotencyDeadline,
 } from '../src/app-runs';
 
 const digest = `sha256:${'a'.repeat(64)}`;
@@ -243,6 +245,13 @@ describe('App Run contract', () => {
     assert.equal(
       retentionDeadline('extended', from).getTime() - from.getTime(),
       APP_RUN_SECRET_RETENTION_MS.extended,
+    );
+    assert.equal(
+      idempotencyDeadline('standard', from).getTime() - from.getTime(),
+      APP_RUN_IDEMPOTENCY_RETENTION_MS.standard,
+    );
+    assert.ok(
+      idempotencyDeadline('extended', from).getTime() > retentionDeadline('extended', from).getTime(),
     );
   });
 });


### PR DESCRIPTION
## Summary

- add the effect-free App Run lifecycle, replay, retention, reconciliation, and fail-closed access seams
- add a claimed-attempt engine with durable call boundaries, leases, retry ancestry, crash recovery, known-result repair, and exact-result retention
- add the forward-only preview.18 hardening upgrade for bounded idempotency, advisory cancellation, single-active-attempt fencing, and immutable claim ownership
- keep the engine dependency-injected and dormant: no Capability Service cutover, real MCP executor, route, approval adapter, or production worker registration

## Safety boundary

This is Phase 3 PR B (Loops 3-4). Existing Capability Service and legacy execution paths are unchanged. App origin remains disabled. The worker handler is an unregistered factory, the provider is a test-only counting fake, and the production flag still has no execution consumer.

## Evidence

- shared contracts: 54 tests passed
- supported upgrade/schema checks: 20 tests passed
- App Run engine DB matrix: 9 tests passed
- queue and worker reliability: 11 tests passed
- relevant App Run secret/architecture and Capability Service/architecture tests passed
- repository-wide typecheck passed
- API production build passed
- preview.17 -> preview.18 applied and re-applied successfully on a disposable PostgreSQL 16 database
- final diff check clean; disposable database removed

Local fresh-schema bootstrap was not repeated because the documented local pgvector installation is unavailable. Existing CI remains the fresh-schema/image/browser evidence.