### PR TITLE
feat(apps): complete Phase 3 trust and data train

### DIFF
--- a/apps/api/src/lib/agent-approval-resolver.ts
+++ b/apps/api/src/lib/agent-approval-resolver.ts
@@ -79,6 +79,10 @@ import {
   sanitizeModuleTaskLinkActionParamsForHistory,
 } from './agent-actions.js';
 import { ACTION_TOOLS } from './agent-tools.js';
+import {
+  APP_RUN_APPROVAL_ACTION,
+  postgresAppRunApprovalResolver,
+} from './app-run-approval-adapter.js';
 import { isAgentToolDisabled } from './agent-tool-policy.js';
 import {
   MODULE_OPERATION_DEFINITIONS,
@@ -127,7 +131,11 @@ async function publishApprovalResolution(actionId: string, actorUserId: string):
       .from(agentActions)
       .where(eq(agentActions.id, actionId))
       .limit(1);
-    if (!row?.agent_employee_id || !['approved', 'rejected'].includes(row.approval_status)) return;
+    if (
+      !row?.agent_employee_id
+      || row.action === APP_RUN_APPROVAL_ACTION
+      || !['approved', 'rejected'].includes(row.approval_status)
+    ) return;
 
     const [employee] = await db
       .select({ runtime_kind: agentEmployees.runtime_kind })
@@ -756,7 +764,14 @@ async function approveActionLocked(
   // terminal retry may create missing receipts/attention artifacts, so it is
   // not a side-effect-free read and must not be reachable cross-org.
   const membership = await loadReviewMembership(approverUserId, row.org_id);
-  const canReview = options.internal || (
+  const humanCanReview = membership !== null && (
+    actionRequesterId(row) === approverUserId
+    || membership.role === 'owner'
+    || membership.role === 'admin'
+  );
+  const canReview = row.action === APP_RUN_APPROVAL_ACTION
+    ? !options.internal && humanCanReview
+    : options.internal || (
     membership !== null && (
       actionRequesterId(row) === approverUserId ||
       membership.role === 'owner' ||
@@ -769,6 +784,10 @@ async function approveActionLocked(
       code: 'FORBIDDEN',
       message: 'only the requester or an org owner/admin may approve this action',
     };
+  }
+
+  if (row.action === APP_RUN_APPROVAL_ACTION) {
+    return postgresAppRunApprovalResolver.approve(actionId, approverUserId);
   }
 
   const resumesApprovedModule = isModuleMutation
@@ -1224,6 +1243,10 @@ async function rejectActionOnce(
       code: 'FORBIDDEN',
       message: 'only the requester or an org owner/admin may reject this action',
     };
+  }
+
+  if (row.action === APP_RUN_APPROVAL_ACTION) {
+    return postgresAppRunApprovalResolver.reject(actionId, rejecterUserId);
   }
 
   if (row.approval_status === 'rejected') {

--- a/apps/api/src/lib/app-run-approval-adapter.ts
+++ b/apps/api/src/lib/app-run-approval-adapter.ts
@@ -1,0 +1,251 @@
+import {
+  APP_RUN_CONTRACT_VERSIONS,
+  AppRunSafeOutcomeSchema,
+  type AppRunSubmission,
+} from '@deft/shared';
+import { agentActions, agentEmployees } from '@deft/db/schema';
+import { and, eq, sql } from 'drizzle-orm';
+import { db } from './db.js';
+import { PostgresAppRunLiveAuthorization } from './app-run-live-authorization.js';
+import {
+  PostgresAppRunRepository,
+  type AppRunSafeView,
+  type AppRunTransaction,
+} from './app-run-repository.js';
+
+export const APP_RUN_APPROVAL_ACTION = 'app_run_invoke';
+
+export type AppRunApprovalResolution =
+  | { status: 'approved'; message?: string; result?: unknown }
+  | { status: 'rejected'; message?: string }
+  | { status: 'error'; code: 'NOT_FOUND' | 'INVALID_STATE'; message: string };
+
+export interface AppRunApprovalAdapter {
+  create(input: Readonly<{
+    tx: AppRunTransaction;
+    run: AppRunSafeView;
+    submission: AppRunSubmission;
+    now: Date;
+  }>): Promise<string>;
+}
+
+async function approvalOwnerUserId(
+  tx: AppRunTransaction,
+  submission: AppRunSubmission,
+): Promise<string> {
+  if (submission.initiating_actor.actor_type === 'human') {
+    return submission.initiating_actor.user_id;
+  }
+  if (submission.initiating_actor.actor_type === 'agent_employee') {
+    const [employee] = await tx.select({ user_id: agentEmployees.user_id })
+      .from(agentEmployees)
+      .where(and(
+        eq(agentEmployees.org_id, submission.org_id),
+        eq(agentEmployees.id, submission.initiating_actor.agent_employee_id),
+      )).limit(1);
+    if (employee) return employee.user_id;
+  }
+  throw new Error('APP_RUN_ACCESS_DENIED');
+}
+
+export const postgresAppRunApprovalAdapter = Object.freeze<AppRunApprovalAdapter>({
+  async create({ tx, run, submission, now }) {
+    const actionId = crypto.randomUUID();
+    const userId = await approvalOwnerUserId(tx, submission);
+    const [created] = await tx.insert(agentActions).values({
+      id: actionId,
+      org_id: run.org_id,
+      user_id: userId,
+      agent_employee_id: submission.execution_actor.actor_type === 'agent_employee'
+        ? submission.execution_actor.agent_employee_id
+        : null,
+      source: 'app_run',
+      app_run_id: run.id,
+      action: APP_RUN_APPROVAL_ACTION,
+      params: {
+        run_id: run.id,
+        capability_label: run.operation_name.slice(0, 200),
+        provider_label: run.provider_instance_id.slice(0, 200),
+        resource_ids: submission.safe_preview.resource_refs.map((ref) => ref.resource_id),
+        safe_preview: submission.safe_preview,
+      },
+      approval_tier: 'full',
+      approval_status: 'pending',
+      created_at: now,
+      updated_at: now,
+    }).returning({ id: agentActions.id });
+    if (!created) throw new Error('APP_RUN_ILLEGAL_TRANSITION');
+    return created.id;
+  },
+});
+
+export class PostgresAppRunApprovalResolver {
+  constructor(
+    private readonly repository = new PostgresAppRunRepository(),
+    private readonly liveAuthorization = new PostgresAppRunLiveAuthorization(),
+    private readonly now: () => Date = () => new Date(),
+  ) {}
+
+  async approve(
+    actionId: string,
+    approverUserId: string,
+  ): Promise<AppRunApprovalResolution> {
+    return db.transaction(async (tx) => {
+      const action = await this.#lockAction(tx, actionId);
+      if (!action?.app_run_id || action.action !== APP_RUN_APPROVAL_ACTION) {
+        return { status: 'error', code: 'NOT_FOUND', message: 'App Run approval was not found' };
+      }
+      let run = await this.repository.lockRun(tx, action.org_id, action.app_run_id);
+      if (!run) return { status: 'error', code: 'NOT_FOUND', message: 'App Run approval was not found' };
+
+      if (run.execution_release_kind === 'approved') {
+        await this.#markApproved(tx, action.id, approverUserId, run);
+        return { status: 'approved', message: 'already approved', result: this.#safeResult(run, true) };
+      }
+      if (run.state === 'cancelled') {
+        await this.#markRejected(tx, action.id);
+        return { status: 'rejected', message: 'already rejected' };
+      }
+      if (run.state === 'expired' || run.state === 'failed') {
+        await this.#markExpired(tx, action.id);
+        return { status: 'error', code: 'INVALID_STATE', message: 'App Run approval is no longer valid' };
+      }
+      if (action.approval_status === 'rejected') {
+        return { status: 'rejected', message: 'already rejected' };
+      }
+      if (action.approval_status === 'expired') {
+        return { status: 'error', code: 'INVALID_STATE', message: 'App Run approval is no longer valid' };
+      }
+      if (
+        run.state !== 'pending_approval'
+        || !await this.liveAuthorization.authorizeApprovalInTransaction(tx, run)
+      ) {
+        const now = this.now();
+        await this.#markExpired(tx, action.id);
+        if (run.state === 'pending_approval') {
+          run = await this.repository.transition(tx, {
+            run,
+            state: 'expired',
+            actor: { actor_type: 'human', user_id: approverUserId },
+            now,
+            event_type: 'approval_resolved',
+            error_code: 'APP_RUN_AUTHORIZATION_STALE',
+            safe_outcome: AppRunSafeOutcomeSchema.parse({
+              success: false,
+              provider_call_attempted: false,
+              result_status: 'unavailable',
+              error_code: 'APP_RUN_AUTHORIZATION_STALE',
+            }),
+          });
+        }
+        return { status: 'error', code: 'INVALID_STATE', message: 'App Run authorization changed before approval' };
+      }
+
+      run = await this.repository.recordApprovedExecutionRelease(
+        tx,
+        run,
+        { actor_type: 'human', user_id: approverUserId },
+        this.now(),
+      );
+      await this.#markApproved(tx, action.id, approverUserId, run);
+      return { status: 'approved', result: this.#safeResult(run, true) };
+    });
+  }
+
+  async reject(
+    actionId: string,
+    rejecterUserId: string,
+  ): Promise<AppRunApprovalResolution> {
+    return db.transaction(async (tx) => {
+      const action = await this.#lockAction(tx, actionId);
+      if (!action?.app_run_id || action.action !== APP_RUN_APPROVAL_ACTION) {
+        return { status: 'error', code: 'NOT_FOUND', message: 'App Run approval was not found' };
+      }
+      let run = await this.repository.lockRun(tx, action.org_id, action.app_run_id);
+      if (!run) return { status: 'error', code: 'NOT_FOUND', message: 'App Run approval was not found' };
+
+      if (run.execution_release_kind === 'approved') {
+        await this.#markApproved(tx, action.id, action.approved_by_user_id ?? rejecterUserId, run);
+        return { status: 'approved', message: 'already approved', result: this.#safeResult(run, true) };
+      }
+      if (run.state === 'cancelled' || action.approval_status === 'rejected') {
+        await this.#markRejected(tx, action.id);
+        return { status: 'rejected', message: 'already rejected' };
+      }
+      if (run.state !== 'pending_approval') {
+        await this.#markExpired(tx, action.id);
+        return { status: 'error', code: 'INVALID_STATE', message: 'App Run approval is no longer valid' };
+      }
+
+      const now = this.now();
+      await this.#markRejected(tx, action.id);
+      run = await this.repository.transition(tx, {
+        run,
+        state: 'cancelled',
+        actor: { actor_type: 'human', user_id: rejecterUserId },
+        now,
+        event_type: 'approval_resolved',
+        error_code: 'APP_RUN_APPROVAL_REJECTED',
+        safe_outcome: AppRunSafeOutcomeSchema.parse({
+          success: false,
+          provider_call_attempted: false,
+          result_status: 'unavailable',
+          error_code: 'APP_RUN_APPROVAL_REJECTED',
+        }),
+      });
+      return { status: 'rejected' };
+    });
+  }
+
+  async #lockAction(tx: AppRunTransaction, actionId: string) {
+    await tx.execute(sql`SELECT id FROM agent_actions WHERE id = ${actionId} FOR UPDATE`);
+    const [action] = await tx.select().from(agentActions)
+      .where(eq(agentActions.id, actionId)).limit(1);
+    return action ?? null;
+  }
+
+  async #markApproved(
+    tx: AppRunTransaction,
+    actionId: string,
+    approverUserId: string,
+    run: AppRunSafeView,
+  ): Promise<void> {
+    await tx.update(agentActions).set({
+      approval_status: 'approved',
+      approved_at: this.now(),
+      approved_by_user_id: approverUserId,
+      result: this.#safeResult(run, true),
+      error: null,
+      updated_at: this.now(),
+    }).where(eq(agentActions.id, actionId));
+  }
+
+  async #markRejected(tx: AppRunTransaction, actionId: string): Promise<void> {
+    await tx.update(agentActions).set({
+      approval_status: 'rejected',
+      result: null,
+      error: 'App Run approval rejected',
+      updated_at: this.now(),
+    }).where(eq(agentActions.id, actionId));
+  }
+
+  async #markExpired(tx: AppRunTransaction, actionId: string): Promise<void> {
+    await tx.update(agentActions).set({
+      approval_status: 'expired',
+      result: null,
+      error: 'App Run authorization changed before approval',
+      updated_at: this.now(),
+    }).where(eq(agentActions.id, actionId));
+  }
+
+  #safeResult(run: AppRunSafeView, released: boolean): Record<string, unknown> {
+    return {
+      schema_version: APP_RUN_CONTRACT_VERSIONS.run,
+      run_id: run.id,
+      run_state: run.state,
+      execution_released: released,
+    };
+  }
+}
+
+export const postgresAppRunApprovalResolver = new PostgresAppRunApprovalResolver();

--- a/apps/api/src/lib/app-run-approval-adapter.ts
+++ b/apps/api/src/lib/app-run-approval-adapter.ts
@@ -12,6 +12,14 @@ import {
   type AppRunSafeView,
   type AppRunTransaction,
 } from './app-run-repository.js';
+import {
+  noOpAppRunReceiptWriter,
+  type AppRunReceiptWriter,
+} from './app-run-receipts.js';
+import {
+  noOpAppRunAttentionProjector,
+  type AppRunAttentionProjector,
+} from './app-run-attention.js';
 
 export const APP_RUN_APPROVAL_ACTION = 'app_run_invoke';
 
@@ -28,6 +36,11 @@ export interface AppRunApprovalAdapter {
     now: Date;
   }>): Promise<string>;
 }
+
+type AppRunApprovalLiveAuthorization = Pick<
+  PostgresAppRunLiveAuthorization,
+  'authorizeApprovalInTransaction'
+>;
 
 async function approvalOwnerUserId(
   tx: AppRunTransaction,
@@ -82,15 +95,17 @@ export const postgresAppRunApprovalAdapter = Object.freeze<AppRunApprovalAdapter
 export class PostgresAppRunApprovalResolver {
   constructor(
     private readonly repository = new PostgresAppRunRepository(),
-    private readonly liveAuthorization = new PostgresAppRunLiveAuthorization(),
+    private readonly liveAuthorization: AppRunApprovalLiveAuthorization = new PostgresAppRunLiveAuthorization(),
     private readonly now: () => Date = () => new Date(),
+    private readonly receiptWriter: AppRunReceiptWriter = noOpAppRunReceiptWriter,
+    private readonly attention: AppRunAttentionProjector = noOpAppRunAttentionProjector,
   ) {}
 
   async approve(
     actionId: string,
     approverUserId: string,
   ): Promise<AppRunApprovalResolution> {
-    return db.transaction(async (tx) => {
+    const result = await db.transaction(async (tx): Promise<AppRunApprovalResolution> => {
       const action = await this.#lockAction(tx, actionId);
       if (!action?.app_run_id || action.action !== APP_RUN_APPROVAL_ACTION) {
         return { status: 'error', code: 'NOT_FOUND', message: 'App Run approval was not found' };
@@ -100,6 +115,14 @@ export class PostgresAppRunApprovalResolver {
 
       if (run.execution_release_kind === 'approved') {
         await this.#markApproved(tx, action.id, approverUserId, run);
+        await this.#writeApprovalReceipt(
+          tx,
+          action.id,
+          run,
+          { actor_type: 'human', user_id: action.approved_by_user_id ?? approverUserId },
+          'approved',
+          run.execution_released_at ?? this.now(),
+        );
         return { status: 'approved', message: 'already approved', result: this.#safeResult(run, true) };
       }
       if (run.state === 'cancelled') {
@@ -137,6 +160,14 @@ export class PostgresAppRunApprovalResolver {
               error_code: 'APP_RUN_AUTHORIZATION_STALE',
             }),
           });
+          await this.#writeApprovalReceipt(
+            tx,
+            action.id,
+            run,
+            { actor_type: 'human', user_id: approverUserId },
+            'expired',
+            run.terminal_at ?? now,
+          );
         }
         return { status: 'error', code: 'INVALID_STATE', message: 'App Run authorization changed before approval' };
       }
@@ -148,15 +179,25 @@ export class PostgresAppRunApprovalResolver {
         this.now(),
       );
       await this.#markApproved(tx, action.id, approverUserId, run);
+      await this.#writeApprovalReceipt(
+        tx,
+        action.id,
+        run,
+        { actor_type: 'human', user_id: approverUserId },
+        'approved',
+        run.execution_released_at ?? this.now(),
+      );
       return { status: 'approved', result: this.#safeResult(run, true) };
     });
+    await this.#resolveApprovalAttention(actionId, approverUserId);
+    return result;
   }
 
   async reject(
     actionId: string,
     rejecterUserId: string,
   ): Promise<AppRunApprovalResolution> {
-    return db.transaction(async (tx) => {
+    const result = await db.transaction(async (tx): Promise<AppRunApprovalResolution> => {
       const action = await this.#lockAction(tx, actionId);
       if (!action?.app_run_id || action.action !== APP_RUN_APPROVAL_ACTION) {
         return { status: 'error', code: 'NOT_FOUND', message: 'App Run approval was not found' };
@@ -193,8 +234,18 @@ export class PostgresAppRunApprovalResolver {
           error_code: 'APP_RUN_APPROVAL_REJECTED',
         }),
       });
+      await this.#writeApprovalReceipt(
+        tx,
+        action.id,
+        run,
+        { actor_type: 'human', user_id: rejecterUserId },
+        'rejected',
+        run.terminal_at ?? now,
+      );
       return { status: 'rejected' };
     });
+    await this.#resolveApprovalAttention(actionId, rejecterUserId);
+    return result;
   }
 
   async #lockAction(tx: AppRunTransaction, actionId: string) {
@@ -245,6 +296,43 @@ export class PostgresAppRunApprovalResolver {
       run_state: run.state,
       execution_released: released,
     };
+  }
+
+  async #writeApprovalReceipt(
+    tx: AppRunTransaction,
+    actionId: string,
+    run: AppRunSafeView,
+    actor: Readonly<{ actor_type: 'human'; user_id: string }>,
+    decision: 'approved' | 'rejected' | 'expired',
+    occurredAt: Date,
+  ): Promise<void> {
+    await this.receiptWriter.write(tx, {
+      receipt_key: `approval:${actionId}`,
+      receipt_kind: 'approval',
+      run,
+      actor,
+      facts: { decision, action_id: actionId },
+      occurred_at: occurredAt,
+    });
+  }
+
+  async #resolveApprovalAttention(actionId: string, actorUserId: string): Promise<void> {
+    try {
+      const [action] = await db.select({
+        org_id: agentActions.org_id,
+        approval_status: agentActions.approval_status,
+      }).from(agentActions).where(eq(agentActions.id, actionId)).limit(1);
+      if (!action || action.approval_status === 'pending') return;
+      await this.attention.resolveApproval(
+        action.org_id,
+        actionId,
+        actorUserId,
+        action.approval_status,
+      );
+    } catch (error) {
+      console.warn('[app-runs] approval Attention resolution failed:',
+        error instanceof Error ? error.message : 'unknown error');
+    }
   }
 }
 

--- a/apps/api/src/lib/app-run-attempt-runner.ts
+++ b/apps/api/src/lib/app-run-attempt-runner.ts
@@ -1,13 +1,20 @@
 import { createHash } from 'node:crypto';
+import { setTimeout as delay } from 'node:timers/promises';
 import { and, asc, desc, eq, inArray, lte, sql } from 'drizzle-orm';
 import { appRunAttempts } from '@deft/db/schema';
 import {
+  APP_RUN_CONTRACT_VERSIONS,
+  AppRunRetainedProviderResultSchema,
   AppRunSafeOutcomeSchema,
   assertAppRunOutputWithinBudget,
   classifyAppRunCrashRecovery,
   type AppRunSafeOutcome,
 } from '@deft/shared';
 import { db } from './db.js';
+import {
+  denyAllAppRunExecutionAuthorizer,
+  type AppRunExecutionAuthorizer,
+} from './app-run-authorization.js';
 import { AppRunError } from './app-run-errors.js';
 import type { AppRunProviderExecutor, AppRunProviderExecutionResult } from './app-run-provider-executor.js';
 import { PostgresAppRunRepository, type AppRunSafeView, type AppRunTransaction } from './app-run-repository.js';
@@ -36,13 +43,21 @@ export class AppRunAttemptRunner {
     private readonly secretRepository: AppRunSecretRepository,
     private readonly secrets: AppRunSecretService,
     private readonly executor: AppRunProviderExecutor,
+    private readonly executionAuthorizer: AppRunExecutionAuthorizer = denyAllAppRunExecutionAuthorizer,
     private readonly now: () => Date = () => new Date(),
     private readonly leaseMs = 60_000,
+    private readonly heartbeatIntervalMs = Math.max(250, Math.floor(boundedLeaseMs(leaseMs) / 3)),
   ) {}
 
-  async run(orgId: string, runId: string, workerId: string, signal?: AbortSignal): Promise<AppRunSafeView> {
-    await this.recoverRun(orgId, runId);
-    const claimed = await this.#claim(orgId, runId, workerId);
+  async run(
+    orgId: string,
+    runId: string,
+    attemptId: string,
+    workerId: string,
+    signal?: AbortSignal,
+  ): Promise<AppRunSafeView> {
+    await this.recoverRun(orgId, runId, attemptId);
+    const claimed = await this.#claim(orgId, runId, attemptId, workerId);
     if (!claimed) return this.repository.inspect(orgId, runId).then((run) => {
       if (!run) throw new AppRunError('APP_RUN_ACCESS_DENIED');
       return run;
@@ -59,6 +74,7 @@ export class AppRunAttemptRunner {
     const stableProviderKey = claimed.run.retry_class === 'idempotent_with_key'
       ? providerIdempotencyKey(runId)
       : undefined;
+    const stopHeartbeat = this.#startLeaseHeartbeat(claimed);
     let result: AppRunProviderExecutionResult;
     try {
       result = await this.executor.execute({
@@ -72,17 +88,52 @@ export class AppRunAttemptRunner {
       });
     } catch {
       result = { status: 'indeterminate' };
+    } finally {
+      await stopHeartbeat();
     }
 
     if (result.status === 'indeterminate') {
-      await this.#settleIndeterminate(orgId, runId, claimed.attempt.id);
+      await this.#settleIndeterminate(
+        orgId,
+        runId,
+        claimed.attempt.id,
+        claimed.attempt.claim_token!,
+      );
       return this.repository.inspect(orgId, runId).then((run) => run!);
     }
 
     const known = await this.#knownOutcome(claimed.run, result);
-    await this.#persistKnownResult(orgId, runId, claimed.attempt.id, result, known);
-    await this.#finalizeKnownResult(orgId, runId, claimed.attempt.id);
+    await this.#persistKnownResult(
+      orgId,
+      runId,
+      claimed.attempt.id,
+      claimed.attempt.claim_token!,
+      result,
+      known,
+    );
+    await this.#finalizeKnownResult(orgId, runId, claimed.attempt.id, claimed.attempt.claim_token!);
     return this.repository.inspect(orgId, runId).then((run) => run!);
+  }
+
+  async prepareAttempt(orgId: string, runId: string): Promise<string | null> {
+    const now = this.now();
+    return this.repository.transaction(async (tx) => {
+      const run = await this.repository.lockRun(tx, orgId, runId);
+      if (
+        !run
+        || !run.execution_released_at
+        || ['succeeded', 'failed', 'cancelled', 'expired', 'unknown_outcome'].includes(run.state)
+        || !await this.executionAuthorizer.authorizeExecution({ org_id: orgId, run })
+      ) return null;
+      if (run.input_expires_at <= now) return null;
+      const [existing] = await tx.select({ id: appRunAttempts.id }).from(appRunAttempts).where(and(
+        eq(appRunAttempts.org_id, orgId),
+        eq(appRunAttempts.run_id, runId),
+        inArray(appRunAttempts.state, ['pending', 'claimed', 'provider_call_started']),
+      )).orderBy(asc(appRunAttempts.attempt_number)).limit(1);
+      if (existing) return existing.id;
+      return (await this.#createAttempt(tx, run, now))?.id ?? null;
+    });
   }
 
   async renewLease(orgId: string, attemptId: string, claimToken: string): Promise<boolean> {
@@ -117,6 +168,38 @@ export class AppRunAttemptRunner {
     });
   }
 
+  #startLeaseHeartbeat(claimed: ClaimedAttempt): () => Promise<void> {
+    const controller = new AbortController();
+    const task = (async () => {
+      while (!controller.signal.aborted) {
+        try {
+          await delay(Math.max(1, this.heartbeatIntervalMs), undefined, { signal: controller.signal });
+        } catch (error) {
+          if (controller.signal.aborted) return;
+          throw error;
+        }
+        let renewed = false;
+        try {
+          renewed = await this.renewLease(
+            claimed.run.org_id,
+            claimed.attempt.id,
+            claimed.attempt.claim_token!,
+          );
+        } catch {
+          return;
+        }
+        if (!renewed) return;
+      }
+    })();
+    let stopped = false;
+    return async () => {
+      if (stopped) return;
+      stopped = true;
+      controller.abort();
+      await task;
+    };
+  }
+
   async recoverStale(limit = 100): Promise<number> {
     const now = this.now();
     const rows = await db.select({
@@ -131,7 +214,7 @@ export class AppRunAttemptRunner {
     return recovered;
   }
 
-  async recoverRun(orgId: string, runId: string): Promise<number> {
+  async recoverRun(orgId: string, runId: string, attemptId?: string): Promise<number> {
     const now = this.now();
     return this.repository.transaction(async (tx) => {
       const run = await this.repository.lockRun(tx, orgId, runId);
@@ -139,6 +222,7 @@ export class AppRunAttemptRunner {
       const [attempt] = await tx.select().from(appRunAttempts).where(and(
         eq(appRunAttempts.org_id, orgId),
         eq(appRunAttempts.run_id, runId),
+        ...(attemptId ? [eq(appRunAttempts.id, attemptId)] : []),
         inArray(appRunAttempts.state, ['claimed', 'provider_call_started']),
         lte(appRunAttempts.lease_expires_at, now),
       )).orderBy(asc(appRunAttempts.attempt_number)).limit(1);
@@ -153,11 +237,21 @@ export class AppRunAttemptRunner {
     });
   }
 
-  async #claim(orgId: string, runId: string, workerId: string): Promise<ClaimedAttempt | null> {
+  async #claim(
+    orgId: string,
+    runId: string,
+    attemptId: string,
+    workerId: string,
+  ): Promise<ClaimedAttempt | null> {
     const now = this.now();
     return this.repository.transaction(async (tx) => {
       let run = await this.repository.lockRun(tx, orgId, runId);
-      if (!run || ['succeeded', 'failed', 'cancelled', 'expired', 'unknown_outcome'].includes(run.state)) return null;
+      if (
+        !run
+        || !run.execution_released_at
+        || ['succeeded', 'failed', 'cancelled', 'expired', 'unknown_outcome'].includes(run.state)
+        || !await this.executionAuthorizer.authorizeExecution({ org_id: orgId, run })
+      ) return null;
       if (run.input_expires_at <= now) {
         run = await this.repository.transition(tx, {
           run, state: 'expired', now, error_code: 'APP_RUN_EXPIRED',
@@ -168,13 +262,11 @@ export class AppRunAttemptRunner {
         });
         return null;
       }
-      const [existingAttempt] = await tx.select().from(appRunAttempts).where(and(
+      const [attempt] = await tx.select().from(appRunAttempts).where(and(
         eq(appRunAttempts.org_id, orgId),
         eq(appRunAttempts.run_id, runId),
-        inArray(appRunAttempts.state, ['pending', 'claimed', 'provider_call_started']),
-      )).orderBy(asc(appRunAttempts.attempt_number)).limit(1);
-      let attempt: typeof appRunAttempts.$inferSelect | null | undefined = existingAttempt;
-      if (!attempt) attempt = await this.#createAttempt(tx, run, now);
+        eq(appRunAttempts.id, attemptId),
+      )).limit(1);
       if (!attempt || attempt.state !== 'pending') return null;
       const claimToken = crypto.randomUUID();
       const [claimed] = await tx.update(appRunAttempts).set({
@@ -235,7 +327,12 @@ export class AppRunAttemptRunner {
     const now = this.now();
     return this.repository.transaction(async (tx) => {
       let run = await this.repository.lockRun(tx, claimed.run.org_id, claimed.run.id);
-      if (!run || run.state === 'cancelled') return false;
+      if (
+        !run
+        || !run.execution_released_at
+        || run.state === 'cancelled'
+        || !await this.executionAuthorizer.authorizeExecution({ org_id: run.org_id, run })
+      ) return false;
       await tx.execute(sql`SELECT id FROM app_run_attempts
         WHERE org_id = ${claimed.run.org_id} AND id = ${claimed.attempt.id} FOR UPDATE`);
       const [current] = await tx.select().from(appRunAttempts).where(and(
@@ -269,24 +366,34 @@ export class AppRunAttemptRunner {
     });
   }
 
-  async #knownOutcome(run: AppRunSafeView, result: Exclude<AppRunProviderExecutionResult, { status: 'indeterminate' }>): Promise<AppRunSafeOutcome> {
-    if (result.status === 'failed') {
+  async #knownOutcome(
+    run: AppRunSafeView,
+    result: Exclude<AppRunProviderExecutionResult, { status: 'indeterminate' }>,
+  ): Promise<AppRunSafeOutcome> {
+    if (result.status === 'not_attempted') {
       return AppRunSafeOutcomeSchema.parse({
-        success: false, provider_call_attempted: true,
-        result_status: 'unavailable', error_code: 'APP_RUN_PROVIDER_ERROR',
+        success: false, provider_call_attempted: false,
+        result_status: 'unavailable',
+        error_code: result.error_code ?? 'APP_RUN_PROVIDER_UNAVAILABLE',
       });
     }
     let retained = run.result_expires_at > this.now();
     if (retained) {
       try {
-        assertAppRunOutputWithinBudget(result.output);
+        const envelope = AppRunRetainedProviderResultSchema.parse({
+          schema_version: APP_RUN_CONTRACT_VERSIONS.provider_result,
+          provider_succeeded: result.provider_succeeded,
+          output: result.output,
+        });
+        assertAppRunOutputWithinBudget(envelope);
       } catch {
         retained = false;
       }
     }
     return AppRunSafeOutcomeSchema.parse({
-      success: true, provider_call_attempted: true,
+      success: result.provider_succeeded, provider_call_attempted: true,
       result_status: retained ? 'retained' : 'unavailable',
+      ...(result.provider_succeeded ? {} : { error_code: 'APP_RUN_PROVIDER_ERROR' }),
     });
   }
 
@@ -294,6 +401,7 @@ export class AppRunAttemptRunner {
     orgId: string,
     runId: string,
     attemptId: string,
+    claimToken: string,
     result: Exclude<AppRunProviderExecutionResult, { status: 'indeterminate' }>,
     outcome: AppRunSafeOutcome,
   ): Promise<void> {
@@ -307,17 +415,30 @@ export class AppRunAttemptRunner {
           const [attempt] = await tx.select().from(appRunAttempts).where(and(
             eq(appRunAttempts.org_id, orgId), eq(appRunAttempts.id, attemptId),
           )).limit(1);
-          if (!attempt || attempt.state !== 'provider_call_started') return;
+          if (
+            !attempt
+            || attempt.state !== 'provider_call_started'
+            || attempt.claim_token !== claimToken
+          ) return;
           if (attempt.provider_call_finished_at && attempt.safe_outcome) return;
-          if (result.status === 'succeeded' && outcome.result_status === 'retained') {
+          if (result.status === 'returned' && outcome.result_status === 'retained') {
+            const envelope = AppRunRetainedProviderResultSchema.parse({
+              schema_version: APP_RUN_CONTRACT_VERSIONS.provider_result,
+              provider_succeeded: result.provider_succeeded,
+              output: result.output,
+            });
             await this.secretRepository.insertOutput(tx, {
               org_id: orgId, run_id: runId, attempt_id: attemptId,
-              value: result.output, expires_at: run.result_expires_at,
+              value: envelope, expires_at: run.result_expires_at,
             });
           }
           await tx.update(appRunAttempts).set({
             provider_call_finished_at: this.now(), safe_outcome: outcome, updated_at: this.now(),
-          }).where(and(eq(appRunAttempts.org_id, orgId), eq(appRunAttempts.id, attemptId)));
+          }).where(and(
+            eq(appRunAttempts.org_id, orgId),
+            eq(appRunAttempts.id, attemptId),
+            eq(appRunAttempts.claim_token, claimToken),
+          ));
         });
         return;
       } catch (error) {
@@ -327,7 +448,12 @@ export class AppRunAttemptRunner {
     throw lastError;
   }
 
-  async #finalizeKnownResult(orgId: string, runId: string, attemptId: string): Promise<void> {
+  async #finalizeKnownResult(
+    orgId: string,
+    runId: string,
+    attemptId: string,
+    claimToken: string,
+  ): Promise<void> {
     await this.repository.transaction(async (tx) => {
       const run = await this.repository.lockRun(tx, orgId, runId);
       if (!run) return;
@@ -335,7 +461,12 @@ export class AppRunAttemptRunner {
       const [attempt] = await tx.select().from(appRunAttempts).where(and(
         eq(appRunAttempts.org_id, orgId), eq(appRunAttempts.id, attemptId),
       )).limit(1);
-      if (!attempt || attempt.state !== 'provider_call_started' || !attempt.safe_outcome) return;
+      if (
+        !attempt
+        || attempt.state !== 'provider_call_started'
+        || attempt.claim_token !== claimToken
+        || !attempt.safe_outcome
+      ) return;
       await this.#finalizeKnownInTransaction(tx, run, attempt, this.now());
     });
   }
@@ -369,7 +500,11 @@ export class AppRunAttemptRunner {
       const run = await this.repository.lockRun(tx, claimed.run.org_id, claimed.run.id);
       if (!run) return;
       await tx.update(appRunAttempts).set({ state: 'failed', error_code: code, updated_at: now })
-        .where(and(eq(appRunAttempts.org_id, run.org_id), eq(appRunAttempts.id, claimed.attempt.id)));
+        .where(and(
+          eq(appRunAttempts.org_id, run.org_id),
+          eq(appRunAttempts.id, claimed.attempt.id),
+          eq(appRunAttempts.claim_token, claimed.attempt.claim_token!),
+        ));
       await this.repository.transition(tx, {
         run, state: 'expired', now, error_code: code,
         safe_outcome: AppRunSafeOutcomeSchema.parse({
@@ -380,7 +515,12 @@ export class AppRunAttemptRunner {
     });
   }
 
-  async #settleIndeterminate(orgId: string, runId: string, attemptId: string): Promise<void> {
+  async #settleIndeterminate(
+    orgId: string,
+    runId: string,
+    attemptId: string,
+    claimToken: string,
+  ): Promise<void> {
     await this.repository.transaction(async (tx) => {
       const run = await this.repository.lockRun(tx, orgId, runId);
       if (!run) return;
@@ -388,7 +528,11 @@ export class AppRunAttemptRunner {
       const [attempt] = await tx.select().from(appRunAttempts).where(and(
         eq(appRunAttempts.org_id, orgId), eq(appRunAttempts.id, attemptId),
       )).limit(1);
-      if (!attempt || attempt.state !== 'provider_call_started') return;
+      if (
+        !attempt
+        || attempt.state !== 'provider_call_started'
+        || attempt.claim_token !== claimToken
+      ) return;
       await this.#recoverUnknownInTransaction(tx, run, attempt, this.now());
     });
   }

--- a/apps/api/src/lib/app-run-attempt-runner.ts
+++ b/apps/api/src/lib/app-run-attempt-runner.ts
@@ -123,7 +123,9 @@ export class AppRunAttemptRunner {
         !run
         || !run.execution_released_at
         || ['succeeded', 'failed', 'cancelled', 'expired', 'unknown_outcome'].includes(run.state)
-        || !await this.executionAuthorizer.authorizeExecution({ org_id: orgId, run })
+        || !await this.executionAuthorizer.authorizeExecution({
+          org_id: orgId, run, tx, stage: 'prepare', now,
+        })
       ) return null;
       if (run.input_expires_at <= now) return null;
       const [existing] = await tx.select({ id: appRunAttempts.id }).from(appRunAttempts).where(and(
@@ -250,7 +252,9 @@ export class AppRunAttemptRunner {
         !run
         || !run.execution_released_at
         || ['succeeded', 'failed', 'cancelled', 'expired', 'unknown_outcome'].includes(run.state)
-        || !await this.executionAuthorizer.authorizeExecution({ org_id: orgId, run })
+        || !await this.executionAuthorizer.authorizeExecution({
+          org_id: orgId, run, tx, stage: 'claim', now,
+        })
       ) return null;
       if (run.input_expires_at <= now) {
         run = await this.repository.transition(tx, {
@@ -331,7 +335,9 @@ export class AppRunAttemptRunner {
         !run
         || !run.execution_released_at
         || run.state === 'cancelled'
-        || !await this.executionAuthorizer.authorizeExecution({ org_id: run.org_id, run })
+        || !await this.executionAuthorizer.authorizeExecution({
+          org_id: run.org_id, run, tx, stage: 'provider_call', now,
+        })
       ) return false;
       await tx.execute(sql`SELECT id FROM app_run_attempts
         WHERE org_id = ${claimed.run.org_id} AND id = ${claimed.attempt.id} FOR UPDATE`);

--- a/apps/api/src/lib/app-run-attempt-runner.ts
+++ b/apps/api/src/lib/app-run-attempt-runner.ts
@@ -18,6 +18,14 @@ import {
 import { AppRunError } from './app-run-errors.js';
 import type { AppRunProviderExecutor, AppRunProviderExecutionResult } from './app-run-provider-executor.js';
 import { PostgresAppRunRepository, type AppRunSafeView, type AppRunTransaction } from './app-run-repository.js';
+import {
+  noOpAppRunReceiptWriter,
+  type AppRunReceiptWriter,
+} from './app-run-receipts.js';
+import {
+  noOpAppRunAttentionProjector,
+  type AppRunAttentionProjector,
+} from './app-run-attention.js';
 import { AppRunSecretRepository } from './app-run-secret-repository.js';
 import type { AppRunSecretService } from './app-run-secrets.js';
 
@@ -47,6 +55,8 @@ export class AppRunAttemptRunner {
     private readonly now: () => Date = () => new Date(),
     private readonly leaseMs = 60_000,
     private readonly heartbeatIntervalMs = Math.max(250, Math.floor(boundedLeaseMs(leaseMs) / 3)),
+    private readonly receiptWriter: AppRunReceiptWriter = noOpAppRunReceiptWriter,
+    private readonly attention: AppRunAttentionProjector = noOpAppRunAttentionProjector,
   ) {}
 
   async run(
@@ -66,7 +76,9 @@ export class AppRunAttemptRunner {
     const input = await this.secretRepository.readInput(orgId, runId);
     if (input === null) {
       await this.#settleBeforeCallFailure(claimed, 'APP_RUN_EXPIRED');
-      return this.repository.inspect(orgId, runId).then((run) => run!);
+      const settled = await this.repository.inspect(orgId, runId).then((run) => run!);
+      await this.#projectState(settled);
+      return settled;
     }
     const boundaryCommitted = await this.#markProviderCallStarted(claimed);
     if (!boundaryCommitted) return this.repository.inspect(orgId, runId).then((run) => run!);
@@ -99,7 +111,9 @@ export class AppRunAttemptRunner {
         claimed.attempt.id,
         claimed.attempt.claim_token!,
       );
-      return this.repository.inspect(orgId, runId).then((run) => run!);
+      const settled = await this.repository.inspect(orgId, runId).then((run) => run!);
+      await this.#projectState(settled);
+      return settled;
     }
 
     const known = await this.#knownOutcome(claimed.run, result);
@@ -112,7 +126,9 @@ export class AppRunAttemptRunner {
       known,
     );
     await this.#finalizeKnownResult(orgId, runId, claimed.attempt.id, claimed.attempt.claim_token!);
-    return this.repository.inspect(orgId, runId).then((run) => run!);
+    const settled = await this.repository.inspect(orgId, runId).then((run) => run!);
+    await this.#projectState(settled);
+    return settled;
   }
 
   async prepareAttempt(orgId: string, runId: string): Promise<string | null> {
@@ -218,7 +234,7 @@ export class AppRunAttemptRunner {
 
   async recoverRun(orgId: string, runId: string, attemptId?: string): Promise<number> {
     const now = this.now();
-    return this.repository.transaction(async (tx) => {
+    const recovered = await this.repository.transaction(async (tx) => {
       const run = await this.repository.lockRun(tx, orgId, runId);
       if (!run) return 0;
       const [attempt] = await tx.select().from(appRunAttempts).where(and(
@@ -237,6 +253,11 @@ export class AppRunAttemptRunner {
       await this.#recoverUnknownInTransaction(tx, run, attempt, now);
       return 1;
     });
+    if (recovered > 0) {
+      const run = await this.repository.inspect(orgId, runId);
+      if (run) await this.#projectState(run);
+    }
+    return recovered;
   }
 
   async #claim(
@@ -494,10 +515,11 @@ export class AppRunAttemptRunner {
       id: crypto.randomUUID(), org_id: run.org_id, run_id: run.id,
       event_type: 'attempt_terminal', payload: { attempt_id: attempt.id, state: attemptState }, now,
     });
-    await this.repository.transition(tx, {
+    const terminalRun = await this.repository.transition(tx, {
       run, state: outcome.success ? 'succeeded' : 'failed', safe_outcome: outcome,
       error_code: outcome.error_code, now,
     });
+    await this.#writeAttemptReceipt(tx, terminalRun, attempt.id, attemptState, now, outcome.error_code);
   }
 
   async #settleBeforeCallFailure(claimed: ClaimedAttempt, code: 'APP_RUN_EXPIRED'): Promise<void> {
@@ -511,13 +533,29 @@ export class AppRunAttemptRunner {
           eq(appRunAttempts.id, claimed.attempt.id),
           eq(appRunAttempts.claim_token, claimed.attempt.claim_token!),
         ));
-      await this.repository.transition(tx, {
+      await this.repository.appendEvent(tx, {
+        id: crypto.randomUUID(),
+        org_id: run.org_id,
+        run_id: run.id,
+        event_type: 'attempt_terminal',
+        payload: { attempt_id: claimed.attempt.id, state: 'failed' },
+        now,
+      });
+      const terminalRun = await this.repository.transition(tx, {
         run, state: 'expired', now, error_code: code,
         safe_outcome: AppRunSafeOutcomeSchema.parse({
           success: false, provider_call_attempted: false,
           result_status: 'unavailable', error_code: code,
         }),
       });
+      await this.#writeAttemptReceipt(
+        tx,
+        terminalRun,
+        claimed.attempt.id,
+        'failed',
+        now,
+        code,
+      );
     });
   }
 
@@ -570,19 +608,38 @@ export class AppRunAttemptRunner {
     });
     if (decision === 'create_retry_attempt' && attempt.attempt_number < run.attempt_limit && run.input_expires_at > now) {
       await this.#createAttempt(tx, run, now);
+      await this.#writeAttemptReceipt(
+        tx,
+        run,
+        attempt.id,
+        terminalAttemptState,
+        now,
+        terminalAttemptState === 'unknown_outcome'
+          ? 'APP_RUN_UNKNOWN_OUTCOME'
+          : 'APP_RUN_PROVIDER_UNAVAILABLE',
+        true,
+      );
       return;
     }
     if (attempt.state === 'claimed') {
-      await this.repository.transition(tx, {
+      const terminalRun = await this.repository.transition(tx, {
         run, state: 'failed', now, error_code: 'APP_RUN_PROVIDER_UNAVAILABLE',
         safe_outcome: AppRunSafeOutcomeSchema.parse({
           success: false, provider_call_attempted: false,
           result_status: 'unavailable', error_code: 'APP_RUN_PROVIDER_UNAVAILABLE',
         }),
       });
+      await this.#writeAttemptReceipt(
+        tx,
+        terminalRun,
+        attempt.id,
+        terminalAttemptState,
+        now,
+        'APP_RUN_PROVIDER_UNAVAILABLE',
+      );
       return;
     }
-    await this.repository.transition(tx, {
+    const terminalRun = await this.repository.transition(tx, {
       run, state: 'unknown_outcome', now, error_code: 'APP_RUN_UNKNOWN_OUTCOME',
       safe_outcome: AppRunSafeOutcomeSchema.parse({
         success: false,
@@ -591,5 +648,51 @@ export class AppRunAttemptRunner {
         error_code: 'APP_RUN_UNKNOWN_OUTCOME',
       }),
     });
+    await this.#writeAttemptReceipt(
+      tx,
+      terminalRun,
+      attempt.id,
+      terminalAttemptState,
+      now,
+      'APP_RUN_UNKNOWN_OUTCOME',
+    );
+  }
+
+  async #writeAttemptReceipt(
+    tx: AppRunTransaction,
+    run: AppRunSafeView,
+    attemptId: string,
+    attemptState: 'succeeded' | 'failed' | 'cancelled' | 'unknown_outcome',
+    occurredAt: Date,
+    errorCode?: string,
+    retryScheduled = false,
+  ): Promise<void> {
+    await this.receiptWriter.write(tx, {
+      receipt_key: `attempt-terminal:${attemptId}`,
+      receipt_kind: 'attempt_terminal',
+      run,
+      attempt_id: attemptId,
+      facts: {
+        attempt_state: attemptState,
+        retry_scheduled: retryScheduled,
+        ...(errorCode ? { error_code: errorCode } : {}),
+      },
+      occurred_at: occurredAt,
+    });
+  }
+
+  async #projectState(run: AppRunSafeView): Promise<void> {
+    const kind = run.state === 'unknown_outcome'
+      ? 'unknown_outcome' as const
+      : run.state === 'failed'
+        ? 'failure' as const
+        : null;
+    if (!kind) return;
+    try {
+      await this.attention.projectRunState(run, kind);
+    } catch (error) {
+      console.warn('[app-runs] terminal Attention projection failed:',
+        error instanceof Error ? error.message : 'unknown error');
+    }
   }
 }

--- a/apps/api/src/lib/app-run-attention.ts
+++ b/apps/api/src/lib/app-run-attention.ts
@@ -1,0 +1,143 @@
+import { agentActions, agentEmployees } from '@deft/db/schema';
+import { and, eq } from 'drizzle-orm';
+import {
+  resolveAttentionBySource,
+  syncApprovalToAttention,
+  upsertAttentionItem,
+} from './attention.js';
+import { db } from './db.js';
+import type { AppRunSafeView } from './app-run-repository.js';
+
+export type AppRunAttentionKind = 'failure' | 'unknown_outcome' | 'repair_gap' | 'reconciled';
+
+export interface AppRunAttentionProjector {
+  projectApprovalRequested(orgId: string, runId: string): Promise<void>;
+  resolveApproval(orgId: string, actionId: string, actorUserId: string, resolution: string): Promise<void>;
+  resolveRun(orgId: string, runId: string, actorUserId: string, resolution: string): Promise<void>;
+  projectRunState(run: AppRunSafeView, kind: AppRunAttentionKind): Promise<void>;
+}
+
+export const noOpAppRunAttentionProjector: AppRunAttentionProjector = Object.freeze({
+  async projectApprovalRequested() {},
+  async resolveApproval() {},
+  async resolveRun() {},
+  async projectRunState() {},
+});
+
+export class PostgresAppRunAttentionProjector implements AppRunAttentionProjector {
+  constructor(private readonly deliver = true) {}
+
+  async projectApprovalRequested(orgId: string, runId: string): Promise<void> {
+    const [action] = await db.select().from(agentActions).where(and(
+      eq(agentActions.org_id, orgId),
+      eq(agentActions.app_run_id, runId),
+      eq(agentActions.action, 'app_run_invoke'),
+    )).limit(1);
+    if (action) await syncApprovalToAttention(action, { deliver: this.deliver });
+  }
+
+  async resolveApproval(
+    orgId: string,
+    actionId: string,
+    actorUserId: string,
+    resolution: string,
+  ): Promise<void> {
+    await resolveAttentionBySource({
+      orgId,
+      sourceType: 'agent_action',
+      sourceId: actionId,
+      resolution,
+      actorUserId,
+    });
+  }
+
+  async resolveRun(
+    orgId: string,
+    runId: string,
+    actorUserId: string,
+    resolution: string,
+  ): Promise<void> {
+    await resolveAttentionBySource({
+      orgId,
+      sourceType: 'app_run',
+      sourceId: runId,
+      resolution,
+      actorUserId,
+    });
+  }
+
+  async projectRunState(run: AppRunSafeView, kind: AppRunAttentionKind): Promise<void> {
+    const userId = await this.#recipientUserId(run);
+    if (!userId) return;
+    if (kind === 'reconciled') {
+      await this.resolveRun(run.org_id, run.id, userId, 'reconciled');
+    }
+    const occurredAt = kind === 'unknown_outcome'
+      ? run.unknown_outcome_at
+      : kind === 'reconciled'
+        ? run.reconciled_at
+        : run.terminal_at;
+    const presentation = kind === 'unknown_outcome'
+      ? {
+          lane: 'needs_you' as const,
+          priority: 'critical' as const,
+          title: 'App Run outcome needs review',
+          body: `${run.operation_name} may have reached its provider; do not retry it blindly.`,
+        }
+      : kind === 'repair_gap'
+        ? {
+            lane: 'needs_you' as const,
+            priority: 'critical' as const,
+            title: 'App Run ledger needs repair',
+            body: `${run.operation_name} is missing a required audit projection.`,
+          }
+        : kind === 'failure'
+          ? {
+              lane: 'needs_you' as const,
+              priority: 'high' as const,
+              title: 'App Run failed',
+              body: `${run.operation_name} did not complete successfully.`,
+            }
+          : {
+              lane: 'updates' as const,
+              priority: 'normal' as const,
+              title: 'App Run outcome reconciled',
+              body: `${run.operation_name} now has an operator-recorded outcome.`,
+            };
+    await upsertAttentionItem({
+      orgId: run.org_id,
+      userId,
+      kind: `app_run_${kind}`,
+      lane: presentation.lane,
+      priority: presentation.priority,
+      dedupeKey: `app-run:${kind}:${run.id}`,
+      sourceType: 'app_run',
+      sourceId: run.id,
+      sourceEventId: `app-run:${run.id}:${kind}`,
+      title: presentation.title,
+      body: presentation.body,
+      metadata: {
+        run_id: run.id,
+        root_run_id: run.root_run_id,
+        parent_run_id: run.parent_run_id,
+        depth: run.depth,
+        run_state: run.state,
+        provider_kind: run.provider_kind,
+        operation_name: run.operation_name,
+        risk_class: run.risk_class,
+      },
+      occurredAt: occurredAt ?? run.updated_at,
+    }, { deliver: this.deliver });
+  }
+
+  async #recipientUserId(run: AppRunSafeView): Promise<string | null> {
+    if (run.initiating_actor_type === 'human') return run.initiating_actor_id;
+    if (run.initiating_actor_type !== 'agent_employee') return null;
+    const [employee] = await db.select({ user_id: agentEmployees.user_id })
+      .from(agentEmployees).where(and(
+        eq(agentEmployees.org_id, run.org_id),
+        eq(agentEmployees.id, run.initiating_actor_id),
+      )).limit(1);
+    return employee?.user_id ?? null;
+  }
+}

--- a/apps/api/src/lib/app-run-authorization.ts
+++ b/apps/api/src/lib/app-run-authorization.ts
@@ -1,5 +1,5 @@
 import type { AppRunActor } from '@deft/shared';
-import type { AppRunSafeView } from './app-run-repository.js';
+import type { AppRunSafeView, AppRunTransaction } from './app-run-repository.js';
 
 export type AppRunAccessAction = 'inspect' | 'result' | 'cancel' | 'reconcile';
 
@@ -22,6 +22,9 @@ export interface AppRunExecutionAuthorizer {
   authorizeExecution(input: Readonly<{
     org_id: string;
     run: AppRunSafeView;
+    tx: AppRunTransaction;
+    stage: 'prepare' | 'claim' | 'provider_call';
+    now: Date;
   }>): Promise<boolean>;
 }
 

--- a/apps/api/src/lib/app-run-authorization.ts
+++ b/apps/api/src/lib/app-run-authorization.ts
@@ -17,3 +17,16 @@ export const denyAllAppRunAuthorizer: AppRunAuthorizer = Object.freeze({
     return false;
   },
 });
+
+export interface AppRunExecutionAuthorizer {
+  authorizeExecution(input: Readonly<{
+    org_id: string;
+    run: AppRunSafeView;
+  }>): Promise<boolean>;
+}
+
+export const denyAllAppRunExecutionAuthorizer: AppRunExecutionAuthorizer = Object.freeze({
+  async authorizeExecution() {
+    return false;
+  },
+});

--- a/apps/api/src/lib/app-run-errors.ts
+++ b/apps/api/src/lib/app-run-errors.ts
@@ -9,6 +9,7 @@ const SAFE_MESSAGES: Record<AppRunErrorCode, string> = {
   APP_RUN_OUTPUT_TOO_LARGE: 'App Run output exceeds its limit',
   APP_RUN_IDEMPOTENCY_CONFLICT: 'The App Run idempotency key conflicts with an existing Run',
   APP_RUN_ILLEGAL_TRANSITION: 'The App Run state transition is not allowed',
+  APP_RUN_EXECUTION_NOT_RELEASED: 'The App Run is not released for execution',
   APP_RUN_ACCESS_DENIED: 'Access to the App Run is denied',
   APP_RUN_AUTHORIZATION_STALE: 'App Run authorization is no longer current',
   APP_RUN_PROVIDER_UNAVAILABLE: 'The App Run provider is unavailable',

--- a/apps/api/src/lib/app-run-live-authorization.ts
+++ b/apps/api/src/lib/app-run-live-authorization.ts
@@ -1,0 +1,463 @@
+import { createHash } from 'node:crypto';
+import {
+  APP_RUN_CONTRACT_VERSIONS,
+  AppRunAuthorizationSnapshotSchema,
+  CapabilityProviderDiscoverySnapshotSchema,
+  canonicalCapabilityJson,
+  type AppRunActor,
+  type AppRunAuthorizationSnapshot,
+  type AppRunPolicySnapshot,
+} from '@deft/shared';
+import {
+  agentEmployees,
+  appRuns,
+  capabilityProviderSnapshots,
+  mcpConnections,
+  mcpTokens,
+  mcpToolOverrides,
+  oauthAccessTokens,
+  orgMembers,
+} from '@deft/db/schema';
+import { and, eq, isNull, sql } from 'drizzle-orm';
+import { db } from './db.js';
+import type { AppRunExecutionAuthorizer } from './app-run-authorization.js';
+import type {
+  AppRunSafeView,
+  AppRunTransaction,
+} from './app-run-repository.js';
+import { canonicalMcpToolName, isMcpToolEnabled } from './mcp-runtime.js';
+
+const HOST_POLICY_VERSION = 'deft.app_run.host_policy.v1';
+
+type AuthorityRef = AppRunAuthorizationSnapshot['authority_refs'][number];
+type TokenAuthority = Readonly<{
+  token_kind: 'mcp' | 'oauth';
+  token_id: string;
+}>;
+
+export type AppRunAuthorizationCapture = Readonly<{
+  org_id: string;
+  authenticated_subject: AppRunActor;
+  execution_actor: AppRunActor;
+  provider_instance_id: string;
+  provider_snapshot_id: string;
+  operation_name: string;
+  policy: AppRunPolicySnapshot;
+  token_authorities?: readonly TokenAuthority[];
+}>;
+
+type InternalRunAuthorization = Readonly<{
+  authorization_snapshot: Record<string, unknown>;
+  provider_snapshot_id: string;
+  budget_reserved_at: Date | null;
+  budget_reserved_count: number | null;
+  budget_limit_at_reservation: number | null;
+}>;
+
+function authorityVersion(domain: string, value: unknown): string {
+  return `sha256:${createHash('sha256')
+    .update(`deft.app_run.authority.v1\0${domain}\0`)
+    .update(canonicalCapabilityJson(value))
+    .digest('hex')}`;
+}
+
+function actorIdentity(actor: AppRunActor): string {
+  switch (actor.actor_type) {
+    case 'human': return actor.user_id;
+    case 'agent_employee': return actor.agent_employee_id;
+    case 'system': return actor.system_id;
+    case 'automation': return actor.automation_id;
+  }
+}
+
+function runActor(type: AppRunSafeView['execution_actor_type'], id: string): AppRunActor {
+  switch (type) {
+    case 'human': return { actor_type: 'human', user_id: id };
+    case 'agent_employee': return { actor_type: 'agent_employee', agent_employee_id: id };
+    case 'system': return { actor_type: 'system', system_id: id };
+    case 'automation': return { actor_type: 'automation', automation_id: id };
+  }
+}
+
+function sameAuthorityRefs(
+  left: readonly AuthorityRef[],
+  right: readonly AuthorityRef[],
+): boolean {
+  const encode = (ref: AuthorityRef) => `${ref.authority_kind}\0${ref.authority_id}\0${ref.version}`;
+  if (left.length !== right.length) return false;
+  const expected = new Set(right.map(encode));
+  return left.every((ref) => expected.has(encode(ref)));
+}
+
+/**
+ * Host-owned authorization snapshot builder and live verifier for governed
+ * Runs. Callers receive only opaque versions; live rows remain authoritative.
+ */
+export class PostgresAppRunLiveAuthorization implements AppRunExecutionAuthorizer {
+  async capture(input: AppRunAuthorizationCapture): Promise<AppRunAuthorizationSnapshot> {
+    return db.transaction((tx) => this.#capture(tx, input));
+  }
+
+  async authorizeApproval(input: Readonly<{
+    org_id: string;
+    run: AppRunSafeView;
+  }>): Promise<boolean> {
+    try {
+      return await db.transaction(async (tx) => {
+        const internal = await this.#loadInternalRun(tx, input.org_id, input.run.id);
+        return internal !== null && await this.#matchesLiveState(tx, input.run, internal);
+      });
+    } catch {
+      return false;
+    }
+  }
+
+  async authorizeExecution(input: Parameters<AppRunExecutionAuthorizer['authorizeExecution']>[0]): Promise<boolean> {
+    try {
+      if (input.org_id !== input.run.org_id) return false;
+      const internal = await this.#loadInternalRun(input.tx, input.org_id, input.run.id);
+      if (!internal || !await this.#matchesLiveState(input.tx, input.run, internal)) return false;
+
+      if (input.run.execution_actor_type !== 'agent_employee') {
+        return internal.budget_reserved_at === null
+          && internal.budget_reserved_count === null
+          && internal.budget_limit_at_reservation === null;
+      }
+
+      if (input.stage !== 'prepare') {
+        return internal.budget_reserved_at !== null
+          && internal.budget_reserved_count === 1
+          && internal.budget_limit_at_reservation !== null;
+      }
+      if (internal.budget_reserved_at !== null) {
+        return internal.budget_reserved_count === 1
+          && internal.budget_limit_at_reservation !== null;
+      }
+
+      const [reservation] = await input.tx
+        .update(agentEmployees)
+        .set({ daily_action_count: sql`${agentEmployees.daily_action_count} + 1` })
+        .where(and(
+          eq(agentEmployees.org_id, input.org_id),
+          eq(agentEmployees.id, input.run.execution_actor_id),
+          eq(agentEmployees.is_active, true),
+          eq(agentEmployees.is_deleted, false),
+          eq(agentEmployees.unhealthy, false),
+          sql`${agentEmployees.daily_action_count} < ${agentEmployees.max_daily_actions}`,
+        ))
+        .returning({
+          count: agentEmployees.daily_action_count,
+          limit: agentEmployees.max_daily_actions,
+        });
+      if (!reservation) return false;
+
+      const [recorded] = await input.tx.update(appRuns).set({
+        budget_reserved_at: input.now,
+        budget_reserved_count: 1,
+        budget_limit_at_reservation: reservation.limit,
+        updated_at: input.now,
+      }).where(and(
+        eq(appRuns.org_id, input.org_id),
+        eq(appRuns.id, input.run.id),
+        isNull(appRuns.budget_reserved_at),
+      )).returning({ id: appRuns.id });
+      return Boolean(recorded);
+    } catch {
+      return false;
+    }
+  }
+
+  async #loadInternalRun(
+    tx: AppRunTransaction,
+    orgId: string,
+    runId: string,
+  ): Promise<InternalRunAuthorization | null> {
+    const [row] = await tx.select({
+      authorization_snapshot: appRuns.authorization_snapshot,
+      provider_snapshot_id: appRuns.provider_snapshot_id,
+      budget_reserved_at: appRuns.budget_reserved_at,
+      budget_reserved_count: appRuns.budget_reserved_count,
+      budget_limit_at_reservation: appRuns.budget_limit_at_reservation,
+    }).from(appRuns).where(and(eq(appRuns.org_id, orgId), eq(appRuns.id, runId))).limit(1);
+    return row ?? null;
+  }
+
+  async #matchesLiveState(
+    tx: AppRunTransaction,
+    run: AppRunSafeView,
+    internal: InternalRunAuthorization,
+  ): Promise<boolean> {
+    const stored = AppRunAuthorizationSnapshotSchema.parse(internal.authorization_snapshot);
+    if (
+      stored.authenticated_subject.actor_type !== run.initiating_actor_type
+      || actorIdentity(stored.authenticated_subject) !== run.initiating_actor_id
+    ) return false;
+
+    const tokenAuthorities = stored.authority_refs
+      .filter((ref) => ref.authority_kind === 'token_scope')
+      .map((ref) => ({ token_id: ref.authority_id }));
+    const current = await this.#capture(tx, {
+      org_id: run.org_id,
+      authenticated_subject: stored.authenticated_subject,
+      execution_actor: runActor(run.execution_actor_type, run.execution_actor_id),
+      provider_instance_id: run.provider_instance_id,
+      provider_snapshot_id: internal.provider_snapshot_id,
+      operation_name: run.operation_name,
+      policy: {
+        risk_class: run.risk_class,
+        review_requirement: run.review_requirement,
+        review_scope: run.review_scope,
+        retry_class: run.retry_class,
+      },
+      token_authorities: await Promise.all(tokenAuthorities.map(async ({ token_id }) => ({
+        token_id,
+        token_kind: await this.#tokenKind(tx, run.org_id, token_id),
+      }))),
+    });
+    return sameAuthorityRefs(stored.authority_refs, current.authority_refs);
+  }
+
+  async #capture(
+    tx: AppRunTransaction,
+    input: AppRunAuthorizationCapture,
+  ): Promise<AppRunAuthorizationSnapshot> {
+    const refs = new Map<string, AuthorityRef>();
+    const add = (ref: AuthorityRef): void => {
+      refs.set(`${ref.authority_kind}\0${ref.authority_id}`, ref);
+    };
+
+    const employees = new Map<string, typeof agentEmployees.$inferSelect>();
+    const captureActor = async (actor: AppRunActor, reserveBudgetAuthority: boolean): Promise<void> => {
+      if (actor.actor_type === 'system' || actor.actor_type === 'automation') {
+        throw new Error('APP_RUN_AUTHORIZATION_STALE');
+      }
+      if (actor.actor_type === 'human') {
+        add(await this.#membership(tx, input.org_id, actor.user_id));
+        return;
+      }
+      let employee = employees.get(actor.agent_employee_id);
+      if (!employee) {
+        employee = await this.#employee(tx, input.org_id, actor.agent_employee_id);
+        employees.set(actor.agent_employee_id, employee);
+        add(await this.#membership(tx, input.org_id, employee.user_id));
+        add({
+          authority_kind: 'employee_health',
+          authority_id: employee.id,
+          version: authorityVersion('employee_health', {
+            id: employee.id,
+            authority_version: employee.app_run_authorization_version,
+          }),
+        });
+      }
+      if (reserveBudgetAuthority) {
+        add({
+          authority_kind: 'employee_budget',
+          authority_id: employee.id,
+          version: authorityVersion('employee_budget', {
+            id: employee.id,
+            authority_version: employee.app_run_authorization_version,
+          }),
+        });
+      }
+    };
+
+    await captureActor(input.authenticated_subject, false);
+    await captureActor(input.execution_actor, input.execution_actor.actor_type === 'agent_employee');
+
+    const [connection] = await tx.select().from(mcpConnections).where(and(
+      eq(mcpConnections.org_id, input.org_id),
+      eq(mcpConnections.id, input.provider_instance_id),
+      eq(mcpConnections.is_active, true),
+    )).limit(1);
+    if (!connection || !isMcpToolEnabled(connection.enabled_tools, connection.slug, input.operation_name)) {
+      throw new Error('APP_RUN_AUTHORIZATION_STALE');
+    }
+    const overrideRows = await tx.select().from(mcpToolOverrides).where(and(
+      eq(mcpToolOverrides.org_id, input.org_id),
+      eq(mcpToolOverrides.mcp_connection_id, connection.id),
+    ));
+    const operationOverrides = overrideRows.filter(
+      (row) => canonicalMcpToolName(row.tool_name) === input.operation_name,
+    );
+    if (operationOverrides.some((row) => row.is_disabled)) {
+      throw new Error('APP_RUN_AUTHORIZATION_STALE');
+    }
+    add({
+      authority_kind: 'connector',
+      authority_id: connection.id,
+      version: authorityVersion('connector', {
+        id: connection.id,
+        authority_version: connection.app_run_authorization_version,
+        overrides: operationOverrides
+          .map((row) => ({
+            id: row.id,
+            authority_version: row.app_run_authorization_version,
+          }))
+          .sort((left, right) => left.id.localeCompare(right.id)),
+      }),
+    });
+
+    if (input.execution_actor.actor_type === 'agent_employee') {
+      const employee = employees.get(input.execution_actor.agent_employee_id)!;
+      if (!(employee.mcp_connection_ids ?? []).includes(connection.id)) {
+        throw new Error('APP_RUN_AUTHORIZATION_STALE');
+      }
+      if ((employee.disabled_tools ?? []).some(
+        (name) => canonicalMcpToolName(name) === input.operation_name,
+      )) throw new Error('APP_RUN_AUTHORIZATION_STALE');
+      add({
+        authority_kind: 'assignment',
+        authority_id: `${employee.id}:${connection.id}`,
+        version: authorityVersion('assignment', {
+          employee_id: employee.id,
+          connection_id: connection.id,
+          employee_authority_version: employee.app_run_authorization_version,
+          connector_authority_version: connection.app_run_authorization_version,
+        }),
+      });
+    }
+
+    const [snapshotRow] = await tx.select().from(capabilityProviderSnapshots).where(and(
+      eq(capabilityProviderSnapshots.org_id, input.org_id),
+      eq(capabilityProviderSnapshots.id, input.provider_snapshot_id),
+      eq(capabilityProviderSnapshots.provider_kind, 'mcp'),
+      eq(capabilityProviderSnapshots.provider_instance_id, connection.id),
+    )).limit(1);
+    if (!snapshotRow) throw new Error('APP_RUN_AUTHORIZATION_STALE');
+    const snapshot = CapabilityProviderDiscoverySnapshotSchema.parse(snapshotRow.safe_snapshot);
+    if (
+      snapshot.snapshot_digest !== snapshotRow.snapshot_digest
+      || snapshot.adapter_contract_version !== snapshotRow.adapter_contract_version
+    ) throw new Error('APP_RUN_AUTHORIZATION_STALE');
+    const operation = snapshot.operations.find(
+      (candidate) => candidate.identity.operation_name === input.operation_name,
+    );
+    if (!operation) throw new Error('APP_RUN_AUTHORIZATION_STALE');
+    add({
+      authority_kind: 'provider_schema',
+      authority_id: `${connection.id}:${input.operation_name}`,
+      version: authorityVersion('provider_schema', {
+        snapshot_id: snapshotRow.id,
+        snapshot_digest: snapshotRow.snapshot_digest,
+        adapter_contract_version: snapshotRow.adapter_contract_version,
+        schema_digest: operation.schema_digest,
+      }),
+    });
+    add({
+      authority_kind: 'policy',
+      authority_id: `${connection.id}:${input.operation_name}`,
+      version: authorityVersion('policy', {
+        host_policy_version: HOST_POLICY_VERSION,
+        policy: input.policy,
+      }),
+    });
+
+    for (const token of input.token_authorities ?? []) {
+      add(await this.#tokenAuthority(tx, input, token));
+    }
+
+    return AppRunAuthorizationSnapshotSchema.parse({
+      schema_version: APP_RUN_CONTRACT_VERSIONS.run,
+      authenticated_subject: input.authenticated_subject,
+      authority_refs: [...refs.values()].sort((left, right) => {
+        const leftKey = `${left.authority_kind}\0${left.authority_id}`;
+        const rightKey = `${right.authority_kind}\0${right.authority_id}`;
+        return leftKey < rightKey ? -1 : leftKey > rightKey ? 1 : 0;
+      }),
+    });
+  }
+
+  async #membership(tx: AppRunTransaction, orgId: string, userId: string): Promise<AuthorityRef> {
+    const [membership] = await tx.select().from(orgMembers).where(and(
+      eq(orgMembers.org_id, orgId),
+      eq(orgMembers.user_id, userId),
+      eq(orgMembers.is_active, true),
+    )).limit(1);
+    if (!membership) throw new Error('APP_RUN_AUTHORIZATION_STALE');
+    return {
+      authority_kind: 'membership',
+      authority_id: userId,
+      version: authorityVersion('membership', {
+        id: membership.id,
+        authority_version: membership.app_run_authorization_version,
+      }),
+    };
+  }
+
+  async #employee(tx: AppRunTransaction, orgId: string, employeeId: string) {
+    const [employee] = await tx.select().from(agentEmployees).where(and(
+      eq(agentEmployees.org_id, orgId),
+      eq(agentEmployees.id, employeeId),
+      eq(agentEmployees.is_active, true),
+      eq(agentEmployees.is_deleted, false),
+      eq(agentEmployees.unhealthy, false),
+    )).limit(1);
+    if (!employee) throw new Error('APP_RUN_AUTHORIZATION_STALE');
+    return employee;
+  }
+
+  async #tokenKind(
+    tx: AppRunTransaction,
+    orgId: string,
+    tokenId: string,
+  ): Promise<TokenAuthority['token_kind']> {
+    const [mcp] = await tx.select({ id: mcpTokens.id }).from(mcpTokens).where(and(
+      eq(mcpTokens.org_id, orgId), eq(mcpTokens.id, tokenId),
+    )).limit(1);
+    if (mcp) return 'mcp';
+    const [oauth] = await tx.select({ id: oauthAccessTokens.id }).from(oauthAccessTokens).where(and(
+      eq(oauthAccessTokens.org_id, orgId), eq(oauthAccessTokens.id, tokenId),
+    )).limit(1);
+    if (oauth) return 'oauth';
+    throw new Error('APP_RUN_AUTHORIZATION_STALE');
+  }
+
+  async #tokenAuthority(
+    tx: AppRunTransaction,
+    input: AppRunAuthorizationCapture,
+    token: TokenAuthority,
+  ): Promise<AuthorityRef> {
+    if (token.token_kind === 'mcp') {
+      const [row] = await tx.select().from(mcpTokens).where(and(
+        eq(mcpTokens.org_id, input.org_id),
+        eq(mcpTokens.id, token.token_id),
+        isNull(mcpTokens.revoked_at),
+      )).limit(1);
+      if (!row) throw new Error('APP_RUN_AUTHORIZATION_STALE');
+      const subjectMatches = input.authenticated_subject.actor_type === 'human'
+        ? row.principal_kind === 'human' && row.user_id === input.authenticated_subject.user_id
+        : input.authenticated_subject.actor_type === 'agent_employee'
+          && row.principal_kind === 'agent'
+          && row.agent_employee_id === input.authenticated_subject.agent_employee_id;
+      if (!subjectMatches) throw new Error('APP_RUN_AUTHORIZATION_STALE');
+      return {
+        authority_kind: 'token_scope',
+        authority_id: row.id,
+        version: authorityVersion('mcp_token_scope', {
+          id: row.id,
+          authority_version: row.app_run_authorization_version,
+        }),
+      };
+    }
+
+    if (input.authenticated_subject.actor_type !== 'human') {
+      throw new Error('APP_RUN_AUTHORIZATION_STALE');
+    }
+    const [row] = await tx.select().from(oauthAccessTokens).where(and(
+      eq(oauthAccessTokens.org_id, input.org_id),
+      eq(oauthAccessTokens.id, token.token_id),
+      eq(oauthAccessTokens.user_id, input.authenticated_subject.user_id),
+      isNull(oauthAccessTokens.revoked_at),
+      sql`${oauthAccessTokens.expires_at} > now()`,
+    )).limit(1);
+    if (!row) throw new Error('APP_RUN_AUTHORIZATION_STALE');
+    return {
+      authority_kind: 'token_scope',
+      authority_id: row.id,
+      version: authorityVersion('oauth_token_scope', {
+        id: row.id,
+        authority_version: row.app_run_authorization_version,
+      }),
+    };
+  }
+}

--- a/apps/api/src/lib/app-run-live-authorization.ts
+++ b/apps/api/src/lib/app-run-live-authorization.ts
@@ -112,6 +112,18 @@ export class PostgresAppRunLiveAuthorization implements AppRunExecutionAuthorize
     }
   }
 
+  async authorizeApprovalInTransaction(
+    tx: AppRunTransaction,
+    run: AppRunSafeView,
+  ): Promise<boolean> {
+    try {
+      const internal = await this.#loadInternalRun(tx, run.org_id, run.id);
+      return internal !== null && await this.#matchesLiveState(tx, run, internal);
+    } catch {
+      return false;
+    }
+  }
+
   async authorizeExecution(input: Parameters<AppRunExecutionAuthorizer['authorizeExecution']>[0]): Promise<boolean> {
     try {
       if (input.org_id !== input.run.org_id) return false;

--- a/apps/api/src/lib/app-run-operations.ts
+++ b/apps/api/src/lib/app-run-operations.ts
@@ -1,0 +1,376 @@
+import {
+  agentActions,
+  appRunAttempts,
+  appRunEvents,
+  appRunReceipts,
+  appRuns,
+  attentionItems,
+} from '@deft/db/schema';
+import type { AppRunActor, AppRunState } from '@deft/shared';
+import { and, asc, desc, eq, inArray, or, sql } from 'drizzle-orm';
+import {
+  noOpAppRunAttentionProjector,
+  type AppRunAttentionProjector,
+} from './app-run-attention.js';
+import { AppRunError } from './app-run-errors.js';
+import {
+  PostgresAppRunRepository,
+  safeRunSelection,
+  type AppRunSafeView,
+} from './app-run-repository.js';
+import {
+  noOpAppRunReceiptWriter,
+  type AppRunReceiptWriter,
+} from './app-run-receipts.js';
+import { db } from './db.js';
+
+export type AppRunOperationalAction = 'list' | 'metrics' | 'audit' | 'repair';
+
+export interface AppRunOperationsAuthorizer {
+  authorize(input: Readonly<{
+    action: AppRunOperationalAction;
+    org_id: string;
+    actor: AppRunActor;
+  }>): Promise<boolean>;
+}
+
+export const denyAllAppRunOperationsAuthorizer: AppRunOperationsAuthorizer = Object.freeze({
+  async authorize() { return false; },
+});
+
+export type AppRunRepairGap = Readonly<{
+  run_id: string;
+  gap: 'missing_terminal_event' | 'missing_receipt' | 'missing_attention' | 'missing_approval_action';
+  artifact: 'run' | 'attempt' | 'approval' | 'attention';
+  attempt_id?: string;
+  action_id?: string;
+}>;
+
+export type AppRunOperationalMetric = Readonly<{
+  state: AppRunState;
+  risk_class: AppRunSafeView['risk_class'];
+  provider_kind: AppRunSafeView['provider_kind'];
+  count: number;
+}>;
+
+function boundedLimit(limit: number | undefined): number {
+  return Math.max(1, Math.min(limit ?? 50, 100));
+}
+
+function actorUserId(actor: AppRunActor): string | null {
+  return actor.actor_type === 'human' ? actor.user_id : null;
+}
+
+function payloadAttemptId(payload: Record<string, unknown>): string | null {
+  return typeof payload.attempt_id === 'string' ? payload.attempt_id : null;
+}
+
+function payloadToState(payload: Record<string, unknown>): string | null {
+  return typeof payload.to_state === 'string' ? payload.to_state : null;
+}
+
+export class AppRunOperationsService {
+  constructor(
+    private readonly repository = new PostgresAppRunRepository(),
+    private readonly authorizer: AppRunOperationsAuthorizer = denyAllAppRunOperationsAuthorizer,
+    private readonly receipts: AppRunReceiptWriter = noOpAppRunReceiptWriter,
+    private readonly attention: AppRunAttentionProjector = noOpAppRunAttentionProjector,
+    private readonly now: () => Date = () => new Date(),
+  ) {}
+
+  async list(input: Readonly<{
+    org_id: string;
+    actor: AppRunActor;
+    states?: readonly AppRunState[];
+    limit?: number;
+  }>): Promise<readonly AppRunSafeView[]> {
+    await this.#authorize('list', input.org_id, input.actor);
+    const states = input.states?.length ? [...new Set(input.states)] : null;
+    return db.select(safeRunSelection).from(appRuns).where(and(
+      eq(appRuns.org_id, input.org_id),
+      ...(states ? [inArray(appRuns.state, states)] : []),
+    )).orderBy(desc(appRuns.updated_at), desc(appRuns.id)).limit(boundedLimit(input.limit));
+  }
+
+  async metrics(input: Readonly<{
+    org_id: string;
+    actor: AppRunActor;
+  }>): Promise<readonly AppRunOperationalMetric[]> {
+    await this.#authorize('metrics', input.org_id, input.actor);
+    const rows = await db.select({
+      state: appRuns.state,
+      risk_class: appRuns.risk_class,
+      provider_kind: appRuns.provider_kind,
+      count: sql<number>`count(*)::int`,
+    }).from(appRuns).where(eq(appRuns.org_id, input.org_id))
+      .groupBy(appRuns.state, appRuns.risk_class, appRuns.provider_kind)
+      .orderBy(asc(appRuns.state), asc(appRuns.risk_class), asc(appRuns.provider_kind));
+    return rows.map((row) => Object.freeze(row));
+  }
+
+  async auditGaps(input: Readonly<{
+    org_id: string;
+    actor: AppRunActor;
+    run_id?: string;
+    limit?: number;
+  }>): Promise<readonly AppRunRepairGap[]> {
+    await this.#authorize('audit', input.org_id, input.actor);
+    return this.#auditGaps(input.org_id, input.run_id, input.limit);
+  }
+
+  async repair(input: Readonly<{
+    org_id: string;
+    run_id: string;
+    actor: AppRunActor;
+  }>): Promise<readonly AppRunRepairGap[]> {
+    await this.#authorize('repair', input.org_id, input.actor);
+    const gaps = await this.#auditGaps(input.org_id, input.run_id, 100);
+    if (gaps.length === 0) return [];
+
+    const repaired = await this.repository.transaction(async (tx) => {
+      const run = await this.repository.lockRun(tx, input.org_id, input.run_id);
+      if (!run) throw new AppRunError('APP_RUN_ACCESS_DENIED');
+      const now = this.now();
+      const eventId = crypto.randomUUID();
+      const attempts = await tx.select().from(appRunAttempts).where(and(
+        eq(appRunAttempts.org_id, input.org_id),
+        eq(appRunAttempts.run_id, input.run_id),
+      ));
+      const actions = await tx.select().from(agentActions).where(and(
+        eq(agentActions.org_id, input.org_id),
+        eq(agentActions.app_run_id, input.run_id),
+        eq(agentActions.action, 'app_run_invoke'),
+      ));
+
+      if (gaps.some((gap) => gap.gap === 'missing_terminal_event' && gap.artifact === 'run')) {
+        await this.repository.appendEvent(tx, {
+          id: crypto.randomUUID(),
+          org_id: run.org_id,
+          run_id: run.id,
+          event_type: 'run_transitioned',
+          actor: input.actor,
+          payload: { to_state: run.state, repaired: true },
+          now,
+        });
+      }
+      for (const gap of gaps.filter((item) =>
+        item.gap === 'missing_terminal_event' && item.artifact === 'attempt')) {
+        const attempt = attempts.find((item) => item.id === gap.attempt_id);
+        if (!attempt) continue;
+        await this.repository.appendEvent(tx, {
+          id: crypto.randomUUID(),
+          org_id: run.org_id,
+          run_id: run.id,
+          event_type: 'attempt_terminal',
+          actor: input.actor,
+          payload: { attempt_id: attempt.id, state: attempt.state, repaired: true },
+          now,
+        });
+      }
+      for (const gap of gaps.filter((item) => item.gap === 'missing_receipt')) {
+        if (gap.artifact === 'attempt') {
+          const attempt = attempts.find((item) => item.id === gap.attempt_id);
+          if (!attempt) continue;
+          await this.receipts.write(tx, {
+            receipt_key: `attempt-terminal:${attempt.id}`,
+            receipt_kind: 'attempt_terminal',
+            run,
+            attempt_id: attempt.id,
+            actor: input.actor,
+            facts: { attempt_state: attempt.state, repaired: true },
+            occurred_at: attempt.updated_at,
+          });
+        } else if (gap.artifact === 'approval') {
+          const action = actions.find((item) => item.id === gap.action_id);
+          if (!action) continue;
+          await this.receipts.write(tx, {
+            receipt_key: `approval:${action.id}`,
+            receipt_kind: 'approval',
+            run,
+            actor: action.approved_by_user_id
+              ? { actor_type: 'human', user_id: action.approved_by_user_id }
+              : input.actor,
+            facts: { decision: action.approval_status, repaired: true },
+            occurred_at: action.approved_at ?? action.updated_at,
+          });
+        }
+      }
+
+      await this.repository.appendEvent(tx, {
+        id: eventId,
+        org_id: run.org_id,
+        run_id: run.id,
+        event_type: 'repair_gap',
+        actor: input.actor,
+        payload: {
+          repaired_gap_count: gaps.length,
+          repaired_gap_kinds: [...new Set(gaps.map((gap) => gap.gap))],
+        },
+        now,
+      });
+      await this.receipts.write(tx, {
+        receipt_key: `repair:${eventId}`,
+        receipt_kind: 'repair',
+        run,
+        actor: input.actor,
+        facts: {
+          repaired_gap_count: gaps.length,
+          repaired_gap_kinds: [...new Set(gaps.map((gap) => gap.gap))],
+        },
+        occurred_at: now,
+      });
+      return run;
+    });
+
+    try {
+      if (gaps.some((gap) => gap.artifact === 'approval')) {
+        await this.attention.projectApprovalRequested(repaired.org_id, repaired.id);
+      }
+      if (repaired.state === 'unknown_outcome') {
+        await this.attention.projectRunState(repaired, 'unknown_outcome');
+      } else if (repaired.state === 'failed') {
+        await this.attention.projectRunState(repaired, 'failure');
+      }
+      const remaining = await this.#auditGaps(repaired.org_id, repaired.id, 100);
+      if (remaining.length > 0) {
+        await this.attention.projectRunState(repaired, 'repair_gap');
+      } else {
+        await this.attention.resolveRun(
+          repaired.org_id,
+          repaired.id,
+          actorUserId(input.actor)!,
+          'repaired',
+        );
+      }
+    } catch (error) {
+      console.warn('[app-runs] repair Attention projection failed:',
+        error instanceof Error ? error.message : 'unknown error');
+    }
+    return gaps;
+  }
+
+  async #auditGaps(
+    orgId: string,
+    runId: string | undefined,
+    limit: number | undefined,
+  ): Promise<readonly AppRunRepairGap[]> {
+    const runs = await db.select(safeRunSelection).from(appRuns).where(and(
+      eq(appRuns.org_id, orgId),
+      ...(runId ? [eq(appRuns.id, runId)] : []),
+    )).orderBy(desc(appRuns.updated_at), desc(appRuns.id)).limit(boundedLimit(limit));
+    if (runs.length === 0) return [];
+    const runIds = runs.map((run) => run.id);
+    const [attempts, actions, events, receipts] = await Promise.all([
+      db.select().from(appRunAttempts).where(and(
+        eq(appRunAttempts.org_id, orgId),
+        inArray(appRunAttempts.run_id, runIds),
+        inArray(appRunAttempts.state, ['succeeded', 'failed', 'cancelled', 'unknown_outcome']),
+      )),
+      db.select().from(agentActions).where(and(
+        eq(agentActions.org_id, orgId),
+        inArray(agentActions.app_run_id, runIds),
+        eq(agentActions.action, 'app_run_invoke'),
+      )),
+      db.select().from(appRunEvents).where(and(
+        eq(appRunEvents.org_id, orgId),
+        inArray(appRunEvents.run_id, runIds),
+      )),
+      db.select().from(appRunReceipts).where(and(
+        eq(appRunReceipts.org_id, orgId),
+        inArray(appRunReceipts.run_id, runIds),
+      )),
+    ]);
+    const actionIds = actions.map((action) => action.id);
+    const attention = await db.select({
+      source_type: attentionItems.source_type,
+      source_id: attentionItems.source_id,
+    }).from(attentionItems).where(and(
+      eq(attentionItems.org_id, orgId),
+      or(
+        and(eq(attentionItems.source_type, 'app_run'), inArray(attentionItems.source_id, runIds)),
+        ...(actionIds.length > 0
+          ? [and(eq(attentionItems.source_type, 'agent_action'), inArray(attentionItems.source_id, actionIds))]
+          : []),
+      ),
+    ));
+    const gaps: AppRunRepairGap[] = [];
+    const terminalRunStates = new Set(['succeeded', 'failed', 'cancelled', 'expired', 'unknown_outcome']);
+
+    for (const run of runs) {
+      const runEvents = events.filter((event) => event.run_id === run.id);
+      const runReceipts = receipts.filter((receipt) => receipt.run_id === run.id);
+      const action = actions.find((candidate) => candidate.app_run_id === run.id);
+      if (run.review_requirement === 'always' && !action) {
+        gaps.push({ run_id: run.id, gap: 'missing_approval_action', artifact: 'approval' });
+      }
+      if (
+        action
+        && action.approval_status === 'pending'
+        && !attention.some((item) => item.source_type === 'agent_action' && item.source_id === action.id)
+      ) gaps.push({
+        run_id: run.id,
+        gap: 'missing_attention',
+        artifact: 'approval',
+        action_id: action.id,
+      });
+      if (
+        action
+        && action.approval_status !== 'pending'
+        && !runReceipts.some((receipt) =>
+          receipt.receipt_kind === 'approval' && receipt.receipt_key === `approval:${action.id}`)
+      ) gaps.push({
+        run_id: run.id,
+        gap: 'missing_receipt',
+        artifact: 'approval',
+        action_id: action.id,
+      });
+      if (
+        (run.state === 'failed' || run.state === 'unknown_outcome')
+        && !attention.some((item) => item.source_type === 'app_run' && item.source_id === run.id)
+      ) gaps.push({ run_id: run.id, gap: 'missing_attention', artifact: 'attention' });
+      if (
+        terminalRunStates.has(run.state)
+        && !runEvents.some((event) =>
+          (event.event_type === 'run_transitioned' || event.event_type === 'reconciliation_recorded')
+          && payloadToState(event.payload) === run.state)
+      ) gaps.push({ run_id: run.id, gap: 'missing_terminal_event', artifact: 'run' });
+
+      for (const attempt of attempts.filter((candidate) => candidate.run_id === run.id)) {
+        if (!runEvents.some((event) =>
+          event.event_type === 'attempt_terminal'
+          && payloadAttemptId(event.payload) === attempt.id)) {
+          gaps.push({
+            run_id: run.id,
+            gap: 'missing_terminal_event',
+            artifact: 'attempt',
+            attempt_id: attempt.id,
+          });
+        }
+        if (!runReceipts.some((receipt) =>
+          receipt.receipt_kind === 'attempt_terminal'
+          && receipt.attempt_id === attempt.id)) {
+          gaps.push({
+            run_id: run.id,
+            gap: 'missing_receipt',
+            artifact: 'attempt',
+            attempt_id: attempt.id,
+          });
+        }
+      }
+    }
+    return gaps.slice(0, boundedLimit(limit));
+  }
+
+  async #authorize(
+    action: AppRunOperationalAction,
+    orgId: string,
+    actor: AppRunActor,
+  ): Promise<void> {
+    if (!await this.authorizer.authorize({ action, org_id: orgId, actor })) {
+      throw new AppRunError('APP_RUN_ACCESS_DENIED');
+    }
+    if (action === 'repair' && actorUserId(actor) === null) {
+      throw new AppRunError('APP_RUN_ACCESS_DENIED');
+    }
+  }
+}

--- a/apps/api/src/lib/app-run-provider-executor.ts
+++ b/apps/api/src/lib/app-run-provider-executor.ts
@@ -11,8 +11,11 @@ export type AppRunProviderExecutionRequest = Readonly<{
 }>;
 
 export type AppRunProviderExecutionResult =
-  | Readonly<{ status: 'succeeded'; output: unknown }>
-  | Readonly<{ status: 'failed'; no_effect: true }>
+  | Readonly<{
+      status: 'not_attempted';
+      error_code?: 'APP_RUN_PROVIDER_UNAVAILABLE' | 'APP_RUN_PROVIDER_TIMEOUT';
+    }>
+  | Readonly<{ status: 'returned'; provider_succeeded: boolean; output: unknown }>
   | Readonly<{ status: 'indeterminate' }>;
 
 export interface AppRunProviderExecutor {

--- a/apps/api/src/lib/app-run-receipts.ts
+++ b/apps/api/src/lib/app-run-receipts.ts
@@ -1,0 +1,169 @@
+import { createHash } from 'node:crypto';
+import { appRunReceipts, appRuns } from '@deft/db/schema';
+import {
+  APP_RUN_CONTRACT_VERSIONS,
+  canonicalCapabilityJson,
+  parseAppRunReceiptEnvelope,
+  type AppRunActor,
+  type AppRunReceiptKind,
+  type AppRunSafeMetadata,
+} from '@deft/shared';
+import { and, eq } from 'drizzle-orm';
+import { AppRunError } from './app-run-errors.js';
+import { db } from './db.js';
+import type { AppRunSafeView, AppRunTransaction } from './app-run-repository.js';
+import type { AppRunSecretRepository } from './app-run-secret-repository.js';
+import type { AppRunSecretService } from './app-run-secrets.js';
+
+export type AppRunReceiptWrite = Readonly<{
+  receipt_key: string;
+  receipt_kind: AppRunReceiptKind;
+  run: AppRunSafeView;
+  attempt_id?: string;
+  actor?: AppRunActor;
+  facts?: AppRunSafeMetadata;
+  occurred_at: Date;
+}>;
+
+export interface AppRunReceiptWriter {
+  write(tx: AppRunTransaction, input: AppRunReceiptWrite): Promise<void>;
+}
+
+export const noOpAppRunReceiptWriter: AppRunReceiptWriter = Object.freeze({
+  async write() {},
+});
+
+function sha256(value: unknown): string {
+  return `sha256:${createHash('sha256')
+    .update(canonicalCapabilityJson(value))
+    .digest('hex')}`;
+}
+
+function receiptId(orgId: string, runId: string, receiptKey: string): string {
+  return `app-run-receipt:${createHash('sha256')
+    .update('deft.app_run_receipt_id.v1\0')
+    .update(orgId)
+    .update('\0')
+    .update(runId)
+    .update('\0')
+    .update(receiptKey)
+    .digest('hex')}`;
+}
+
+export class PostgresAppRunReceiptWriter implements AppRunReceiptWriter {
+  constructor(
+    private readonly secrets: AppRunSecretService,
+    private readonly secretRepository: AppRunSecretRepository,
+  ) {}
+
+  async write(tx: AppRunTransaction, input: AppRunReceiptWrite): Promise<void> {
+    if (
+      !input.receipt_key
+      || input.receipt_key !== input.receipt_key.trim()
+      || Buffer.byteLength(input.receipt_key, 'utf8') > 512
+    ) throw new AppRunError('APP_RUN_REPAIR_REQUIRED');
+    if (input.receipt_kind === 'attempt_terminal' && !input.attempt_id) {
+      throw new AppRunError('APP_RUN_REPAIR_REQUIRED');
+    }
+
+    const [internal] = await tx.select({
+      input_fingerprint_key_version: appRuns.input_fingerprint_key_version,
+      input_fingerprint: appRuns.input_fingerprint,
+    }).from(appRuns).where(and(
+      eq(appRuns.org_id, input.run.org_id),
+      eq(appRuns.id, input.run.id),
+    )).limit(1);
+    if (!internal) throw new AppRunError('APP_RUN_REPAIR_REQUIRED');
+
+    const outputEnvelopeDigest = input.attempt_id
+      ? await this.secretRepository.outputEnvelopeDigest(
+        tx,
+        input.run.org_id,
+        input.run.id,
+        input.attempt_id,
+      )
+      : undefined;
+    const id = receiptId(input.run.org_id, input.run.id, input.receipt_key);
+    const envelope = parseAppRunReceiptEnvelope({
+      schema_version: APP_RUN_CONTRACT_VERSIONS.receipt,
+      receipt_id: id,
+      receipt_kind: input.receipt_kind,
+      org_id: input.run.org_id,
+      run_id: input.run.id,
+      ...(input.attempt_id ? { attempt_id: input.attempt_id } : {}),
+      run_state: input.run.state,
+      ...(input.actor ? { actor: input.actor } : {}),
+      operation: {
+        provider: {
+          org_id: input.run.org_id,
+          provider_kind: input.run.provider_kind,
+          provider_instance_id: input.run.provider_instance_id,
+        },
+        operation_name: input.run.operation_name,
+      },
+      policy: {
+        risk_class: input.run.risk_class,
+        review_requirement: input.run.review_requirement,
+        review_scope: input.run.review_scope,
+        retry_class: input.run.retry_class,
+      },
+      input_fingerprint: {
+        key_version: internal.input_fingerprint_key_version,
+        fingerprint: internal.input_fingerprint,
+      },
+      ...(outputEnvelopeDigest ? { output_envelope_digest: outputEnvelopeDigest } : {}),
+      facts: input.facts ?? {},
+      occurred_at: input.occurred_at.toISOString(),
+    });
+    const envelopeDigest = sha256(envelope);
+    const signature = this.secrets.signReceipt(envelope);
+    const [created] = await tx.insert(appRunReceipts).values({
+      id,
+      org_id: input.run.org_id,
+      run_id: input.run.id,
+      attempt_id: input.attempt_id ?? null,
+      receipt_key: input.receipt_key,
+      receipt_kind: input.receipt_kind,
+      envelope,
+      envelope_digest: envelopeDigest,
+      signing_key_version: signature.key_version,
+      signature_hmac: signature.signature_hmac,
+      signed_at: input.occurred_at,
+      created_at: input.occurred_at,
+    }).onConflictDoNothing().returning({ id: appRunReceipts.id });
+    if (created) return;
+
+    const [existing] = await tx.select().from(appRunReceipts).where(and(
+      eq(appRunReceipts.org_id, input.run.org_id),
+      eq(appRunReceipts.run_id, input.run.id),
+      eq(appRunReceipts.receipt_key, input.receipt_key),
+    )).limit(1);
+    if (
+      !existing
+      || existing.envelope_digest !== envelopeDigest
+      || canonicalCapabilityJson(existing.envelope) !== canonicalCapabilityJson(envelope)
+      || !this.secrets.verifyReceipt(
+        existing.envelope,
+        existing.signing_key_version,
+        existing.signature_hmac,
+      )
+    ) throw new AppRunError('APP_RUN_REPAIR_REQUIRED');
+  }
+
+  async verifyStored(orgId: string, runId: string, receiptKey: string): Promise<boolean> {
+    const [receipt] = await db.select().from(appRunReceipts).where(and(
+      eq(appRunReceipts.org_id, orgId),
+      eq(appRunReceipts.run_id, runId),
+      eq(appRunReceipts.receipt_key, receiptKey),
+    )).limit(1);
+    return Boolean(
+      receipt
+      && receipt.envelope_digest === sha256(receipt.envelope)
+      && this.secrets.verifyReceipt(
+        receipt.envelope,
+        receipt.signing_key_version,
+        receipt.signature_hmac,
+      ),
+    );
+  }
+}

--- a/apps/api/src/lib/app-run-repository.ts
+++ b/apps/api/src/lib/app-run-repository.ts
@@ -43,6 +43,8 @@ const safeRunSelection = {
   result_expires_at: appRuns.result_expires_at,
   idempotency_expires_at: appRuns.idempotency_expires_at,
   attempt_limit: appRuns.attempt_limit,
+  execution_release_kind: appRuns.execution_release_kind,
+  execution_released_at: appRuns.execution_released_at,
   input_purged_at: appRuns.input_purged_at,
   result_purged_at: appRuns.result_purged_at,
   started_at: appRuns.started_at,
@@ -152,7 +154,7 @@ export class PostgresAppRunRepository {
       provider_instance_id: input.submission.operation.provider.provider_instance_id,
       operation_name: input.submission.operation.operation_name,
       provider_snapshot_id: input.provider_snapshot_id,
-      state: 'pending',
+      state: input.submission.policy.review_requirement === 'always' ? 'pending_approval' : 'pending',
       risk_class: input.submission.policy.risk_class,
       review_requirement: input.submission.policy.review_requirement,
       review_scope: input.submission.policy.review_scope,
@@ -170,6 +172,12 @@ export class PostgresAppRunRepository {
       result_expires_at: input.result_expires_at,
       idempotency_expires_at: input.idempotency_expires_at,
       attempt_limit: input.attempt_limit,
+      execution_release_kind: input.submission.policy.review_requirement === 'policy'
+        ? 'policy_satisfied'
+        : null,
+      execution_released_at: input.submission.policy.review_requirement === 'policy'
+        ? input.now
+        : null,
       created_at: input.now,
       updated_at: input.now,
     }).returning(safeRunSelection);
@@ -284,6 +292,38 @@ export class PostgresAppRunRepository {
     return updated;
   }
 
+  async recordApprovedExecutionRelease(
+    tx: AppRunTransaction,
+    run: AppRunSafeView,
+    actor: AppRunActor,
+    now: Date,
+  ): Promise<AppRunSafeView> {
+    if (run.execution_release_kind) {
+      if (run.execution_release_kind === 'approved') return run;
+      throw new Error('APP_RUN_ILLEGAL_TRANSITION');
+    }
+    const [updated] = await tx.update(appRuns).set({
+      execution_release_kind: 'approved',
+      execution_released_at: now,
+      updated_at: now,
+    }).where(and(
+      eq(appRuns.org_id, run.org_id),
+      eq(appRuns.id, run.id),
+      eq(appRuns.state, 'pending_approval'),
+    )).returning(safeRunSelection);
+    if (!updated) throw new Error('APP_RUN_ILLEGAL_TRANSITION');
+    await this.appendEvent(tx, {
+      id: crypto.randomUUID(),
+      org_id: run.org_id,
+      run_id: run.id,
+      event_type: 'approval_resolved',
+      actor,
+      payload: { resolution: 'approved', execution_release_kind: 'approved' },
+      now,
+    });
+    return updated;
+  }
+
   async activeKeyReferences(now: Date): Promise<readonly { purpose: 'fingerprint'; key_id: string }[]> {
     const rows = await db.select({
       idempotency: appRuns.idempotency_key_version,
@@ -302,11 +342,12 @@ export class PostgresAppRunRepository {
     return rows.map((row) => row.id);
   }
 
-  async latestSuccessfulAttemptId(orgId: string, runId: string): Promise<string | null> {
+  async latestRetainedAttemptId(orgId: string, runId: string): Promise<string | null> {
     const [row] = await db.select({ id: appRunAttempts.id }).from(appRunAttempts).where(and(
       eq(appRunAttempts.org_id, orgId),
       eq(appRunAttempts.run_id, runId),
-      eq(appRunAttempts.state, 'succeeded'),
+      sql`${appRunAttempts.provider_call_finished_at} IS NOT NULL`,
+      sql`${appRunAttempts.safe_outcome}->>'result_status' = 'retained'`,
     )).orderBy(sql`${appRunAttempts.attempt_number} DESC`).limit(1);
     return row?.id ?? null;
   }

--- a/apps/api/src/lib/app-run-repository.ts
+++ b/apps/api/src/lib/app-run-repository.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, gt, inArray, or, sql } from 'drizzle-orm';
+import { and, asc, eq, gt, inArray, isNull, or, sql } from 'drizzle-orm';
 import {
   appRunAttempts,
   appRunEvents,
@@ -16,7 +16,7 @@ import { db } from './db.js';
 
 export type AppRunTransaction = Parameters<Parameters<typeof db.transaction>[0]>[0];
 
-const safeRunSelection = {
+export const safeRunSelection = {
   id: appRuns.id,
   org_id: appRuns.org_id,
   contract_version: appRuns.contract_version,
@@ -74,6 +74,24 @@ function actorColumns(actor: AppRunActor) {
 
 export type FingerprintCandidate = Readonly<{ key_version: string; fingerprint: string }>;
 
+export type AppRunChildLineage = Readonly<{
+  parent: AppRunSafeView;
+  ancestors: readonly AppRunSafeView[];
+  parent_authorization_snapshot: Record<string, unknown>;
+  root_budget_reserved_at: Date | null;
+  root_budget_reserved_count: number | null;
+  root_budget_limit_at_reservation: number | null;
+}>;
+
+export type AppRunLineageInsert = Readonly<{
+  root_run_id: string;
+  parent_run_id: string;
+  depth: number;
+  budget_reserved_at: Date | null;
+  budget_reserved_count: number | null;
+  budget_limit_at_reservation: number | null;
+}>;
+
 export class PostgresAppRunRepository {
   async transaction<T>(work: (tx: AppRunTransaction) => Promise<T>): Promise<T> {
     return db.transaction(work);
@@ -98,6 +116,7 @@ export class PostgresAppRunRepository {
     submission: AppRunSubmission,
     candidates: readonly FingerprintCandidate[],
     now: Date,
+    parentRunId: string | null = null,
   ): Promise<(AppRunSafeView & {
     input_fingerprint_key_version: string;
     input_fingerprint: string;
@@ -119,9 +138,60 @@ export class PostgresAppRunRepository {
       eq(appRuns.provider_instance_id, submission.operation.provider.provider_instance_id),
       eq(appRuns.operation_name, submission.operation.operation_name),
       gt(appRuns.idempotency_expires_at, now),
+      parentRunId === null
+        ? isNull(appRuns.parent_run_id)
+        : eq(appRuns.parent_run_id, parentRunId),
       or(...candidateFilters),
     )).limit(1);
     return row ?? null;
+  }
+
+  async loadChildLineage(
+    tx: AppRunTransaction,
+    orgId: string,
+    parentRunId: string,
+  ): Promise<AppRunChildLineage | null> {
+    const ancestors: AppRunSafeView[] = [];
+    let cursor: string | null = parentRunId;
+    while (cursor !== null && ancestors.length <= 8) {
+      const run = await this.lockRun(tx, orgId, cursor);
+      if (!run) return null;
+      ancestors.push(run);
+      cursor = run.parent_run_id;
+    }
+    if (cursor !== null || ancestors.length === 0) return null;
+
+    const parent = ancestors[0]!;
+    const root = ancestors.at(-1)!;
+    if (
+      root.id !== parent.root_run_id
+      || root.id !== root.root_run_id
+      || root.depth !== 0
+    ) return null;
+
+    const [internal] = await tx.select({
+      authorization_snapshot: appRuns.authorization_snapshot,
+    }).from(appRuns).where(and(
+      eq(appRuns.org_id, orgId),
+      eq(appRuns.id, parent.id),
+    )).limit(1);
+    const [rootBudget] = await tx.select({
+      budget_reserved_at: appRuns.budget_reserved_at,
+      budget_reserved_count: appRuns.budget_reserved_count,
+      budget_limit_at_reservation: appRuns.budget_limit_at_reservation,
+    }).from(appRuns).where(and(
+      eq(appRuns.org_id, orgId),
+      eq(appRuns.id, root.id),
+    )).limit(1);
+    if (!internal || !rootBudget) return null;
+    return Object.freeze({
+      parent,
+      ancestors: Object.freeze(ancestors),
+      parent_authorization_snapshot: internal.authorization_snapshot,
+      root_budget_reserved_at: rootBudget.budget_reserved_at,
+      root_budget_reserved_count: rootBudget.budget_reserved_count,
+      root_budget_limit_at_reservation: rootBudget.budget_limit_at_reservation,
+    });
   }
 
   async insertRun(
@@ -136,6 +206,7 @@ export class PostgresAppRunRepository {
       result_expires_at: Date;
       idempotency_expires_at: Date;
       attempt_limit: number;
+      lineage?: AppRunLineageInsert;
       now: Date;
     }>,
   ): Promise<AppRunSafeView> {
@@ -166,12 +237,16 @@ export class PostgresAppRunRepository {
       input_fingerprint: input.input_fingerprint.fingerprint,
       authorization_snapshot: input.submission.authorization_snapshot,
       safe_preview: input.submission.safe_preview,
-      root_run_id: input.id,
-      depth: 0,
+      root_run_id: input.lineage?.root_run_id ?? input.id,
+      parent_run_id: input.lineage?.parent_run_id ?? null,
+      depth: input.lineage?.depth ?? 0,
       input_expires_at: input.input_expires_at,
       result_expires_at: input.result_expires_at,
       idempotency_expires_at: input.idempotency_expires_at,
       attempt_limit: input.attempt_limit,
+      budget_reserved_at: input.lineage?.budget_reserved_at ?? null,
+      budget_reserved_count: input.lineage?.budget_reserved_count ?? null,
+      budget_limit_at_reservation: input.lineage?.budget_limit_at_reservation ?? null,
       execution_release_kind: input.submission.policy.review_requirement === 'policy'
         ? 'policy_satisfied'
         : null,

--- a/apps/api/src/lib/app-run-secret-repository.ts
+++ b/apps/api/src/lib/app-run-secret-repository.ts
@@ -1,6 +1,7 @@
+import { createHash } from 'node:crypto';
 import { and, asc, eq, lte, sql } from 'drizzle-orm';
-import { appRunEvents, appRuns, appRunSecretPayloads } from '@deft/db/schema';
-import type { CapabilityJsonValue } from '@deft/shared';
+import { appRunEvents, appRunReceipts, appRuns, appRunSecretPayloads } from '@deft/db/schema';
+import { canonicalCapabilityJson, type CapabilityJsonValue } from '@deft/shared';
 import { db } from './db.js';
 import type { AppRunTransaction } from './app-run-repository.js';
 import {
@@ -119,11 +120,44 @@ export class AppRunSecretRepository {
     });
   }
 
+  async outputEnvelopeDigest(
+    tx: AppRunTransaction,
+    orgId: string,
+    runId: string,
+    attemptId: string,
+  ): Promise<string | undefined> {
+    const [row] = await tx.select({
+      envelope_version: appRunSecretPayloads.envelope_version,
+      algorithm: appRunSecretPayloads.algorithm,
+      key_version: appRunSecretPayloads.key_version,
+      nonce_b64: appRunSecretPayloads.nonce_b64,
+      ciphertext_b64: appRunSecretPayloads.ciphertext_b64,
+      auth_tag_b64: appRunSecretPayloads.auth_tag_b64,
+    }).from(appRunSecretPayloads).where(and(
+      eq(appRunSecretPayloads.org_id, orgId),
+      eq(appRunSecretPayloads.run_id, runId),
+      eq(appRunSecretPayloads.attempt_id, attemptId),
+      eq(appRunSecretPayloads.payload_kind, 'output'),
+    )).limit(1);
+    return row
+      ? `sha256:${createHash('sha256').update(canonicalCapabilityJson(row)).digest('hex')}`
+      : undefined;
+  }
+
   async retainedKeyReferences(now: Date): Promise<readonly { purpose: 'run_encryption'; key_id: string }[]> {
     const rows = await db.selectDistinct({ key_id: appRunSecretPayloads.key_version })
       .from(appRunSecretPayloads)
       .where(sql`${appRunSecretPayloads.expires_at} > ${now}`);
     return rows.map((row) => ({ purpose: 'run_encryption' as const, key_id: row.key_id }));
+  }
+
+  async receiptSigningKeyReferences(): Promise<readonly {
+    purpose: 'receipt_signing';
+    key_id: string;
+  }[]> {
+    const rows = await db.selectDistinct({ key_id: appRunReceipts.signing_key_version })
+      .from(appRunReceipts);
+    return rows.map((row) => ({ purpose: 'receipt_signing' as const, key_id: row.key_id }));
   }
 
   async purgeExpiredBatch(now = new Date(), limit = 100): Promise<number> {

--- a/apps/api/src/lib/app-run-service.ts
+++ b/apps/api/src/lib/app-run-service.ts
@@ -26,6 +26,10 @@ import {
   type AppRunSafeView,
 } from './app-run-repository.js';
 import { AppRunSecretRepository } from './app-run-secret-repository.js';
+import {
+  postgresAppRunApprovalAdapter,
+  type AppRunApprovalAdapter,
+} from './app-run-approval-adapter.js';
 
 export type AppRunTrustedContext = Readonly<{
   org_id: string;
@@ -70,6 +74,7 @@ export class AppRunService {
     private readonly keys: AppRunKeyProvider,
     private readonly authorizer: AppRunAuthorizer = denyAllAppRunAuthorizer,
     private readonly now: () => Date = () => new Date(),
+    private readonly approvalAdapter: AppRunApprovalAdapter = postgresAppRunApprovalAdapter,
   ) {}
 
   async submit(context: AppRunTrustedContext, rawSubmission: unknown): Promise<AppRunSafeView> {
@@ -141,6 +146,23 @@ export class AppRunService {
         event_type: 'run_created', actor: submission.initiating_actor,
         payload: { state: run.state }, now,
       });
+      if (run.state === 'pending_approval') {
+        const actionId = await this.approvalAdapter.create({
+          tx,
+          run,
+          submission,
+          now,
+        });
+        await this.repository.appendEvent(tx, {
+          id: crypto.randomUUID(),
+          org_id: submission.org_id,
+          run_id: runId,
+          event_type: 'approval_requested',
+          actor: submission.initiating_actor,
+          payload: { action_id: actionId },
+          now,
+        });
+      }
       return run;
     });
   }

--- a/apps/api/src/lib/app-run-service.ts
+++ b/apps/api/src/lib/app-run-service.ts
@@ -139,7 +139,7 @@ export class AppRunService {
       await this.repository.appendEvent(tx, {
         id: crypto.randomUUID(), org_id: submission.org_id, run_id: runId,
         event_type: 'run_created', actor: submission.initiating_actor,
-        payload: { state: 'pending' }, now,
+        payload: { state: run.state }, now,
       });
       return run;
     });
@@ -226,7 +226,7 @@ export class AppRunService {
     if (run.result_purged_at || run.result_expires_at <= this.now()) {
       throw new AppRunError('APP_RUN_RESULT_EXPIRED');
     }
-    const attemptId = await this.repository.latestSuccessfulAttemptId(orgId, runId);
+    const attemptId = await this.repository.latestRetainedAttemptId(orgId, runId);
     if (!attemptId) throw new AppRunError('APP_RUN_RESULT_EXPIRED');
     const value = await this.secretRepository.readOutput(orgId, runId, attemptId);
     if (value === null) throw new AppRunError('APP_RUN_RESULT_EXPIRED');

--- a/apps/api/src/lib/app-run-service.ts
+++ b/apps/api/src/lib/app-run-service.ts
@@ -1,12 +1,17 @@
 import { createHash } from 'node:crypto';
 import {
   APP_RUN_DEFAULT_ATTEMPT_LIMIT,
+  APP_RUN_LIMITS,
+  AppRunAuthorizationSnapshotSchema,
   AppRunSafeOutcomeSchema,
   idempotencyDeadline,
   parseAppRunSubmission,
   retentionDeadline,
   type AppRunActor,
   type AppRunErrorCode,
+  type AppRunRetentionClass,
+  type AppRunRetryClass,
+  type AppRunRiskClass,
   type AppRunSubmission,
 } from '@deft/shared';
 import {
@@ -23,6 +28,8 @@ import { AppRunError, asAppRunError } from './app-run-errors.js';
 import {
   PostgresAppRunRepository,
   appRunActorId,
+  type AppRunChildLineage,
+  type AppRunLineageInsert,
   type AppRunSafeView,
 } from './app-run-repository.js';
 import { AppRunSecretRepository } from './app-run-secret-repository.js';
@@ -30,6 +37,14 @@ import {
   postgresAppRunApprovalAdapter,
   type AppRunApprovalAdapter,
 } from './app-run-approval-adapter.js';
+import {
+  noOpAppRunReceiptWriter,
+  type AppRunReceiptWriter,
+} from './app-run-receipts.js';
+import {
+  noOpAppRunAttentionProjector,
+  type AppRunAttentionProjector,
+} from './app-run-attention.js';
 
 export type AppRunTrustedContext = Readonly<{
   org_id: string;
@@ -41,7 +56,7 @@ function sameActor(left: AppRunActor, right: AppRunActor): boolean {
   return left.actor_type === right.actor_type && appRunActorId(left) === appRunActorId(right);
 }
 
-function derivedSubmissionLock(submission: AppRunSubmission): string {
+function derivedSubmissionLock(submission: AppRunSubmission, parentRunId: string | null): string {
   const actor = appRunActorId(submission.initiating_actor);
   const digest = createHash('sha256');
   digest.update('deft.app_run.submit_lock.v1\0');
@@ -53,11 +68,92 @@ function derivedSubmissionLock(submission: AppRunSubmission): string {
     submission.operation.provider.provider_instance_id,
     submission.operation.operation_name,
     submission.idempotency_key,
+    parentRunId ?? 'root',
   ]) {
     digest.update(value);
     digest.update('\0');
   }
   return digest.digest('hex');
+}
+
+const AMBIENT_AUTHORITY_KINDS = new Set([
+  'membership',
+  'token_scope',
+  'employee_health',
+  'employee_budget',
+]);
+
+function riskRank(value: AppRunRiskClass): number {
+  return ['read', 'internal_write', 'external_write', 'destructive', 'privileged'].indexOf(value);
+}
+
+function retryPermissionRank(value: AppRunRetryClass): number {
+  return ['unsafe_or_unknown', 'idempotent_with_key', 'safe'].indexOf(value);
+}
+
+function retentionRank(value: AppRunRetentionClass): number {
+  return ['ephemeral', 'standard', 'extended'].indexOf(value);
+}
+
+function childLineageInsert(
+  lineage: AppRunChildLineage,
+  submission: AppRunSubmission,
+): AppRunLineageInsert {
+  const parent = lineage.parent;
+  if (
+    (parent.state !== 'running' && parent.state !== 'waiting_external')
+    || parent.depth >= APP_RUN_LIMITS.max_child_depth
+  ) throw new AppRunError('APP_RUN_ANCESTRY_LIMIT');
+  if (
+    parent.initiating_actor_type !== submission.initiating_actor.actor_type
+    || parent.initiating_actor_id !== appRunActorId(submission.initiating_actor)
+    || parent.execution_actor_type !== submission.execution_actor.actor_type
+    || parent.execution_actor_id !== appRunActorId(submission.execution_actor)
+    || parent.origin_kind !== submission.origin.origin_kind
+  ) throw new AppRunError('APP_RUN_ACCESS_DENIED');
+
+  if (lineage.ancestors.some((ancestor) =>
+    ancestor.provider_kind === submission.operation.provider.provider_kind
+    && ancestor.provider_instance_id === submission.operation.provider.provider_instance_id
+    && ancestor.operation_name === submission.operation.operation_name)) {
+    throw new AppRunError('APP_RUN_CAPABILITY_CYCLE');
+  }
+
+  const parentAuthorization = AppRunAuthorizationSnapshotSchema.parse(
+    lineage.parent_authorization_snapshot,
+  );
+  const parentRefs = new Set(parentAuthorization.authority_refs.map((ref) =>
+    `${ref.authority_kind}\0${ref.authority_id}\0${ref.version}`));
+  const ambientExpanded = submission.authorization_snapshot.authority_refs.some((ref) =>
+    AMBIENT_AUTHORITY_KINDS.has(ref.authority_kind)
+    && !parentRefs.has(`${ref.authority_kind}\0${ref.authority_id}\0${ref.version}`));
+  if (ambientExpanded) throw new AppRunError('APP_RUN_ACCESS_DENIED');
+
+  if (
+    riskRank(submission.policy.risk_class) > riskRank(parent.risk_class)
+    || (parent.review_requirement === 'always' && submission.policy.review_requirement !== 'always')
+    || submission.policy.review_scope !== parent.review_scope
+    || retryPermissionRank(submission.policy.retry_class) > retryPermissionRank(parent.retry_class)
+    || retentionRank(submission.retention_class) > retentionRank(parent.retention_class)
+  ) throw new AppRunError('APP_RUN_ACCESS_DENIED');
+
+  if (
+    submission.execution_actor.actor_type === 'agent_employee'
+    && (
+      lineage.root_budget_reserved_at === null
+      || lineage.root_budget_reserved_count !== 1
+      || lineage.root_budget_limit_at_reservation === null
+    )
+  ) throw new AppRunError('APP_RUN_ACCESS_DENIED');
+
+  return Object.freeze({
+    root_run_id: parent.root_run_id,
+    parent_run_id: parent.id,
+    depth: parent.depth + 1,
+    budget_reserved_at: lineage.root_budget_reserved_at,
+    budget_reserved_count: lineage.root_budget_reserved_count,
+    budget_limit_at_reservation: lineage.root_budget_limit_at_reservation,
+  });
 }
 
 function replayExecutionMatches(run: AppRunSafeView, submission: AppRunSubmission): boolean {
@@ -75,9 +171,30 @@ export class AppRunService {
     private readonly authorizer: AppRunAuthorizer = denyAllAppRunAuthorizer,
     private readonly now: () => Date = () => new Date(),
     private readonly approvalAdapter: AppRunApprovalAdapter = postgresAppRunApprovalAdapter,
+    private readonly receiptWriter: AppRunReceiptWriter = noOpAppRunReceiptWriter,
+    private readonly attention: AppRunAttentionProjector = noOpAppRunAttentionProjector,
   ) {}
 
   async submit(context: AppRunTrustedContext, rawSubmission: unknown): Promise<AppRunSafeView> {
+    return this.#submit(context, rawSubmission, null);
+  }
+
+  async submitChild(
+    context: AppRunTrustedContext,
+    parentRunId: string,
+    rawSubmission: unknown,
+  ): Promise<AppRunSafeView> {
+    if (!parentRunId || parentRunId !== parentRunId.trim()) {
+      throw new AppRunError('APP_RUN_INPUT_INVALID');
+    }
+    return this.#submit(context, rawSubmission, parentRunId);
+  }
+
+  async #submit(
+    context: AppRunTrustedContext,
+    rawSubmission: unknown,
+    parentRunId: string | null,
+  ): Promise<AppRunSafeView> {
     let submission: AppRunSubmission;
     try {
       submission = parseAppRunSubmission(rawSubmission);
@@ -102,15 +219,21 @@ export class AppRunService {
     const replayCandidates = this.secrets.fingerprintTextCandidates('idempotency', submission.idempotency_key);
     const inputFingerprint = this.secrets.fingerprintJson('input', submission.input);
     const inputCandidates = this.secrets.fingerprintJsonCandidates('input', submission.input);
-    const lock = derivedSubmissionLock(submission);
+    const lock = derivedSubmissionLock(submission, parentRunId);
     const runId = crypto.randomUUID();
     const inputExpiresAt = retentionDeadline(submission.retention_class, now);
     const resultExpiresAt = retentionDeadline(submission.retention_class, now);
     const idempotencyExpiresAt = idempotencyDeadline(submission.retention_class, now);
 
-    return this.repository.transaction(async (tx) => {
+    const submitted = await this.repository.transaction(async (tx) => {
       await this.repository.acquireSubmissionLock(tx, lock);
-      const replay = await this.repository.findReplay(tx, submission, replayCandidates, now);
+      const replay = await this.repository.findReplay(
+        tx,
+        submission,
+        replayCandidates,
+        now,
+        parentRunId,
+      );
       if (replay) {
         const sameInput = inputCandidates.some((candidate) =>
           candidate.key_version === replay.input_fingerprint_key_version
@@ -121,25 +244,47 @@ export class AppRunService {
         const { input_fingerprint: _fingerprint, input_fingerprint_key_version: _version, ...safe } = replay;
         return safe;
       }
+      const lineage = parentRunId === null
+        ? undefined
+        : await this.repository.loadChildLineage(tx, submission.org_id, parentRunId);
+      if (parentRunId !== null && !lineage) {
+        throw new AppRunError('APP_RUN_ACCESS_DENIED');
+      }
+      const lineageInsert = lineage ? childLineageInsert(lineage, submission) : undefined;
       const snapshot = await this.repository.findProviderSnapshot(tx, submission);
       if (!snapshot) throw new AppRunError('APP_RUN_PROVIDER_UNAVAILABLE');
+      const boundedInputExpiry = lineage
+        ? new Date(Math.min(inputExpiresAt.getTime(), lineage.parent.input_expires_at.getTime()))
+        : inputExpiresAt;
+      const boundedResultExpiry = lineage
+        ? new Date(Math.min(resultExpiresAt.getTime(), lineage.parent.result_expires_at.getTime()))
+        : resultExpiresAt;
+      const boundedIdempotencyExpiry = lineage
+        ? new Date(Math.min(idempotencyExpiresAt.getTime(), lineage.parent.idempotency_expires_at.getTime()))
+        : idempotencyExpiresAt;
+      if (boundedInputExpiry <= now || boundedResultExpiry <= now || boundedIdempotencyExpiry <= now) {
+        throw new AppRunError('APP_RUN_EXPIRED');
+      }
       const run = await this.repository.insertRun(tx, {
         id: runId,
         submission,
         provider_snapshot_id: snapshot.id,
         idempotency,
         input_fingerprint: inputFingerprint,
-        input_expires_at: inputExpiresAt,
-        result_expires_at: resultExpiresAt,
-        idempotency_expires_at: idempotencyExpiresAt,
-        attempt_limit: APP_RUN_DEFAULT_ATTEMPT_LIMIT,
+        input_expires_at: boundedInputExpiry,
+        result_expires_at: boundedResultExpiry,
+        idempotency_expires_at: boundedIdempotencyExpiry,
+        attempt_limit: lineage
+          ? Math.min(APP_RUN_DEFAULT_ATTEMPT_LIMIT, lineage.parent.attempt_limit)
+          : APP_RUN_DEFAULT_ATTEMPT_LIMIT,
+        lineage: lineageInsert,
         now,
       });
       await this.secretRepository.insertInput(tx, {
         org_id: submission.org_id,
         run_id: runId,
         value: submission.input,
-        expires_at: inputExpiresAt,
+        expires_at: boundedInputExpiry,
       });
       await this.repository.appendEvent(tx, {
         id: crypto.randomUUID(), org_id: submission.org_id, run_id: runId,
@@ -165,6 +310,15 @@ export class AppRunService {
       }
       return run;
     });
+    if (submitted.state === 'pending_approval') {
+      try {
+        await this.attention.projectApprovalRequested(submitted.org_id, submitted.id);
+      } catch (error) {
+        console.warn('[app-runs] approval Attention projection failed:',
+          error instanceof Error ? error.message : 'unknown error');
+      }
+    }
+    return submitted;
   }
 
   async inspect(orgId: string, runId: string, actor: AppRunActor): Promise<AppRunSafeView> {
@@ -218,7 +372,7 @@ export class AppRunService {
   ): Promise<AppRunSafeView> {
     const visible = await this.requiredRun(orgId, runId);
     await this.assertAuthorized('reconcile', orgId, actor, visible);
-    return this.repository.transaction(async (tx) => {
+    const reconciled = await this.repository.transaction(async (tx) => {
       const run = await this.repository.lockRun(tx, orgId, runId);
       if (!run || run.state !== 'unknown_outcome') {
         throw new AppRunError('APP_RUN_ILLEGAL_TRANSITION');
@@ -226,7 +380,7 @@ export class AppRunService {
       const errorCode: AppRunErrorCode | undefined = resolution === 'failed'
         ? 'APP_RUN_PROVIDER_ERROR'
         : undefined;
-      return this.repository.transition(tx, {
+      const resolved = await this.repository.transition(tx, {
         run, state: resolution, actor, now: this.now(), error_code: errorCode,
         event_type: 'reconciliation_recorded',
         safe_outcome: AppRunSafeOutcomeSchema.parse({
@@ -236,7 +390,23 @@ export class AppRunService {
           ...(errorCode ? { error_code: errorCode } : {}),
         }),
       });
+      await this.receiptWriter.write(tx, {
+        receipt_key: `reconciliation:${run.id}:${resolved.reconciled_at?.toISOString() ?? 'recorded'}`,
+        receipt_kind: 'reconciliation',
+        run: resolved,
+        actor,
+        facts: { resolution },
+        occurred_at: resolved.reconciled_at ?? this.now(),
+      });
+      return resolved;
     });
+    try {
+      await this.attention.projectRunState(reconciled, 'reconciled');
+    } catch (error) {
+      console.warn('[app-runs] reconciliation Attention projection failed:',
+        error instanceof Error ? error.message : 'unknown error');
+    }
+    return reconciled;
   }
 
   async result(orgId: string, runId: string, actor: AppRunActor): Promise<Readonly<{
@@ -263,6 +433,7 @@ export class AppRunService {
     const references = [
       ...await this.repository.activeKeyReferences(now),
       ...await this.secretRepository.retainedKeyReferences(now),
+      ...await this.secretRepository.receiptSigningKeyReferences(),
     ];
     assertAppRunReferencedKeysAvailable(this.keys, references);
   }

--- a/apps/api/src/lib/app-run-worker-handler.ts
+++ b/apps/api/src/lib/app-run-worker-handler.ts
@@ -5,13 +5,14 @@ import type { AppRunAttemptRunner } from './app-run-attempt-runner.js';
 const AppRunJobSchema = z.object({
   orgId: z.string().min(1).max(512),
   runId: z.string().min(1).max(512),
+  attemptId: z.string().min(1).max(512),
 }).strict();
 
-// PR B deliberately exports an injectable factory without registering it in
-// the production worker registry. PR C owns the cutover decision.
+// C0 deliberately keeps this injectable factory out of the production worker
+// registry. C4 owns provider/queue wiring and C5 owns the cutover decision.
 export function createAppRunAttemptJobHandler(runner: AppRunAttemptRunner): JobHandler {
   return async (job) => {
     const payload = AppRunJobSchema.parse(job.data);
-    await runner.run(payload.orgId, payload.runId, `job:${job.id}`, job.signal);
+    await runner.run(payload.orgId, payload.runId, payload.attemptId, `job:${job.id}`, job.signal);
   };
 }

--- a/apps/api/test/app-run-architecture.test.ts
+++ b/apps/api/test/app-run-architecture.test.ts
@@ -72,3 +72,18 @@ test('Run submission has one repository writer behind the advisory-lock service'
   }
   assert.deepEqual(violations, []);
 });
+
+test('the App Run approval bridge has one safe compatibility writer and no executor', async () => {
+  const adapter = await readFile(join(sourceRoot, 'lib/app-run-approval-adapter.ts'), 'utf8');
+  const service = await readFile(join(sourceRoot, 'lib/app-run-service.ts'), 'utf8');
+  const resolver = await readFile(join(sourceRoot, 'lib/agent-approval-resolver.ts'), 'utf8');
+
+  assert.match(adapter, /\.insert\(agentActions\)/);
+  assert.match(adapter, /action:\s*APP_RUN_APPROVAL_ACTION/);
+  assert.match(adapter, /approval_tier:\s*'full'/);
+  assert.match(adapter, /resource_ids/);
+  assert.match(adapter, /safe_preview/);
+  assert.doesNotMatch(adapter, /\b(?:executeTool|AppRunAttemptRunner|idempotency_key|raw_input|raw_output)\b/);
+  assert.match(service, /approvalAdapter\.create/);
+  assert.match(resolver, /row\.action === APP_RUN_APPROVAL_ACTION/);
+});

--- a/apps/api/test/app-run-architecture.test.ts
+++ b/apps/api/test/app-run-architecture.test.ts
@@ -61,3 +61,14 @@ test('the governed engine stays unwired from production entrances', async () => 
     assert.doesNotMatch(source, /\b(?:AppRunService|AppRunAttemptRunner|createAppRunAttemptJobHandler)\b/);
   }
 });
+
+test('Run submission has one repository writer behind the advisory-lock service', async () => {
+  const violations: string[] = [];
+  for (const path of await typescriptFiles(sourceRoot)) {
+    const sourcePath = relative(sourceRoot, path).replaceAll('\\', '/');
+    if (sourcePath === 'lib/app-run-repository.ts') continue;
+    const source = await readFile(path, 'utf8');
+    if (/\.insert\(appRuns\)/.test(source)) violations.push(sourcePath);
+  }
+  assert.deepEqual(violations, []);
+});

--- a/apps/api/test/app-run-architecture.test.ts
+++ b/apps/api/test/app-run-architecture.test.ts
@@ -87,3 +87,20 @@ test('the App Run approval bridge has one safe compatibility writer and no execu
   assert.match(service, /approvalAdapter\.create/);
   assert.match(resolver, /row\.action === APP_RUN_APPROVAL_ACTION/);
 });
+
+test('Run operations can repair projections but cannot call a provider', async () => {
+  const operations = await readFile(join(sourceRoot, 'lib/app-run-operations.ts'), 'utf8');
+  const receipts = await readFile(join(sourceRoot, 'lib/app-run-receipts.ts'), 'utf8');
+  const attention = await readFile(join(sourceRoot, 'lib/app-run-attention.ts'), 'utf8');
+
+  for (const source of [operations, receipts, attention]) {
+    assert.doesNotMatch(source, /\b(?:executeTool|AppRunProviderExecutor|provider_idempotency_key|claim_token)\b/);
+  }
+  assert.match(operations, /safeRunSelection/);
+  assert.match(operations, /Math\.max\(1, Math\.min\(limit \?\? 50, 100\)\)/);
+  assert.match(operations, /receipt_kind:\s*'repair'/);
+  assert.match(operations, /event_type:\s*'repair_gap'/);
+  assert.doesNotMatch(operations, /\b(?:authorization_snapshot|idempotency_fingerprint|input_fingerprint)\b/);
+  assert.match(receipts, /parseAppRunReceiptEnvelope/);
+  assert.match(attention, /sourceType:\s*'app_run'/);
+});

--- a/apps/api/test/app-run-engine-db.test.ts
+++ b/apps/api/test/app-run-engine-db.test.ts
@@ -56,6 +56,7 @@ function keyProvider(
 }
 
 const allowAll = { async authorize() { return true; } };
+const allowExecution = { async authorizeExecution() { return true; } };
 
 function service(
   now: () => Date = () => new Date(),
@@ -88,7 +89,7 @@ function submission(overrides: Record<string, unknown> = {}) {
     provider_snapshot_digest: digest,
     policy: {
       risk_class: 'external_write',
-      review_requirement: 'always',
+      review_requirement: 'policy',
       review_scope: 'per_invocation',
       retry_class: 'unsafe_or_unknown',
     },
@@ -123,6 +124,10 @@ before(async () => {
   await client.connect();
   await client.query('INSERT INTO orgs (id, name, slug) VALUES ($1, $2, $3)', [ORG_ID, 'App Run Test', ORG_ID]);
   await client.query(
+    'INSERT INTO users (id, email, name) VALUES ($1, $2, $3)',
+    [USER_ID, `${USER_ID}@example.test`, 'App Run Test User'],
+  );
+  await client.query(
     `INSERT INTO capability_provider_snapshots
       (id, org_id, provider_kind, provider_instance_id, adapter_contract_version,
        snapshot_digest, safe_snapshot, captured_at)
@@ -133,7 +138,9 @@ before(async () => {
 
 after(async () => {
   if (client) {
+    await client.query('DELETE FROM agent_actions WHERE user_id = $1', [USER_ID]);
     await client.query('DELETE FROM orgs WHERE id = $1', [ORG_ID]);
+    await client.query('DELETE FROM users WHERE id = $1', [USER_ID]);
     await client.end();
   }
   for (const provider of providers) provider.destroy();
@@ -186,6 +193,30 @@ test('submission is atomic, rotation-safe, tenant-scoped, and replay-conflict aw
   );
 });
 
+test('idempotency keys can be reused once their host-owned horizon expires', async () => {
+  let clock = new Date('2026-01-01T00:00:00.000Z');
+  const setup = service(() => clock);
+  const request = submission({
+    idempotency_key: `horizon-${suffix}`,
+    retention_class: 'ephemeral',
+  });
+  const first = await setup.service.submit(trusted, request);
+  clock = new Date('2026-01-09T00:00:00.000Z');
+  const replacements = await Promise.all(
+    Array.from({ length: 20 }, () => setup.service.submit(trusted, request)),
+  );
+  assert.equal(new Set(replacements.map((run) => run.id)).size, 1);
+  assert.notEqual(replacements[0]!.id, first.id);
+  const count = await client.query<{ count: string }>(
+    `SELECT count(*) FROM app_runs
+      WHERE org_id = $1 AND idempotency_fingerprint = (
+        SELECT idempotency_fingerprint FROM app_runs WHERE id = $2
+      )`,
+    [ORG_ID, first.id],
+  );
+  assert.equal(count.rows[0]!.count, '2');
+});
+
 class CountingExecutor implements AppRunProviderExecutor {
   calls: AppRunProviderExecutionRequest[] = [];
   results: AppRunProviderExecutionResult[] = [];
@@ -196,9 +227,133 @@ class CountingExecutor implements AppRunProviderExecutor {
     this.calls.push(request);
     this.entered?.();
     if (this.wait) await this.wait;
-    return this.results.shift() ?? { status: 'succeeded', output: { message_id: 'message-1' } };
+    return this.results.shift() ?? {
+      status: 'returned', provider_succeeded: true, output: { message_id: 'message-1' },
+    };
   }
 }
+
+async function prepareAttempt(runner: AppRunAttemptRunner, runId: string): Promise<string> {
+  const attemptId = await runner.prepareAttempt(ORG_ID, runId);
+  assert.ok(attemptId);
+  return attemptId;
+}
+
+test('approval release and live execution authorization both fail closed', async () => {
+  const setup = service();
+  const approvalRequired = await setup.service.submit(trusted, submission({
+    idempotency_key: `approval-gate-${suffix}`,
+    policy: {
+      risk_class: 'external_write', review_requirement: 'always',
+      review_scope: 'per_invocation', retry_class: 'unsafe_or_unknown',
+    },
+  }));
+  assert.equal(approvalRequired.state, 'pending_approval');
+  assert.equal(approvalRequired.execution_released_at, null);
+
+  const executor = new CountingExecutor();
+  const allowedRunner = new AppRunAttemptRunner(
+    setup.repository, setup.secretRepository, setup.secrets, executor, allowExecution,
+  );
+  assert.equal(await allowedRunner.prepareAttempt(ORG_ID, approvalRequired.id), null);
+  await allowedRunner.run(ORG_ID, approvalRequired.id, randomUUID(), 'unreleased-worker');
+  assert.equal(executor.calls.length, 0);
+  await assert.rejects(
+    client.query(
+      `UPDATE app_runs SET state = 'running', started_at = now()
+       WHERE org_id = $1 AND id = $2`,
+      [ORG_ID, approvalRequired.id],
+    ),
+    /APP_RUN_EXECUTION_NOT_RELEASED/,
+  );
+  await assert.rejects(
+    client.query(
+      `INSERT INTO app_run_attempts (id, org_id, run_id, attempt_number, state)
+       VALUES ($1, $2, $3, 1, 'pending')`,
+      [randomUUID(), ORG_ID, approvalRequired.id],
+    ),
+    /APP_RUN_EXECUTION_NOT_RELEASED/,
+  );
+
+  const policyReleased = await setup.service.submit(trusted, submission({
+    idempotency_key: `execution-authorizer-${suffix}`,
+  }));
+  await client.query(
+    `UPDATE app_runs
+        SET budget_reserved_at = now(), budget_reserved_count = 1, budget_limit_at_reservation = 10
+      WHERE org_id = $1 AND id = $2`,
+    [ORG_ID, policyReleased.id],
+  );
+  await assert.rejects(
+    client.query(
+      `UPDATE app_runs SET budget_reserved_count = 2 WHERE org_id = $1 AND id = $2`,
+      [ORG_ID, policyReleased.id],
+    ),
+    /APP_RUN_IMMUTABLE_FIELD/,
+  );
+  const deniedRunner = new AppRunAttemptRunner(
+    setup.repository, setup.secretRepository, setup.secrets, executor,
+  );
+  assert.equal(policyReleased.execution_release_kind, 'policy_satisfied');
+  assert.equal(await deniedRunner.prepareAttempt(ORG_ID, policyReleased.id), null);
+
+  const approved = await setup.repository.transaction(async (tx) => {
+    const run = await setup.repository.lockRun(tx, ORG_ID, approvalRequired.id);
+    assert.ok(run);
+    return setup.repository.recordApprovedExecutionRelease(
+      tx, run, trusted.initiating_actor, new Date(),
+    );
+  });
+  assert.equal(approved.execution_release_kind, 'approved');
+  await assert.rejects(
+    client.query(
+      `UPDATE app_runs SET execution_release_kind = 'policy_satisfied'
+       WHERE org_id = $1 AND id = $2`,
+      [ORG_ID, approvalRequired.id],
+    ),
+    /APP_RUN_IMMUTABLE_FIELD/,
+  );
+  const attemptId = await prepareAttempt(allowedRunner, approvalRequired.id);
+  assert.equal((await allowedRunner.run(
+    ORG_ID, approvalRequired.id, attemptId, 'approved-worker',
+  )).state, 'succeeded');
+  assert.equal(executor.calls.length, 1);
+  const events = await client.query<{ count: string }>(
+    `SELECT count(*) FROM app_run_events
+      WHERE org_id = $1 AND run_id = $2 AND event_type = 'approval_resolved'`,
+    [ORG_ID, approvalRequired.id],
+  );
+  assert.equal(events.rows[0]!.count, '1');
+});
+
+test('approval compatibility links are exact, bounded, and safe-key allowlisted', async () => {
+  const setup = service();
+  const created = await setup.service.submit(trusted, submission({
+    idempotency_key: `approval-link-${suffix}`,
+  }));
+  await client.query(
+    `INSERT INTO agent_actions
+      (id, org_id, user_id, app_run_id, action, params, approval_tier, approval_status)
+     VALUES ($1, $2, $3, $4, 'app_run_invoke', $5::jsonb, 'quick', 'pending')`,
+    [randomUUID(), ORG_ID, USER_ID, created.id, JSON.stringify({ run_id: created.id })],
+  );
+  for (const [action, appRunId, params] of [
+    ['create_task', created.id, { run_id: created.id }],
+    ['app_run_invoke', null, { run_id: created.id }],
+    ['app_run_invoke', created.id, { safe_preview: { title: 'Missing identity' } }],
+    ['app_run_invoke', created.id, { run_id: created.id, input: { secret: true } }],
+  ] as const) {
+    await assert.rejects(
+      client.query(
+        `INSERT INTO agent_actions
+          (id, org_id, user_id, app_run_id, action, params, approval_tier, approval_status)
+         VALUES ($1, $2, $3, $4, $5, $6::jsonb, 'quick', 'pending')`,
+        [randomUUID(), ORG_ID, USER_ID, appRunId, action, JSON.stringify(params)],
+      ),
+      /agent_actions_app_run_shape_check/,
+    );
+  }
+});
 
 test('concurrent runners call once, commit the call boundary, and replay retained output with authorization', async () => {
   const setup = service();
@@ -208,13 +363,14 @@ test('concurrent runners call once, commit the call boundary, and replay retaine
   executor.wait = new Promise<void>((resolve) => { release = resolve; });
   const entered = new Promise<void>((resolve) => { executor.entered = resolve; });
   const runner = new AppRunAttemptRunner(
-    setup.repository, setup.secretRepository, setup.secrets, executor,
+    setup.repository, setup.secretRepository, setup.secrets, executor, allowExecution,
   );
 
-  const firstExecution = runner.run(ORG_ID, created.id, 'worker-0');
+  const attemptId = await prepareAttempt(runner, created.id);
+  const firstExecution = runner.run(ORG_ID, created.id, attemptId, 'worker-0');
   await entered;
   const competitors = Array.from({ length: 15 }, (_, index) =>
-    runner.run(ORG_ID, created.id, `worker-${index + 1}`));
+    runner.run(ORG_ID, created.id, attemptId, `worker-${index + 1}`));
   await Promise.all(competitors);
   const boundary = await client.query<{ state: string; run_state: string }>(
     `SELECT a.state, r.state AS run_state
@@ -239,7 +395,9 @@ test('concurrent runners call once, commit the call boundary, and replay retaine
   const finished = await setup.service.inspect(ORG_ID, created.id, trusted.initiating_actor);
   assert.equal(finished.state, 'succeeded');
   assert.deepEqual((await setup.service.result(ORG_ID, created.id, trusted.initiating_actor)).value, {
-    message_id: 'message-1',
+    schema_version: APP_RUN_CONTRACT_VERSIONS.provider_result,
+    provider_succeeded: true,
+    output: { message_id: 'message-1' },
   });
   const attemptCounts = await client.query<{ attempts: string; outputs: string }>(
     `SELECT
@@ -262,37 +420,153 @@ test('concurrent runners call once, commit the call boundary, and replay retaine
   assert.equal(touchedSecret, false);
 });
 
+test('provider-reported failures retain an authorized exact response without recalling the provider', async () => {
+  const setup = service();
+  const created = await setup.service.submit(trusted, submission({
+    idempotency_key: `known-provider-error-${suffix}`,
+  }));
+  const privateMarker = `provider-private-${suffix}`;
+  const executor = new CountingExecutor();
+  executor.results.push({
+    status: 'returned',
+    provider_succeeded: false,
+    output: { is_error: true, code: 'recipient_rejected', detail: privateMarker },
+  });
+  const runner = new AppRunAttemptRunner(
+    setup.repository, setup.secretRepository, setup.secrets, executor, allowExecution,
+  );
+  const attemptId = await prepareAttempt(runner, created.id);
+  const finished = await runner.run(ORG_ID, created.id, attemptId, 'known-error-worker');
+  assert.equal(finished.state, 'failed');
+  assert.deepEqual(finished.safe_outcome, {
+    success: false,
+    provider_call_attempted: true,
+    result_status: 'retained',
+    error_code: 'APP_RUN_PROVIDER_ERROR',
+  });
+  assert.deepEqual((await setup.service.result(
+    ORG_ID, created.id, trusted.initiating_actor,
+  )).value, {
+    schema_version: APP_RUN_CONTRACT_VERSIONS.provider_result,
+    provider_succeeded: false,
+    output: { is_error: true, code: 'recipient_rejected', detail: privateMarker },
+  });
+  await runner.run(ORG_ID, created.id, attemptId, 'known-error-duplicate');
+  assert.equal(executor.calls.length, 1);
+  const safeResidue = await client.query<{ row: string }>(
+    `SELECT row_to_json(safe)::text AS row FROM (
+       SELECT state, safe_preview, safe_outcome FROM app_runs WHERE id = $1
+     ) safe`,
+    [created.id],
+  );
+  assert.doesNotMatch(safeResidue.rows[0]!.row, new RegExp(privateMarker));
+});
+
+test('a provider call known not to have started fails without an indeterminate outcome', async () => {
+  const setup = service();
+  const created = await setup.service.submit(trusted, submission({
+    idempotency_key: `not-attempted-${suffix}`,
+  }));
+  const executor = new CountingExecutor();
+  executor.results.push({ status: 'not_attempted' });
+  const runner = new AppRunAttemptRunner(
+    setup.repository, setup.secretRepository, setup.secrets, executor, allowExecution,
+  );
+  const attemptId = await prepareAttempt(runner, created.id);
+  const finished = await runner.run(ORG_ID, created.id, attemptId, 'not-attempted-worker');
+  assert.equal(finished.state, 'failed');
+  assert.deepEqual(finished.safe_outcome, {
+    success: false,
+    provider_call_attempted: false,
+    result_status: 'unavailable',
+    error_code: 'APP_RUN_PROVIDER_UNAVAILABLE',
+  });
+  await runner.run(ORG_ID, created.id, attemptId, 'not-attempted-duplicate');
+  assert.equal(executor.calls.length, 1);
+  await assert.rejects(
+    setup.service.result(ORG_ID, created.id, trusted.initiating_actor),
+    (error: any) => error?.code === 'APP_RUN_RESULT_EXPIRED',
+  );
+});
+
+test('attempt heartbeats keep a long provider call fenced across lease intervals', async () => {
+  const setup = service();
+  const created = await setup.service.submit(trusted, submission({
+    idempotency_key: `heartbeat-${suffix}`,
+  }));
+  const executor = new CountingExecutor();
+  let release!: () => void;
+  executor.wait = new Promise<void>((resolve) => { release = resolve; });
+  const entered = new Promise<void>((resolve) => { executor.entered = resolve; });
+  let clock = new Date('2026-04-01T00:00:00.000Z');
+  const runner = new AppRunAttemptRunner(
+    setup.repository, setup.secretRepository, setup.secrets, executor,
+    allowExecution, () => clock, 1_000, 50,
+  );
+  const originalRenew = runner.renewLease.bind(runner);
+  let renewals = 0;
+  const waiters: Array<{ target: number; resolve: () => void }> = [];
+  runner.renewLease = async (...args: Parameters<AppRunAttemptRunner['renewLease']>) => {
+    const renewed = await originalRenew(...args);
+    if (renewed) {
+      renewals += 1;
+      for (const waiter of waiters.filter((item) => item.target <= renewals)) waiter.resolve();
+    }
+    return renewed;
+  };
+  const waitForRenewals = async (target: number) => {
+    if (renewals >= target) return;
+    await new Promise<void>((resolve) => { waiters.push({ target, resolve }); });
+  };
+
+  const attemptId = await prepareAttempt(runner, created.id);
+  const inFlight = runner.run(ORG_ID, created.id, attemptId, 'heartbeat-worker');
+  await entered;
+  clock = new Date('2026-04-01T00:00:00.900Z');
+  await waitForRenewals(1);
+  clock = new Date('2026-04-01T00:00:01.800Z');
+  await waitForRenewals(2);
+  assert.equal(await runner.recoverRun(ORG_ID, created.id), 0);
+  release();
+  assert.equal((await inFlight).state, 'succeeded');
+  assert.ok(renewals >= 2);
+});
+
 test('unsafe indeterminate effects never retry while safe and idempotent effects use new attempts', async () => {
   const unsafeSetup = service();
   const unsafe = await unsafeSetup.service.submit(trusted, submission({ idempotency_key: `unsafe-${suffix}` }));
   const unsafeExecutor = new CountingExecutor();
   unsafeExecutor.results.push({ status: 'indeterminate' });
   const unsafeRunner = new AppRunAttemptRunner(
-    unsafeSetup.repository, unsafeSetup.secretRepository, unsafeSetup.secrets, unsafeExecutor,
+    unsafeSetup.repository, unsafeSetup.secretRepository, unsafeSetup.secrets, unsafeExecutor, allowExecution,
   );
-  assert.equal((await unsafeRunner.run(ORG_ID, unsafe.id, 'unsafe-1')).state, 'unknown_outcome');
-  await unsafeRunner.run(ORG_ID, unsafe.id, 'unsafe-2');
+  const unsafeAttempt = await prepareAttempt(unsafeRunner, unsafe.id);
+  assert.equal((await unsafeRunner.run(ORG_ID, unsafe.id, unsafeAttempt, 'unsafe-1')).state, 'unknown_outcome');
+  await unsafeRunner.run(ORG_ID, unsafe.id, unsafeAttempt, 'unsafe-2');
   assert.equal(unsafeExecutor.calls.length, 1);
 
   const idempotentSetup = service();
   const idempotent = await idempotentSetup.service.submit(trusted, submission({
     idempotency_key: `idempotent-${suffix}`,
     policy: {
-      risk_class: 'external_write', review_requirement: 'always',
+      risk_class: 'external_write', review_requirement: 'policy',
       review_scope: 'per_invocation', retry_class: 'idempotent_with_key',
     },
   }));
   const idempotentExecutor = new CountingExecutor();
   idempotentExecutor.results.push(
     { status: 'indeterminate' },
-    { status: 'succeeded', output: { delivered: true } },
+    { status: 'returned', provider_succeeded: true, output: { delivered: true } },
   );
   const idempotentRunner = new AppRunAttemptRunner(
     idempotentSetup.repository, idempotentSetup.secretRepository, idempotentSetup.secrets,
-    idempotentExecutor,
+    idempotentExecutor, allowExecution,
   );
-  assert.equal((await idempotentRunner.run(ORG_ID, idempotent.id, 'idempotent-1')).state, 'running');
-  assert.equal((await idempotentRunner.run(ORG_ID, idempotent.id, 'idempotent-2')).state, 'succeeded');
+  const firstAttempt = await prepareAttempt(idempotentRunner, idempotent.id);
+  assert.equal((await idempotentRunner.run(ORG_ID, idempotent.id, firstAttempt, 'idempotent-1')).state, 'running');
+  const secondAttempt = await prepareAttempt(idempotentRunner, idempotent.id);
+  assert.notEqual(secondAttempt, firstAttempt);
+  assert.equal((await idempotentRunner.run(ORG_ID, idempotent.id, secondAttempt, 'idempotent-2')).state, 'succeeded');
   assert.equal(idempotentExecutor.calls.length, 2);
   assert.equal(idempotentExecutor.calls[0]!.provider_idempotency_key, idempotentExecutor.calls[1]!.provider_idempotency_key);
   const attempts = await client.query<{ attempt_number: number; retry_of_attempt_id: string | null }>(
@@ -303,6 +577,44 @@ test('unsafe indeterminate effects never retry while safe and idempotent effects
   assert.equal(attempts.rows.length, 2);
   assert.equal(attempts.rows[0]!.retry_of_attempt_id, null);
   assert.ok(attempts.rows[1]!.retry_of_attempt_id);
+});
+
+test('a stale exact-attempt job cannot claim a later retry', async () => {
+  const setup = service();
+  const created = await setup.service.submit(trusted, submission({
+    idempotency_key: `stale-job-${suffix}`,
+    policy: {
+      risk_class: 'external_write', review_requirement: 'policy',
+      review_scope: 'per_invocation', retry_class: 'idempotent_with_key',
+    },
+  }));
+  const executor = new CountingExecutor();
+  executor.results.push(
+    { status: 'indeterminate' },
+    { status: 'returned', provider_succeeded: true, output: { delivered: true } },
+  );
+  const runner = new AppRunAttemptRunner(
+    setup.repository, setup.secretRepository, setup.secrets, executor, allowExecution,
+  );
+  const handler = createAppRunAttemptJobHandler(runner);
+  const firstAttempt = await prepareAttempt(runner, created.id);
+  await handler({
+    id: 'first-attempt-job', name: 'app-run-attempt', attempts: 1,
+    data: { orgId: ORG_ID, runId: created.id, attemptId: firstAttempt },
+  });
+  const secondAttempt = await prepareAttempt(runner, created.id);
+  assert.notEqual(secondAttempt, firstAttempt);
+  await handler({
+    id: 'stale-attempt-job', name: 'app-run-attempt', attempts: 2,
+    data: { orgId: ORG_ID, runId: created.id, attemptId: firstAttempt },
+  });
+  assert.equal(executor.calls.length, 1);
+  await handler({
+    id: 'second-attempt-job', name: 'app-run-attempt', attempts: 1,
+    data: { orgId: ORG_ID, runId: created.id, attemptId: secondAttempt },
+  });
+  assert.equal(executor.calls.length, 2);
+  assert.equal((await setup.repository.inspect(ORG_ID, created.id))?.state, 'succeeded');
 });
 
 test('retention purge is one-way, audited, and leaves only safe terminal residue', async () => {
@@ -334,9 +646,10 @@ test('a hard crash after the call boundary recovers unsafe work as unknown and f
   const entered = new Promise<void>((resolve) => { executor.entered = resolve; });
   let clock = new Date();
   const runner = new AppRunAttemptRunner(
-    setup.repository, setup.secretRepository, setup.secrets, executor, () => clock, 1_000,
+    setup.repository, setup.secretRepository, setup.secrets, executor, allowExecution, () => clock, 1_000, 60_000,
   );
-  const inFlight = runner.run(ORG_ID, created.id, 'crash-worker');
+  const attemptId = await prepareAttempt(runner, created.id);
+  const inFlight = runner.run(ORG_ID, created.id, attemptId, 'crash-worker');
   await entered;
   clock = new Date(clock.getTime() + 2_000);
   assert.equal(await runner.recoverRun(ORG_ID, created.id), 1);
@@ -361,9 +674,13 @@ test('a durable known result survives finalization failure and repair never reca
     return originalTransition(tx, input);
   };
   const runner = new AppRunAttemptRunner(
-    setup.repository, setup.secretRepository, setup.secrets, executor,
+    setup.repository, setup.secretRepository, setup.secrets, executor, allowExecution,
   );
-  await assert.rejects(runner.run(ORG_ID, created.id, 'repair-worker'), /injected finalization failure/);
+  const attemptId = await prepareAttempt(runner, created.id);
+  await assert.rejects(
+    runner.run(ORG_ID, created.id, attemptId, 'repair-worker'),
+    /injected finalization failure/,
+  );
   assert.equal(executor.calls.length, 1);
   const marker = await client.query<{ state: string; provider_call_finished_at: Date | null }>(
     'SELECT state, provider_call_finished_at FROM app_run_attempts WHERE org_id = $1 AND run_id = $2',
@@ -378,7 +695,7 @@ test('a durable known result survives finalization failure and repair never reca
   };
   const future = new Date(Date.now() + 2 * 60_000);
   const repairRunner = new AppRunAttemptRunner(
-    setup.repository, setup.secretRepository, setup.secrets, repairExecutor, () => future,
+    setup.repository, setup.secretRepository, setup.secrets, repairExecutor, allowExecution, () => future,
   );
   assert.equal(await repairRunner.recoverRun(ORG_ID, created.id), 1);
   assert.equal((await setup.repository.inspect(ORG_ID, created.id))?.state, 'succeeded');
@@ -389,14 +706,17 @@ test('oversized post-effect output remains known success without exact result or
   const setup = service();
   const created = await setup.service.submit(trusted, submission({ idempotency_key: `oversized-${suffix}` }));
   const executor = new CountingExecutor();
-  executor.results.push({ status: 'succeeded', output: { value: 'x'.repeat(1024 * 1024 + 1) } });
+  executor.results.push({
+    status: 'returned', provider_succeeded: true, output: { value: 'x'.repeat(1024 * 1024 + 1) },
+  });
   const runner = new AppRunAttemptRunner(
-    setup.repository, setup.secretRepository, setup.secrets, executor,
+    setup.repository, setup.secretRepository, setup.secrets, executor, allowExecution,
   );
-  const finished = await runner.run(ORG_ID, created.id, 'oversized-worker');
+  const attemptId = await prepareAttempt(runner, created.id);
+  const finished = await runner.run(ORG_ID, created.id, attemptId, 'oversized-worker');
   assert.equal(finished.state, 'succeeded');
   assert.equal(finished.safe_outcome?.result_status, 'unavailable');
-  await runner.run(ORG_ID, created.id, 'oversized-worker-2');
+  await runner.run(ORG_ID, created.id, attemptId, 'oversized-worker-2');
   assert.equal(executor.calls.length, 1);
   await assert.rejects(
     setup.service.result(ORG_ID, created.id, trusted.initiating_actor),
@@ -444,19 +764,27 @@ test('database fencing rejects a second active attempt and mutable ownership', a
   );
 });
 
-test('the worker adapter accepts ID-only jobs and remains dependency injected', async () => {
+test('the worker adapter accepts exact identity-only jobs and remains dependency injected', async () => {
   const calls: unknown[] = [];
   const runner = {
-    async run(orgId: string, runId: string, workerId: string, signal?: AbortSignal) {
-      calls.push({ orgId, runId, workerId, signal });
+    async run(orgId: string, runId: string, attemptId: string, workerId: string, signal?: AbortSignal) {
+      calls.push({ orgId, runId, attemptId, workerId, signal });
       return {} as never;
     },
   } as AppRunAttemptRunner;
   const handler = createAppRunAttemptJobHandler(runner);
   const signal = new AbortController().signal;
-  await handler({ id: 'job-1', name: 'app-run-attempt', data: { orgId: ORG_ID, runId: 'run-1' }, attempts: 1, signal });
-  assert.deepEqual(calls, [{ orgId: ORG_ID, runId: 'run-1', workerId: 'job:job-1', signal }]);
+  await handler({
+    id: 'job-1', name: 'app-run-attempt',
+    data: { orgId: ORG_ID, runId: 'run-1', attemptId: 'attempt-1' }, attempts: 1, signal,
+  });
+  assert.deepEqual(calls, [{
+    orgId: ORG_ID, runId: 'run-1', attemptId: 'attempt-1', workerId: 'job:job-1', signal,
+  }]);
   await assert.rejects(
-    handler({ id: 'job-2', name: 'app-run-attempt', data: { orgId: ORG_ID, runId: 'run-1', input: 'secret' }, attempts: 1 }),
+    handler({
+      id: 'job-2', name: 'app-run-attempt',
+      data: { orgId: ORG_ID, runId: 'run-1', attemptId: 'attempt-1', input: 'secret' }, attempts: 1,
+    }),
   );
 });

--- a/apps/api/test/app-run-engine-db.test.ts
+++ b/apps/api/test/app-run-engine-db.test.ts
@@ -17,6 +17,7 @@ import { AppRunSecretRepository } from '../src/lib/app-run-secret-repository.js'
 import { AppRunSecretService } from '../src/lib/app-run-secrets.js';
 import { AppRunService } from '../src/lib/app-run-service.js';
 import { PostgresAppRunLiveAuthorization } from '../src/lib/app-run-live-authorization.js';
+import { approveAction, rejectAction } from '../src/lib/agent-approval-resolver.js';
 import { createAppRunAttemptJobHandler } from '../src/lib/app-run-worker-handler.js';
 import { parseEnvironmentAppRunKeyrings, type EnvironmentAppRunKeyProvider } from '../src/lib/app-run-keyrings.js';
 import { closeDb } from '../src/lib/db.js';
@@ -305,16 +306,16 @@ test('live authority revocation is sticky and the execution budget is reserved e
 
   const live = new PostgresAppRunLiveAuthorization();
   const executionActor = { actor_type: 'agent_employee' as const, agent_employee_id: employeeId };
-  const capture = () => live.capture({
+  const capture = (effectivePolicy = policy) => live.capture({
     org_id: ORG_ID,
     authenticated_subject: trusted.initiating_actor,
     execution_actor: executionActor,
     provider_instance_id: providerId,
     provider_snapshot_id: snapshotId,
     operation_name: operationName,
-    policy,
+    policy: effectivePolicy,
   });
-  const liveSubmission = async (key: string) => ({
+  const liveSubmission = async (key: string, effectivePolicy = policy) => ({
     ...submission({
       idempotency_key: key,
       execution_actor: executionActor,
@@ -324,12 +325,29 @@ test('live authority revocation is sticky and the execution budget is reserved e
         operation_name: operationName,
       },
       provider_snapshot_digest: snapshot.snapshot_digest,
-      policy,
-      authorization_snapshot: await capture(),
+      policy: effectivePolicy,
+      authorization_snapshot: await capture(effectivePolicy),
     }),
   });
   const liveTrusted = { ...trusted, execution_actor: executionActor };
   const setup = service();
+  const alwaysPolicy = {
+    ...policy,
+    review_requirement: 'always' as const,
+  };
+  const staleApproval = await setup.service.submit(
+    liveTrusted,
+    await liveSubmission(`live-stale-approval-${suffix}`, alwaysPolicy),
+  );
+  const staleApprovalAction = await client.query<{ id: string; params: unknown }>(
+    `SELECT id, params FROM agent_actions WHERE org_id = $1 AND app_run_id = $2`,
+    [ORG_ID, staleApproval.id],
+  );
+  assert.equal(staleApprovalAction.rowCount, 1);
+  assert.doesNotMatch(
+    JSON.stringify(staleApprovalAction.rows[0]!.params),
+    new RegExp(`raw-marker-${suffix}|live-stale-approval-${suffix}|recipient|body`),
+  );
   const stale = await setup.service.submit(
     liveTrusted,
     await liveSubmission(`live-stale-${suffix}`),
@@ -345,6 +363,25 @@ test('live authority revocation is sticky and the execution budget is reserved e
     `UPDATE org_members SET is_active = true WHERE org_id = $1 AND user_id = $2`,
     [ORG_ID, USER_ID],
   );
+  const staleApprovalResult = await approveAction(staleApprovalAction.rows[0]!.id, USER_ID);
+  assert.equal(staleApprovalResult.status, 'error');
+  const staleApprovalState = await client.query<{
+    run_state: string;
+    action_state: string;
+    execution_release_kind: string | null;
+  }>(
+    `SELECT r.state AS run_state, a.approval_status AS action_state,
+            r.execution_release_kind
+       FROM app_runs r JOIN agent_actions a
+         ON a.org_id = r.org_id AND a.app_run_id = r.id
+      WHERE r.org_id = $1 AND r.id = $2`,
+    [ORG_ID, staleApproval.id],
+  );
+  assert.deepEqual(staleApprovalState.rows[0], {
+    run_state: 'expired',
+    action_state: 'expired',
+    execution_release_kind: null,
+  });
   const executor = new CountingExecutor();
   const runner = new AppRunAttemptRunner(
     setup.repository, setup.secretRepository, setup.secrets, executor, live,
@@ -399,6 +436,62 @@ test('live authority revocation is sticky and the execution budget is reserved e
   );
   assert.equal(versions.rows[0]!.member, 3);
   assert.equal(versions.rows[0]!.connector, 3);
+
+  const raced = await setup.service.submit(
+    liveTrusted,
+    await liveSubmission(`live-approval-race-${suffix}`, alwaysPolicy),
+  );
+  const raceAction = await client.query<{ id: string; params: unknown }>(
+    `SELECT id, params FROM agent_actions WHERE org_id = $1 AND app_run_id = $2`,
+    [ORG_ID, raced.id],
+  );
+  assert.equal(raceAction.rowCount, 1);
+  assert.equal(await runner.prepareAttempt(ORG_ID, raced.id), null);
+  const internalBypass = await approveAction(raceAction.rows[0]!.id, USER_ID, { internal: true });
+  assert.deepEqual(internalBypass, {
+    status: 'error',
+    code: 'FORBIDDEN',
+    message: 'only the requester or an org owner/admin may approve this action',
+  });
+  await Promise.all(Array.from({ length: 20 }, (_, index) => (
+    index % 2 === 0
+      ? approveAction(raceAction.rows[0]!.id, USER_ID)
+      : rejectAction(raceAction.rows[0]!.id, USER_ID, `ignored raw reason ${index}`)
+  )));
+  const raceState = await client.query<{
+    run_state: string;
+    execution_release_kind: string | null;
+    action_state: string;
+    approval_events: string;
+    attempts: string;
+    error: string | null;
+  }>(
+    `SELECT r.state AS run_state, r.execution_release_kind,
+            a.approval_status AS action_state, a.error,
+            (SELECT count(*) FROM app_run_events e
+              WHERE e.org_id = r.org_id AND e.run_id = r.id
+                AND e.event_type = 'approval_resolved') AS approval_events,
+            (SELECT count(*) FROM app_run_attempts ra
+              WHERE ra.org_id = r.org_id AND ra.run_id = r.id) AS attempts
+       FROM app_runs r JOIN agent_actions a
+         ON a.org_id = r.org_id AND a.app_run_id = r.id
+      WHERE r.org_id = $1 AND r.id = $2`,
+    [ORG_ID, raced.id],
+  );
+  const resolution = raceState.rows[0]!;
+  assert.equal(resolution.approval_events, '1');
+  assert.equal(resolution.attempts, '0');
+  assert.doesNotMatch(resolution.error ?? '', /ignored raw reason/);
+  if (resolution.execution_release_kind === 'approved') {
+    assert.equal(resolution.run_state, 'pending_approval');
+    assert.equal(resolution.action_state, 'approved');
+    assert.ok(await runner.prepareAttempt(ORG_ID, raced.id));
+  } else {
+    assert.equal(resolution.execution_release_kind, null);
+    assert.equal(resolution.run_state, 'cancelled');
+    assert.equal(resolution.action_state, 'rejected');
+    assert.equal(await runner.prepareAttempt(ORG_ID, raced.id), null);
+  }
 });
 
 async function prepareAttempt(runner: AppRunAttemptRunner, runId: string): Promise<string> {

--- a/apps/api/test/app-run-engine-db.test.ts
+++ b/apps/api/test/app-run-engine-db.test.ts
@@ -2,7 +2,10 @@ import assert from 'node:assert/strict';
 import { randomUUID } from 'node:crypto';
 import test, { after, before } from 'node:test';
 import pg from 'pg';
-import { APP_RUN_CONTRACT_VERSIONS } from '@deft/shared';
+import {
+  APP_RUN_CONTRACT_VERSIONS,
+  createCapabilityProviderDiscoverySnapshot,
+} from '@deft/shared';
 import { AppRunAttemptRunner } from '../src/lib/app-run-attempt-runner.js';
 import type {
   AppRunProviderExecutionRequest,
@@ -13,6 +16,7 @@ import { PostgresAppRunRepository } from '../src/lib/app-run-repository.js';
 import { AppRunSecretRepository } from '../src/lib/app-run-secret-repository.js';
 import { AppRunSecretService } from '../src/lib/app-run-secrets.js';
 import { AppRunService } from '../src/lib/app-run-service.js';
+import { PostgresAppRunLiveAuthorization } from '../src/lib/app-run-live-authorization.js';
 import { createAppRunAttemptJobHandler } from '../src/lib/app-run-worker-handler.js';
 import { parseEnvironmentAppRunKeyrings, type EnvironmentAppRunKeyProvider } from '../src/lib/app-run-keyrings.js';
 import { closeDb } from '../src/lib/db.js';
@@ -139,6 +143,8 @@ before(async () => {
 after(async () => {
   if (client) {
     await client.query('DELETE FROM agent_actions WHERE user_id = $1', [USER_ID]);
+    await client.query('DELETE FROM agent_employees WHERE user_id = $1', [USER_ID]);
+    await client.query('DELETE FROM mcp_connections WHERE created_by = $1', [USER_ID]);
     await client.query('DELETE FROM orgs WHERE id = $1', [ORG_ID]);
     await client.query('DELETE FROM users WHERE id = $1', [USER_ID]);
     await client.end();
@@ -232,6 +238,168 @@ class CountingExecutor implements AppRunProviderExecutor {
     };
   }
 }
+
+test('live authority revocation is sticky and the execution budget is reserved exactly once', async () => {
+  const providerId = `live-provider-${suffix}`;
+  const snapshotId = `live-snapshot-${suffix}`;
+  const employeeId = `live-employee-${suffix}`;
+  const operationName = 'send_email';
+  const policy = {
+    risk_class: 'external_write' as const,
+    review_requirement: 'policy' as const,
+    review_scope: 'per_invocation' as const,
+    retry_class: 'unsafe_or_unknown' as const,
+  };
+  await client.query(
+    `INSERT INTO org_members (id, org_id, user_id, role, is_active)
+     VALUES ($1, $2, $3, 'owner', true)
+     ON CONFLICT (org_id, user_id) DO UPDATE SET is_active = true`,
+    [`live-member-${suffix}`, ORG_ID, USER_ID],
+  );
+  await client.query(
+    `INSERT INTO mcp_connections
+      (id, org_id, name, slug, server_url, transport, auth_type, is_active,
+       default_trust_tier, enabled_tools, created_by)
+     VALUES ($1, $2, 'Live provider', $3, 'https://example.test/mcp',
+       'streamable-http', 'none', true, 'full', $4, $5)`,
+    [providerId, ORG_ID, providerId, [operationName], USER_ID],
+  );
+  await client.query(
+    `INSERT INTO agent_employees
+      (id, org_id, user_id, name, slug, role, system_prompt, mcp_connection_ids,
+       trust_level, max_daily_actions, daily_action_count, unhealthy, is_active,
+       is_deleted, created_by)
+     VALUES ($1, $2, $3, 'Live employee', $4, 'custom', 'Test', $5,
+       'autonomous', 5, 0, false, true, false, $3)`,
+    [employeeId, ORG_ID, USER_ID, employeeId, [providerId]],
+  );
+  const snapshot = await createCapabilityProviderDiscoverySnapshot({
+    adapter_contract_version: 'deft.capability.mcp-adapter.v1',
+    provider: {
+      org_id: ORG_ID,
+      provider_kind: 'mcp',
+      provider_instance_id: providerId,
+    },
+    captured_at: new Date().toISOString(),
+    operations: [{
+      identity: {
+        provider: {
+          org_id: ORG_ID,
+          provider_kind: 'mcp',
+          provider_instance_id: providerId,
+        },
+        operation_name: operationName,
+      },
+      description: 'Send one test email',
+      input_schema: { type: 'object' },
+    }],
+  });
+  await client.query(
+    `INSERT INTO capability_provider_snapshots
+      (id, org_id, provider_kind, provider_instance_id, adapter_contract_version,
+       snapshot_digest, safe_snapshot, captured_at)
+     VALUES ($1, $2, 'mcp', $3, $4, $5, $6::jsonb, $7)`,
+    [snapshotId, ORG_ID, providerId, snapshot.adapter_contract_version,
+      snapshot.snapshot_digest, JSON.stringify(snapshot), snapshot.captured_at],
+  );
+
+  const live = new PostgresAppRunLiveAuthorization();
+  const executionActor = { actor_type: 'agent_employee' as const, agent_employee_id: employeeId };
+  const capture = () => live.capture({
+    org_id: ORG_ID,
+    authenticated_subject: trusted.initiating_actor,
+    execution_actor: executionActor,
+    provider_instance_id: providerId,
+    provider_snapshot_id: snapshotId,
+    operation_name: operationName,
+    policy,
+  });
+  const liveSubmission = async (key: string) => ({
+    ...submission({
+      idempotency_key: key,
+      execution_actor: executionActor,
+      origin: { origin_kind: 'legacy_connector', connection_id: providerId },
+      operation: {
+        provider: { org_id: ORG_ID, provider_kind: 'mcp', provider_instance_id: providerId },
+        operation_name: operationName,
+      },
+      provider_snapshot_digest: snapshot.snapshot_digest,
+      policy,
+      authorization_snapshot: await capture(),
+    }),
+  });
+  const liveTrusted = { ...trusted, execution_actor: executionActor };
+  const setup = service();
+  const stale = await setup.service.submit(
+    liveTrusted,
+    await liveSubmission(`live-stale-${suffix}`),
+  );
+
+  // Restoring the same visible membership state still bumps the monotonic
+  // version, so a proposal captured before revocation cannot revive.
+  await client.query(
+    `UPDATE org_members SET is_active = false WHERE org_id = $1 AND user_id = $2`,
+    [ORG_ID, USER_ID],
+  );
+  await client.query(
+    `UPDATE org_members SET is_active = true WHERE org_id = $1 AND user_id = $2`,
+    [ORG_ID, USER_ID],
+  );
+  const executor = new CountingExecutor();
+  const runner = new AppRunAttemptRunner(
+    setup.repository, setup.secretRepository, setup.secrets, executor, live,
+  );
+  assert.equal(await runner.prepareAttempt(ORG_ID, stale.id), null);
+
+  const fresh = await setup.service.submit(
+    liveTrusted,
+    await liveSubmission(`live-fresh-${suffix}`),
+  );
+  const attempts = await Promise.all(
+    Array.from({ length: 12 }, () => runner.prepareAttempt(ORG_ID, fresh.id)),
+  );
+  assert.equal(new Set(attempts).size, 1);
+  assert.ok(attempts[0]);
+  const reservation = await client.query<{
+    daily_action_count: number;
+    budget_reserved_count: number;
+    budget_limit_at_reservation: number;
+  }>(
+    `SELECT e.daily_action_count, r.budget_reserved_count, r.budget_limit_at_reservation
+       FROM agent_employees e JOIN app_runs r
+         ON r.org_id = e.org_id AND r.execution_actor_id = e.id
+      WHERE r.org_id = $1 AND r.id = $2`,
+    [ORG_ID, fresh.id],
+  );
+  assert.deepEqual(reservation.rows[0], {
+    daily_action_count: 1,
+    budget_reserved_count: 1,
+    budget_limit_at_reservation: 5,
+  });
+
+  // Ordinary budget consumption does not change the bound authority version,
+  // while the Run's own reservation remains write-once.
+  await client.query(
+    `UPDATE agent_employees SET daily_action_count = daily_action_count + 1 WHERE id = $1`,
+    [employeeId],
+  );
+  assert.equal(await runner.prepareAttempt(ORG_ID, fresh.id), attempts[0]);
+
+  await client.query(`UPDATE mcp_connections SET is_active = false WHERE id = $1`, [providerId]);
+  await client.query(`UPDATE mcp_connections SET is_active = true WHERE id = $1`, [providerId]);
+  const stopped = await runner.run(ORG_ID, fresh.id, attempts[0]!, 'live-worker');
+  assert.equal(stopped.state, 'pending');
+  assert.equal(executor.calls.length, 0);
+  const versions = await client.query<{ member: number; connector: number }>(
+    `SELECT m.app_run_authorization_version AS member,
+            c.app_run_authorization_version AS connector
+       FROM org_members m CROSS JOIN mcp_connections c
+      WHERE m.org_id = $1 AND m.user_id = $2 AND c.id = $3`,
+    [ORG_ID, USER_ID, providerId],
+  );
+  assert.equal(versions.rows[0]!.member, 3);
+  assert.equal(versions.rows[0]!.connector, 3);
+});
 
 async function prepareAttempt(runner: AppRunAttemptRunner, runId: string): Promise<string> {
   const attemptId = await runner.prepareAttempt(ORG_ID, runId);

--- a/apps/api/test/app-run-engine-db.test.ts
+++ b/apps/api/test/app-run-engine-db.test.ts
@@ -17,9 +17,20 @@ import { AppRunSecretRepository } from '../src/lib/app-run-secret-repository.js'
 import { AppRunSecretService } from '../src/lib/app-run-secrets.js';
 import { AppRunService } from '../src/lib/app-run-service.js';
 import { PostgresAppRunLiveAuthorization } from '../src/lib/app-run-live-authorization.js';
+import {
+  PostgresAppRunApprovalResolver,
+  postgresAppRunApprovalAdapter,
+} from '../src/lib/app-run-approval-adapter.js';
+import { PostgresAppRunAttentionProjector } from '../src/lib/app-run-attention.js';
+import { AppRunOperationsService } from '../src/lib/app-run-operations.js';
+import { PostgresAppRunReceiptWriter } from '../src/lib/app-run-receipts.js';
 import { approveAction, rejectAction } from '../src/lib/agent-approval-resolver.js';
 import { createAppRunAttemptJobHandler } from '../src/lib/app-run-worker-handler.js';
-import { parseEnvironmentAppRunKeyrings, type EnvironmentAppRunKeyProvider } from '../src/lib/app-run-keyrings.js';
+import {
+  assertAppRunReferencedKeysAvailable,
+  parseEnvironmentAppRunKeyrings,
+  type EnvironmentAppRunKeyProvider,
+} from '../src/lib/app-run-keyrings.js';
 import { closeDb } from '../src/lib/db.js';
 
 const DATABASE_URL = process.env.DEFT_TEST_DATABASE_URL
@@ -238,6 +249,25 @@ class CountingExecutor implements AppRunProviderExecutor {
       status: 'returned', provider_succeeded: true, output: { message_id: 'message-1' },
     };
   }
+}
+
+function receiptRotationKeyProvider(
+  current: 'sig-v1' | 'sig-v2',
+  includeV1 = true,
+): EnvironmentAppRunKeyProvider {
+  const provider = parseEnvironmentAppRunKeyrings(JSON.stringify({
+    schema_version: APP_RUN_CONTRACT_VERSIONS.keyring,
+    run_encryption: { current: 'enc-v1', keys: { 'enc-v1': key(1) } },
+    receipt_signing: {
+      current,
+      keys: includeV1
+        ? { 'sig-v1': key(2), 'sig-v2': key(5) }
+        : { 'sig-v2': key(5) },
+    },
+    fingerprint: { current: 'fp-v1', keys: { 'fp-v1': key(3), 'fp-old': key(4) } },
+  }));
+  providers.push(provider);
+  return provider;
 }
 
 test('live authority revocation is sticky and the execution budget is reserved exactly once', async () => {
@@ -1022,6 +1052,387 @@ test('database fencing rejects a second active attempt and mutable ownership', a
       [randomUUID(), ORG_ID, created.id, attemptId],
     ),
     /app_run_attempts_one_active_unique/,
+  );
+});
+
+test('child Runs enforce cycle, depth, authority, policy, and root-budget ceilings', async () => {
+  const setup = service();
+  const root = await setup.service.submit(trusted, submission({
+    idempotency_key: `lineage-root-${suffix}`,
+  }));
+  await client.query(
+    `UPDATE app_runs SET state = 'running', started_at = now(), updated_at = now()
+     WHERE org_id = $1 AND id = $2`,
+    [ORG_ID, root.id],
+  );
+
+  await assert.rejects(
+    setup.service.submitChild(trusted, root.id, submission({
+      idempotency_key: `lineage-cycle-${suffix}`,
+    })),
+    (error: any) => error?.code === 'APP_RUN_CAPABILITY_CYCLE',
+  );
+  await assert.rejects(
+    setup.service.submitChild(trusted, root.id, submission({
+      idempotency_key: `lineage-policy-${suffix}`,
+      operation: {
+        provider: { org_id: ORG_ID, provider_kind: 'mcp', provider_instance_id: PROVIDER_ID },
+        operation_name: 'privileged_child',
+      },
+      policy: {
+        risk_class: 'privileged',
+        review_requirement: 'policy',
+        review_scope: 'per_invocation',
+        retry_class: 'unsafe_or_unknown',
+      },
+    })),
+    (error: any) => error?.code === 'APP_RUN_ACCESS_DENIED',
+  );
+  await assert.rejects(
+    setup.service.submitChild(trusted, root.id, submission({
+      idempotency_key: `lineage-authority-${suffix}`,
+      operation: {
+        provider: { org_id: ORG_ID, provider_kind: 'mcp', provider_instance_id: PROVIDER_ID },
+        operation_name: 'authority_child',
+      },
+      authorization_snapshot: {
+        schema_version: APP_RUN_CONTRACT_VERSIONS.run,
+        authenticated_subject: trusted.initiating_actor,
+        authority_refs: [
+          { authority_kind: 'membership', authority_id: USER_ID, version: '1' },
+          { authority_kind: 'token_scope', authority_id: 'new-token', version: '1' },
+          { authority_kind: 'connector', authority_id: PROVIDER_ID, version: '1' },
+        ],
+      },
+    })),
+    (error: any) => error?.code === 'APP_RUN_ACCESS_DENIED',
+  );
+
+  let parent = root;
+  for (let depth = 1; depth <= 8; depth += 1) {
+    const child = await setup.service.submitChild(trusted, parent.id, submission({
+      idempotency_key: `lineage-depth-${depth}-${suffix}`,
+      operation: {
+        provider: { org_id: ORG_ID, provider_kind: 'mcp', provider_instance_id: PROVIDER_ID },
+        operation_name: `child_operation_${depth}`,
+      },
+    }));
+    assert.equal(child.root_run_id, root.id);
+    assert.equal(child.parent_run_id, parent.id);
+    assert.equal(child.depth, depth);
+    assert.ok(child.input_expires_at <= parent.input_expires_at);
+    if (depth < 8) {
+      await client.query(
+        `UPDATE app_runs SET state = 'running', started_at = now(), updated_at = now()
+         WHERE org_id = $1 AND id = $2`,
+        [ORG_ID, child.id],
+      );
+    }
+    parent = child;
+  }
+  await assert.rejects(
+    setup.service.submitChild(trusted, parent.id, submission({
+      idempotency_key: `lineage-too-deep-${suffix}`,
+      operation: {
+        provider: { org_id: ORG_ID, provider_kind: 'mcp', provider_instance_id: PROVIDER_ID },
+        operation_name: 'too_deep',
+      },
+    })),
+    (error: any) => error?.code === 'APP_RUN_ANCESTRY_LIMIT',
+  );
+
+  const employeeId = `lineage-agent-${suffix}`;
+  const agentTrusted = {
+    org_id: ORG_ID,
+    initiating_actor: { actor_type: 'agent_employee' as const, agent_employee_id: employeeId },
+    execution_actor: { actor_type: 'agent_employee' as const, agent_employee_id: employeeId },
+  };
+  const agentSubmission = (operationName: string, idempotencyKey: string) => submission({
+    initiating_actor: agentTrusted.initiating_actor,
+    execution_actor: agentTrusted.execution_actor,
+    idempotency_key: idempotencyKey,
+    operation: {
+      provider: { org_id: ORG_ID, provider_kind: 'mcp', provider_instance_id: PROVIDER_ID },
+      operation_name: operationName,
+    },
+    authorization_snapshot: {
+      schema_version: APP_RUN_CONTRACT_VERSIONS.run,
+      authenticated_subject: agentTrusted.initiating_actor,
+      authority_refs: [
+        { authority_kind: 'membership', authority_id: USER_ID, version: '1' },
+        { authority_kind: 'employee_health', authority_id: employeeId, version: '1' },
+        { authority_kind: 'employee_budget', authority_id: employeeId, version: '1' },
+        { authority_kind: 'connector', authority_id: PROVIDER_ID, version: '1' },
+      ],
+    },
+  });
+  const agentRoot = await setup.service.submit(
+    agentTrusted,
+    agentSubmission('agent_root', `lineage-agent-root-${suffix}`),
+  );
+  await client.query(
+    `UPDATE app_runs SET state = 'running', started_at = now(),
+       budget_reserved_at = now(), budget_reserved_count = 1,
+       budget_limit_at_reservation = 25, updated_at = now()
+     WHERE org_id = $1 AND id = $2`,
+    [ORG_ID, agentRoot.id],
+  );
+  const agentChild = await setup.service.submitChild(
+    agentTrusted,
+    agentRoot.id,
+    agentSubmission('agent_child', `lineage-agent-child-${suffix}`),
+  );
+  const inheritedBudget = await client.query<{
+    budget_reserved_count: number | null;
+    budget_limit_at_reservation: number | null;
+  }>(
+    `SELECT budget_reserved_count, budget_limit_at_reservation
+       FROM app_runs WHERE org_id = $1 AND id = $2`,
+    [ORG_ID, agentChild.id],
+  );
+  assert.deepEqual(inheritedBudget.rows[0], {
+    budget_reserved_count: 1,
+    budget_limit_at_reservation: 25,
+  });
+});
+
+test('native receipts, Attention, operator reconciliation, and repair stay safe and idempotent', async () => {
+  await client.query(
+    `INSERT INTO org_members (id, org_id, user_id, role, is_active)
+     VALUES ($1, $2, $3, 'owner', true)
+     ON CONFLICT (org_id, user_id) DO UPDATE SET role = 'owner', is_active = true`,
+    [`ops-member-${suffix}`, ORG_ID, USER_ID],
+  );
+  const keys = receiptRotationKeyProvider('sig-v1');
+  const secrets = new AppRunSecretService(keys);
+  const repository = new PostgresAppRunRepository();
+  const secretRepository = new AppRunSecretRepository(secrets);
+  const receipts = new PostgresAppRunReceiptWriter(secrets, secretRepository);
+  const attention = new PostgresAppRunAttentionProjector(false);
+  const runs = new AppRunService(
+    repository,
+    secretRepository,
+    secrets,
+    keys,
+    allowAll,
+    () => new Date(),
+    postgresAppRunApprovalAdapter,
+    receipts,
+    attention,
+  );
+
+  const approvalRun = await runs.submit(trusted, submission({
+    idempotency_key: `native-approval-${suffix}`,
+    policy: {
+      risk_class: 'external_write',
+      review_requirement: 'always',
+      review_scope: 'per_invocation',
+      retry_class: 'unsafe_or_unknown',
+    },
+  }));
+  const action = await client.query<{ id: string }>(
+    `SELECT id FROM agent_actions WHERE org_id = $1 AND app_run_id = $2`,
+    [ORG_ID, approvalRun.id],
+  );
+  assert.equal(action.rowCount, 1);
+  const approvalAttention = await client.query<{ state: string }>(
+    `SELECT state FROM attention_items
+      WHERE org_id = $1 AND source_type = 'agent_action' AND source_id = $2`,
+    [ORG_ID, action.rows[0]!.id],
+  );
+  assert.equal(approvalAttention.rows[0]?.state, 'open_unseen');
+
+  const resolver = new PostgresAppRunApprovalResolver(
+    repository,
+    { async authorizeApprovalInTransaction() { return true; } },
+    () => new Date(),
+    receipts,
+    attention,
+  );
+  assert.equal((await resolver.approve(action.rows[0]!.id, USER_ID)).status, 'approved');
+  assert.equal(await receipts.verifyStored(
+    ORG_ID,
+    approvalRun.id,
+    `approval:${action.rows[0]!.id}`,
+  ), true);
+  const resolvedAttention = await client.query<{ state: string }>(
+    `SELECT state FROM attention_items
+      WHERE org_id = $1 AND source_type = 'agent_action' AND source_id = $2`,
+    [ORG_ID, action.rows[0]!.id],
+  );
+  assert.equal(resolvedAttention.rows[0]?.state, 'resolved');
+
+  const executor = new CountingExecutor();
+  const runner = new AppRunAttemptRunner(
+    repository,
+    secretRepository,
+    secrets,
+    executor,
+    allowExecution,
+    () => new Date(),
+    60_000,
+    20_000,
+    receipts,
+    attention,
+  );
+  const approvalAttempt = await prepareAttempt(runner, approvalRun.id);
+  assert.equal((await runner.run(
+    ORG_ID,
+    approvalRun.id,
+    approvalAttempt,
+    'native-receipt-worker',
+  )).state, 'succeeded');
+  assert.equal(await receipts.verifyStored(
+    ORG_ID,
+    approvalRun.id,
+    `attempt-terminal:${approvalAttempt}`,
+  ), true);
+  const storedReceipt = await client.query<{
+    envelope: Record<string, unknown>;
+    signing_key_version: string;
+    signature_hmac: string;
+  }>(
+    `SELECT envelope, signing_key_version, signature_hmac FROM app_run_receipts
+      WHERE org_id = $1 AND run_id = $2 AND receipt_key = $3`,
+    [ORG_ID, approvalRun.id, `attempt-terminal:${approvalAttempt}`],
+  );
+  assert.equal(secrets.verifyReceipt(
+    { ...storedReceipt.rows[0]!.envelope, run_state: 'failed' },
+    storedReceipt.rows[0]!.signing_key_version,
+    storedReceipt.rows[0]!.signature_hmac,
+  ), false);
+  const rotatedKeys = receiptRotationKeyProvider('sig-v2');
+  const rotatedSecrets = new AppRunSecretService(rotatedKeys);
+  const rotatedWriter = new PostgresAppRunReceiptWriter(
+    rotatedSecrets,
+    new AppRunSecretRepository(rotatedSecrets),
+  );
+  assert.equal(await rotatedWriter.verifyStored(
+    ORG_ID,
+    approvalRun.id,
+    `attempt-terminal:${approvalAttempt}`,
+  ), true);
+  const retiredKeys = receiptRotationKeyProvider('sig-v2', false);
+  await assert.rejects(
+    async () => assertAppRunReferencedKeysAvailable(
+      retiredKeys,
+      await secretRepository.receiptSigningKeyReferences(),
+    ),
+    (error: any) => error?.code === 'APP_RUN_KEY_VERSION_UNAVAILABLE',
+  );
+
+  const unknownExecutor = new CountingExecutor();
+  unknownExecutor.results.push({ status: 'indeterminate' });
+  const unknownRun = await runs.submit(trusted, submission({
+    idempotency_key: `native-unknown-${suffix}`,
+  }));
+  const unknownRunner = new AppRunAttemptRunner(
+    repository,
+    secretRepository,
+    secrets,
+    unknownExecutor,
+    allowExecution,
+    () => new Date(),
+    60_000,
+    20_000,
+    receipts,
+    attention,
+  );
+  const unknownAttempt = await prepareAttempt(unknownRunner, unknownRun.id);
+  assert.equal((await unknownRunner.run(
+    ORG_ID,
+    unknownRun.id,
+    unknownAttempt,
+    'unknown-worker',
+  )).state, 'unknown_outcome');
+  assert.equal(unknownExecutor.calls.length, 1);
+  assert.equal((await runs.reconcileUnknown(
+    ORG_ID,
+    unknownRun.id,
+    trusted.initiating_actor,
+    'succeeded',
+  )).state, 'succeeded');
+  assert.equal(unknownExecutor.calls.length, 1);
+  const reconciliationReceipts = await client.query<{ count: string }>(
+    `SELECT count(*) FROM app_run_receipts
+      WHERE org_id = $1 AND run_id = $2 AND receipt_kind = 'reconciliation'`,
+    [ORG_ID, unknownRun.id],
+  );
+  assert.equal(reconciliationReceipts.rows[0]!.count, '1');
+
+  const missingProjectionRun = await runs.submit(trusted, submission({
+    idempotency_key: `native-repair-${suffix}`,
+  }));
+  const failedExecutor = new CountingExecutor();
+  failedExecutor.results.push({
+    status: 'returned',
+    provider_succeeded: false,
+    output: { provider_error: 'safe-code' },
+  });
+  const unprojectedRunner = new AppRunAttemptRunner(
+    repository,
+    secretRepository,
+    secrets,
+    failedExecutor,
+    allowExecution,
+  );
+  const missingAttempt = await prepareAttempt(unprojectedRunner, missingProjectionRun.id);
+  assert.equal((await unprojectedRunner.run(
+    ORG_ID,
+    missingProjectionRun.id,
+    missingAttempt,
+    'unprojected-worker',
+  )).state, 'failed');
+
+  const allowOperations = { async authorize() { return true; } };
+  const operations = new AppRunOperationsService(
+    repository,
+    allowOperations,
+    receipts,
+    attention,
+  );
+  const beforeRepair = await operations.auditGaps({
+    org_id: ORG_ID,
+    actor: trusted.initiating_actor,
+    run_id: missingProjectionRun.id,
+  });
+  assert.ok(beforeRepair.some((gap) => gap.gap === 'missing_receipt'));
+  assert.ok(beforeRepair.some((gap) => gap.gap === 'missing_attention'));
+  await operations.repair({
+    org_id: ORG_ID,
+    run_id: missingProjectionRun.id,
+    actor: trusted.initiating_actor,
+  });
+  assert.deepEqual(await operations.auditGaps({
+    org_id: ORG_ID,
+    actor: trusted.initiating_actor,
+    run_id: missingProjectionRun.id,
+  }), []);
+  const safeList = await operations.list({
+    org_id: ORG_ID,
+    actor: trusted.initiating_actor,
+    states: ['failed'],
+    limit: 10,
+  });
+  assert.ok(safeList.some((run) => run.id === missingProjectionRun.id));
+  assert.doesNotMatch(
+    JSON.stringify(safeList),
+    /raw-marker|idempotency_key|ciphertext|nonce_b64|auth_tag_b64|claim_token/i,
+  );
+  const metrics = await operations.metrics({
+    org_id: ORG_ID,
+    actor: trusted.initiating_actor,
+  });
+  assert.ok(metrics.every((metric) =>
+    Object.keys(metric).every((key) => ['state', 'risk_class', 'provider_kind', 'count'].includes(key))));
+  assert.deepEqual(await operations.list({
+    org_id: `other-${suffix}`,
+    actor: trusted.initiating_actor,
+  }), []);
+  const denied = new AppRunOperationsService();
+  await assert.rejects(
+    denied.list({ org_id: ORG_ID, actor: trusted.initiating_actor }),
+    (error: any) => error?.code === 'APP_RUN_ACCESS_DENIED',
   );
 });
 

--- a/docs/decisions/2026-08-30-governed-app-runs-rollout.md
+++ b/docs/decisions/2026-08-30-governed-app-runs-rollout.md
@@ -252,6 +252,23 @@ Rejection commits the compatibility decision plus Run cancellation together.
 Concurrent or replayed resolutions converge on the Run and never create an
 attempt or provider call in the approval transaction.
 
+### Child lineage and operational projections
+
+Child Runs are host-created only. The service rejects repeated capability
+identity, depth beyond eight, actor/origin changes, ambient-authority expansion,
+or a weaker policy ceiling before insert. Upgrade `.21` independently verifies
+the parent/root chain and copies the root budget evidence, so orchestration can
+neither reset an agent quota nor manufacture a broader child through direct
+database writes.
+
+Receipts and Attention are projections over the Run ledger, not alternate
+execution authorities. Native receipts contain only validated safe facts and a
+digest of any encrypted result envelope; signing-key references are inventoried
+inside the secret boundary. Operator list/metrics/audit surfaces select an
+explicit safe field set, are tenant-scoped and bounded, and have no provider
+executor dependency. Repair may append missing events, receipts, and Attention,
+but never invokes or retries an external effect.
+
 ## Consequences
 
 - Phase 3 is larger than a local refactor and may span more than one release.

--- a/docs/decisions/2026-08-30-governed-app-runs-rollout.md
+++ b/docs/decisions/2026-08-30-governed-app-runs-rollout.md
@@ -237,6 +237,21 @@ inside the locked first-attempt transaction and recorded as write-once Run
 evidence. No production entrance uses this gate until the later guarded
 Capability Service cutover.
 
+### Approval compatibility ownership
+
+For `review_requirement: always`, Run submission atomically creates one linked
+`app_run_invoke` action with a strict safe-field allowlist. `app_runs` remains
+the source of truth: the compatibility row cannot execute a tool, carry raw
+params, release itself, or override a terminal Run state.
+
+The existing reviewer API delegates that one action kind to a Run-native
+resolver. The requester or an owner/admin must be an active human member;
+legacy internal approval bypasses are rejected. Approval rechecks live
+authority and commits the action decision plus write-once Run release together.
+Rejection commits the compatibility decision plus Run cancellation together.
+Concurrent or replayed resolutions converge on the Run and never create an
+attempt or provider call in the approval transaction.
+
 ## Consequences
 
 - Phase 3 is larger than a local refactor and may span more than one release.

--- a/docs/decisions/2026-08-30-governed-app-runs-rollout.md
+++ b/docs/decisions/2026-08-30-governed-app-runs-rollout.md
@@ -222,6 +222,21 @@ transaction-scoped advisory lock, not an unbounded unique index. The unique
 index is therefore replaced by a non-unique lookup index, and architecture
 tests keep Run insertion behind that single service/repository writer.
 
+### Live authority revisions
+
+Additive upgrade `.20` gives each existing live authority row a monotonic App
+Run authorization version. Table-specific triggers advance it only when fields
+that can change execution authority change. This prevents a revoke-then-restore
+cycle from reviving an old Run without making action counters, heartbeat data,
+provider caches, or last-used timestamps invalidate valid approvals.
+
+The host captures opaque versions and rederives them from tenant-scoped live
+rows before approval, attempt preparation, claim, and the final provider-call
+boundary. For agent execution, the daily action slot is reserved exactly once
+inside the locked first-attempt transaction and recorded as write-once Run
+evidence. No production entrance uses this gate until the later guarded
+Capability Service cutover.
+
 ## Consequences
 
 - Phase 3 is larger than a local refactor and may span more than one release.

--- a/docs/decisions/2026-08-30-governed-app-runs-rollout.md
+++ b/docs/decisions/2026-08-30-governed-app-runs-rollout.md
@@ -193,6 +193,35 @@ planning branch is now rebased onto the exact squash merge. The upgrade manifest
 ends at `0.3.0-preview.16` on that baseline, so `.17` is the current candidate;
 Loop 0 must re-confirm it immediately before the first schema implementation.
 
+### Post-engine cutover gate
+
+PR B remained dormant, but its pre-integration audit found that release,
+dispatch, and replay needed stronger enforceable identities. Before any live
+Capability Service path is selected, additive upgrade `0.3.0-preview.19` adds
+write-once execution-release and budget-reservation evidence. The database
+rejects attempts and a `running` transition without execution release, while
+the runner independently retains a default-deny live execution authorizer.
+`review_requirement: always` starts unreleased in `pending_approval`; policy
+submissions record `policy_satisfied` atomically but still cannot execute until
+the live authorizer allows them.
+
+Queue work identifies `(org_id, run_id, attempt_id)`. A stale job can inspect or
+repair only that attempt and cannot claim a later retry. Claimed provider calls
+heartbeat their lease and every post-call write is fenced by the immutable
+claim token.
+
+Provider execution distinguishes a call that was not attempted, a determinate
+provider response (success or error), and an indeterminate dispatch. Every
+bounded JSON determinate response is stored only as a versioned encrypted
+provider-result envelope; generic Run projections retain only the safe outcome.
+Oversized or non-JSON determinate responses remain known but unavailable and
+never cause a second provider call.
+
+The fixed idempotency horizon is enforced by lookup plus the App Run service's
+transaction-scoped advisory lock, not an unbounded unique index. The unique
+index is therefore replaced by a non-unique lookup index, and architecture
+tests keep Run insertion behind that single service/repository writer.
+
 ## Consequences
 
 - Phase 3 is larger than a local refactor and may span more than one release.

--- a/docs/superpowers/plans/2026-08-29-full-surface-app-platform.md
+++ b/docs/superpowers/plans/2026-08-29-full-surface-app-platform.md
@@ -2,12 +2,19 @@
 
 | Field | Value |
 |---|---|
-| **Status** | Phases 1–2 merged; Phase 3 dormant foundation (Loops 0–2) implemented for review on `9ba7b7c8` |
-| **Date** | 2026-08-29; Phase 2 rebaseline 2026-08-30 |
-| **Baseline inspected** | Phase 2 starts from `origin/master` at `bdb137ee`, the squash merge of Phase 1 PR #269 |
+| **Status** | Canonical capability map and threat model; Phases 0–2 merged and Phase 3 closeout pending |
+| **Date** | 2026-08-29; execution rebaseline 2026-08-30 |
+| **Baseline inspected** | `origin/master` at `399cd030`; local Phase 3 closeout baseline `5050b0f1` is unreleased |
 | **North star** | A Deft user can ask Codex to build a useful application, install it into their Deft workspace, and have it participate natively in the human UI, search and knowledge, tasks and chat, Defty, employee agents, human MCP, automation, approvals, runs, receipts, and audit. |
 | **First delivery principle** | Build one safe participation protocol in stages; do not turn `deft.module.json` into an arbitrary plugin runtime. |
 | **Relationship to earlier work** | Supersedes the provisional App Protocol v2 implementation sequence while retaining its certified Module, Capability, App Run, and approval-boundary decisions as design input. Absorbs the useful resource-graph and solution-composition ideas from the modular work-management proposal. |
+| **Current delivery plan** | `docs/superpowers/plans/2026-08-30-full-surface-app-platform-delivery-plan.md` supersedes only the linear execution sequence; this document remains authoritative for the destination architecture and security boundaries. |
+
+> **Execution note (2026-08-30):** the baseline assessment and phase
+> checklists below preserve the architectural requirements captured on
+> 2026-08-29; they are not the live execution tracker. Use the revised delivery
+> plan for completed-work status, Phase 3 closeout, the Phase 4–6 connected
+> kernel, and the independently selectable privileged-plane tracks.
 
 ## Executive decision
 

--- a/docs/superpowers/plans/2026-08-30-app-platform-phase-3-closeout-loops.md
+++ b/docs/superpowers/plans/2026-08-30-app-platform-phase-3-closeout-loops.md
@@ -1,0 +1,491 @@
+# App Platform Phase 3 — Closeout and Release Loops
+
+| Field | Value |
+|---|---|
+| **Status** | In execution; Loops 0–1 complete, Loop 2 next |
+| **Date** | 2026-08-30 |
+| **Architecture source** | `docs/superpowers/plans/2026-08-29-full-surface-app-platform.md` |
+| **Delivery source** | `docs/superpowers/plans/2026-08-30-full-surface-app-platform-delivery-plan.md` |
+| **Merged base** | `origin/master` at `399cd030` |
+| **Local closeout baseline** | clean worktree at `5050b0f1`; local-only and unreleased |
+| **Outcome** | Merge and release the guarded Phase 3 execution substrate with Run draining separated from legacy MCP intake, then hand Phase 4 one immutable supported baseline. |
+
+## Decision
+
+Close Phase 3 before beginning Phase 4 implementation.
+
+Use two review trains:
+
+1. **PR C — trust and data completion:** existing C0–C3 commits through
+   `d5192c55`, followed by one docs-only commit that persists the reviewed
+   architecture, delivery, and closeout plan sources.
+2. **PR D — guarded runtime and execution closeout:** existing C4–D2 work,
+   rebuilt on PR C's actual merge commit when necessary, plus one narrow rollout
+   control change and truthful closeout documentation.
+
+Do not redesign the completed engine. Do not begin ResourceRef, App grants,
+App-origin execution, connected App UI, or Authoring Kit beta work inside these
+trains.
+
+## Current immutable facts
+
+- `origin/master` includes the Phase 3 foundation and fake-provider engine.
+- The Phase 3 worktree is clean on a linear local-only chain:
+  - `4c4f48c1` — C0 engine/cutover hardening;
+  - `e6274c41` — C1 live authority and budget evidence;
+  - `c3670207` — C2 approval compatibility projection;
+  - `d5192c55` — C3 receipts, Attention, ancestry, and internal operations;
+  - `ffdab418` — C4 runtime/worker composition;
+  - `944b265f` — C5 legacy capability cutover;
+  - `5050b0f1` — local certification documentation.
+- None of the local hashes is merged, released, or an operational rollback
+  floor.
+- Before Loop 0, the revised delivery and closeout plans plus the intended
+  canonical-plan header/pointer edits existed only in the dirty main worktree.
+  The dirty main copy of the canonical plan predates newer Phase 1–3 evidence,
+  so only its reviewed header/pointer intent may be applied to the current
+  tracked body; the dirty originals and unrelated Hermes work remain untouched.
+- Additive migrations `.19`–`.21` are implemented and tested. Preserve them;
+  rewriting their history provides no functional value and invalidates useful
+  evidence.
+- The current single `DEFT_APP_RUNS_ENABLED` value controls Run runtime/key
+  availability and selects new legacy MCP intake. That coupling prevents a safe
+  drain-only mode and must be split before PR D closes.
+- App origin, system origin, and automation origin remain fail-closed.
+- The current local host lacks pgvector and a running Docker release
+  environment. Do not retry those known local limitations; run their gates once
+  on release-capable infrastructure.
+
+## Frozen rollout-control contract
+
+Keep the existing variable as the engine/drain control:
+
+- `DEFT_APP_RUNS_ENABLED=false`: no Run keyring required; durable Run workers
+  defer without spending attempts; existing MCP behavior remains legacy.
+- `DEFT_APP_RUNS_ENABLED=true`: valid Run keyrings are required; the runtime may
+  decrypt, resume, and drain already accepted governed work.
+
+Add one new exact default-false legacy intake control:
+
+- `DEFT_APP_RUN_LEGACY_MCP_CUTOVER_ENABLED=false`: new MCP capability requests
+  continue through the legacy path.
+- `DEFT_APP_RUN_LEGACY_MCP_CUTOVER_ENABLED=true`: supported legacy MCP requests
+  enter the governed Run path.
+- Legacy cutover `true` while the Run engine is `false` is an invalid startup
+  configuration and fails closed.
+
+| Run engine | Legacy MCP intake | Supported meaning |
+|---|---|---|
+| Off | Off | Existing behavior; no keyrings required |
+| On | Off | Run service can drain/resume; new MCP calls remain legacy |
+| On | On | Exact default-off legacy MCP canary enters App Runs |
+| Off | On | Invalid; startup rejects the configuration |
+
+Do not add an App-origin flag in Phase 3. Phase 5 adds that control with the
+first real grant/binding entrance and persisted App installation/version/grant
+authority.
+
+## Frozen transition semantics
+
+- App Runs are canonical execution state for governed work.
+- `agent_actions` remains the current approval-inbox projection for the legacy
+  compatibility path; it is not independent execution authority.
+- Legacy action receipts remain historical compatibility. New App paths may not
+  depend on the dual ledger after native App approval/Run UI and Phase 6 parity
+  are certified.
+- `AppRunOperationsService` remains an internal, production-denied repair
+  primitive. Present operator access is the bounded runbook/SQL path; Phase 3
+  makes no public operations API or UI claim.
+- `944b265f` may be named only as a local source checkpoint. The operational
+  rollback floor becomes the first released image containing the final closeout
+  contract.
+
+## Loop 0 — Persist plan sources and freeze merge mechanics
+
+**Mode:** one docs-only preservation commit, then read-only audit.
+
+### Work
+
+- Create a clean PR C worktree/branch from the C3 tip. Do not use the dirty main
+  worktree as the execution checkout.
+- Preserve the reviewed revised delivery and closeout plans in that worktree.
+  Apply the reviewed status/current-delivery pointer to the current tracked
+  `2026-08-29-full-surface-app-platform.md`; do not replace its newer Phase 1–3
+  implementation evidence with the older dirty-main body. Inspect and commit
+  the three results as one docs-only plan-source change. Do not delete, move, or
+  rewrite the copies in the dirty main worktree or any unrelated Hermes
+  material.
+- Fetch and inspect current `origin/master`, migration manifest, branch ancestry,
+  and both worktrees without changing the dirty main worktree.
+- Freeze PR C as `399cd030..d5192c55` plus that one plan-source commit.
+- Freeze PR D as C4–D2 plus the rollout-control and closeout corrections in this
+  plan.
+- Prefer a merge commit for PR C so the reviewed local ancestry remains useful.
+  If repository policy or the final merge uses squash/rebase, stop and rebuild
+  PR D from the actual merged default branch.
+- Freeze the final validation matrix now; later loops do not add unrelated
+  certification.
+
+### Evidence
+
+- Clean Phase 3 worktree.
+- Correct merge base and bounded name-status diffs.
+- No migration-number conflict with current default branch.
+- All three plan sources are tracked in PR C and their cross-links resolve.
+- Written PR boundaries and flag truth table agree with this plan.
+
+**Loop 0 result (2026-08-30):** `origin/master` remained `399cd030`; PR C
+remained based on that commit through C3 `d5192c55`; upgrade slots `.19`–`.21`
+were unclaimed on the base; the worker factory remained production-unregistered;
+and the three plan sources were isolated on `codex/app-platform-phase-3-pr-c`
+without modifying the dirty main worktree.
+
+### Stop conditions
+
+- Default branch moved in a way that conflicts with migrations `.19`–`.21`.
+- C4/C5 behavior is required merely to make PR C schema boot safely.
+- PR C contains a reachable provider entrance.
+- The flag split would require changing the certified attempt/state model rather
+  than only entrance selection.
+
+## Loop 1 — Review and certify PR C
+
+**Outcome:** the trust/data train is independently safe, additive, and dormant.
+
+### Included work
+
+- C0 release fencing, exact attempt jobs, result classification, and budget
+  evidence hooks.
+- C1 live membership, employee, token, connector, assignment, provider-schema,
+  and budget authority versions.
+- C2 App Run-owned approval resolution with one safe compatibility projection.
+- C3 tenant-bound ancestry constraints, receipts, Attention projections, and
+  internal repair invariants.
+- Migrations `.19`–`.21` exactly as currently reviewed unless Loop 0 discovers
+  an actual defect.
+
+### Excluded work
+
+- Runtime construction, worker registration, provider entrance, legacy MCP
+  selection, App routes, or App-origin authority.
+- Refactors, renames, generalized operation surfaces, or new retention/ancestry
+  behavior.
+
+### Focused evidence
+
+- Shared App Run contract tests.
+- Database upgrade representation for `.19`–`.21`.
+- Disposable-database Run lifecycle, live-authority, approval, ancestry,
+  receipt, leakage, and repair tests.
+- App Run architecture checks and focused approval/trust sentinels.
+- API typecheck.
+
+Do not run browser, Docker, production image, pgvector fresh bootstrap,
+capability flag parity, or a repository-wide production build in PR C.
+
+**Loop 1 result (2026-08-30):** shared App Run contracts passed 10/10;
+upgrade/schema representation passed 23/23; the complete C3 App Run database
+suite passed 19/19; approval-resolver database behavior passed 23/23; focused
+keyring, architecture, approval-matrix, and MCP trust-boundary suites passed;
+and the API typecheck passed. The disposable database used the current schema
+with only the two unrelated embedding columns represented as `bytea`, then
+applied and verified extras `.16`–`.21`; no `CREATE EXTENSION vector`, browser,
+Docker, production build, or supported fresh-schema claim was made.
+
+## Loop 2 — Open, review, and merge PR C
+
+### Work
+
+- Inspect the final diff and untracked files from the PR C worktree.
+- Confirm every new persistent object has a production writer, bounded reader,
+  tenant check, retention/cleanup owner, and a known runtime consumer in PR D.
+- Open PR C and wait for required CI/review.
+- Merge only when required checks pass.
+- Record the actual merge commit and migration checksums.
+
+### Rebase rule
+
+If PR C is squash/rebase merged, no later local hash is treated as proof against
+the new default branch. Create a fresh PR D branch from the actual merge and
+replay only C4, C5, certification docs, and the closeout changes. Update every
+affected hash/reference once.
+
+## Loop 3 — Re-anchor PR D
+
+**Mode:** structural only unless conflicts require a correction.
+
+### Work
+
+- Fetch the merged default branch.
+- Rebase/rebuild the runtime closeout train according to Loop 2's merge result.
+- Prove the resulting review diff begins with runtime/worker composition rather
+  than repeating PR C.
+- Update source-checkpoint references if ancestry changed.
+
+### Evidence
+
+- Clean status.
+- Bounded `origin/master...HEAD` diff.
+- PR C files appear only where C4/C5 genuinely modify them.
+- No test rerun when the re-anchor is conflict-free; changed conflicts receive
+  only their mapped focused tests.
+
+## Loop 4 — Split Run draining from legacy MCP intake
+
+**Outcome:** operators can enable the Run engine to drain accepted work without
+routing new legacy MCP calls into it.
+
+### Production changes
+
+- `apps/api/src/lib/env.ts`
+  - parse/export `DEFT_APP_RUN_LEGACY_MCP_CUTOVER_ENABLED`;
+  - reject legacy cutover when `DEFT_APP_RUNS_ENABLED` is not enabled;
+  - keep keyring validation bound to the Run engine flag.
+- `apps/api/src/lib/capability-service.ts`
+  - choose governed versus legacy execution from the legacy intake flag;
+  - never shadow-call or fall back after governed execution begins.
+- `apps/api/src/lib/agent-actions.ts`
+  - skip the legacy employee budget reservation only when legacy MCP intake is
+    actually routed through App Runs.
+
+`app-run-runtime.ts` and `app-run-worker-handler.ts` continue to use
+`DEFT_APP_RUNS_ENABLED` as the engine/drain gate. Change only misleading
+comments unless a focused test proves a behavior defect.
+
+### Test changes
+
+- Update the shared immediate/action disposable-database fixture to select
+  governed cases from the intake flag, not the engine flag.
+- Add Capability Service coverage for engine-on/intake-off and
+  engine-on/intake-on with one selected path and no fallback.
+- Add a small configuration test for invalid engine-off/intake-on startup.
+- Add architecture assertions that engine consumers and intake consumers use
+  the correct controls.
+- Touch worker queue coverage only to prove the new intake flag does not pause
+  draining; preserve the existing engine-off defer/no-attempt behavior.
+
+### Configuration and documentation
+
+- Update `.env.example`, self-hosting, the App Run runbook, rollout decision,
+  Phase 3 loop plan, and certification audit.
+- Add explicit Compose wiring only if repository policy requires documented
+  variables to be repeated; the existing `.env` pass-through is otherwise
+  sufficient.
+
+### Acceptance
+
+- Engine off/intake off preserves exact legacy behavior and requires no Run
+  keys.
+- Engine on/intake off leaves new MCP calls legacy while accepted Run work can
+  resume.
+- Engine on/intake on creates one Run/attempt and at most one provider call.
+- Engine off/intake on fails startup.
+- All unspecified/malformed values fail closed.
+
+## Loop 5 — Correct closeout truth and ownership
+
+**Outcome:** documentation describes the shipped boundary rather than local
+checkpoint assumptions.
+
+### Work
+
+- Record the dual-ledger exit and native App transition gate.
+- Mark Operations as an internal production-denied primitive.
+- Replace local-source rollback claims with the future released-image floor.
+- Correct any schema/code comment that still calls the post-C5 engine only a
+  dormant foundation.
+- Record the supported flag combinations and distinct merge versus publication
+  gates.
+- Create a new certification checkpoint because the flag contract is newer than
+  `5050b0f1`.
+
+### Evidence
+
+- Documentation/link checks when available.
+- `git diff --check`.
+- No database, browser, Docker, or build rerun for prose-only changes.
+
+## Loop 6 — Run one PR D delta certification
+
+**Outcome:** fresh evidence covers exactly the runtime/cutover and split-control
+boundaries.
+
+### Required matrix
+
+1. Capability Service unit and architecture tests.
+2. One shared disposable database/provider fixture in three supported modes:
+   - engine off, intake off — exact legacy parity;
+   - engine on, intake off — new calls legacy plus focused durable-job
+     drain/resume;
+   - engine on, intake on — governed safe/read and reviewed-action cases.
+3. One accepted-approval drain transition:
+   - create a Run that is pending approval with engine and intake on;
+   - restart with engine on and intake off, then approve and prove exactly one
+     Run execution, no second budget reservation, and no legacy fallback;
+   - prove engine off leaves the approval pending/fail-closed rather than
+     resolving it through the legacy path.
+4. Engine off/intake on startup rejection.
+5. The complete existing `apps/api/test/app-run-engine-db.test.ts` suite once at
+   the final PR D tip; C4/C5 materially change runtime composition and intake.
+6. Focused worker defer/resume, connector, trust, approval, keyring, leakage,
+   and low-level MCP-boundary tests.
+7. API and participating-package typecheck.
+8. `git diff --check` and final worktree inspection.
+9. One final production source build only if normal PR CI does not already run
+   the equivalent build against the exact tip.
+
+### Evidence reuse
+
+- Preserve PR C evidence for unchanged C0–C3 boundaries through merge ancestry,
+  but do not use it to skip the final full engine database suite required above.
+- Treat evidence at `5050b0f1` as historical review support, not proof of the
+  new split-control contract.
+- Reuse one provider stub, database setup, and parity assertion suite across all
+  modes.
+
+### Explicitly excluded local repetition
+
+- No browser visual audit; no web UI changes exist.
+- No Docker image or Compose build before the release candidate.
+- No retry of `CREATE EXTENSION vector` on the known deficient local host.
+- No repeated fresh-schema bootstrap locally.
+- No unrelated Hermes or full API certification outside normal CI.
+
+## Loop 7 — Open, review, and merge PR D default-off
+
+### Work
+
+- Inspect the complete runtime/cutover diff and untracked files.
+- Confirm only provider adapters call the low-level MCP client.
+- Confirm App, system, and automation origins remain denied.
+- Confirm no new App manifest, Resource, scope/token, UI, public API, or hosted
+  dependency surface entered the diff.
+- Open PR D and wait for required CI/review.
+- Merge default-off only after all required checks pass.
+
+### Result
+
+The merged commit is the authoritative source floor and a release candidate.
+It is not yet the operational rollback floor and does not permit an opt-in,
+default-on, or community App claim.
+
+## Loop 8 — Run the release-candidate operational gate once
+
+**Environment:** release-capable CI or a designated host with Docker,
+pgvector/current schema, a deterministic MCP provider, and authority to perform
+backup/restore and image rollback. Do not use the known deficient local host.
+
+### Frozen release inputs
+
+- The current repository candidate for the supported predecessor is
+  `v0.3.0-preview.12` at `23694ef8`. Before running this gate, verify that its
+  corresponding published immutable image/digest still exists and is the
+  documented supported upgrade and rollback source.
+- Record that source digest, its database migration ledger, its required
+  configuration/key contract, and the exact quiescence query from
+  `docs/app-run-operations.md` covering nonterminal Runs, pending compatibility
+  approvals, and active App Run jobs.
+- If no supported immutable predecessor artifact exists, stop the release gate
+  and repair the release inputs. Do not substitute a local build of `399cd030`
+  or any other unreleased commit as rollback evidence.
+
+### Work
+
+1. Build the immutable production image from the merged candidate.
+2. Prove a fresh pgvector-backed installation.
+3. On the frozen predecessor, create one legacy compatibility fixture containing
+   an MCP connection, encrypted credential, assignment, pending approval,
+   previously approved action, and legacy receipt. Record stable identifiers,
+   authority/scope, and ciphertext fingerprints before upgrade.
+4. Prove the supported upgrade from the frozen predecessor through the complete
+   pending manifest path `.14`–`.21`; assert the Phase 3 `.17`–`.21` objects and
+   current Agent Channel approval projections explicitly.
+5. After upgrade, prove the preserved connector fixture still supports
+   engine-off legacy execution and the opt-in governed canary without ciphertext
+   rewrite, authority widening, duplicate provider effect, or receipt/history
+   corruption.
+6. Exercise all four flag combinations and their startup/runtime behavior.
+7. Run one deterministic-provider approval/browser smoke without claiming a
+   public Run UI.
+8. Reuse the existing Hello Workspace reference fixture to install, activate,
+   open, and disable the declarative App on the upgraded release image.
+9. Back up and restore database, uploads/App artifacts where applicable, and
+   all required keyrings at consistent points.
+10. Rotate encryption, fingerprint, and signing keys; prove retained payload/
+    receipt reads and referenced-key retirement refusal.
+11. Prove flag-off pause and flag-on resume without attempt debit or duplicate
+    provider dispatch.
+12. Use the frozen quiescence query to prove no nonterminal Runs, pending
+   compatibility approvals, or active Run jobs remain, then perform the actual
+   supported rollback drill between the recorded immutable source and target
+   images.
+13. Record the immutable image digest and normal release security/provenance
+    evidence.
+
+### Failure rule
+
+A failed gate keeps the affected entrance unsupported/off. Repair only the
+failed boundary and rerun its dependent evidence; do not widen or restart the
+whole phase. If repair would change the frozen Run state machine, provider-call
+boundary, approval source of truth, secret-envelope/key contract, migration
+checksums or constraints, or rollout truth table, stop closeout and reopen the
+architecture gate before editing those contracts.
+
+## Loop 9 — Seal Phase 3 and hand off Phase 4 planning
+
+### Phase 3 decision record
+
+- Record the merged and released revision and immutable image as the operational
+  rollback floor.
+- Record whether the legacy MCP canary is supported as opt-in or remains
+  rejected based on release evidence.
+- Keep App origin off until Phase 5.
+- Publish the exact control matrix, key-loss limits, backup/restore contract,
+  and remaining non-claims.
+- Link the reviewed per-plane evidence record required by the proof-debt gate.
+
+### Phase 4 planning handoff
+
+Create a read-only Phase 4 loop plan against the exact released baseline. Freeze:
+
+- independent Contacts and Campaigns artifacts and deterministic sandbox MCP
+  provider;
+- exact Campaign-to-Contact resource operations and caller surfaces;
+- host-bound `ResourceRef` shape and additive Module reference schema version;
+- ResourceAuthorizationService delegation boundary and closed adapter map;
+- reference disable/archive/delete/dangling semantics;
+- whether Task belongs in the first proof or the immediately following
+  heterogeneous fixture;
+- search/context shadow comparison and cutover/rollback rules;
+- next available migration slot;
+- focused acceptance matrix, release environment, exclusions, and stop
+  conditions.
+
+No Phase 4 code begins before the Phase 3 release evidence record exists.
+
+## Phase 3 closeout exclusions
+
+Route any request for the following to its owning phase rather than accepting it
+as closeout follow-up work:
+
+- ResourceRef, resource adapters, cross-App relations, picker, or search/context
+  cutover — Phase 4.
+- App resource/capability/dependency/action manifest fields, grants, connector
+  bindings, persisted App-origin authority, AppActionService, action UI, safe
+  Run APIs, or App token scopes — Phase 5.
+- Sandbox-email interface expansion, connected templates/simulator, or external
+  Contacts/Campaigns proof — Phases 5–6.
+- Removing the approval compatibility projection or legacy receipt history —
+  only after native App UI and Phase 6 parity.
+- Connector ciphertext migration/re-encryption or legacy-key retirement.
+- New App/system/automation/runtime origins or expansion of ancestry,
+  reconciliation, retention, repair, Attention, or operator surfaces.
+- Default-on rollout, arbitrary code, custom UI, automation, runtime, sync,
+  public ingress, hosted KMS, marketplace, billing, or SaaS infrastructure.
+
+## Completion definition
+
+Phase 3 is complete only when both PRs are merged, the release-candidate gate
+passes, the immutable rollback floor and control matrix are recorded, and the
+Phase 4 handoff is based on that exact released state. A default-off code merge
+without the operational gate is merged infrastructure, not completed rollout.

--- a/docs/superpowers/plans/2026-08-30-app-platform-phase-3-governed-runs-loops.md
+++ b/docs/superpowers/plans/2026-08-30-app-platform-phase-3-governed-runs-loops.md
@@ -1,8 +1,9 @@
 # App Platform Phase 3: Governed App Runs and Secret Service loops
 
 **Status:** accepted and in progress; PR A (#271) and PR B (#272) merged the
-dormant Loops 0–4 foundation and fake-provider engine. The C0 cutover-hardening
-gate is in progress from merge `399cd030`.
+dormant Loops 0–4 foundation and fake-provider engine. C0 is complete at local
+checkpoint `4c4f48c1`; C1 live authorization and budget integration is stacked
+on it pending review and publication.
 
 **Rebaseline record:** Phase 2 PR #270 merged with every required check green;
 the foundation selected `.17`, PR B selected `.18`, and the post-engine audit
@@ -56,6 +57,27 @@ fixed before any production ingress exists. C0 is a separate additive merge:
 C0 does not register a worker, call MCP, add an ingress route or flag, alter UI,
 or reserve a live employee budget. Its evidence uses fake providers and the
 disposable database only.
+
+### C1 live authorization and budget gate
+
+C1 adds upgrade `.20` and a host-owned authorization snapshot builder/verifier:
+
+- security-relevant membership, employee, connector, override, MCP-token, and
+  OAuth-token changes advance monotonic authority versions, including a
+  revoke-then-restore cycle; ordinary counters, heartbeats, caches, and
+  last-used timestamps do not;
+- live authorization rederives membership, initiating/execution actor health,
+  employee budget policy, token binding, connector activity, employee
+  assignment, provider schema, and the bound host-policy version before an
+  approval or attempt;
+- agent action budget is reserved once in the same Run-locked transaction that
+  creates the first attempt, and later claim/provider-call checks require that
+  durable evidence; and
+- system/automation actors remain fail-closed until a later host-owned
+  authority source is explicitly designed.
+
+C1 remains production-unwired. It adds no route, worker registration, provider
+call, flag, UI, environment variable, or deployment dependency.
 
 ### Milestone C: compatibility integration
 

--- a/docs/superpowers/plans/2026-08-30-app-platform-phase-3-governed-runs-loops.md
+++ b/docs/superpowers/plans/2026-08-30-app-platform-phase-3-governed-runs-loops.md
@@ -1,11 +1,12 @@
 # App Platform Phase 3: Governed App Runs and Secret Service loops
 
-**Status:** accepted and in progress; PR A implements the dormant Loops 0–2
-foundation on Phase 2 squash merge `9ba7b7c8`
+**Status:** accepted and in progress; PR A (#271) and PR B (#272) merged the
+dormant Loops 0–4 foundation and fake-provider engine. The C0 cutover-hardening
+gate is in progress from merge `399cd030`.
 
 **Rebaseline record:** Phase 2 PR #270 merged with every required check green;
-the current upgrade manifest ends at `0.3.0-preview.16`, making `.17` the
-candidate first Phase 3 schema slot. Loop 2 re-confirmed and selected `.17`.
+the foundation selected `.17`, PR B selected `.18`, and the post-engine audit
+re-confirmed `.19` as the additive C0 cutover-gate slot.
 
 **Outcome:** Deft has an opt-in, actor-neutral, durable execution envelope with
 encrypted retained inputs, governed approvals, explicit attempts and unknown
@@ -34,6 +35,27 @@ off. Existing execution and existing ciphertext writes do not change.
 
 Loops 3–4 implement lifecycle, idempotency, attempts, recovery, and retention
 against fake providers. There is still no production cutover.
+
+### C0 hardening gate before compatibility integration
+
+The merged engine remains dormant, but its audit found boundaries that must be
+fixed before any production ingress exists. C0 is a separate additive merge:
+
+- persist a write-once execution release and refuse attempt creation, claim, or
+  `running` transition while it is absent;
+- keep a default-deny live execution-authorizer seam even after release;
+- persist write-once budget-reservation evidence for the C1 budget adapter;
+- pin every worker job to one exact attempt and heartbeat that attempt's lease;
+- distinguish `not_attempted`, determinate provider return, and indeterminate
+  dispatch, retaining bounded encrypted success or provider-error responses;
+- make the idempotency index non-unique so the advisory-lock writer can create
+  exactly one new Run after the fixed horizon; and
+- constrain the future `agent_actions` compatibility row to
+  `action = app_run_invoke`, the same safe Run ID, and a bounded allowlist.
+
+C0 does not register a worker, call MCP, add an ingress route or flag, alter UI,
+or reserve a live employee budget. Its evidence uses fake providers and the
+disposable database only.
 
 ### Milestone C: compatibility integration
 
@@ -389,12 +411,17 @@ service interface. They do not receive decrypted input or a provider callback.
    schema, no execution cutover.
 2. **PR B — engine:** Loops 3–4; lifecycle, idempotency, retention, attempts, fake
    providers, and recovery.
-3. **PR C — integration:** Loops 5–7; approval adapter, Capability Service flag,
-   compatibility, ancestry, receipts, Attention, and operator surfaces.
-4. **PR D — certification:** Loops 8–9; release/rotation/rollback evidence and the
+3. **PR C0 — engine cutover gate:** additive `.19`, execution-release and budget
+   evidence, exact-attempt jobs, lease heartbeat, provider-result taxonomy, and
+   horizon-safe replay; the engine remains unwired.
+4. **C1–C5 — integration train:** live authorization/budget, safe approval
+   adapter, receipts/Attention/operator/ancestry, pinned provider runtime and
+   worker, then an explicit guarded cutover. Each slice must be independently
+   green and may be its own PR.
+5. **D1–D2 — certification:** release/rotation/rollback evidence and the
    explicit opt-in decision.
 
-Do not hold all four PRs for one final merge. Merge each independently green,
+Do not hold all merge trains for one final merge. Merge each independently green,
 then rebase the next train onto its merge commit. This preserves reviewability,
 forward-only migration order, and rollback diagnosis.
 

--- a/docs/superpowers/plans/2026-08-30-app-platform-phase-3-governed-runs-loops.md
+++ b/docs/superpowers/plans/2026-08-30-app-platform-phase-3-governed-runs-loops.md
@@ -2,8 +2,8 @@
 
 **Status:** accepted and in progress; PR A (#271) and PR B (#272) merged the
 dormant Loops 0–4 foundation and fake-provider engine. C0 is complete at local
-checkpoint `4c4f48c1`; C1 live authorization/budget and C2 approval
-compatibility are stacked on it pending review and publication.
+checkpoint `4c4f48c1`; C1 live authorization/budget, C2 approval compatibility,
+and C3 operational safety are stacked on it pending review and publication.
 
 **Rebaseline record:** Phase 2 PR #270 merged with every required check green;
 the foundation selected `.17`, PR B selected `.18`, and the post-engine audit
@@ -97,6 +97,38 @@ event, and user-supplied rejection prose is not copied into the safe ledger.
 
 C2 still does not enqueue an attempt or call a provider. C4 owns worker
 scheduling after the remaining receipt and runtime boundaries exist.
+
+### C3 lineage and operational safety
+
+C3 adds additive upgrade `.21`, which validates every child Run insert against
+its tenant-bound parent and root. A child must be created while its parent is
+running, remain within depth eight, preserve initiating/execution actors and
+origin, stay below the parent's risk/review/retry/retention ceilings, reuse only
+ambient membership/token/employee authorities already present above it, and
+inherit the root agent-budget reservation without incrementing it. Synchronous
+service checks reject capability cycles before insert; the database independently
+guards lineage, policy, and budget continuity.
+
+App-native approval, attempt-terminal, reconciliation, and repair receipts now
+use deterministic identities and validated safe envelopes. Each envelope signs
+immutable operation/policy/input-fingerprint facts plus an optional digest of
+the encrypted result envelope; it never stores the result or ciphertext.
+Verification survives signing-key rotation, detects envelope tampering, and the
+key inventory refuses retirement while any retained receipt still references a
+version.
+
+The existing Attention service receives idempotent approval, failure,
+`unknown_outcome`, reconciliation, and repair-gap projections. A bounded,
+tenant-scoped operations service lists safe Run views, emits only fixed-cardinality
+state/risk/provider-kind metrics, reports missing terminal events, receipts,
+approval rows, or Attention, and repairs projections without a provider port.
+Operator resolution of an unknown outcome appends its event and signed receipt
+in one transaction; Attention remains a post-commit projection and is itself
+repairable.
+
+C3 remains production-unwired. C4 owns the single runtime composition that
+injects these receipt and Attention implementations into the resolver, runner,
+worker, and Capability Service entrance.
 
 ### Milestone C: compatibility integration
 

--- a/docs/superpowers/plans/2026-08-30-app-platform-phase-3-governed-runs-loops.md
+++ b/docs/superpowers/plans/2026-08-30-app-platform-phase-3-governed-runs-loops.md
@@ -2,8 +2,8 @@
 
 **Status:** accepted and in progress; PR A (#271) and PR B (#272) merged the
 dormant Loops 0–4 foundation and fake-provider engine. C0 is complete at local
-checkpoint `4c4f48c1`; C1 live authorization and budget integration is stacked
-on it pending review and publication.
+checkpoint `4c4f48c1`; C1 live authorization/budget and C2 approval
+compatibility are stacked on it pending review and publication.
 
 **Rebaseline record:** Phase 2 PR #270 merged with every required check green;
 the foundation selected `.17`, PR B selected `.18`, and the post-engine audit
@@ -78,6 +78,25 @@ C1 adds upgrade `.20` and a host-owned authorization snapshot builder/verifier:
 
 C1 remains production-unwired. It adds no route, worker registration, provider
 call, flag, UI, environment variable, or deployment dependency.
+
+### C2 safe approval compatibility adapter
+
+C2 creates exactly one `app_run_invoke` compatibility action in the same
+transaction as every `pending_approval` Run. The row contains only Run ID,
+bounded capability/provider labels, resource identities, and the validated safe
+preview; it never contains invocation input, retry identity, provider output,
+credentials, or ciphertext.
+
+The existing approve/reject entrance delegates only this action kind to a
+Run-native resolver. Human requester/owner/admin review is required and the
+legacy internal bypass is explicitly refused. Resolution locks both rows,
+rechecks C1 live authority, and atomically either records the write-once
+approval release or cancels/expires the Run. The Run repairs the compatibility
+row if they ever disagree, approval/rejection races append one resolution
+event, and user-supplied rejection prose is not copied into the safe ledger.
+
+C2 still does not enqueue an attempt or call a provider. C4 owns worker
+scheduling after the remaining receipt and runtime boundaries exist.
 
 ### Milestone C: compatibility integration
 

--- a/docs/superpowers/plans/2026-08-30-full-surface-app-platform-delivery-plan.md
+++ b/docs/superpowers/plans/2026-08-30-full-surface-app-platform-delivery-plan.md
@@ -1,0 +1,765 @@
+# Deft Full-Surface App Platform — Revised Delivery Plan
+
+| Field | Value |
+|---|---|
+| **Status** | Proposed execution plan; Phases 0–2 merged, Phase 3 closeout pending |
+| **Date** | 2026-08-30 |
+| **Architecture source** | `docs/superpowers/plans/2026-08-29-full-surface-app-platform.md` |
+| **Execution baseline** | Phase 1 `bdb137ee`; Phase 2 `9ba7b7c8`; merged Phase 3 engine `399cd030`; existing local Phase 3 certification baseline `5050b0f1` (not the final closeout tip) |
+| **North star** | A community member can ask Codex to build any feasible Deft App, install it on an ordinary self-hosted workspace, and have it participate through governed resources, knowledge, agents, capabilities, experiences, automation, runtimes, sync, and public ingress as required by that App. |
+
+## Decision
+
+Keep the full-surface architecture. Change its delivery shape.
+
+The architecture document remains the capability map and threat model. This
+document supersedes only its mostly linear implementation sequence. Work now
+follows a **foundation -> independent proof -> evidence-led generalization**
+rhythm. A necessary trust boundary may be built for its first consumer; broad
+provider, resource, workflow, or ecosystem abstractions wait for evidence from
+multiple heterogeneous consumers.
+
+This is not an MVP reduction. It is a durability rule: public contracts are
+small when first published, every privileged plane proves its own safety and
+self-host operation, and later Apps compose proven planes instead of depending
+on speculative protocol surface.
+
+## Product boundary
+
+"Any feasible App" does not mean arbitrary installed code runs inside Deft's
+trusted API, web, or worker processes.
+
+- Tier 1 declarative Apps use Deft-owned resources and rendering.
+- Tier 2 connected Apps add exact grants, connector bindings, governed actions,
+  and native actor surfaces.
+- Tier 3 full-surface Apps compose isolated custom UI, operator-managed
+  runtimes, specialized resources/sync, automation, and public ingress.
+- Apps may request authority. Deft owns effective authorization, risk,
+  approval floors, retry policy, retention ceilings, and revocation.
+- Self-hosting never requires a hosted Deft service, registry, marketplace, or
+  managed runtime merely to use the protocol.
+- A future SaaS deployment implements replaceable operational providers around
+  the same App protocol and authorization model; it does not fork them.
+
+## Non-negotiable invariants
+
+1. Tenant, actor, installation, provider, and resource identity come from
+   authenticated host context and live records, never App-supplied claims.
+2. Installed artifacts cannot execute code in Deft's trusted processes, create
+   connectors, widen tokens, select runtimes, or enable automation implicitly.
+3. Every App-defined capability and App-mediated external effect uses
+   CapabilityService and one governed App Run with approval, idempotency,
+   attempt, unknown-outcome, receipt, and revocation semantics appropriate to
+   its host-owned classification. Existing native Deft actions retain their
+   certified path unless a separately justified migration moves them.
+4. Every resource disclosure or mutation resolves and authorizes live. Cached
+   labels, search projections, provider assertions, and App metadata never
+   authorize.
+5. Disable and revocation stop future Deft-mediated access. Documentation and
+   UI state honestly when already delivered data or independently held
+   credentials cannot be clawed back.
+6. Public protocol contracts are versioned, closed, bounded, independently
+   buildable, and additive until an explicit compatibility policy says
+   otherwise.
+7. Core remains domain-neutral. Reference Apps prove behavior without adding
+   CRM, marketing, booking, newsletter, email, or agent-console branches to
+   Deft core.
+8. Fresh installs, supported upgrades, backup/restore, rollback floors, and
+   ordinary self-host operation are release properties, not SaaS-only work.
+
+## Current state and immediate decision
+
+### Completed and preserved
+
+- **Phase 0:** architecture, terminology, trust boundaries, licensing, and
+  disabled-by-default plane policy.
+- **Phase 1:** deterministic declarative App packages, lifecycle, lineage,
+  developer pairing, Authoring Kit alpha, and Hello Workspace proof.
+- **Phase 2:** actor-neutral CapabilityService with MCP as the first adapter and
+  behavior-parity coverage.
+- **Phase 3 PR A/B:** dormant App Run contracts, schema, secrets, lifecycle,
+  attempts, replay, failure classification, and fake-provider engine merged
+  through `399cd030`.
+
+The remaining chain is local-only and unreleased:
+`4c4f48c1` (C0) -> `e6274c41` (C1) -> `c3670207` (C2) ->
+`d5192c55` (C3) -> `ffdab418` (C4) -> `944b265f` (C5) ->
+`5050b0f1` (certification docs). None of those hashes is a supported rollback
+floor. The rollback floor is the eventual merged and released image revision.
+
+No completed phase is restarted or redesigned. Later work must consume these
+deep services rather than create parallel execution, package, or authorization
+paths.
+
+### Phase 3 closeout gate
+
+The local C0–D2 work through `5050b0f1` is treated as completion and hardening
+of the merged engine, not as an App-facing feature.
+
+Before it merges:
+
+1. Record the dual-ledger exit: App Runs are canonical execution state;
+   `agent_actions` is the current approval projection and legacy receipts remain
+   historical compatibility. After native App approval/Run UI and Phase 6
+   parity are proven, no new App path may depend on the compatibility ledger.
+2. Preserve the already tested additive `.19`–`.21` migrations by default.
+   Consolidate them only if repository policy requires one unreleased train to
+   equal one migration, no supported or retained environment has recorded
+   their checksums, disposable environments are reset, and the resulting
+   upgrade/engine evidence is rerun.
+3. Describe `AppRunOperationsService` as an internal repair primitive with a
+   runbook/SQL operator path. Do not claim a public operations surface until
+   one exists.
+4. Keep `origin = app`, system/automation origins, and broad rollout fail-closed
+   until later phases provide their host-owned authority sources.
+5. Keep the exact flag-on legacy MCP path default-off, with no shadow provider
+   call and no fallback after a governed attempt begins.
+6. Separate rollout controls for Run runtime/key availability, App-origin
+   entrance, and legacy-connector cutover. Document supported combinations,
+   prerequisites, compatible image floor, owner, and retirement/permanent
+   status. Enabling community Apps must not implicitly migrate all existing MCP
+   traffic.
+7. Because the split controls change code/startup contracts beyond
+   `5050b0f1`, create a new closeout checkpoint and rerun the flag-combination,
+   startup, queue-deferral, keyring, rollback, and compatibility delta before
+   PR D is certified.
+
+Recommended review shape:
+
+- **PR C — trust and data completion:** C0–C3 release fencing, live authority,
+  budget evidence, approval adapter, selected ancestry constraints, receipts,
+  Attention, and repair invariants.
+- **PR D — guarded runtime and certification:** C4–C5 composition, exact
+  default-off legacy canary, rollback/key runbook, and the certification record.
+
+PR D may stack on PR C only while commit ancestry is preserved. If PR C is
+squash-merged or rewritten, rebuild/rebase PR D on the resulting default branch
+and recertify the changed delta rather than treating old hashes as evidence.
+
+Merge evidence is limited to changed boundaries plus one consolidated delta
+matrix: shared contracts, final upgrade representation, App Run database suite,
+one flag-off and one flag-on disposable-database fixture, focused
+approval/trust/connector/worker/crypto/architecture tests, repository typecheck,
+and one production source build. Browser testing is required only if web code
+changes. Production-image, current-schema, backup/restore, rollback, and
+deterministic-provider browser drills remain rollout gates and run once on the
+release candidate.
+
+## Revised delivery graph
+
+```text
+Phases 0–3: governed foundation
+              |
+              v
+Phase 4: Resource participation kernel
+              |
+              v
+Phase 5: Connected grants, bindings, and App-origin Runs
+              |
+              v
+Phase 6: Independent connected-App proof and beta
+              |
+              +--> Track A: governed automation
+              +--> Track B: isolated custom experiences
+              +--> Track C: runtime --> specialized resources and sync
+              +--> Track D: public ingress
+                              |
+                              v
+                Compound full-surface proofs
+                              |
+                              v
+              Protocol and operations stabilization
+                              |
+                              v
+                    Optional ecosystem work
+```
+
+Phases 4–6 remain sequential because they establish the connected kernel.
+Tracks A–D are independently selectable after Phase 6. Track C's sync work
+depends on its runtime/resource-provider kernel; the other tracks do not depend
+on one another unless a selected proof explicitly combines them.
+
+## Phase 4 — Resource participation kernel
+
+**Outcome:** independently authored Apps can address and relate authorized Deft
+resources through a stable, live-checked contract without forcing every core
+resource through a universal rewrite.
+
+### Loop 4.0 — Freeze the connected proof
+
+- Freeze independently authored Contacts and Campaigns Apps plus a deterministic
+  sandbox email provider.
+- Make cross-App composition an explicit first connected-platform claim: one
+  community App can depend on and reference resources from another without
+  copying them or knowing its source. The added reference/dependency work is
+  therefore intentional, not incidental test scaffolding.
+- List the exact resource reads, mutations, links, search/context reads, and
+  caller surfaces required by the proof.
+- Keep unrelated core-resource adapters and specialized-provider behavior out
+  of the phase gate.
+
+### Loop 4.1 — ResourceRef and authorization seam
+
+- Add a bounded, versioned `ResourceRef` with provider, resource type, and
+  opaque resource identity. Organization always comes from authenticated host
+  context. If a persisted or serialized reference carries a tenant component,
+  it is host-minted, must exactly match that context, and can never select the
+  tenant.
+- Add a closed host-owned adapter map/resolver and one
+  `ResourceAuthorizationService` entry point with stable structured errors.
+  Do not publish generalized registry/discovery semantics until Task or a
+  specialized provider becomes the second real resource consumer.
+- Delegate actual authorization to current resource owners; do not duplicate
+  Module or Task access rules in the registry.
+- Treat provider security facts as inputs or denials only. The host makes the
+  final allow decision.
+
+### Loop 4.2 — First heterogeneous adapters
+
+- Implement the Module-record adapter first. Add Task as the first
+  heterogeneous core adapter when the proof links work or as the immediately
+  following connected-kernel generalization fixture; it does not block the
+  initial Campaign action.
+- Support only bounded resolve, safe projection, authorized create/update/
+  archive where the underlying resource already supports it, and optimistic
+  concurrency where required.
+- Route network or independently operated mutations through CapabilityService
+  and App Runs; Resource `update` cannot conceal an external effect.
+
+### Loop 4.3 — Cross-App relations
+
+- Add tenant-bound, typed reference edges with authorized endpoint resolution.
+- Add them through a new versioned Module reference contract/schema rather than
+  changing schema `1` parsing or digest behavior.
+- Support Campaign-to-Contact references without copying records.
+- Keep reference storage/resolution separate from Phase 5 App dependency and
+  grant binding. Phase 4 fixtures may reference two already installed Modules;
+  Phase 5 pins an App requirement to an exact installed lineage/version.
+- Define installation disable, resource archive/delete, App upgrade, dangling
+  reference, picker, and search/citation behavior.
+- Cached labels and snippets remain presentation hints, never authority.
+
+### Loop 4.4 — Search, context, and compatibility
+
+- Route only the proof's Module search, context, and citation reads through the
+  Resource seam. Do not cut over unrelated existing callers merely for
+  architectural symmetry.
+- Shadow-compare against existing authorized results before selecting the new
+  path.
+- Preserve current Module relations, task links, IDs, APIs, and agent behavior.
+
+### Phase 4 acceptance
+
+- Cross-organization and cross-security-context resolution fails at database
+  and service boundaries.
+- Membership/resource-ACL loss and Module/App disable or archive immediately
+  remove resolve/search/context visibility. App-grant revocation begins in
+  Phase 5.
+- Stale projections and malicious-provider access claims cannot authorize.
+- Relation lifecycle is deterministic across disable, upgrade, archive, and
+  deletion.
+- Module parity passes; Task parity becomes mandatory in the merge that adds
+  the Task adapter.
+- Existing Module schema `1` parsing, canonicalization, and manifest digests are
+  unchanged. A later schema version is additive and cannot reinterpret v1.
+- No message, wiki, note, file, calendar, people, team, sync, generalized blob,
+  or CRM-specific implementation is required to pass this phase.
+
+Those adapters remain required for the full platform, but are added when a
+proof consumes them or during evidence-led connected-kernel generalization.
+
+## Phase 5 — Connected grants, bindings, and App-origin Runs
+
+**Outcome:** an installed App can request, receive, expose, and invoke one exact
+governed capability through the same host-owned authorization path on every
+interactive actor surface.
+
+### Loop 5.0 — Freeze the first capability contract
+
+- Freeze the smallest useful sandbox-email send contract with strict
+  input/output schemas and code-owned risk, review, egress,
+  retry/idempotency, retention, and automation eligibility. Keep it namespaced
+  and App-private unless independent provider/App evidence already justifies a
+  reviewed standard interface.
+- Implement the first sandbox provider through the existing `mcp` provider
+  kind. A second provider kind or runtime abstraction is outside the connected
+  kernel.
+- Provider descriptions and App copy cannot lower those floors.
+- Keep the interface narrow; attachments, bulk delivery, templates, tracking,
+  suppression, and provider-specific extensions remain absent unless the proof
+  requires them.
+
+### Loop 5.1 — Manifest atoms
+
+- Extend `deft.app.json` only with the resource requirement, capability
+  requirement, existing-connector requirement, dependency, and closed action
+  binding used by the proof.
+- A manifest atom lands only with strict parsing, immutable persistence,
+  permission review, enforcement, lifecycle revocation, App Kit support, and
+  conformance coverage.
+- Maintain one host-owned supported-plane registry used by parser, persistence,
+  review, routing, lifecycle, and conformance tests. CI rejects a manifest key
+  that is accepted without all required handlers. Phase 5 ships the
+  authoritative schema/types/parser and minimum install/review tooling;
+  Phase 6 adds the external template, simulator, guidance, and author trial.
+- Continue rejecting custom code, runtime, sync, automation, and public-ingress
+  fields.
+
+### Loop 5.2 — Exact grants and provider binding
+
+- Add immutable requested/effective grant snapshots.
+- Bind exact installation version + capability interface + connector/provider
+  instance + operation/schema snapshot.
+- Include exact rights for App-owned Module resource reads/mutations needed by
+  the binding; a capability grant does not silently confer resource authority.
+- Staging grants zero authority. An owner/admin explicitly selects an existing
+  connector and accepts the Deft-owned classification.
+- Reject ambiguous providers, cycles, implicit dependency upgrades, and
+  cross-lineage grant inheritance.
+- Pin App dependencies/resource requirements to selected installed lineage and
+  compatible version locks. Do not auto-install or auto-upgrade dependencies.
+
+### Loop 5.3 — Live lifecycle authorization
+
+- Bind work to installation, actor, membership/token, connector/provider, App
+  version, interface, and grant authorization versions.
+- Freeze caller-to-connector authority per surface: the current human
+  membership, Defty execution identity, employee health/assignment/budget, or
+  human-MCP token scopes remain live requirements. Owner selection during
+  binding is not continuing execution authority, and an App never runs as the
+  owner who installed or bound it.
+- Persist tenant-bound installation ID, App version ID, binding key, and grant
+  snapshot ID on every App-origin Run with exact database/repository
+  validation. Recheck them before approval, claim, provider dispatch, and
+  result delivery.
+- Pin exact provider operation identity and schema digest. Schema drift makes
+  the binding unhealthy and fail-closed; owner review/rebinding creates a new
+  immutable grant snapshot rather than silently following a slug or discovery
+  result.
+- Disable, revocation, security-sensitive upgrade, or reassignment advances the
+  relevant epoch and invalidates stale sessions, approvals, claims, and
+  invocations.
+- Define bounded drain, expiry, cancellation, and unknown-outcome behavior;
+  never silently rebind old work to a new version or provider.
+- Keep the beta lifecycle closed: staged -> active -> disabled, with an atomic
+  version-pointer upgrade from a separately staged version. Uninstall requires
+  disabled state, no unresolved dependent references, an explicit decision for
+  retained/exported data, and safe expiry or retention of pinned Runs/receipts.
+
+### Loop 5.4 — AppActionService and native bindings
+
+- Add one deep `AppActionService` used by all callers.
+- Limit it to binding/grant/input resolution and list/resolve/invoke
+  orchestration. App Service owns lifecycle, resource providers own resource
+  authorization, CapabilityService owns provider policy/execution, and App Run
+  Service owns effect state. Architecture tests prevent surface adapters from
+  bypassing it and prevent it from calling the low-level MCP client.
+- Resolve binding inputs only from authorized resource fields/references and
+  explicit user input. Do not add arbitrary mapping, templating, or expression
+  languages, JSONPath, hidden secret constants, or author-defined transforms.
+  Resolve fields live at invocation and pin the effective values and relevant
+  resource revisions into the Run while keeping sensitive values out of safe
+  previews and logs.
+- Use a host-owned binding ingress that resolves immutable connector/provider
+  IDs and actor/token context. App execution never reuses the legacy
+  slug-selected CapabilityService ingress.
+- Add generic host-rendered action placement and stable small App discovery/
+  invocation/Run operations rather than generated top-level tools.
+- Enable `origin = app` only through the exact grant/binding path into
+  CapabilityService and App Runs.
+- Make App Run approval authoritative for native App actions. Any approval
+  inbox row is an idempotent projection and cannot independently authorize or
+  execute the effect.
+
+### Loop 5.5 — Review and management surfaces
+
+- Add the minimum Settings surfaces for requested/effective grants, exact
+  connector selection, provenance, health, disable, and Run status.
+- Add approval/Run state to the host-rendered action surface.
+- Add actor-scoped safe Run inspect/result operations backed by App Run Service,
+  not the dormant deny-all internal operations primitive.
+- Add explicit App scopes; broad pre-App OAuth/MCP scopes remain blind until
+  separately reauthorized.
+
+### Phase 5 acceptance
+
+- Staging cannot invoke and activation cannot create a connector, widen a
+  token, select a runtime, or enable a schedule.
+- Manifest/provider metadata cannot lower host policy.
+- Disabled, ambiguous, revoked, cross-tenant, or stale bindings fail before the
+  effect; post-boundary ambiguity is recorded truthfully.
+- Concurrent replay produces one provider call and one terminal Run identity.
+- A widening upgrade requires fresh review and failed activation leaves the old
+  version active.
+- A non-widening connected-App upgrade preserves bindings only when action,
+  interface, dependency, and provider requirements remain compatible and
+  unchanged; otherwise it restages for review. Transform-requiring Module
+  upgrades leave active pointers/data untouched.
+- Phase 1 App/module bindings migrate through a tested v0-to-v1 adapter. Hello
+  Workspace and existing Module data remain usable.
+- Dependency ownership distinguishes pre-existing, App-installed, and shared
+  artifacts; disable/uninstall never cascades silently and requires explicit
+  export/retention decisions where data would become unreachable.
+- For the beta, bound dependency, upgrade, drain, export/retention, and
+  uninstall behavior to the exact Contacts -> Campaigns graph and its current
+  lifecycle state machine. General dependency solving and heterogeneous
+  ownership policy remain Gate G work.
+- App-owned route, command, binding, resource, and action keys are lineage-
+  namespaced and reject reserved-core, ambiguous, and Unicode-confusable
+  collisions.
+- UI, Defty, employee, and human MCP adapters are shallow callers of the same
+  AppActionService and use the same binding identity, Run identity model, and
+  replay semantics under equivalent actor, installation, assignment, and token
+  grants. Discovery may correctly differ when effective authority differs.
+- Existing tokens cannot discover App bindings, provider schemas, or Run
+  metadata and cannot invoke Apps until explicit App scopes are reauthorized.
+- Core contains no Contacts, Campaign, or email-domain service branch.
+
+## Phase 6 — Independent connected-App proof and beta
+
+**Outcome:** a community-style external author can build, install, operate,
+upgrade, disable, and recover a Tier 2 connected App using only published Deft
+contracts and tooling.
+
+### Loop 6.0 — Connected Authoring Kit
+
+- Extend schemas, generated types, CLI, lock format, templates, `doctor`, host
+  simulator, and fake provider fixtures only for supported Phase 4–5 contracts.
+- Keep the beta kit narrow: manifest/types/build/install and the connected
+  example are mandatory; a generalized simulator, dependency solver, interface
+  registry, or large fixture matrix requires a demonstrated second consumer.
+- Publish Codex/AGENTS guidance with safe extension choices and explicit
+  non-claims.
+
+### Loop 6.1 — Independent proof artifacts
+
+- Build Contacts and Campaigns from clean external directories/repositories
+  using version-matched packed artifacts and no monorepo-private imports.
+- Consume local packed/versioned artifacts rather than workspace links. Public
+  registry publication is a separate release decision and does not block this
+  proof.
+- Implement the sandbox provider against the frozen interface.
+- Keep all domain behavior in the Apps/provider.
+
+### Loop 6.2 — Native workflow
+
+- Stage, review, bind, activate, open, search, cite, relate, invoke, approve,
+  inspect the receipt, upgrade, disable, and re-enable.
+- Campaign references Contact without copying it.
+- Keep the first send single-recipient or tightly bounded and human-initiated.
+  The App Run receipt is its durable send audit. A domain send-log projection
+  requires a separately designed idempotent result-projection/workflow contract
+  and is not implemented ad hoc before the automation/event plane.
+
+### Loop 6.3 — Adversarial and parity proof
+
+- Exercise approval/revocation races, provider timeout and ambiguous outcome,
+  replay, result expiry, post-provider finalization failure, App disable,
+  connector disable, membership removal, upgrade, restart, and restore.
+- Run one shared native-equivalence harness across human UI, Defty, employee,
+  and human MCP. All surfaces must share binding identity, policy floor, Run
+  identity model, idempotency, receipt, and result semantics; replaying the
+  same logical invocation returns the same Run without another provider call
+  only inside the same initiating actor, execution actor, installation/version,
+  grant, binding, provider, and idempotency scope. Cross-actor, cross-token, and
+  cross-tenant keys cannot collide, reveal a retained result, or suppress a
+  separately authorized invocation.
+
+### Loop 6.4 — External author trial and beta gate
+
+- Give a clean Codex task only the published kit, contracts, documentation, and
+  self-host endpoint.
+- Record authoring friction and change public contracts only for demonstrated
+  blockers.
+- Run one release certification: Phase 4–6 conformance, supported upgrade from
+  the Phase 3 release, fresh-schema release-image check, production image and
+  Compose smoke, desktop/mobile journey, repository typecheck/build, and
+  database + key-material backup/restore.
+
+### Phase 6 acceptance
+
+- A clean external author builds and installs the proof without core edits.
+- Self-hosting requires no hosted account, registry, or managed runtime.
+- The App and its local data surface install and open without network access;
+  an offline connector is reported as unhealthy rather than preventing boot.
+- Grant and package diffs are deterministic and understandable.
+- Disable/revocation is live across every interactive surface.
+- Failure and recovery claims match durable evidence.
+- Key generation, validation, storage, backup inclusion, rotation, retirement,
+  lost-key behavior, and startup diagnostics are usable by an ordinary
+  self-host operator without a hosted KMS or ephemeral production keys.
+- Runs, retained ciphertext, provider snapshots, action discovery, pending
+  approvals, queue backlog, retry, payload, and retention behavior have bounded
+  operator-visible ceilings and cleanup/degraded-mode behavior.
+- This permits the claim **Connected App Platform beta**. It does not yet permit
+  automated, custom-experience, runtime, sync, public-ingress, or arbitrary
+  full-surface claims.
+
+## Gate G — Evidence-led connected-kernel generalization
+
+Phase 6 proves the minimum kernel; it does not erase the canonical platform's
+broader resource, privacy, lifecycle, or private-capability requirements. Gate
+G is an incremental ownership list, not another big-bang phase. Each privileged
+track completes the Gate G items it consumes. All applicable items must be
+complete before the general full-surface platform claim.
+
+- Add Task, messages/chat, wiki/notes, files/blobs, calendar, people, and teams
+  adapters when a proof first consumes each type. Complete live ACL/search/
+  context/citation parity for every resource named in a product claim.
+- Add reusable organization, team, user-private, explicit-share, and role-
+  restricted security contexts as heterogeneous resources require them.
+- Make attachments/blobs inherit parent authorization; broker access without
+  exposing storage credentials and enforce size, MIME/sniffing, disposition,
+  active-content, and quarantine hooks.
+- Add lineage-namespaced App-private capability contracts with fail-closed host
+  defaults so community Apps do not depend on Deft standardizing every domain
+  verb. Promote a private interface only after repeated compatible provider/App
+  evidence and review.
+- Generalize dependency ownership, upgrade compatibility, drain/supersede,
+  uninstall/export/retention, and namespace policy only where a second
+  heterogeneous package/resource/runtime proves the shared rule.
+- Preserve exact v0 compatibility and current data. No generalized adapter may
+  reinterpret an existing identifier, digest, grant, visibility rule, or
+  lifecycle outcome without migration and rollback evidence.
+
+A track may start after Phase 6 with its declared Gate G dependencies. It may
+not silently change shared `ResourceRef`, manifest, grant, binding, or App Run
+contracts. Such a change requires a common-kernel rebaseline and conformance
+run for every active dependent track.
+
+## Privileged-plane tracks after Phase 6
+
+Each track follows the same cadence: pre-proof using existing contracts, one
+new capability claim, deterministic fixture, independent App, adversarial
+revocation/failure proof, self-host operations proof, and only then contract
+promotion. Completing one track does not automatically start another.
+
+### Track A — Governed automation
+
+Minimum first slice:
+
+- transactional event/outbox record only where the producer needs it;
+- distinct non-admin automation principal;
+- immutable approved schedule/action definition;
+- timezone/DST/misfire behavior, unique fire claims, pause/resume, budgets,
+  retry/dead-letter, loop detection, and kill switch;
+- one App Run/receipt per external effect;
+- manifest, review UI, Authoring Kit, simulator, and conformance together.
+
+Event-delivery retry and external-effect retry are separate decisions. Replaying
+an event may rediscover an existing Run; it must not retry an unsafe effect
+whose dispatch outcome is ambiguous.
+
+First proof: bounded Scheduled Campaign. Rich branching, general expression
+languages, durable arbitrary waits, and compensation remain deferred until
+multiple Apps require them.
+
+### Track B — Isolated custom experiences
+
+Minimum first slice:
+
+- complete the browser-isolation spike before freezing the manifest contract;
+- immutable content-addressed static bundle;
+- per-App/version isolation with no ambient Deft cookie or reusable bearer
+  token;
+- restrictive CSP/sandbox/Permissions Policy and closed MessageChannel bridge;
+- no shared App storage, parent DOM access, general network proxy, mutable
+  remote bundle, or browser egress channel;
+- resource/action SDK backed by live Resource/App Run authorization;
+- accessibility, mobile, storage clearing, hostile-content, egress, and
+  revocation tests.
+
+First proof: custom Agent Operations Console.
+
+### Track C — Runtime and specialized resources/sync
+
+Runtime kernel first:
+
+- operator-administered runtime registration and explicit credential ownership;
+- short-lived pull claims, leases, heartbeat/cancel/reconcile, bounded signed
+  callbacks, budgets, health, revocation, and SSRF/target validation;
+- no connector credentials, installing-user impersonation, or manifest-created
+  process/network targets.
+
+Sync/resource-provider slice second:
+
+- declare canonical ownership, recovery/resync support, freshness, cursors,
+  tombstones, and retention;
+- provider-authoritative one-way projection first;
+- specialized-resource authorization, live permission-aware search/context/
+  citation resolution, inherited attachment/blob ACLs, and safe attachment
+  handoff;
+- Deft-owned push and bidirectional sync require separate conflict/loop proofs.
+
+First compound proof: Email Lite with isolated UI plus one operator-owned
+sandbox or standards-based provider. Runtime and sync may ship separately, but
+Email Lite is not claimed until both recovery models are proven.
+
+### Track D — Public Gateway
+
+Minimum first slice:
+
+- isolated public principal and public-only middleware that ignores ambient
+  workspace cookies;
+- opaque enable/disable endpoints, strict schemas, payload/rate limits,
+  retention, consent, abuse controls, and deduplicated durable ingress;
+- transactional public resource claims;
+- raw-byte signature profiles and replay windows for reviewed webhook types;
+- App-specific verification code runs only in an operator-managed runtime.
+
+For a Deft-canonical booking slot, commit the deduplicated ingress row, unique
+idempotent slot reservation, and outbox event in one database transaction;
+success means the reservation committed, and a conflict never returns a
+confirmation. For an externally canonical calendar, `202 Accepted` means only
+that the request was durably accepted—not that a meeting was booked—and a later
+governed capability confirms or rejects it. Never claim transactional remote
+booking across a provider call.
+
+The proof includes cookie isolation, double-book protection, raw-byte signature
+verification, crash-before/after the durable response boundary, replay,
+disable, retention, payload/rate ceilings, and public-log leakage tests.
+Ordinary workspace mutation unrelated to the bounded slot-claim transaction
+does not occur inline; later governed work handles it.
+
+First proof: Booking. Newsletter unsubscribe/bounce/complaint handling is a
+separate compound proof with Track A and must serialize suppression against
+send claims.
+
+## Cumulative certification and platform stabilization
+
+Certification is attached to each plane rather than deferred until a late
+construction phase. A completed subset permits claims only for Apps composed
+from that subset. After all four tracks and their applicable Gate G items pass,
+run two compound proofs:
+
+1. **Email Lite:** Experience Host + Runtime + specialized resources/sync.
+2. **Public automated workflow:** Automation + Public Gateway through Booking or
+   newsletter compliance flows.
+
+Then permit the general **full-surface App platform** claim and freeze
+compatibility/deprecation policy only after:
+
+- at least two independently authored heterogeneous Apps use the same public
+  kernel without core changes;
+- fresh install, supported upgrade, rollback, backup/restore, provider outage,
+  restart, lease expiry, runtime compromise, and unknown outcomes pass on
+  release images;
+- tenant isolation covers database, queue, blobs, search, logs, key hierarchy,
+  runtime claims, and operator tooling;
+- performance budgets exist for resource resolution/search, Runs, event
+  backlog, sync, iframe startup, and runtime callbacks;
+- focused independent security review covers the highest-risk published
+  boundaries;
+- README, self-hosting, and product claims match only certified planes.
+
+## Optional ecosystem and hosted work
+
+Do not begin marketplace work merely because the protocol can describe Apps.
+Require stable package identity, compatibility evidence, and multiple external
+publishers first.
+
+Optional ecosystem work includes publisher signatures, portable provenance,
+registry metadata, community conformance CI, install-by-URL, update policy,
+managed runtime offers, reviews, entitlements, payments, and marketplace UX.
+
+Hosted SaaS work begins after the corresponding protocol is useful self-hosted:
+
+- hosted KMS, object storage, runtime scheduling, email, and other services are
+  replaceable provider implementations;
+- tenant quotas, rate limits, metering, abuse controls, and kill switches are
+  operational policy, not App-granted authority;
+- multi-replica API/worker evidence covers idempotency, attempt leases, approval
+  races, queue fairness, revocation, result delivery, and key access; in-process
+  composition or caches are never assumed globally unique;
+- rolling mixed-version migration, regional failure, key-loss, and fleet
+  backup/restore drills precede hosted claims;
+- tenant deletion defines and tests the fate of App artifacts, encrypted Run
+  payloads, receipts, provider-owned data, blobs, logs, backups, keys, and
+  runtime-held copies. One tenant's deletion or key rotation cannot affect
+  another tenant;
+- hosted operators cannot silently broaden grants or impersonate an installing
+  owner;
+- community Apps remain locally installable unless a capability is truthfully
+  declared hosted-only;
+- billing and marketplace metadata never become execution authority.
+
+## Execution rules
+
+1. **Zero proof debt:** do not start another privileged plane while the previous
+   published plane lacks an independent end-to-end proof.
+2. **Foundation/proof pairing:** a structural merge must be followed by a
+   behavioral merge that exercises it; do not accumulate schema-only trains.
+3. **Persistent-object ownership:** every table/object needs a current writer,
+   reader, authorization/revocation path, retention/cleanup owner, and proof
+   consumer. Tests cover its production writer, bounded reader, tenant
+   isolation, lifecycle cleanup, and upgrade preservation; architecture checks
+   flag App-platform tables referenced only by schema, migrations, tests, or
+   docs.
+4. **Two-consumer generalization:** use a narrow adapter for the first
+   implementation. Create a universal provider/registry/DSL only after two
+   heterogeneous consumers expose the same invariant. Concrete security
+   boundaries are the exception; the architecture decision must name whether a
+   seam is security centralization or convenience generalization and identify
+   its consumers.
+5. **One privileged plane per proof:** combine planes only for a deliberate
+   compound conformance proof.
+6. **Manifest atom:** parser, persistence, review, enforcement, revocation,
+   authoring support, and conformance land together.
+7. **Host-owned policy:** Apps request; Deft classifies and authorizes.
+8. **No premature expression language:** explicit inputs and bounded authorized
+   field mappings precede templates, expressions, or workflow DSLs.
+9. **Deep shared entrances:** every caller surface uses the same Resource or
+   AppAction service. Surface-specific copies of authorization are forbidden.
+10. **Feature flags are rollout gates:** each has an owner, enablement evidence,
+    supported combination matrix, compatible released-image floor, rollback
+    evidence, and removal-or-permanent-control decision. Startup rejects unsafe
+    combinations.
+11. **Proportional evidence:** always test tenant isolation, live revocation,
+    approval, replay, provider-boundary crash, disable, and leakage. Add broader
+    combinations only for distinct code paths.
+12. **Stop decision:** after every proof, record what worked, what required
+    manual glue, which invariant failed, and which single next plane unlocks the
+    most leverage. Numbering alone never authorizes the next track.
+13. **Hard proof-debt gate:** a plane is not supported and the next plane does
+    not begin until one clean external App, deterministic provider/runtime
+    fixture, revocation/crash evidence, released-image self-host smoke, and a
+    supported/non-supported decision have an owner and evidence link. Maintain
+    one reviewed evidence record per plane containing the external revision,
+    package digests, deterministic fixture result, adversarial matrix,
+    release-image/self-host evidence, claim status, and owner. A PR adding the
+    next privileged manifest/runtime surface must link its completed predecessor
+    record or fail review/CI.
+14. **No dormant expansion:** guarded Phase 3 ancestry, reconciliation,
+    retention, and operator primitives may remain, but receive no generalized
+    extension until a connected or automation proof consumes them.
+
+## Claim ladder
+
+| Gate | Permitted claim |
+|---|---|
+| Phase 1 | Codex can build and install a declarative Deft App. |
+| Phase 3 internal gate | Deft has a guarded governed-effect substrate; no new App claim. |
+| Phase 6 | Codex can build connected Apps using resources, agents, approvals, and external capabilities. |
+| Track A | Apps can schedule and react through bounded governed automation. |
+| Track B | Apps can provide isolated custom UI. |
+| Track C | Apps can use operator-managed computation and synchronized specialized resources. |
+| Track D | Apps can expose governed public workflows. |
+| Compound proofs | Deft supports independently authored full-surface Apps by composing certified planes. |
+| Stabilization | Community protocol compatibility is supported. |
+| Ecosystem | Registry/marketplace claims are evidence-backed. |
+
+## Next action
+
+The executable closeout sequence is
+`docs/superpowers/plans/2026-08-30-app-platform-phase-3-closeout-loops.md`.
+
+Close Phase 3 through the two guarded review trains above. Do not begin a
+maximal universal Resource Service in parallel. Once Phase 3 is merged
+default-off, establish one released connected-kernel merge base and plan Phase
+4 Loops 4.0–4.4 against the exact Contacts/Campaigns proof and current schema.
+Then execute Phase 4–6 as one connected-kernel program with separate reviewable
+merges and one final release certification. Every later track declares that
+released connected-kernel revision as its minimum dependency, starts from and
+continuously integrates the latest security-supported default branch, and
+records shared-contract rebases. No optional track starts from an unmerged
+local stack or remains pinned to an obsolete release.

--- a/packages/db/scripts/apply-extras.ts
+++ b/packages/db/scripts/apply-extras.ts
@@ -59,6 +59,10 @@ async function main() {
     await client.query(readFileSync(resolve(upgradesDir, appRunLiveAuthorityFile), 'utf8'));
     console.log(`[apply-extras] applied ${appRunLiveAuthorityFile}`);
 
+    const appRunAncestryGuardFile = '0.3.0-preview.21-app-run-ancestry-guard.sql';
+    await client.query(readFileSync(resolve(upgradesDir, appRunAncestryGuardFile), 'utf8'));
+    console.log(`[apply-extras] applied ${appRunAncestryGuardFile}`);
+
     // Expression-based unique indexes can't be declared in schema.ts, so
     // `drizzle-kit push` silently drops them. Re-create the ones the app
     // depends on so pushed and migrated databases behave the same.
@@ -194,6 +198,7 @@ async function main() {
       'app_run_receipts_append_only_trigger',
       'app_runs_cutover_gate_trigger',
       'app_run_attempts_execution_release_trigger',
+      'app_runs_ancestry_insert_trigger',
       'org_members_app_run_authorization_version_trigger',
       'agent_employees_app_run_authorization_version_trigger',
       'mcp_connections_app_run_authorization_version_trigger',

--- a/packages/db/scripts/apply-extras.ts
+++ b/packages/db/scripts/apply-extras.ts
@@ -51,6 +51,10 @@ async function main() {
     await client.query(readFileSync(resolve(upgradesDir, appRunEngineHardeningFile), 'utf8'));
     console.log(`[apply-extras] applied ${appRunEngineHardeningFile}`);
 
+    const appRunCutoverGateFile = '0.3.0-preview.19-governed-app-run-cutover-gate.sql';
+    await client.query(readFileSync(resolve(upgradesDir, appRunCutoverGateFile), 'utf8'));
+    console.log(`[apply-extras] applied ${appRunCutoverGateFile}`);
+
     // Expression-based unique indexes can't be declared in schema.ts, so
     // `drizzle-kit push` silently drops them. Re-create the ones the app
     // depends on so pushed and migrated databases behave the same.
@@ -93,6 +97,8 @@ async function main() {
       'app_runs_idempotency_expiry_check',
       'app_runs_attempt_limit_check',
       'app_runs_cancel_request_check',
+      'app_runs_execution_release_shape_check',
+      'app_runs_budget_reservation_shape_check',
       'app_run_attempts_retry_shape_check',
       'app_run_secret_payloads_org_run_fk',
       'app_run_secret_payloads_org_attempt_fk',
@@ -100,6 +106,7 @@ async function main() {
       'app_run_receipts_org_run_fk',
       'app_run_receipts_org_attempt_fk',
       'agent_actions_org_app_run_fk',
+      'agent_actions_app_run_shape_check',
     ];
     const installedConstraints = await client.query<{ conname: string }>(
       `SELECT conname
@@ -131,7 +138,7 @@ async function main() {
       'app_developer_pairings_code_hash_unique',
       'app_developer_pairings_session_hash_unique',
       'capability_provider_snapshots_identity_digest_unique',
-      'app_runs_idempotency_unique',
+      'app_runs_idempotency_lookup_idx',
       'app_run_attempts_number_unique',
       'app_run_attempts_one_active_unique',
       'app_runs_idempotency_expiry_idx',
@@ -175,6 +182,8 @@ async function main() {
       'app_run_secret_payloads_append_only_trigger',
       'app_run_events_append_only_trigger',
       'app_run_receipts_append_only_trigger',
+      'app_runs_cutover_gate_trigger',
+      'app_run_attempts_execution_release_trigger',
     ];
     const installedAppRunTriggers = await client.query<{ tgname: string }>(
       `SELECT tgname

--- a/packages/db/scripts/apply-extras.ts
+++ b/packages/db/scripts/apply-extras.ts
@@ -55,6 +55,10 @@ async function main() {
     await client.query(readFileSync(resolve(upgradesDir, appRunCutoverGateFile), 'utf8'));
     console.log(`[apply-extras] applied ${appRunCutoverGateFile}`);
 
+    const appRunLiveAuthorityFile = '0.3.0-preview.20-app-run-live-authority-versions.sql';
+    await client.query(readFileSync(resolve(upgradesDir, appRunLiveAuthorityFile), 'utf8'));
+    console.log(`[apply-extras] applied ${appRunLiveAuthorityFile}`);
+
     // Expression-based unique indexes can't be declared in schema.ts, so
     // `drizzle-kit push` silently drops them. Re-create the ones the app
     // depends on so pushed and migrated databases behave the same.
@@ -107,6 +111,12 @@ async function main() {
       'app_run_receipts_org_attempt_fk',
       'agent_actions_org_app_run_fk',
       'agent_actions_app_run_shape_check',
+      'org_members_app_run_authorization_version_check',
+      'agent_employees_app_run_authorization_version_check',
+      'mcp_connections_app_run_authorization_version_check',
+      'mcp_tool_overrides_app_run_authorization_version_check',
+      'mcp_tokens_app_run_authorization_version_check',
+      'oauth_access_tokens_app_run_authorization_version_check',
     ];
     const installedConstraints = await client.query<{ conname: string }>(
       `SELECT conname
@@ -184,6 +194,12 @@ async function main() {
       'app_run_receipts_append_only_trigger',
       'app_runs_cutover_gate_trigger',
       'app_run_attempts_execution_release_trigger',
+      'org_members_app_run_authorization_version_trigger',
+      'agent_employees_app_run_authorization_version_trigger',
+      'mcp_connections_app_run_authorization_version_trigger',
+      'mcp_tool_overrides_app_run_authorization_version_trigger',
+      'mcp_tokens_app_run_authorization_version_trigger',
+      'oauth_access_tokens_app_run_authorization_version_trigger',
     ];
     const installedAppRunTriggers = await client.query<{ tgname: string }>(
       `SELECT tgname

--- a/packages/db/scripts/upgrade.test.ts
+++ b/packages/db/scripts/upgrade.test.ts
@@ -189,6 +189,54 @@ test('governed App Run engine hardening is additive and fences replay and attemp
   assert.match(applyExtrasSource, /0\.3\.0-preview\.18-governed-app-run-engine-hardening\.sql/);
 });
 
+test('governed App Run cutover gate is additive and fails closed before integration', () => {
+  const migration = upgradeManifest.migrations.find((item) => item.version === '0.3.0-preview.19');
+  assert.ok(migration);
+  const scriptsDir = dirname(fileURLToPath(import.meta.url));
+  const sql = readFileSync(resolve(scriptsDir, '..', 'upgrades', migration.file), 'utf8');
+  const applyExtrasSource = readFileSync(resolve(scriptsDir, 'apply-extras.ts'), 'utf8');
+  const run = getTableConfig(appRuns);
+  const action = getTableConfig(agentActions);
+
+  for (const boundary of [
+    'execution_release_kind',
+    'execution_released_at',
+    'budget_reserved_at',
+    'budget_reserved_count',
+    'budget_limit_at_reservation',
+    'app_runs_execution_release_shape_check',
+    'app_runs_budget_reservation_shape_check',
+    'app_run_attempts_execution_release_trigger',
+    'APP_RUN_EXECUTION_NOT_RELEASED',
+    'agent_actions_app_run_shape_check',
+    'app_runs_idempotency_lookup_idx',
+  ]) {
+    assert.match(sql, new RegExp(boundary, 'i'));
+  }
+  assert.match(sql, /DROP INDEX IF EXISTS app_runs_idempotency_unique/i);
+  assert.doesNotMatch(sql, /CREATE UNIQUE INDEX[^;]+app_runs_idempotency_lookup_idx/is);
+  assert.doesNotMatch(sql, /^\s*UPDATE\s+app_runs/im);
+  assert.doesNotMatch(sql, /^\s*UPDATE\s+agent_actions/im);
+  assert.match(applyExtrasSource, /0\.3\.0-preview\.19-governed-app-run-cutover-gate\.sql/);
+  assert.match(applyExtrasSource, /'app_runs_idempotency_lookup_idx'/);
+  assert.match(applyExtrasSource, /'app_run_attempts_execution_release_trigger'/);
+  assert.doesNotMatch(applyExtrasSource, /'app_runs_idempotency_unique'/);
+  for (const column of [
+    'execution_release_kind',
+    'execution_released_at',
+    'budget_reserved_at',
+    'budget_reserved_count',
+    'budget_limit_at_reservation',
+  ]) {
+    assert.ok(run.columns.some((item) => item.name === column));
+  }
+  assert.ok(run.indexes.some((item) => item.config.name === 'app_runs_idempotency_lookup_idx'));
+  assert.equal(run.indexes.some((item) => item.config.name === 'app_runs_idempotency_unique'), false);
+  assert.ok(run.checks.some((item) => item.name === 'app_runs_execution_release_shape_check'));
+  assert.ok(run.checks.some((item) => item.name === 'app_runs_budget_reservation_shape_check'));
+  assert.ok(action.checks.some((item) => item.name === 'agent_actions_app_run_shape_check'));
+});
+
 test('parseUpgradeArgs recognizes status and dry run', () => {
   assert.deepEqual(parseUpgradeArgs(['--status']), { status: true, dryRun: false });
   assert.deepEqual(parseUpgradeArgs(['--dry-run']), { status: false, dryRun: true });

--- a/packages/db/scripts/upgrade.test.ts
+++ b/packages/db/scripts/upgrade.test.ts
@@ -102,6 +102,8 @@ test('governed App Run fresh schema is tenant-bound and keeps ciphertext separat
   ));
   assert.ok(run.uniqueConstraints.some((item) => item.name === 'app_runs_org_id_id_unique'));
   assert.ok(foreignKeyNames(run).includes('app_runs_org_provider_snapshot_fk'));
+  assert.ok(foreignKeyNames(run).includes('app_runs_org_root_run_fk'));
+  assert.ok(foreignKeyNames(run).includes('app_runs_org_parent_run_fk'));
   assert.ok(foreignKeyNames(attempt).includes('app_run_attempts_org_run_fk'));
   assert.ok(attempt.indexes.some((item) => item.config.name === 'app_run_attempts_one_active_unique'));
   assert.deepEqual(
@@ -277,6 +279,27 @@ test('App Run live authority versions are additive, monotonic, and ignore ordina
     const config = getTableConfig(table);
     assert.ok(config.columns.some((column) => column.name === 'app_run_authorization_version'));
   }
+});
+
+test('App Run ancestry upgrade guards lineage, ceilings, and root budget continuity', () => {
+  const migration = upgradeManifest.migrations.find((item) => item.version === '0.3.0-preview.21');
+  assert.ok(migration);
+  const scriptsDir = dirname(fileURLToPath(import.meta.url));
+  const sql = readFileSync(resolve(scriptsDir, '..', 'upgrades', migration.file), 'utf8');
+  const applyExtrasSource = readFileSync(resolve(scriptsDir, 'apply-extras.ts'), 'utf8');
+
+  for (const invariant of [
+    'app_runs_ancestry_insert_trigger',
+    'APP_RUN_ANCESTRY_INVALID',
+    'APP_RUN_AUTHORIZATION_CEILING',
+    'APP_RUN_POLICY_CEILING',
+    'APP_RUN_BUDGET_CONTINUITY',
+  ]) assert.match(sql, new RegExp(invariant, 'i'));
+  assert.match(sql, /parent_row\.state NOT IN \('running', 'waiting_external'\)/i);
+  assert.match(sql, /jsonb_array_elements\(NEW\.authorization_snapshot->'authority_refs'\)/i);
+  assert.doesNotMatch(sql, /^\s*UPDATE\s+app_runs/im);
+  assert.match(applyExtrasSource, /0\.3\.0-preview\.21-app-run-ancestry-guard\.sql/);
+  assert.match(applyExtrasSource, /'app_runs_ancestry_insert_trigger'/);
 });
 
 test('parseUpgradeArgs recognizes status and dry run', () => {

--- a/packages/db/scripts/upgrade.test.ts
+++ b/packages/db/scripts/upgrade.test.ts
@@ -13,6 +13,7 @@ import {
 import { upgradeManifest } from '../upgrades/manifest.ts';
 import {
   attachmentDerivatives,
+  agentEmployees,
   agentChannelEvents,
   agentChannelConnections,
   appInstallations,
@@ -34,6 +35,10 @@ import {
   files,
   messageAttachments,
   messages,
+  mcpConnections,
+  mcpTokens,
+  mcpToolOverrides,
+  oauthAccessTokens,
   orgMembers,
   taskAttachments,
   tasks,
@@ -235,6 +240,43 @@ test('governed App Run cutover gate is additive and fails closed before integrat
   assert.ok(run.checks.some((item) => item.name === 'app_runs_execution_release_shape_check'));
   assert.ok(run.checks.some((item) => item.name === 'app_runs_budget_reservation_shape_check'));
   assert.ok(action.checks.some((item) => item.name === 'agent_actions_app_run_shape_check'));
+});
+
+test('App Run live authority versions are additive, monotonic, and ignore ordinary counters', () => {
+  const migration = upgradeManifest.migrations.find((item) => item.version === '0.3.0-preview.20');
+  assert.ok(migration);
+  const scriptsDir = dirname(fileURLToPath(import.meta.url));
+  const sql = readFileSync(resolve(scriptsDir, '..', 'upgrades', migration.file), 'utf8');
+  const applyExtrasSource = readFileSync(resolve(scriptsDir, 'apply-extras.ts'), 'utf8');
+
+  for (const boundary of [
+    'org_members_app_run_authorization_version_trigger',
+    'agent_employees_app_run_authorization_version_trigger',
+    'mcp_connections_app_run_authorization_version_trigger',
+    'mcp_tool_overrides_app_run_authorization_version_trigger',
+    'mcp_tokens_app_run_authorization_version_trigger',
+    'oauth_access_tokens_app_run_authorization_version_trigger',
+  ]) assert.match(sql, new RegExp(boundary, 'i'));
+
+  assert.match(sql, /NEW\.max_daily_actions/i);
+  assert.match(sql, /NEW\.revoked_at/i);
+  assert.doesNotMatch(sql, /NEW\.daily_action_count/i);
+  assert.doesNotMatch(sql, /NEW\.daily_cost_cents/i);
+  assert.doesNotMatch(sql, /NEW\.last_used_at/i);
+  assert.doesNotMatch(sql, /^\s*UPDATE\s+(?:org_members|agent_employees|mcp_connections|mcp_tool_overrides|mcp_tokens|oauth_access_tokens)/im);
+  assert.match(applyExtrasSource, /0\.3\.0-preview\.20-app-run-live-authority-versions\.sql/);
+
+  for (const table of [
+    orgMembers,
+    agentEmployees,
+    mcpConnections,
+    mcpToolOverrides,
+    mcpTokens,
+    oauthAccessTokens,
+  ]) {
+    const config = getTableConfig(table);
+    assert.ok(config.columns.some((column) => column.name === 'app_run_authorization_version'));
+  }
 });
 
 test('parseUpgradeArgs recognizes status and dry run', () => {

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -727,6 +727,16 @@ export const appRuns = pgTable('app_runs', {
     foreignColumns: [capabilityProviderSnapshots.org_id, capabilityProviderSnapshots.id],
     name: 'app_runs_org_provider_snapshot_fk',
   }).onDelete('no action'),
+  foreignKey({
+    columns: [t.org_id, t.root_run_id],
+    foreignColumns: [t.org_id, t.id],
+    name: 'app_runs_org_root_run_fk',
+  }).onDelete('no action'),
+  foreignKey({
+    columns: [t.org_id, t.parent_run_id],
+    foreignColumns: [t.org_id, t.id],
+    name: 'app_runs_org_parent_run_fk',
+  }).onDelete('no action'),
   index('app_runs_idempotency_lookup_idx').on(
     t.org_id,
     t.initiating_actor_type,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -208,6 +208,7 @@ export const orgMembers = pgTable('org_members', {
   user_id: text('user_id').notNull().references(() => users.id, { onDelete: 'cascade' }),
   role: orgRoleEnum('role').default('member').notNull(),
   is_active: boolean('is_active').default(true).notNull(),
+  app_run_authorization_version: integer('app_run_authorization_version').default(1).notNull(),
   joined_at: timestamp('joined_at').defaultNow().notNull(),
   ...timestamps(),
 }, (t) => [
@@ -2732,6 +2733,7 @@ export const mcpConnections = pgTable('mcp_connections', {
   tools_cached_at: timestamp('tools_cached_at'),
   default_trust_tier: approvalTierEnum('default_trust_tier').default('full').notNull(),
   enabled_tools: text('enabled_tools').array(),
+  app_run_authorization_version: integer('app_run_authorization_version').default(1).notNull(),
   created_by: text('created_by').notNull().references(() => users.id),
   ...timestamps(),
 }, (t) => [
@@ -2747,6 +2749,7 @@ export const mcpToolOverrides = pgTable('mcp_tool_overrides', {
   tool_name: text('tool_name').notNull(),
   trust_tier_override: approvalTierEnum('trust_tier_override'),
   is_disabled: boolean('is_disabled').default(false).notNull(),
+  app_run_authorization_version: integer('app_run_authorization_version').default(1).notNull(),
   ...timestamps(),
 }, (t) => [
   uniqueIndex('mcp_tool_override_unique').on(t.mcp_connection_id, t.tool_name),
@@ -2826,6 +2829,7 @@ export const agentEmployees = pgTable('agent_employees', {
   // trigger_subscriptions is the routing key for the trigger system (e.g.
   // member.joined, cron:standup) — kept as part of Phase 9.
   trigger_subscriptions: text('trigger_subscriptions').array(),
+  app_run_authorization_version: integer('app_run_authorization_version').default(1).notNull(),
   created_by: text('created_by').notNull().references(() => users.id),
   ...timestamps(),
 }, (t) => [
@@ -2887,6 +2891,7 @@ export const mcpTokens = pgTable('mcp_tokens', {
   scopes: text('scopes').array().notNull(),
   last_used_at: timestamp('last_used_at'),
   revoked_at: timestamp('revoked_at'),
+  app_run_authorization_version: integer('app_run_authorization_version').default(1).notNull(),
   created_by: text('created_by').references(() => users.id),
   ...timestamps(),
 }, (t) => [
@@ -3105,6 +3110,7 @@ export const oauthAccessTokens = pgTable('oauth_access_tokens', {
   expires_at: timestamp('expires_at').notNull(),
   last_used_at: timestamp('last_used_at'),
   revoked_at: timestamp('revoked_at'),
+  app_run_authorization_version: integer('app_run_authorization_version').default(1).notNull(),
   ...timestamps(),
 }, (t) => [
   index('oauth_access_tokens_hash_idx').on(t.token_hash),

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1003,8 +1003,8 @@ export const agentActions = pgTable('agent_actions', {
   agent_employee_id: text('agent_employee_id'),
   tool_use_id: text('tool_use_id'), // Anthropic tool_use block id (toolu_*)
   source: text('source').default('native'),
-  // Nullable compatibility link only. App Runs are dormant and never created
-  // by the current action paths in the foundation phase.
+  // Nullable compatibility link only. Governed Run submission owns the one
+  // app_run_invoke row; the action is never the execution source of truth.
   app_run_id: text('app_run_id'),
   mcp_connection_id: text('mcp_connection_id'),
   plan_id: text('plan_id'),

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -705,6 +705,11 @@ export const appRuns = pgTable('app_runs', {
   result_expires_at: timestamp('result_expires_at').notNull(),
   idempotency_expires_at: timestamp('idempotency_expires_at').notNull(),
   attempt_limit: integer('attempt_limit').notNull(),
+  execution_release_kind: text('execution_release_kind').$type<'policy_satisfied' | 'approved'>(),
+  execution_released_at: timestamp('execution_released_at'),
+  budget_reserved_at: timestamp('budget_reserved_at'),
+  budget_reserved_count: integer('budget_reserved_count'),
+  budget_limit_at_reservation: integer('budget_limit_at_reservation'),
   input_purged_at: timestamp('input_purged_at'),
   result_purged_at: timestamp('result_purged_at'),
   started_at: timestamp('started_at'),
@@ -721,7 +726,7 @@ export const appRuns = pgTable('app_runs', {
     foreignColumns: [capabilityProviderSnapshots.org_id, capabilityProviderSnapshots.id],
     name: 'app_runs_org_provider_snapshot_fk',
   }).onDelete('no action'),
-  uniqueIndex('app_runs_idempotency_unique').on(
+  index('app_runs_idempotency_lookup_idx').on(
     t.org_id,
     t.initiating_actor_type,
     t.initiating_actor_id,
@@ -730,6 +735,7 @@ export const appRuns = pgTable('app_runs', {
     t.operation_name,
     t.idempotency_key_version,
     t.idempotency_fingerprint,
+    t.idempotency_expires_at,
   ),
   index('app_runs_org_state_idx').on(t.org_id, t.state, t.created_at),
   index('app_runs_root_idx').on(t.org_id, t.root_run_id, t.created_at),
@@ -782,6 +788,25 @@ export const appRuns = pgTable('app_runs', {
   check('app_runs_expiry_check', sql`${t.result_expires_at} >= ${t.input_expires_at}`),
   check('app_runs_idempotency_expiry_check', sql`${t.idempotency_expires_at} >= ${t.result_expires_at}`),
   check('app_runs_attempt_limit_check', sql`${t.attempt_limit} BETWEEN 1 AND 10`),
+  check('app_runs_execution_release_shape_check', sql`
+    (${t.execution_release_kind} IS NULL AND ${t.execution_released_at} IS NULL)
+    OR (
+      ${t.execution_release_kind} IS NOT NULL
+      AND ${t.execution_released_at} IS NOT NULL
+      AND (
+        (${t.review_requirement} = 'always' AND ${t.execution_release_kind} = 'approved')
+        OR (${t.review_requirement} = 'policy' AND ${t.execution_release_kind} IN ('policy_satisfied', 'approved'))
+      )
+    )
+  `),
+  check('app_runs_budget_reservation_shape_check', sql`
+    (${t.budget_reserved_at} IS NULL AND ${t.budget_reserved_count} IS NULL AND ${t.budget_limit_at_reservation} IS NULL)
+    OR (
+      ${t.budget_reserved_at} IS NOT NULL
+      AND ${t.budget_reserved_count} BETWEEN 1 AND 1000000
+      AND ${t.budget_limit_at_reservation} >= ${t.budget_reserved_count}
+    )
+  `),
   check('app_runs_cancel_request_check', sql`${t.cancel_requested_at} IS NULL OR ${t.started_at} IS NOT NULL`),
 ]);
 
@@ -1010,6 +1035,19 @@ export const agentActions = pgTable('agent_actions', {
   uniqueIndex('agent_action_app_run_unique')
     .on(t.org_id, t.app_run_id)
     .where(sql`${t.app_run_id} IS NOT NULL`),
+  check('agent_actions_app_run_shape_check', sql`
+    (${t.app_run_id} IS NULL AND ${t.action} <> 'app_run_invoke')
+    OR (
+      ${t.app_run_id} IS NOT NULL
+      AND ${t.action} = 'app_run_invoke'
+      AND jsonb_typeof(${t.params}) = 'object'
+      AND ${t.params} ? 'run_id'
+      AND jsonb_typeof(${t.params}->'run_id') = 'string'
+      AND ${t.params}->>'run_id' = ${t.app_run_id}
+      AND (${t.params} - ARRAY['run_id', 'capability_label', 'provider_label', 'resource_ids', 'safe_preview']::text[]) = '{}'::jsonb
+      AND octet_length(${t.params}::text) <= 32768
+    )
+  `),
 ]);
 
 // ═══ ATTENTION + DELIVERY ═══

--- a/packages/db/upgrades/0.3.0-preview.19-governed-app-run-cutover-gate.sql
+++ b/packages/db/upgrades/0.3.0-preview.19-governed-app-run-cutover-gate.sql
@@ -1,0 +1,106 @@
+-- Forward-only cutover gate for the still-dormant governed App Run engine.
+-- This adds no execution consumer and does not modify legacy action rows.
+
+ALTER TABLE app_runs
+  ADD COLUMN IF NOT EXISTS execution_release_kind text,
+  ADD COLUMN IF NOT EXISTS execution_released_at timestamp,
+  ADD COLUMN IF NOT EXISTS budget_reserved_at timestamp,
+  ADD COLUMN IF NOT EXISTS budget_reserved_count integer,
+  ADD COLUMN IF NOT EXISTS budget_limit_at_reservation integer;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'app_runs_execution_release_shape_check') THEN
+    ALTER TABLE app_runs ADD CONSTRAINT app_runs_execution_release_shape_check CHECK (
+      (execution_release_kind IS NULL AND execution_released_at IS NULL)
+      OR (
+        execution_release_kind IS NOT NULL
+        AND execution_released_at IS NOT NULL
+        AND (
+          (review_requirement = 'always' AND execution_release_kind = 'approved')
+          OR (review_requirement = 'policy' AND execution_release_kind IN ('policy_satisfied', 'approved'))
+        )
+      )
+    );
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'app_runs_budget_reservation_shape_check') THEN
+    ALTER TABLE app_runs ADD CONSTRAINT app_runs_budget_reservation_shape_check CHECK (
+      (budget_reserved_at IS NULL AND budget_reserved_count IS NULL AND budget_limit_at_reservation IS NULL)
+      OR (
+        budget_reserved_at IS NOT NULL
+        AND budget_reserved_count BETWEEN 1 AND 1000000
+        AND budget_limit_at_reservation >= budget_reserved_count
+      )
+    );
+  END IF;
+END $$;
+
+ALTER TABLE agent_actions DROP CONSTRAINT IF EXISTS agent_actions_app_run_shape_check;
+ALTER TABLE agent_actions ADD CONSTRAINT agent_actions_app_run_shape_check CHECK (
+  (app_run_id IS NULL AND action <> 'app_run_invoke')
+  OR (
+    app_run_id IS NOT NULL
+    AND action = 'app_run_invoke'
+    AND jsonb_typeof(params) = 'object'
+    AND params ? 'run_id'
+    AND jsonb_typeof(params->'run_id') = 'string'
+    AND params->>'run_id' = app_run_id
+    AND (params - ARRAY['run_id', 'capability_label', 'provider_label', 'resource_ids', 'safe_preview']::text[]) = '{}'::jsonb
+    AND octet_length(params::text) <= 32768
+  )
+);
+
+DROP INDEX IF EXISTS app_runs_idempotency_unique;
+CREATE INDEX IF NOT EXISTS app_runs_idempotency_lookup_idx ON app_runs(
+  org_id, initiating_actor_type, initiating_actor_id, provider_kind,
+  provider_instance_id, operation_name, idempotency_key_version,
+  idempotency_fingerprint, idempotency_expires_at
+);
+
+CREATE OR REPLACE FUNCTION enforce_app_run_cutover_gate() RETURNS trigger AS $$
+BEGIN
+  IF OLD.execution_release_kind IS NOT NULL AND (
+    NEW.execution_release_kind IS DISTINCT FROM OLD.execution_release_kind
+    OR NEW.execution_released_at IS DISTINCT FROM OLD.execution_released_at
+  ) THEN
+    RAISE EXCEPTION 'APP_RUN_IMMUTABLE_FIELD' USING ERRCODE = '55000';
+  END IF;
+  IF OLD.budget_reserved_at IS NOT NULL AND (
+    NEW.budget_reserved_at IS DISTINCT FROM OLD.budget_reserved_at
+    OR NEW.budget_reserved_count IS DISTINCT FROM OLD.budget_reserved_count
+    OR NEW.budget_limit_at_reservation IS DISTINCT FROM OLD.budget_limit_at_reservation
+  ) THEN
+    RAISE EXCEPTION 'APP_RUN_IMMUTABLE_FIELD' USING ERRCODE = '55000';
+  END IF;
+  IF NEW.state = 'running' AND NEW.execution_released_at IS NULL THEN
+    RAISE EXCEPTION 'APP_RUN_EXECUTION_NOT_RELEASED' USING ERRCODE = '55000';
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS app_runs_cutover_gate_trigger ON app_runs;
+CREATE TRIGGER app_runs_cutover_gate_trigger
+  BEFORE UPDATE ON app_runs
+  FOR EACH ROW EXECUTE FUNCTION enforce_app_run_cutover_gate();
+
+CREATE OR REPLACE FUNCTION enforce_app_run_attempt_execution_release() RETURNS trigger AS $$
+DECLARE
+  released_at timestamp;
+BEGIN
+  IF NEW.state IN ('pending', 'claimed', 'provider_call_started') THEN
+    SELECT execution_released_at INTO released_at
+      FROM app_runs
+      WHERE org_id = NEW.org_id AND id = NEW.run_id;
+    IF released_at IS NULL THEN
+      RAISE EXCEPTION 'APP_RUN_EXECUTION_NOT_RELEASED' USING ERRCODE = '55000';
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS app_run_attempts_execution_release_trigger ON app_run_attempts;
+CREATE TRIGGER app_run_attempts_execution_release_trigger
+  BEFORE INSERT OR UPDATE ON app_run_attempts
+  FOR EACH ROW EXECUTE FUNCTION enforce_app_run_attempt_execution_release();

--- a/packages/db/upgrades/0.3.0-preview.20-app-run-live-authority-versions.sql
+++ b/packages/db/upgrades/0.3.0-preview.20-app-run-live-authority-versions.sql
@@ -1,0 +1,158 @@
+-- Add monotonic, security-relevant authority versions for governed App Runs.
+-- Ordinary counters, heartbeat state, tool caches, and last-used timestamps do
+-- not bump these versions. Revocation followed by restoration still does.
+
+ALTER TABLE org_members
+  ADD COLUMN IF NOT EXISTS app_run_authorization_version integer NOT NULL DEFAULT 1;
+ALTER TABLE agent_employees
+  ADD COLUMN IF NOT EXISTS app_run_authorization_version integer NOT NULL DEFAULT 1;
+ALTER TABLE mcp_connections
+  ADD COLUMN IF NOT EXISTS app_run_authorization_version integer NOT NULL DEFAULT 1;
+ALTER TABLE mcp_tool_overrides
+  ADD COLUMN IF NOT EXISTS app_run_authorization_version integer NOT NULL DEFAULT 1;
+ALTER TABLE mcp_tokens
+  ADD COLUMN IF NOT EXISTS app_run_authorization_version integer NOT NULL DEFAULT 1;
+ALTER TABLE oauth_access_tokens
+  ADD COLUMN IF NOT EXISTS app_run_authorization_version integer NOT NULL DEFAULT 1;
+
+DO $$
+DECLARE
+  table_name text;
+  constraint_name text;
+BEGIN
+  FOREACH table_name IN ARRAY ARRAY[
+    'org_members', 'agent_employees', 'mcp_connections',
+    'mcp_tool_overrides', 'mcp_tokens', 'oauth_access_tokens'
+  ] LOOP
+    constraint_name := table_name || '_app_run_authorization_version_check';
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = constraint_name) THEN
+      EXECUTE format(
+        'ALTER TABLE %I ADD CONSTRAINT %I CHECK (app_run_authorization_version BETWEEN 1 AND 2147483647)',
+        table_name,
+        constraint_name
+      );
+    END IF;
+  END LOOP;
+END $$;
+
+CREATE OR REPLACE FUNCTION bump_org_member_app_run_authorization_version() RETURNS trigger AS $$
+BEGIN
+  IF (NEW.user_id, NEW.role, NEW.is_active)
+    IS DISTINCT FROM (OLD.user_id, OLD.role, OLD.is_active)
+  THEN
+    NEW.app_run_authorization_version := OLD.app_run_authorization_version + 1;
+  ELSE
+    NEW.app_run_authorization_version := OLD.app_run_authorization_version;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION bump_agent_employee_app_run_authorization_version() RETURNS trigger AS $$
+BEGIN
+  IF (NEW.user_id, NEW.mcp_connection_ids, NEW.disabled_tools, NEW.trust_level,
+      NEW.max_daily_actions, NEW.unhealthy, NEW.is_active, NEW.is_deleted)
+    IS DISTINCT FROM
+     (OLD.user_id, OLD.mcp_connection_ids, OLD.disabled_tools, OLD.trust_level,
+      OLD.max_daily_actions, OLD.unhealthy, OLD.is_active, OLD.is_deleted)
+  THEN
+    NEW.app_run_authorization_version := OLD.app_run_authorization_version + 1;
+  ELSE
+    NEW.app_run_authorization_version := OLD.app_run_authorization_version;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION bump_mcp_connection_app_run_authorization_version() RETURNS trigger AS $$
+BEGIN
+  IF (NEW.slug, NEW.server_url, NEW.transport, NEW.stdio_command, NEW.stdio_args,
+      NEW.auth_type, NEW.auth_config_encrypted, NEW.is_active,
+      NEW.default_trust_tier, NEW.enabled_tools)
+    IS DISTINCT FROM
+     (OLD.slug, OLD.server_url, OLD.transport, OLD.stdio_command, OLD.stdio_args,
+      OLD.auth_type, OLD.auth_config_encrypted, OLD.is_active,
+      OLD.default_trust_tier, OLD.enabled_tools)
+  THEN
+    NEW.app_run_authorization_version := OLD.app_run_authorization_version + 1;
+  ELSE
+    NEW.app_run_authorization_version := OLD.app_run_authorization_version;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION bump_mcp_tool_override_app_run_authorization_version() RETURNS trigger AS $$
+BEGIN
+  IF (NEW.mcp_connection_id, NEW.tool_name, NEW.trust_tier_override, NEW.is_disabled)
+    IS DISTINCT FROM
+     (OLD.mcp_connection_id, OLD.tool_name, OLD.trust_tier_override, OLD.is_disabled)
+  THEN
+    NEW.app_run_authorization_version := OLD.app_run_authorization_version + 1;
+  ELSE
+    NEW.app_run_authorization_version := OLD.app_run_authorization_version;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION bump_mcp_token_app_run_authorization_version() RETURNS trigger AS $$
+BEGIN
+  IF (NEW.user_id, NEW.agent_employee_id, NEW.principal_kind, NEW.scopes, NEW.revoked_at)
+    IS DISTINCT FROM
+     (OLD.user_id, OLD.agent_employee_id, OLD.principal_kind, OLD.scopes, OLD.revoked_at)
+  THEN
+    NEW.app_run_authorization_version := OLD.app_run_authorization_version + 1;
+  ELSE
+    NEW.app_run_authorization_version := OLD.app_run_authorization_version;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION bump_oauth_access_token_app_run_authorization_version() RETURNS trigger AS $$
+BEGIN
+  IF (NEW.grant_id, NEW.org_id, NEW.user_id, NEW.client_id, NEW.resource,
+      NEW.scopes, NEW.expires_at, NEW.revoked_at)
+    IS DISTINCT FROM
+     (OLD.grant_id, OLD.org_id, OLD.user_id, OLD.client_id, OLD.resource,
+      OLD.scopes, OLD.expires_at, OLD.revoked_at)
+  THEN
+    NEW.app_run_authorization_version := OLD.app_run_authorization_version + 1;
+  ELSE
+    NEW.app_run_authorization_version := OLD.app_run_authorization_version;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS org_members_app_run_authorization_version_trigger ON org_members;
+CREATE TRIGGER org_members_app_run_authorization_version_trigger
+  BEFORE UPDATE ON org_members FOR EACH ROW
+  EXECUTE FUNCTION bump_org_member_app_run_authorization_version();
+
+DROP TRIGGER IF EXISTS agent_employees_app_run_authorization_version_trigger ON agent_employees;
+CREATE TRIGGER agent_employees_app_run_authorization_version_trigger
+  BEFORE UPDATE ON agent_employees FOR EACH ROW
+  EXECUTE FUNCTION bump_agent_employee_app_run_authorization_version();
+
+DROP TRIGGER IF EXISTS mcp_connections_app_run_authorization_version_trigger ON mcp_connections;
+CREATE TRIGGER mcp_connections_app_run_authorization_version_trigger
+  BEFORE UPDATE ON mcp_connections FOR EACH ROW
+  EXECUTE FUNCTION bump_mcp_connection_app_run_authorization_version();
+
+DROP TRIGGER IF EXISTS mcp_tool_overrides_app_run_authorization_version_trigger ON mcp_tool_overrides;
+CREATE TRIGGER mcp_tool_overrides_app_run_authorization_version_trigger
+  BEFORE UPDATE ON mcp_tool_overrides FOR EACH ROW
+  EXECUTE FUNCTION bump_mcp_tool_override_app_run_authorization_version();
+
+DROP TRIGGER IF EXISTS mcp_tokens_app_run_authorization_version_trigger ON mcp_tokens;
+CREATE TRIGGER mcp_tokens_app_run_authorization_version_trigger
+  BEFORE UPDATE ON mcp_tokens FOR EACH ROW
+  EXECUTE FUNCTION bump_mcp_token_app_run_authorization_version();
+
+DROP TRIGGER IF EXISTS oauth_access_tokens_app_run_authorization_version_trigger ON oauth_access_tokens;
+CREATE TRIGGER oauth_access_tokens_app_run_authorization_version_trigger
+  BEFORE UPDATE ON oauth_access_tokens FOR EACH ROW
+  EXECUTE FUNCTION bump_oauth_access_token_app_run_authorization_version();
+

--- a/packages/db/upgrades/0.3.0-preview.20-app-run-live-authority-versions.sql
+++ b/packages/db/upgrades/0.3.0-preview.20-app-run-live-authority-versions.sql
@@ -155,4 +155,3 @@ DROP TRIGGER IF EXISTS oauth_access_tokens_app_run_authorization_version_trigger
 CREATE TRIGGER oauth_access_tokens_app_run_authorization_version_trigger
   BEFORE UPDATE ON oauth_access_tokens FOR EACH ROW
   EXECUTE FUNCTION bump_oauth_access_token_app_run_authorization_version();
-

--- a/packages/db/upgrades/0.3.0-preview.21-app-run-ancestry-guard.sql
+++ b/packages/db/upgrades/0.3.0-preview.21-app-run-ancestry-guard.sql
@@ -1,0 +1,114 @@
+-- Forward-only child Run lineage guard for the still-guarded App Run engine.
+-- No current entrance creates child Runs; this protects the boundary before
+-- future App orchestration can reach it.
+
+CREATE OR REPLACE FUNCTION enforce_app_run_ancestry_insert() RETURNS trigger AS $$
+DECLARE
+  parent_row app_runs%ROWTYPE;
+  root_row app_runs%ROWTYPE;
+BEGIN
+  IF NEW.depth = 0 THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT * INTO parent_row
+    FROM app_runs
+    WHERE org_id = NEW.org_id AND id = NEW.parent_run_id
+    FOR KEY SHARE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'APP_RUN_ANCESTRY_INVALID' USING ERRCODE = '55000';
+  END IF;
+
+  SELECT * INTO root_row
+    FROM app_runs
+    WHERE org_id = NEW.org_id AND id = NEW.root_run_id
+    FOR KEY SHARE;
+  IF NOT FOUND OR root_row.depth <> 0 OR root_row.root_run_id <> root_row.id THEN
+    RAISE EXCEPTION 'APP_RUN_ANCESTRY_INVALID' USING ERRCODE = '55000';
+  END IF;
+
+  IF parent_row.state NOT IN ('running', 'waiting_external')
+    OR NEW.depth <> parent_row.depth + 1
+    OR NEW.root_run_id <> parent_row.root_run_id
+    OR NEW.id = NEW.parent_run_id
+    OR NEW.id = NEW.root_run_id
+  THEN
+    RAISE EXCEPTION 'APP_RUN_ANCESTRY_INVALID' USING ERRCODE = '55000';
+  END IF;
+
+  IF (NEW.initiating_actor_type, NEW.initiating_actor_id,
+      NEW.execution_actor_type, NEW.execution_actor_id, NEW.origin_kind)
+    IS DISTINCT FROM
+     (parent_row.initiating_actor_type, parent_row.initiating_actor_id,
+      parent_row.execution_actor_type, parent_row.execution_actor_id, parent_row.origin_kind)
+  THEN
+    RAISE EXCEPTION 'APP_RUN_AUTHORIZATION_CEILING' USING ERRCODE = '55000';
+  END IF;
+
+  IF jsonb_typeof(NEW.authorization_snapshot->'authority_refs') <> 'array'
+    OR jsonb_typeof(parent_row.authorization_snapshot->'authority_refs') <> 'array'
+    OR EXISTS (
+      SELECT 1
+      FROM jsonb_array_elements(NEW.authorization_snapshot->'authority_refs') child_ref
+      WHERE child_ref->>'authority_kind' IN (
+        'membership', 'token_scope', 'employee_health', 'employee_budget'
+      )
+      AND NOT EXISTS (
+        SELECT 1
+        FROM jsonb_array_elements(parent_row.authorization_snapshot->'authority_refs') parent_ref
+        WHERE parent_ref->>'authority_kind' = child_ref->>'authority_kind'
+          AND parent_ref->>'authority_id' = child_ref->>'authority_id'
+          AND parent_ref->>'version' = child_ref->>'version'
+      )
+    )
+  THEN
+    RAISE EXCEPTION 'APP_RUN_AUTHORIZATION_CEILING' USING ERRCODE = '55000';
+  END IF;
+
+  IF (CASE NEW.risk_class
+       WHEN 'read' THEN 0 WHEN 'internal_write' THEN 1 WHEN 'external_write' THEN 2
+       WHEN 'destructive' THEN 3 WHEN 'privileged' THEN 4 ELSE 99 END)
+     > (CASE parent_row.risk_class
+       WHEN 'read' THEN 0 WHEN 'internal_write' THEN 1 WHEN 'external_write' THEN 2
+       WHEN 'destructive' THEN 3 WHEN 'privileged' THEN 4 ELSE -1 END)
+    OR (parent_row.review_requirement = 'always' AND NEW.review_requirement <> 'always')
+    OR NEW.review_scope <> parent_row.review_scope
+    OR (CASE NEW.retry_class
+       WHEN 'unsafe_or_unknown' THEN 0 WHEN 'idempotent_with_key' THEN 1
+       WHEN 'safe' THEN 2 ELSE 99 END)
+       > (CASE parent_row.retry_class
+       WHEN 'unsafe_or_unknown' THEN 0 WHEN 'idempotent_with_key' THEN 1
+       WHEN 'safe' THEN 2 ELSE -1 END)
+    OR (CASE NEW.retention_class
+       WHEN 'ephemeral' THEN 0 WHEN 'standard' THEN 1 WHEN 'extended' THEN 2 ELSE 99 END
+       > (CASE parent_row.retention_class
+       WHEN 'ephemeral' THEN 0 WHEN 'standard' THEN 1 WHEN 'extended' THEN 2 ELSE -1 END))
+    OR NEW.input_expires_at > parent_row.input_expires_at
+    OR NEW.result_expires_at > parent_row.result_expires_at
+    OR NEW.idempotency_expires_at > parent_row.idempotency_expires_at
+    OR NEW.attempt_limit > parent_row.attempt_limit
+  THEN
+    RAISE EXCEPTION 'APP_RUN_POLICY_CEILING' USING ERRCODE = '55000';
+  END IF;
+
+  IF (NEW.budget_reserved_count, NEW.budget_limit_at_reservation)
+    IS DISTINCT FROM
+     (root_row.budget_reserved_count, root_row.budget_limit_at_reservation)
+    OR date_trunc('milliseconds', NEW.budget_reserved_at)
+      IS DISTINCT FROM date_trunc('milliseconds', root_row.budget_reserved_at)
+    OR (
+      NEW.execution_actor_type = 'agent_employee'
+      AND root_row.budget_reserved_at IS NULL
+    )
+  THEN
+    RAISE EXCEPTION 'APP_RUN_BUDGET_CONTINUITY' USING ERRCODE = '55000';
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS app_runs_ancestry_insert_trigger ON app_runs;
+CREATE TRIGGER app_runs_ancestry_insert_trigger
+  BEFORE INSERT ON app_runs
+  FOR EACH ROW EXECUTE FUNCTION enforce_app_run_ancestry_insert();

--- a/packages/db/upgrades/manifest.ts
+++ b/packages/db/upgrades/manifest.ts
@@ -112,6 +112,11 @@ export const upgradeManifest = {
       file: '0.3.0-preview.18-governed-app-run-engine-hardening.sql',
       description: 'Harden dormant App Run replay, cancellation, retry ancestry, and attempt fencing',
     },
+    {
+      version: '0.3.0-preview.19',
+      file: '0.3.0-preview.19-governed-app-run-cutover-gate.sql',
+      description: 'Fail closed on App Run release, budget, approval-link, replay-horizon, and attempt dispatch boundaries',
+    },
   ] satisfies UpgradeMigration[],
 } as const;
 

--- a/packages/db/upgrades/manifest.ts
+++ b/packages/db/upgrades/manifest.ts
@@ -117,6 +117,11 @@ export const upgradeManifest = {
       file: '0.3.0-preview.19-governed-app-run-cutover-gate.sql',
       description: 'Fail closed on App Run release, budget, approval-link, replay-horizon, and attempt dispatch boundaries',
     },
+    {
+      version: '0.3.0-preview.20',
+      file: '0.3.0-preview.20-app-run-live-authority-versions.sql',
+      description: 'Add monotonic live authority versions for governed App Run authorization rechecks',
+    },
   ] satisfies UpgradeMigration[],
 } as const;
 

--- a/packages/db/upgrades/manifest.ts
+++ b/packages/db/upgrades/manifest.ts
@@ -122,6 +122,11 @@ export const upgradeManifest = {
       file: '0.3.0-preview.20-app-run-live-authority-versions.sql',
       description: 'Add monotonic live authority versions for governed App Run authorization rechecks',
     },
+    {
+      version: '0.3.0-preview.21',
+      file: '0.3.0-preview.21-app-run-ancestry-guard.sql',
+      description: 'Guard child App Run lineage, authorization ceilings, and root budget continuity',
+    },
   ] satisfies UpgradeMigration[],
 } as const;
 

--- a/packages/shared/src/app-runs.ts
+++ b/packages/shared/src/app-runs.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 
 import {
   CapabilityJsonObjectSchema,
+  CapabilityJsonValueSchema,
   CapabilityProviderOperationIdentitySchema,
   assertCapabilityJsonWithinBudget,
   type CapabilityJsonValue,
@@ -14,6 +15,7 @@ export const APP_RUN_CONTRACT_VERSIONS = {
   secret_envelope: 'deft.secret.v1',
   secret_aad: 'deft.app_run_aad.v1',
   keyring: 'deft.app_run_keyring.v1',
+  provider_result: 'deft.app_run_provider_result.v1',
 } as const;
 
 export const APP_RUN_LIMITS = {
@@ -243,6 +245,7 @@ export const AppRunErrorCodeSchema = z.enum([
   'APP_RUN_OUTPUT_TOO_LARGE',
   'APP_RUN_IDEMPOTENCY_CONFLICT',
   'APP_RUN_ILLEGAL_TRANSITION',
+  'APP_RUN_EXECUTION_NOT_RELEASED',
   'APP_RUN_ACCESS_DENIED',
   'APP_RUN_AUTHORIZATION_STALE',
   'APP_RUN_PROVIDER_UNAVAILABLE',
@@ -355,6 +358,13 @@ export const AppRunSafeOutcomeSchema = z.object({
   }
 });
 export type AppRunSafeOutcome = z.infer<typeof AppRunSafeOutcomeSchema>;
+
+export const AppRunRetainedProviderResultSchema = z.object({
+  schema_version: z.literal(APP_RUN_CONTRACT_VERSIONS.provider_result),
+  provider_succeeded: z.boolean(),
+  output: CapabilityJsonValueSchema,
+}).strict();
+export type AppRunRetainedProviderResult = z.infer<typeof AppRunRetainedProviderResultSchema>;
 
 export const AppRunEventTypeSchema = z.enum([
   'run_created',

--- a/packages/shared/src/app-runs.ts
+++ b/packages/shared/src/app-runs.ts
@@ -400,6 +400,7 @@ export const AppRunReceiptKindSchema = z.enum([
   'reconciliation',
   'repair',
 ]);
+export type AppRunReceiptKind = z.infer<typeof AppRunReceiptKindSchema>;
 
 export const AppRunReceiptEnvelopeSchema = z.object({
   schema_version: z.literal(APP_RUN_CONTRACT_VERSIONS.receipt),

--- a/packages/shared/test/app-runs.test.ts
+++ b/packages/shared/test/app-runs.test.ts
@@ -7,6 +7,7 @@ import {
   APP_RUN_SECRET_RETENTION_MS,
   APP_RUN_IDEMPOTENCY_RETENTION_MS,
   AppRunSafeOutcomeSchema,
+  AppRunRetainedProviderResultSchema,
   AppRunAttemptStateSchema,
   AppRunStateSchema,
   isAppRunAttemptStateTransitionAllowed,
@@ -183,6 +184,29 @@ describe('App Run contract', () => {
       provider_call_attempted: false,
       result_status: 'unavailable',
     }), /require an error code/);
+  });
+
+  test('keeps determinate provider responses in a strict retained envelope', () => {
+    assert.deepEqual(AppRunRetainedProviderResultSchema.parse({
+      schema_version: APP_RUN_CONTRACT_VERSIONS.provider_result,
+      provider_succeeded: false,
+      output: { code: 'recipient_rejected', private_detail: 'retained ciphertext only' },
+    }), {
+      schema_version: APP_RUN_CONTRACT_VERSIONS.provider_result,
+      provider_succeeded: false,
+      output: { code: 'recipient_rejected', private_detail: 'retained ciphertext only' },
+    });
+    assert.throws(() => AppRunRetainedProviderResultSchema.parse({
+      schema_version: APP_RUN_CONTRACT_VERSIONS.provider_result,
+      provider_succeeded: true,
+      output: undefined,
+    }));
+    assert.throws(() => AppRunRetainedProviderResultSchema.parse({
+      schema_version: APP_RUN_CONTRACT_VERSIONS.provider_result,
+      provider_succeeded: true,
+      output: { ok: true },
+      raw_input: { secret: true },
+    }));
   });
 
   test('freezes safe event and receipt envelopes without secret-bearing metadata', () => {


### PR DESCRIPTION
## Summary

- harden governed App Run attempt fencing, live authorization, budget reservation, approval resolution, ancestry, receipts, Attention, and internal repair invariants
- add additive supported-upgrade slots 0.3.0-preview.19 through .21
- preserve the dormant boundary: no production capability entrance, server route, worker registration, App-origin authority, UI, deployment, or environment change
- persist the canonical architecture pointer, revised delivery plan, Phase 3 closeout loops, and fresh PR C certification evidence

## Rollout boundary

This is the trust and data train only. The worker factory remains production-unregistered and the existing provider path remains selected. PR D owns runtime composition, the separate engine-versus-intake controls, and the default-off legacy MCP canary.

Please merge with a merge commit if repository policy permits so the reviewed local ancestry remains usable. If this PR is squash- or rebase-merged, PR D will be rebuilt from the actual resulting master commit.

## Fresh evidence

- shared App Run contracts: 10/10
- upgrade/schema representation: 23/23
- complete C3 App Run database suite: 19/19
- approval-resolver database suite: 23/23
- focused keyring, architecture, approval-matrix, and MCP trust-boundary suites: pass
- API typecheck: pass
- final diff check and clean worktree: pass

The focused disposable database represented only the two unrelated embedding columns as bytea, then applied and verified extras .16 through .21. The known local pgvector limitation was not retried. Browser, Docker, production build, and supported fresh-schema/release claims are intentionally deferred to the later release-candidate gate.