### PR TITLE
feat(apps): add guarded App Run runtime and cutover

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,10 +73,13 @@ NEXT_PUBLIC_FEATURE_HUDDLES=false
 DEFT_APPS_ENABLED=false
 NEXT_PUBLIC_FEATURE_APPS=false
 DEFT_APP_DEVELOPER_PAIRING_ENABLED=false
-# Governed App Runs remain disabled unless both this exact opt-in and valid,
-# purpose-separated keyrings are supplied. See docs/app-run-operations.md.
+# The App Run engine can decrypt and drain accepted work only when this exact
+# opt-in and valid purpose-separated keyrings are supplied.
 DEFT_APP_RUNS_ENABLED=false
 DEFT_APP_RUN_KEYRINGS=
+# New legacy MCP calls remain on the legacy path unless this separate exact
+# opt-in is enabled. This cannot be true while the App Run engine is false.
+DEFT_APP_RUN_LEGACY_MCP_CUTOVER_ENABLED=false
 API_PORT=3001
 
 # MCP connector network policy. HTTPS public origins are the default.

--- a/.env.example
+++ b/.env.example
@@ -73,8 +73,8 @@ NEXT_PUBLIC_FEATURE_HUDDLES=false
 DEFT_APPS_ENABLED=false
 NEXT_PUBLIC_FEATURE_APPS=false
 DEFT_APP_DEVELOPER_PAIRING_ENABLED=false
-# Governed App Runs are dormant unless both this exact opt-in and valid,
-# purpose-separated keyrings are supplied. See docs/self-hosting.md.
+# Governed App Runs remain disabled unless both this exact opt-in and valid,
+# purpose-separated keyrings are supplied. See docs/app-run-operations.md.
 DEFT_APP_RUNS_ENABLED=false
 DEFT_APP_RUN_KEYRINGS=
 API_PORT=3001

--- a/apps/api/src/lib/agent-actions.ts
+++ b/apps/api/src/lib/agent-actions.ts
@@ -31,6 +31,7 @@ import {
   parseMCPToolName,
 } from './mcp-tools.js';
 import { capabilityService } from './capability-service.js';
+import { APP_RUNS_ENABLED } from './env.js';
 import { resolveAssigneeWithMatches } from './resolve-assignee.js';
 import { detectBlocksCycle } from './task-dependency.js';
 import { dispatchAgentEmployeeTask } from './dispatch-agent-task.js';
@@ -1132,7 +1133,7 @@ export async function executeAction(
       }
       return { success: false, result: null, error: policyError };
     }
-    if (agentEmployeeId) {
+    if (agentEmployeeId && !(APP_RUNS_ENABLED && action.startsWith('mcp__'))) {
       const budget = await consumeAgentDailyActionBudget(
         orgId,
         agentEmployeeId,
@@ -1187,6 +1188,9 @@ export async function executeAction(
           operation_name: toolName,
         },
         input: params,
+      }, {
+        legacy_action_id: actionId,
+        idempotency_key: `agent-action:${actionId}`,
       });
       if (!invocation.provider_call_attempted) {
         return { success: false, result: null, error: invocation.error };

--- a/apps/api/src/lib/agent-actions.ts
+++ b/apps/api/src/lib/agent-actions.ts
@@ -31,7 +31,7 @@ import {
   parseMCPToolName,
 } from './mcp-tools.js';
 import { capabilityService } from './capability-service.js';
-import { APP_RUNS_ENABLED } from './env.js';
+import { APP_RUN_LEGACY_MCP_CUTOVER_ENABLED } from './env.js';
 import { resolveAssigneeWithMatches } from './resolve-assignee.js';
 import { detectBlocksCycle } from './task-dependency.js';
 import { dispatchAgentEmployeeTask } from './dispatch-agent-task.js';
@@ -1133,7 +1133,7 @@ export async function executeAction(
       }
       return { success: false, result: null, error: policyError };
     }
-    if (agentEmployeeId && !(APP_RUNS_ENABLED && action.startsWith('mcp__'))) {
+    if (agentEmployeeId && !(APP_RUN_LEGACY_MCP_CUTOVER_ENABLED && action.startsWith('mcp__'))) {
       const budget = await consumeAgentDailyActionBudget(
         orgId,
         agentEmployeeId,

--- a/apps/api/src/lib/agent-approval-resolver.ts
+++ b/apps/api/src/lib/agent-approval-resolver.ts
@@ -81,8 +81,21 @@ import {
 import { ACTION_TOOLS } from './agent-tools.js';
 import {
   APP_RUN_APPROVAL_ACTION,
-  postgresAppRunApprovalResolver,
 } from './app-run-approval-adapter.js';
+import { getAppRunRuntime } from './app-run-runtime.js';
+import type { PostgresAppRunApprovalResolver } from './app-run-approval-adapter.js';
+
+let appRunApprovalResolverForTest: PostgresAppRunApprovalResolver | null = null;
+
+export function _setAppRunApprovalResolverForTest(
+  resolver: PostgresAppRunApprovalResolver | null,
+): void {
+  appRunApprovalResolverForTest = resolver;
+}
+
+async function appRunApprovalResolver(): Promise<PostgresAppRunApprovalResolver> {
+  return appRunApprovalResolverForTest ?? (await getAppRunRuntime()).approvalResolver;
+}
 import { isAgentToolDisabled } from './agent-tool-policy.js';
 import {
   MODULE_OPERATION_DEFINITIONS,
@@ -787,7 +800,7 @@ async function approveActionLocked(
   }
 
   if (row.action === APP_RUN_APPROVAL_ACTION) {
-    return postgresAppRunApprovalResolver.approve(actionId, approverUserId);
+    return (await appRunApprovalResolver()).approve(actionId, approverUserId);
   }
 
   const resumesApprovedModule = isModuleMutation
@@ -1246,7 +1259,7 @@ async function rejectActionOnce(
   }
 
   if (row.action === APP_RUN_APPROVAL_ACTION) {
-    return postgresAppRunApprovalResolver.reject(actionId, rejecterUserId);
+    return (await appRunApprovalResolver()).reject(actionId, rejecterUserId);
   }
 
   if (row.approval_status === 'rejected') {

--- a/apps/api/src/lib/app-run-approval-adapter.ts
+++ b/apps/api/src/lib/app-run-approval-adapter.ts
@@ -20,6 +20,10 @@ import {
   noOpAppRunAttentionProjector,
   type AppRunAttentionProjector,
 } from './app-run-attention.js';
+import {
+  noOpAppRunAttemptScheduler,
+  type AppRunAttemptScheduler,
+} from './app-run-scheduler.js';
 
 export const APP_RUN_APPROVAL_ACTION = 'app_run_invoke';
 
@@ -99,6 +103,7 @@ export class PostgresAppRunApprovalResolver {
     private readonly now: () => Date = () => new Date(),
     private readonly receiptWriter: AppRunReceiptWriter = noOpAppRunReceiptWriter,
     private readonly attention: AppRunAttentionProjector = noOpAppRunAttentionProjector,
+    private readonly attemptScheduler: AppRunAttemptScheduler = noOpAppRunAttemptScheduler,
   ) {}
 
   async approve(
@@ -123,6 +128,7 @@ export class PostgresAppRunApprovalResolver {
           'approved',
           run.execution_released_at ?? this.now(),
         );
+        await this.attemptScheduler.scheduleInTransaction(tx, run, this.now());
         return { status: 'approved', message: 'already approved', result: this.#safeResult(run, true) };
       }
       if (run.state === 'cancelled') {
@@ -187,6 +193,7 @@ export class PostgresAppRunApprovalResolver {
         'approved',
         run.execution_released_at ?? this.now(),
       );
+      await this.attemptScheduler.scheduleInTransaction(tx, run, this.now());
       return { status: 'approved', result: this.#safeResult(run, true) };
     });
     await this.#resolveApprovalAttention(actionId, approverUserId);

--- a/apps/api/src/lib/app-run-attempt-runner.ts
+++ b/apps/api/src/lib/app-run-attempt-runner.ts
@@ -28,6 +28,11 @@ import {
 } from './app-run-attention.js';
 import { AppRunSecretRepository } from './app-run-secret-repository.js';
 import type { AppRunSecretService } from './app-run-secrets.js';
+import {
+  noOpAppRunAttemptQueue,
+  type AppRunAttemptQueue,
+  type AppRunAttemptScheduler,
+} from './app-run-scheduler.js';
 
 type ClaimedAttempt = Readonly<{
   run: AppRunSafeView;
@@ -45,7 +50,7 @@ function boundedLeaseMs(value: number): number {
   return Math.max(1_000, Math.min(value, 15 * 60_000));
 }
 
-export class AppRunAttemptRunner {
+export class AppRunAttemptRunner implements AppRunAttemptScheduler {
   constructor(
     private readonly repository: PostgresAppRunRepository,
     private readonly secretRepository: AppRunSecretRepository,
@@ -57,6 +62,7 @@ export class AppRunAttemptRunner {
     private readonly heartbeatIntervalMs = Math.max(250, Math.floor(boundedLeaseMs(leaseMs) / 3)),
     private readonly receiptWriter: AppRunReceiptWriter = noOpAppRunReceiptWriter,
     private readonly attention: AppRunAttentionProjector = noOpAppRunAttentionProjector,
+    private readonly attemptQueue: AppRunAttemptQueue = noOpAppRunAttemptQueue,
   ) {}
 
   async run(
@@ -135,23 +141,36 @@ export class AppRunAttemptRunner {
     const now = this.now();
     return this.repository.transaction(async (tx) => {
       const run = await this.repository.lockRun(tx, orgId, runId);
-      if (
-        !run
-        || !run.execution_released_at
-        || ['succeeded', 'failed', 'cancelled', 'expired', 'unknown_outcome'].includes(run.state)
-        || !await this.executionAuthorizer.authorizeExecution({
-          org_id: orgId, run, tx, stage: 'prepare', now,
-        })
-      ) return null;
-      if (run.input_expires_at <= now) return null;
-      const [existing] = await tx.select({ id: appRunAttempts.id }).from(appRunAttempts).where(and(
-        eq(appRunAttempts.org_id, orgId),
-        eq(appRunAttempts.run_id, runId),
-        inArray(appRunAttempts.state, ['pending', 'claimed', 'provider_call_started']),
-      )).orderBy(asc(appRunAttempts.attempt_number)).limit(1);
-      if (existing) return existing.id;
-      return (await this.#createAttempt(tx, run, now))?.id ?? null;
+      return run ? this.scheduleInTransaction(tx, run, now) : null;
     });
+  }
+
+  /** Schedule against a Run already locked by the caller. Queue insertion is
+   * in the same transaction as attempt creation/release, closing the crash gap
+   * between durable authority and worker ownership. */
+  async scheduleInTransaction(
+    tx: AppRunTransaction,
+    run: AppRunSafeView,
+    now: Date,
+  ): Promise<string | null> {
+    if (
+      !run.execution_released_at
+      || ['succeeded', 'failed', 'cancelled', 'expired', 'unknown_outcome'].includes(run.state)
+      || !await this.executionAuthorizer.authorizeExecution({
+        org_id: run.org_id, run, tx, stage: 'prepare', now,
+      })
+      || run.input_expires_at <= now
+    ) return null;
+    const [existing] = await tx.select({ id: appRunAttempts.id }).from(appRunAttempts).where(and(
+      eq(appRunAttempts.org_id, run.org_id),
+      eq(appRunAttempts.run_id, run.id),
+      inArray(appRunAttempts.state, ['pending', 'claimed', 'provider_call_started']),
+    )).orderBy(asc(appRunAttempts.attempt_number)).limit(1);
+    if (existing) {
+      await this.attemptQueue.enqueue(tx, run.org_id, run.id, existing.id);
+      return existing.id;
+    }
+    return (await this.#createAttempt(tx, run, now))?.id ?? null;
   }
 
   async renewLease(orgId: string, attemptId: string, claimToken: string): Promise<boolean> {
@@ -345,6 +364,7 @@ export class AppRunAttemptRunner {
       id: crypto.randomUUID(), org_id: run.org_id, run_id: run.id,
       event_type: 'attempt_created', payload: { attempt_id: attempt.id, attempt_number: attemptNumber }, now,
     });
+    await this.attemptQueue.enqueue(tx, run.org_id, run.id, attempt.id);
     return attempt;
   }
 

--- a/apps/api/src/lib/app-run-attempt-runner.ts
+++ b/apps/api/src/lib/app-run-attempt-runner.ts
@@ -39,6 +39,11 @@ type ClaimedAttempt = Readonly<{
   attempt: typeof appRunAttempts.$inferSelect;
 }>;
 
+export type AppRunImmediateExecution = Readonly<{
+  run: AppRunSafeView;
+  provider_result?: AppRunProviderExecutionResult;
+}>;
+
 function providerIdempotencyKey(runId: string): string {
   return createHash('sha256')
     .update('deft.app_run.provider_idempotency.v1\0')
@@ -72,22 +77,49 @@ export class AppRunAttemptRunner implements AppRunAttemptScheduler {
     workerId: string,
     signal?: AbortSignal,
   ): Promise<AppRunSafeView> {
+    return (await this.#runInternal(orgId, runId, attemptId, workerId, signal)).run;
+  }
+
+  /** Synchronous compatibility entrance. The exact provider result is
+   * transient and never enters generic Run APIs, logs, jobs, or projections. */
+  async runImmediate(
+    orgId: string,
+    runId: string,
+    attemptId: string,
+    workerId: string,
+    signal?: AbortSignal,
+  ): Promise<AppRunImmediateExecution> {
+    return this.#runInternal(orgId, runId, attemptId, workerId, signal);
+  }
+
+  async #runInternal(
+    orgId: string,
+    runId: string,
+    attemptId: string,
+    workerId: string,
+    signal?: AbortSignal,
+  ): Promise<AppRunImmediateExecution> {
     await this.recoverRun(orgId, runId, attemptId);
     const claimed = await this.#claim(orgId, runId, attemptId, workerId);
-    if (!claimed) return this.repository.inspect(orgId, runId).then((run) => {
+    if (!claimed) {
+      const run = await this.repository.inspect(orgId, runId);
       if (!run) throw new AppRunError('APP_RUN_ACCESS_DENIED');
-      return run;
-    });
+      return { run };
+    }
 
     const input = await this.secretRepository.readInput(orgId, runId);
     if (input === null) {
       await this.#settleBeforeCallFailure(claimed, 'APP_RUN_EXPIRED');
       const settled = await this.repository.inspect(orgId, runId).then((run) => run!);
       await this.#projectState(settled);
-      return settled;
+      return { run: settled };
     }
     const boundaryCommitted = await this.#markProviderCallStarted(claimed);
-    if (!boundaryCommitted) return this.repository.inspect(orgId, runId).then((run) => run!);
+    if (!boundaryCommitted) {
+      const run = await this.repository.inspect(orgId, runId);
+      if (!run) throw new AppRunError('APP_RUN_ACCESS_DENIED');
+      return { run };
+    }
 
     const stableProviderKey = claimed.run.retry_class === 'idempotent_with_key'
       ? providerIdempotencyKey(runId)
@@ -119,7 +151,7 @@ export class AppRunAttemptRunner implements AppRunAttemptScheduler {
       );
       const settled = await this.repository.inspect(orgId, runId).then((run) => run!);
       await this.#projectState(settled);
-      return settled;
+      return { run: settled, provider_result: result };
     }
 
     const known = await this.#knownOutcome(claimed.run, result);
@@ -134,7 +166,7 @@ export class AppRunAttemptRunner implements AppRunAttemptScheduler {
     await this.#finalizeKnownResult(orgId, runId, claimed.attempt.id, claimed.attempt.claim_token!);
     const settled = await this.repository.inspect(orgId, runId).then((run) => run!);
     await this.#projectState(settled);
-    return settled;
+    return { run: settled, provider_result: result };
   }
 
   async prepareAttempt(orgId: string, runId: string): Promise<string | null> {

--- a/apps/api/src/lib/app-run-authorization.ts
+++ b/apps/api/src/lib/app-run-authorization.ts
@@ -1,4 +1,7 @@
 import type { AppRunActor } from '@deft/shared';
+import { agentEmployees, orgMembers } from '@deft/db/schema';
+import { and, eq } from 'drizzle-orm';
+import { db } from './db.js';
 import type { AppRunSafeView, AppRunTransaction } from './app-run-repository.js';
 
 export type AppRunAccessAction = 'inspect' | 'result' | 'cancel' | 'reconcile';
@@ -17,6 +20,54 @@ export const denyAllAppRunAuthorizer: AppRunAuthorizer = Object.freeze({
     return false;
   },
 });
+
+function actorMatchesRun(actor: AppRunActor, run: AppRunSafeView): boolean {
+  const actorId = actor.actor_type === 'human'
+    ? actor.user_id
+    : actor.actor_type === 'agent_employee'
+      ? actor.agent_employee_id
+      : actor.actor_type === 'system'
+        ? actor.system_id
+        : actor.automation_id;
+  return (
+    actor.actor_type === run.initiating_actor_type && actorId === run.initiating_actor_id
+  ) || (
+    actor.actor_type === run.execution_actor_type && actorId === run.execution_actor_id
+  );
+}
+
+/** Live owner access for exact result replay and cancellation. Operator-wide
+ * inspection remains behind the separate operations authorizer. */
+export class PostgresAppRunAuthorizer implements AppRunAuthorizer {
+  async authorize(input: Parameters<AppRunAuthorizer['authorize']>[0]): Promise<boolean> {
+    if (input.org_id !== input.run.org_id || !actorMatchesRun(input.actor, input.run)) return false;
+    if (input.actor.actor_type === 'human') {
+      const [membership] = await db.select({ id: orgMembers.id }).from(orgMembers).where(and(
+        eq(orgMembers.org_id, input.org_id),
+        eq(orgMembers.user_id, input.actor.user_id),
+        eq(orgMembers.is_active, true),
+      )).limit(1);
+      return Boolean(membership);
+    }
+    if (input.actor.actor_type === 'agent_employee') {
+      const [employee] = await db.select({ user_id: agentEmployees.user_id })
+        .from(agentEmployees).where(and(
+          eq(agentEmployees.org_id, input.org_id),
+          eq(agentEmployees.id, input.actor.agent_employee_id),
+          eq(agentEmployees.is_active, true),
+          eq(agentEmployees.is_deleted, false),
+        )).limit(1);
+      if (!employee) return false;
+      const [membership] = await db.select({ id: orgMembers.id }).from(orgMembers).where(and(
+        eq(orgMembers.org_id, input.org_id),
+        eq(orgMembers.user_id, employee.user_id),
+        eq(orgMembers.is_active, true),
+      )).limit(1);
+      return Boolean(membership);
+    }
+    return false;
+  }
+}
 
 export interface AppRunExecutionAuthorizer {
   authorizeExecution(input: Readonly<{

--- a/apps/api/src/lib/app-run-capability-bridge.ts
+++ b/apps/api/src/lib/app-run-capability-bridge.ts
@@ -1,0 +1,435 @@
+import {
+  APP_RUN_CONTRACT_VERSIONS,
+  AppRunRetainedProviderResultSchema,
+  canonicalCapabilityJson,
+  type AppRunPolicySnapshot,
+} from '@deft/shared';
+import { setTimeout as delay } from 'node:timers/promises';
+import {
+  agentActions,
+  capabilityProviderSnapshots,
+  mcpToolOverrides,
+} from '@deft/db/schema';
+import type { MCPTool, MCPToolOverride } from '@deft/mcp';
+import { and, eq } from 'drizzle-orm';
+import type {
+  McpCapabilityInvocationAdapterResult,
+  McpCapabilityInvocationRequest,
+  McpCapabilityProvider,
+} from './capability-providers/mcp.js';
+import { mcpCapabilityProvider } from './capability-providers/mcp.js';
+import {
+  MCP_APP_RUN_RESULT_VERSION,
+  type AppRunProviderExecutionResult,
+} from './app-run-provider-executor.js';
+import type { AppRunRuntime } from './app-run-runtime.js';
+import { getAppRunRuntime } from './app-run-runtime.js';
+import { canonicalMcpToolName } from './mcp-runtime.js';
+import { db } from './db.js';
+
+export type GovernedCapabilityInvocationOptions = Readonly<{
+  /** Trusted host evidence, never parsed from provider or model input. */
+  legacy_action_id?: string;
+  /** Stable host occurrence identity for compatibility retries. */
+  idempotency_key?: string;
+}>;
+
+type ApprovalTier = MCPTool['approvalTier'];
+
+const APPROVAL_TIER_RANK: Record<ApprovalTier, number> = {
+  'auto-execute': 0,
+  'quick-approve': 1,
+  'full-review': 2,
+};
+
+function mappedTier(value: 'auto' | 'quick' | 'full'): ApprovalTier {
+  return value === 'auto'
+    ? 'auto-execute'
+    : value === 'quick'
+      ? 'quick-approve'
+      : 'full-review';
+}
+
+function stricterTier(left: ApprovalTier, right: ApprovalTier): ApprovalTier {
+  return APPROVAL_TIER_RANK[left] >= APPROVAL_TIER_RANK[right] ? left : right;
+}
+
+function unavailable(
+  request: McpCapabilityInvocationRequest,
+  error: string,
+  errorCode: 'CAPABILITY_PROVIDER_UNAVAILABLE' | 'CAPABILITY_OPERATION_UNAVAILABLE',
+): McpCapabilityInvocationAdapterResult {
+  return {
+    provider: {
+      provider_kind: 'mcp',
+      requested_provider_key: request.provider.connection_slug,
+    },
+    operation_name: request.provider.operation_name,
+    provider_call_attempted: false,
+    provider_succeeded: false,
+    legacy_output: { error },
+    error,
+    error_code: errorCode,
+    duration_ms: 0,
+  };
+}
+
+function providerErrorMessage(output: unknown): string | undefined {
+  if (!output || typeof output !== 'object' || Array.isArray(output)) return undefined;
+  const error = (output as Record<string, unknown>).error;
+  return typeof error === 'string' && error ? error : undefined;
+}
+
+export class PostgresGovernedCapabilityExecutor {
+  constructor(
+    private readonly provider: McpCapabilityProvider = mcpCapabilityProvider,
+    private readonly runtime: () => Promise<AppRunRuntime> = getAppRunRuntime,
+    private readonly now: () => Date = () => new Date(),
+  ) {}
+
+  async invoke(
+    request: McpCapabilityInvocationRequest,
+    options: GovernedCapabilityInvocationOptions = {},
+  ): Promise<McpCapabilityInvocationAdapterResult> {
+    const startedAt = this.now().getTime();
+    const resolved = await this.provider.resolveGoverned(request);
+    if (!resolved.connection) {
+      return unavailable(
+        request,
+        resolved.error,
+        resolved.reason === 'operation_unavailable'
+          ? 'CAPABILITY_OPERATION_UNAVAILABLE'
+          : 'CAPABILITY_PROVIDER_UNAVAILABLE',
+      );
+    }
+    const connection = resolved.connection;
+    const overrideRows = await db.select().from(mcpToolOverrides).where(and(
+      eq(mcpToolOverrides.org_id, request.org_id),
+      eq(mcpToolOverrides.mcp_connection_id, connection.id),
+    ));
+    const operationRows = overrideRows.filter(
+      (row) => canonicalMcpToolName(row.tool_name) === request.provider.operation_name,
+    );
+    const overrides = operationRows.map((row): MCPToolOverride => ({
+      toolName: canonicalMcpToolName(row.tool_name),
+      approvalTier: row.trust_tier_override ? mappedTier(row.trust_tier_override) : undefined,
+      disabled: row.is_disabled,
+    }));
+    const discovery = await this.provider.discover({
+      provider_kind: 'mcp',
+      mode: 'cached',
+      org_id: request.org_id,
+      provider_instance_id: connection.id,
+      overrides,
+    });
+    if (!discovery.snapshot) {
+      return unavailable(request, 'MCP capability snapshot is unavailable', 'CAPABILITY_PROVIDER_UNAVAILABLE');
+    }
+    const tool = discovery.tools.find(
+      (candidate) => candidate.originalName === request.provider.operation_name,
+    );
+    if (!tool || operationRows.some((row) => row.is_disabled)) {
+      return unavailable(
+        request,
+        `MCP tool '${request.provider.operation_name}' is unavailable`,
+        'CAPABILITY_OPERATION_UNAVAILABLE',
+      );
+    }
+
+    const explicitOverride = operationRows
+      .map((row) => row.trust_tier_override ? mappedTier(row.trust_tier_override) : null)
+      .filter((tier): tier is ApprovalTier => tier !== null)
+      .reduce<ApprovalTier | null>(
+        (current, tier) => current ? stricterTier(current, tier) : tier,
+        null,
+      );
+    const configuredTier = mappedTier(connection.default_trust_tier);
+    const effectiveTier = explicitOverride ?? stricterTier(configuredTier, tool.approvalTier);
+    const providerDeclaredSafe = !tool.isWrite && tool.approvalTier === 'auto-execute';
+    const policy: AppRunPolicySnapshot = {
+      risk_class: providerDeclaredSafe ? 'read' : 'external_write',
+      review_requirement: 'policy',
+      review_scope: 'per_invocation',
+      retry_class: providerDeclaredSafe ? 'safe' : 'unsafe_or_unknown',
+    };
+
+    const legacyAction = options.legacy_action_id
+      ? await this.#approvedLegacyAction(request, options.legacy_action_id)
+      : null;
+    if (effectiveTier !== 'auto-execute' || !providerDeclaredSafe) {
+      if (!legacyAction) {
+        return unavailable(
+          request,
+          'MCP operation requires approved legacy action evidence',
+          'CAPABILITY_OPERATION_UNAVAILABLE',
+        );
+      }
+    } else if (options.legacy_action_id && !legacyAction) {
+      return unavailable(
+        request,
+        'MCP legacy action evidence is invalid',
+        'CAPABILITY_OPERATION_UNAVAILABLE',
+      );
+    }
+
+    const snapshotId = await this.#persistSnapshot(discovery.snapshot);
+    const runtime = await this.runtime();
+    const initiatingActor = { actor_type: 'human' as const, user_id: request.actor.user_id };
+    const executionActor = request.actor.agent_employee_id
+      ? { actor_type: 'agent_employee' as const, agent_employee_id: request.actor.agent_employee_id }
+      : initiatingActor;
+    const authorizationSnapshot = await runtime.liveAuthorization.capture({
+      org_id: request.org_id,
+      authenticated_subject: initiatingActor,
+      execution_actor: executionActor,
+      provider_instance_id: connection.id,
+      provider_snapshot_id: snapshotId,
+      operation_name: request.provider.operation_name,
+      policy,
+    });
+    const idempotencyIdentity = options.idempotency_key
+      ?? options.legacy_action_id
+      ?? crypto.randomUUID();
+    const run = await runtime.service.submit({
+      org_id: request.org_id,
+      initiating_actor: initiatingActor,
+      execution_actor: executionActor,
+    }, {
+      schema_version: APP_RUN_CONTRACT_VERSIONS.run,
+      org_id: request.org_id,
+      initiating_actor: initiatingActor,
+      execution_actor: executionActor,
+      origin: { origin_kind: 'legacy_connector', connection_id: connection.id },
+      operation: {
+        provider: {
+          org_id: request.org_id,
+          provider_kind: 'mcp',
+          provider_instance_id: connection.id,
+        },
+        operation_name: request.provider.operation_name,
+      },
+      provider_snapshot_digest: discovery.snapshot.snapshot_digest,
+      policy,
+      retention_class: 'standard',
+      idempotency_key: `legacy-capability:${idempotencyIdentity}`,
+      input: request.input,
+      authorization_snapshot: authorizationSnapshot,
+      safe_preview: {
+        schema_version: APP_RUN_CONTRACT_VERSIONS.run,
+        title: `${connection.name}: ${request.provider.operation_name}`.slice(0, 200),
+        resource_refs: [],
+        fields: {
+          compatibility_approval_tier: effectiveTier,
+          ...(options.legacy_action_id ? { legacy_action_id: options.legacy_action_id } : {}),
+        },
+      },
+    });
+
+    let providerResult: AppRunProviderExecutionResult | undefined;
+    const attemptId = await runtime.attemptRunner.prepareAttempt(request.org_id, run.id);
+    if (attemptId) {
+      const immediate = await runtime.attemptRunner.runImmediate(
+        request.org_id,
+        run.id,
+        attemptId,
+        `capability:${crypto.randomUUID()}`,
+      );
+      providerResult = immediate.provider_result;
+    }
+    const visibleRun = await runtime.service.requiredRun(request.org_id, run.id);
+    await runtime.service.assertAuthorized('result', request.org_id, initiatingActor, visibleRun);
+    return this.#result(
+      request,
+      connection.id,
+      connection.name,
+      run.id,
+      initiatingActor,
+      providerResult,
+      Math.max(0, this.now().getTime() - startedAt),
+      runtime,
+    );
+  }
+
+  async #approvedLegacyAction(
+    request: McpCapabilityInvocationRequest,
+    actionId: string,
+  ): Promise<typeof agentActions.$inferSelect | null> {
+    const [action] = await db.select().from(agentActions).where(and(
+      eq(agentActions.id, actionId),
+      eq(agentActions.org_id, request.org_id),
+      eq(agentActions.user_id, request.actor.user_id),
+    )).limit(1);
+    const expectedAction = `mcp__${request.provider.connection_slug}__${request.provider.operation_name}`;
+    if (
+      !action
+      || action.action !== expectedAction
+      || action.approval_status !== 'approved'
+      || (action.agent_employee_id ?? undefined) !== request.actor.agent_employee_id
+    ) return null;
+    try {
+      if (canonicalCapabilityJson(action.params) !== canonicalCapabilityJson(request.input)) return null;
+    } catch {
+      return null;
+    }
+    return action;
+  }
+
+  async #persistSnapshot(
+    snapshot: NonNullable<Awaited<ReturnType<McpCapabilityProvider['discover']>>['snapshot']>,
+  ): Promise<string> {
+    const id = crypto.randomUUID();
+    await db.insert(capabilityProviderSnapshots).values({
+      id,
+      org_id: snapshot.provider.org_id,
+      provider_kind: snapshot.provider.provider_kind,
+      provider_instance_id: snapshot.provider.provider_instance_id,
+      adapter_contract_version: snapshot.adapter_contract_version,
+      snapshot_digest: snapshot.snapshot_digest,
+      safe_snapshot: snapshot,
+      captured_at: new Date(snapshot.captured_at),
+    }).onConflictDoNothing();
+    const [stored] = await db.select({ id: capabilityProviderSnapshots.id })
+      .from(capabilityProviderSnapshots).where(and(
+        eq(capabilityProviderSnapshots.org_id, snapshot.provider.org_id),
+        eq(capabilityProviderSnapshots.provider_kind, snapshot.provider.provider_kind),
+        eq(capabilityProviderSnapshots.provider_instance_id, snapshot.provider.provider_instance_id),
+        eq(capabilityProviderSnapshots.snapshot_digest, snapshot.snapshot_digest),
+      )).limit(1);
+    if (!stored) throw new Error('APP_RUN_PROVIDER_UNAVAILABLE');
+    return stored.id;
+  }
+
+  async #result(
+    request: McpCapabilityInvocationRequest,
+    providerId: string,
+    providerName: string,
+    runId: string,
+    actor: Readonly<{ actor_type: 'human'; user_id: string }>,
+    transient: AppRunProviderExecutionResult | undefined,
+    elapsedMs: number,
+    runtime: AppRunRuntime,
+  ): Promise<McpCapabilityInvocationAdapterResult> {
+    if (transient?.status === 'indeterminate') {
+      return this.#attemptedError(request, providerId, providerName, {
+        error: 'MCP tool outcome is unknown',
+      }, 'MCP tool outcome is unknown', elapsedMs);
+    }
+    if (transient?.status === 'not_attempted') {
+      return unavailable(request, 'MCP connection is unavailable', 'CAPABILITY_PROVIDER_UNAVAILABLE');
+    }
+
+    let providerSucceeded: boolean;
+    let retainedOutput: unknown;
+    if (transient?.status === 'returned') {
+      providerSucceeded = transient.provider_succeeded;
+      retainedOutput = transient.output;
+    } else {
+      const deadline = Date.now() + 30_000;
+      let visible = await runtime.repository.inspect(request.org_id, runId);
+      while (
+        visible
+        && !['succeeded', 'failed', 'cancelled', 'expired', 'unknown_outcome'].includes(visible.state)
+        && Date.now() < deadline
+      ) {
+        await delay(20);
+        visible = await runtime.repository.inspect(request.org_id, runId);
+      }
+      if (visible?.state === 'unknown_outcome') {
+        return this.#attemptedError(request, providerId, providerName, {
+          error: 'MCP tool outcome is unknown',
+        }, 'MCP tool outcome is unknown', elapsedMs);
+      }
+      try {
+        const exact = await runtime.service.result(request.org_id, runId, actor);
+        const retained = AppRunRetainedProviderResultSchema.parse(exact.value);
+        providerSucceeded = retained.provider_succeeded;
+        retainedOutput = retained.output;
+      } catch {
+        return unavailable(request, 'MCP result is no longer available', 'CAPABILITY_PROVIDER_UNAVAILABLE');
+      }
+    }
+    if (
+      !retainedOutput
+      || typeof retainedOutput !== 'object'
+      || Array.isArray(retainedOutput)
+      || (retainedOutput as Record<string, unknown>).schema_version !== MCP_APP_RUN_RESULT_VERSION
+    ) {
+      return this.#attemptedError(
+        request,
+        providerId,
+        providerName,
+        retainedOutput,
+        'MCP tool result is unavailable',
+        elapsedMs,
+      );
+    }
+    const envelope = retainedOutput as Record<string, unknown>;
+    const legacyOutput = envelope.legacy_output;
+    const durationMs = typeof envelope.duration_ms === 'number'
+      && Number.isInteger(envelope.duration_ms)
+      && envelope.duration_ms >= 0
+      ? envelope.duration_ms
+      : elapsedMs;
+    const error = typeof envelope.error === 'string' && envelope.error
+      ? envelope.error
+      : providerErrorMessage(legacyOutput) ?? 'MCP tool error';
+    if (!providerSucceeded) {
+      return this.#attemptedError(
+        request,
+        providerId,
+        providerName,
+        legacyOutput,
+        error,
+        durationMs,
+      );
+    }
+    return {
+      provider: {
+        provider_kind: 'mcp',
+        requested_provider_key: request.provider.connection_slug,
+        resolved_provider: {
+          org_id: request.org_id,
+          provider_kind: 'mcp',
+          provider_instance_id: providerId,
+        },
+      },
+      provider_display_name: providerName,
+      operation_name: request.provider.operation_name,
+      provider_call_attempted: true,
+      provider_succeeded: true,
+      legacy_output: legacyOutput,
+      duration_ms: durationMs,
+    };
+  }
+
+  #attemptedError(
+    request: McpCapabilityInvocationRequest,
+    providerId: string,
+    providerName: string,
+    output: unknown,
+    error: string,
+    durationMs: number,
+  ): McpCapabilityInvocationAdapterResult {
+    return {
+      provider: {
+        provider_kind: 'mcp',
+        requested_provider_key: request.provider.connection_slug,
+        resolved_provider: {
+          org_id: request.org_id,
+          provider_kind: 'mcp',
+          provider_instance_id: providerId,
+        },
+      },
+      provider_display_name: providerName,
+      operation_name: request.provider.operation_name,
+      provider_call_attempted: true,
+      provider_succeeded: false,
+      legacy_output: output,
+      error,
+      error_code: 'CAPABILITY_PROVIDER_ERROR',
+      duration_ms: durationMs,
+    };
+  }
+}
+
+export const postgresGovernedCapabilityExecutor = new PostgresGovernedCapabilityExecutor();

--- a/apps/api/src/lib/app-run-live-authorization.ts
+++ b/apps/api/src/lib/app-run-live-authorization.ts
@@ -130,7 +130,9 @@ export class PostgresAppRunLiveAuthorization implements AppRunExecutionAuthorize
       const internal = await this.#loadInternalRun(input.tx, input.org_id, input.run.id);
       if (!internal || !await this.#matchesLiveState(input.tx, input.run, internal)) return false;
 
-      if (input.run.execution_actor_type !== 'agent_employee') {
+      const reservesEmployeeBudget = input.run.execution_actor_type === 'agent_employee'
+        && input.run.risk_class !== 'read';
+      if (!reservesEmployeeBudget) {
         return internal.budget_reserved_at === null
           && internal.budget_reserved_count === null
           && internal.budget_limit_at_reservation === null;
@@ -274,7 +276,10 @@ export class PostgresAppRunLiveAuthorization implements AppRunExecutionAuthorize
     };
 
     await captureActor(input.authenticated_subject, false);
-    await captureActor(input.execution_actor, input.execution_actor.actor_type === 'agent_employee');
+    await captureActor(
+      input.execution_actor,
+      input.execution_actor.actor_type === 'agent_employee' && input.policy.risk_class !== 'read',
+    );
 
     const [connection] = await tx.select().from(mcpConnections).where(and(
       eq(mcpConnections.org_id, input.org_id),

--- a/apps/api/src/lib/app-run-provider-executor.ts
+++ b/apps/api/src/lib/app-run-provider-executor.ts
@@ -19,12 +19,20 @@ export type AppRunProviderExecutionResult =
       status: 'not_attempted';
       error_code?: 'APP_RUN_PROVIDER_UNAVAILABLE' | 'APP_RUN_PROVIDER_TIMEOUT';
     }>
-  | Readonly<{ status: 'returned'; provider_succeeded: boolean; output: unknown }>
+  | Readonly<{
+      status: 'returned';
+      provider_succeeded: boolean;
+      output: unknown;
+      error?: string;
+      duration_ms?: number;
+    }>
   | Readonly<{ status: 'indeterminate' }>;
 
 export interface AppRunProviderExecutor {
   execute(request: AppRunProviderExecutionRequest): Promise<AppRunProviderExecutionResult>;
 }
+
+export const MCP_APP_RUN_RESULT_VERSION = 'deft.app_run.mcp_result.v1';
 
 function isInputObject(
   value: CapabilityJsonValue,
@@ -64,6 +72,18 @@ export class PinnedMcpAppRunProviderExecutor implements AppRunProviderExecutor {
           : 'APP_RUN_PROVIDER_UNAVAILABLE',
       };
     }
-    return result;
+    if (result.status === 'indeterminate') return result;
+    return {
+      status: 'returned',
+      provider_succeeded: result.provider_succeeded,
+      output: {
+        schema_version: MCP_APP_RUN_RESULT_VERSION,
+        legacy_output: result.output,
+        duration_ms: result.duration_ms,
+        ...(result.error ? { error: result.error } : {}),
+      },
+      ...(result.error ? { error: result.error } : {}),
+      duration_ms: result.duration_ms,
+    };
   }
 }

--- a/apps/api/src/lib/app-run-provider-executor.ts
+++ b/apps/api/src/lib/app-run-provider-executor.ts
@@ -1,4 +1,8 @@
 import type { CapabilityJsonValue } from '@deft/shared';
+import {
+  McpCapabilityProvider,
+  mcpCapabilityProvider,
+} from './capability-providers/mcp.js';
 
 export type AppRunProviderExecutionRequest = Readonly<{
   org_id: string;
@@ -20,4 +24,46 @@ export type AppRunProviderExecutionResult =
 
 export interface AppRunProviderExecutor {
   execute(request: AppRunProviderExecutionRequest): Promise<AppRunProviderExecutionResult>;
+}
+
+function isInputObject(
+  value: CapabilityJsonValue,
+): value is { [key: string]: CapabilityJsonValue } {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+/** The sole App Run-to-provider bridge. Generic MCP has no portable
+ * out-of-band idempotency-key channel, so key-dependent attempts remain
+ * fail-closed until an explicit provider binding can prove the key is used. */
+export class PinnedMcpAppRunProviderExecutor implements AppRunProviderExecutor {
+  constructor(private readonly provider: McpCapabilityProvider = mcpCapabilityProvider) {}
+
+  async execute(request: AppRunProviderExecutionRequest): Promise<AppRunProviderExecutionResult> {
+    if (
+      request.provider_kind !== 'mcp'
+      || !isInputObject(request.input)
+      || request.provider_idempotency_key !== undefined
+    ) {
+      return { status: 'not_attempted', error_code: 'APP_RUN_PROVIDER_UNAVAILABLE' };
+    }
+    if (request.signal?.aborted) {
+      return { status: 'not_attempted', error_code: 'APP_RUN_PROVIDER_TIMEOUT' };
+    }
+    const result = await this.provider.executePinned({
+      org_id: request.org_id,
+      provider_instance_id: request.provider_instance_id,
+      operation_name: request.operation_name,
+      input: request.input,
+      signal: request.signal,
+    });
+    if (result.status === 'not_attempted') {
+      return {
+        status: 'not_attempted',
+        error_code: request.signal?.aborted
+          ? 'APP_RUN_PROVIDER_TIMEOUT'
+          : 'APP_RUN_PROVIDER_UNAVAILABLE',
+      };
+    }
+    return result;
+  }
 }

--- a/apps/api/src/lib/app-run-runtime.ts
+++ b/apps/api/src/lib/app-run-runtime.ts
@@ -1,0 +1,121 @@
+import { AppRunAttemptRunner } from './app-run-attempt-runner.js';
+import { PostgresAppRunApprovalResolver, postgresAppRunApprovalAdapter } from './app-run-approval-adapter.js';
+import { PostgresAppRunAttentionProjector } from './app-run-attention.js';
+import { denyAllAppRunAuthorizer } from './app-run-authorization.js';
+import { AppRunError } from './app-run-errors.js';
+import { parseEnvironmentAppRunKeyrings, type EnvironmentAppRunKeyProvider } from './app-run-keyrings.js';
+import { PostgresAppRunLiveAuthorization } from './app-run-live-authorization.js';
+import { AppRunOperationsService } from './app-run-operations.js';
+import { PinnedMcpAppRunProviderExecutor } from './app-run-provider-executor.js';
+import { PostgresAppRunReceiptWriter } from './app-run-receipts.js';
+import { PostgresAppRunRepository } from './app-run-repository.js';
+import { postgresAppRunAttemptQueue } from './app-run-scheduler.js';
+import { AppRunSecretRepository } from './app-run-secret-repository.js';
+import { AppRunSecretService } from './app-run-secrets.js';
+import { AppRunService } from './app-run-service.js';
+import { APP_RUNS_ENABLED } from './env.js';
+
+export type AppRunRuntime = Readonly<{
+  keys: EnvironmentAppRunKeyProvider;
+  repository: PostgresAppRunRepository;
+  secretRepository: AppRunSecretRepository;
+  liveAuthorization: PostgresAppRunLiveAuthorization;
+  service: AppRunService;
+  attemptRunner: AppRunAttemptRunner;
+  approvalResolver: PostgresAppRunApprovalResolver;
+  operations: AppRunOperationsService;
+}>;
+
+let runtimePromise: Promise<AppRunRuntime> | null = null;
+
+async function createAppRunRuntime(): Promise<AppRunRuntime> {
+  const keys = parseEnvironmentAppRunKeyrings(process.env.DEFT_APP_RUN_KEYRINGS);
+  const secrets = new AppRunSecretService(keys);
+  const repository = new PostgresAppRunRepository();
+  const secretRepository = new AppRunSecretRepository(secrets);
+  const liveAuthorization = new PostgresAppRunLiveAuthorization();
+  const receipts = new PostgresAppRunReceiptWriter(secrets, secretRepository);
+  const attention = new PostgresAppRunAttentionProjector();
+  const clock = () => new Date();
+  const attemptRunner = new AppRunAttemptRunner(
+    repository,
+    secretRepository,
+    secrets,
+    new PinnedMcpAppRunProviderExecutor(),
+    liveAuthorization,
+    clock,
+    60_000,
+    20_000,
+    receipts,
+    attention,
+    postgresAppRunAttemptQueue,
+  );
+  const service = new AppRunService(
+    repository,
+    secretRepository,
+    secrets,
+    keys,
+    denyAllAppRunAuthorizer,
+    clock,
+    postgresAppRunApprovalAdapter,
+    receipts,
+    attention,
+    attemptRunner,
+  );
+  const approvalResolver = new PostgresAppRunApprovalResolver(
+    repository,
+    liveAuthorization,
+    clock,
+    receipts,
+    attention,
+    attemptRunner,
+  );
+  const operations = new AppRunOperationsService(
+    repository,
+    undefined,
+    receipts,
+    attention,
+    clock,
+  );
+
+  try {
+    await service.assertReferencedKeysAvailable();
+  } catch (error) {
+    keys.destroy();
+    throw error;
+  }
+
+  return Object.freeze({
+    keys,
+    repository,
+    secretRepository,
+    liveAuthorization,
+    service,
+    attemptRunner,
+    approvalResolver,
+    operations,
+  });
+}
+
+/** One process-wide composition root. The exact flag is checked again at the
+ * call boundary so imports alone cannot activate governed execution. */
+export async function getAppRunRuntime(): Promise<AppRunRuntime> {
+  if (!APP_RUNS_ENABLED) throw new AppRunError('APP_RUNS_DISABLED');
+  runtimePromise ??= createAppRunRuntime().catch((error) => {
+    runtimePromise = null;
+    throw error;
+  });
+  return runtimePromise;
+}
+
+export async function shutdownAppRunRuntime(): Promise<void> {
+  const pending = runtimePromise;
+  runtimePromise = null;
+  if (!pending) return;
+  try {
+    const runtime = await pending;
+    runtime.keys.destroy();
+  } catch {
+    // A failed composition already destroys any parsed key material.
+  }
+}

--- a/apps/api/src/lib/app-run-runtime.ts
+++ b/apps/api/src/lib/app-run-runtime.ts
@@ -1,7 +1,7 @@
 import { AppRunAttemptRunner } from './app-run-attempt-runner.js';
 import { PostgresAppRunApprovalResolver, postgresAppRunApprovalAdapter } from './app-run-approval-adapter.js';
 import { PostgresAppRunAttentionProjector } from './app-run-attention.js';
-import { denyAllAppRunAuthorizer } from './app-run-authorization.js';
+import { PostgresAppRunAuthorizer } from './app-run-authorization.js';
 import { AppRunError } from './app-run-errors.js';
 import { parseEnvironmentAppRunKeyrings, type EnvironmentAppRunKeyProvider } from './app-run-keyrings.js';
 import { PostgresAppRunLiveAuthorization } from './app-run-live-authorization.js';
@@ -34,6 +34,7 @@ async function createAppRunRuntime(): Promise<AppRunRuntime> {
   const repository = new PostgresAppRunRepository();
   const secretRepository = new AppRunSecretRepository(secrets);
   const liveAuthorization = new PostgresAppRunLiveAuthorization();
+  const accessAuthorization = new PostgresAppRunAuthorizer();
   const receipts = new PostgresAppRunReceiptWriter(secrets, secretRepository);
   const attention = new PostgresAppRunAttentionProjector();
   const clock = () => new Date();
@@ -55,7 +56,7 @@ async function createAppRunRuntime(): Promise<AppRunRuntime> {
     secretRepository,
     secrets,
     keys,
-    denyAllAppRunAuthorizer,
+    accessAuthorization,
     clock,
     postgresAppRunApprovalAdapter,
     receipts,

--- a/apps/api/src/lib/app-run-scheduler.ts
+++ b/apps/api/src/lib/app-run-scheduler.ts
@@ -1,0 +1,52 @@
+import { QUEUE_NAMES, enqueue } from './queues.js';
+import type { AppRunSafeView, AppRunTransaction } from './app-run-repository.js';
+
+export const APP_RUN_ATTEMPT_JOB = 'app-run-attempt';
+
+export interface AppRunAttemptScheduler {
+  scheduleInTransaction(
+    tx: AppRunTransaction,
+    run: AppRunSafeView,
+    now: Date,
+  ): Promise<string | null>;
+}
+
+export interface AppRunAttemptQueue {
+  enqueue(
+    tx: AppRunTransaction,
+    orgId: string,
+    runId: string,
+    attemptId: string,
+  ): Promise<void>;
+}
+
+export const noOpAppRunAttemptScheduler: AppRunAttemptScheduler = Object.freeze({
+  async scheduleInTransaction() { return null; },
+});
+
+export const noOpAppRunAttemptQueue: AppRunAttemptQueue = Object.freeze({
+  async enqueue() {},
+});
+
+/** Queue identity contains only the exact durable attempt coordinates. The
+ * input and provider credentials stay behind their respective repositories. */
+export const postgresAppRunAttemptQueue: AppRunAttemptQueue = Object.freeze({
+  async enqueue(
+    tx: AppRunTransaction,
+    orgId: string,
+    runId: string,
+    attemptId: string,
+  ) {
+    await enqueue(
+      QUEUE_NAMES.AGENT_JOBS,
+      APP_RUN_ATTEMPT_JOB,
+      { orgId, runId, attemptId },
+      {
+        executor: tx,
+        orgId,
+        dedupeKey: `app-run-attempt:${attemptId}`,
+        maxAttempts: 5,
+      },
+    );
+  },
+});

--- a/apps/api/src/lib/app-run-service.ts
+++ b/apps/api/src/lib/app-run-service.ts
@@ -20,6 +20,10 @@ import {
 } from './app-run-keyrings.js';
 import type { AppRunSecretService } from './app-run-secrets.js';
 import {
+  noOpAppRunAttemptScheduler,
+  type AppRunAttemptScheduler,
+} from './app-run-scheduler.js';
+import {
   denyAllAppRunAuthorizer,
   type AppRunAccessAction,
   type AppRunAuthorizer,
@@ -173,6 +177,7 @@ export class AppRunService {
     private readonly approvalAdapter: AppRunApprovalAdapter = postgresAppRunApprovalAdapter,
     private readonly receiptWriter: AppRunReceiptWriter = noOpAppRunReceiptWriter,
     private readonly attention: AppRunAttentionProjector = noOpAppRunAttentionProjector,
+    private readonly attemptScheduler: AppRunAttemptScheduler = noOpAppRunAttemptScheduler,
   ) {}
 
   async submit(context: AppRunTrustedContext, rawSubmission: unknown): Promise<AppRunSafeView> {
@@ -307,6 +312,9 @@ export class AppRunService {
           payload: { action_id: actionId },
           now,
         });
+      }
+      if (run.execution_released_at) {
+        await this.attemptScheduler.scheduleInTransaction(tx, run, now);
       }
       return run;
     });

--- a/apps/api/src/lib/app-run-worker-handler.ts
+++ b/apps/api/src/lib/app-run-worker-handler.ts
@@ -8,11 +8,24 @@ const AppRunJobSchema = z.object({
   attemptId: z.string().min(1).max(512),
 }).strict();
 
-// C0 deliberately keeps this injectable factory out of the production worker
-// registry. C4 owns provider/queue wiring and C5 owns the cutover decision.
 export function createAppRunAttemptJobHandler(runner: AppRunAttemptRunner): JobHandler {
   return async (job) => {
     const payload = AppRunJobSchema.parse(job.data);
     await runner.run(payload.orgId, payload.runId, payload.attemptId, `job:${job.id}`, job.signal);
   };
 }
+
+/** Production handler resolves the single composition root lazily. Queue data
+ * carries exact durable identity only; decrypted input never enters a job. */
+export const handleAppRunAttempt: JobHandler = async (job) => {
+  const payload = AppRunJobSchema.parse(job.data);
+  const { getAppRunRuntime } = await import('./app-run-runtime.js');
+  const runtime = await getAppRunRuntime();
+  await runtime.attemptRunner.run(
+    payload.orgId,
+    payload.runId,
+    payload.attemptId,
+    `job:${job.id}`,
+    job.signal,
+  );
+};

--- a/apps/api/src/lib/app-run-worker-handler.ts
+++ b/apps/api/src/lib/app-run-worker-handler.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 import type { JobHandler } from '../workers/types.js';
+import { APP_RUNS_ENABLED } from './env.js';
+import { RetryLaterJobError } from './queues.js';
 import type { AppRunAttemptRunner } from './app-run-attempt-runner.js';
 
 const AppRunJobSchema = z.object({
@@ -19,6 +21,9 @@ export function createAppRunAttemptJobHandler(runner: AppRunAttemptRunner): JobH
  * carries exact durable identity only; decrypted input never enters a job. */
 export const handleAppRunAttempt: JobHandler = async (job) => {
   const payload = AppRunJobSchema.parse(job.data);
+  if (!APP_RUNS_ENABLED) {
+    throw new RetryLaterJobError('App Runs are disabled; durable attempt paused', 60_000);
+  }
   const { getAppRunRuntime } = await import('./app-run-runtime.js');
   const runtime = await getAppRunRuntime();
   await runtime.attemptRunner.run(

--- a/apps/api/src/lib/capability-providers/mcp.ts
+++ b/apps/api/src/lib/capability-providers/mcp.ts
@@ -108,7 +108,13 @@ export interface McpCapabilityRuntime {
 
 export type McpPinnedExecutionResult =
   | Readonly<{ status: 'not_attempted' }>
-  | Readonly<{ status: 'returned'; provider_succeeded: boolean; output: unknown }>
+  | Readonly<{
+      status: 'returned';
+      provider_succeeded: boolean;
+      output: unknown;
+      error?: string;
+      duration_ms: number;
+    }>
   | Readonly<{ status: 'indeterminate' }>;
 
 export interface CapabilitySnapshotWarning {
@@ -262,6 +268,17 @@ export class McpCapabilityProvider {
     };
   }
 
+  async resolveGoverned(
+    request: McpCapabilityInvocationRequest,
+  ): Promise<ExecutableMcpConnectionResult> {
+    return this.runtime.resolveExecutable(
+      request.org_id,
+      request.provider.connection_slug,
+      request.provider.operation_name,
+      request.actor.agent_employee_id,
+    );
+  }
+
   /** Execute one App Run attempt against the immutable provider identity.
    * Resolution and target materialization happen before the low-level call;
    * once that call is launched, an abort or transport-only failure is
@@ -313,6 +330,8 @@ export class McpCapabilityProvider {
         status: 'returned',
         provider_succeeded: settled.result.success,
         output: mcpResultPayload(settled.result),
+        ...(settled.result.error ? { error: settled.result.error } : {}),
+        duration_ms: settled.result.durationMs,
       };
     } finally {
       removeAbortListener();

--- a/apps/api/src/lib/capability-providers/mcp.ts
+++ b/apps/api/src/lib/capability-providers/mcp.ts
@@ -21,6 +21,7 @@ import { and, eq } from 'drizzle-orm';
 import { db } from '../db.js';
 import {
   getExecutableMcpConnection,
+  getExecutableMcpConnectionById,
   mcpResultPayload,
   toConnectionConfig,
   type ExecutableMcpConnectionResult,
@@ -98,7 +99,17 @@ export interface McpCapabilityRuntime {
     operationName: string,
     input: Record<string, unknown>,
   ): Promise<MCPResult>;
+  resolvePinnedExecutable?(
+    orgId: string,
+    connectionId: string,
+    operationName: string,
+  ): Promise<ExecutableMcpConnectionResult>;
 }
+
+export type McpPinnedExecutionResult =
+  | Readonly<{ status: 'not_attempted' }>
+  | Readonly<{ status: 'returned'; provider_succeeded: boolean; output: unknown }>
+  | Readonly<{ status: 'indeterminate' }>;
 
 export interface CapabilitySnapshotWarning {
   code: 'CAPABILITY_SNAPSHOT_UNAVAILABLE';
@@ -126,6 +137,7 @@ const databaseMcpConnectionSource: McpConnectionSource = {
 
 const databaseMcpCapabilityRuntime: McpCapabilityRuntime = {
   resolveExecutable: getExecutableMcpConnection,
+  resolvePinnedExecutable: getExecutableMcpConnectionById,
   executeTool: (config, operationName, input) => (
     mcpClientManager.executeTool(config, operationName, input)
   ),
@@ -248,6 +260,63 @@ export class McpCapabilityProvider {
       error: mcpResult.error || 'MCP tool error',
       error_code: 'CAPABILITY_PROVIDER_ERROR',
     };
+  }
+
+  /** Execute one App Run attempt against the immutable provider identity.
+   * Resolution and target materialization happen before the low-level call;
+   * once that call is launched, an abort or transport-only failure is
+   * conservatively indeterminate. */
+  async executePinned(request: Readonly<{
+    org_id: string;
+    provider_instance_id: string;
+    operation_name: string;
+    input: Record<string, unknown>;
+    signal?: AbortSignal;
+  }>): Promise<McpPinnedExecutionResult> {
+    if (request.signal?.aborted) return { status: 'not_attempted' };
+    const resolvePinned = this.runtime.resolvePinnedExecutable;
+    if (!resolvePinned) return { status: 'not_attempted' };
+    const resolved = await resolvePinned(
+      request.org_id,
+      request.provider_instance_id,
+      request.operation_name,
+    );
+    if (!resolved.connection) return { status: 'not_attempted' };
+
+    let config: MCPConnectionConfig;
+    try {
+      config = toConnectionConfig(resolved.connection);
+    } catch {
+      return { status: 'not_attempted' };
+    }
+    if (request.signal?.aborted) return { status: 'not_attempted' };
+
+    const call = Promise.resolve()
+      .then(() => this.runtime.executeTool(config, request.operation_name, request.input))
+      .then(
+        (result) => ({ kind: 'result' as const, result }),
+        () => ({ kind: 'failed' as const }),
+      );
+    let removeAbortListener = () => {};
+    const aborted = new Promise<{ kind: 'aborted' }>((resolve) => {
+      const listener = () => resolve({ kind: 'aborted' });
+      request.signal?.addEventListener('abort', listener, { once: true });
+      removeAbortListener = () => request.signal?.removeEventListener('abort', listener);
+    });
+    try {
+      const settled = request.signal ? await Promise.race([call, aborted]) : await call;
+      if (settled.kind !== 'result') return { status: 'indeterminate' };
+      if (!settled.result.success && settled.result.rawResult === undefined) {
+        return { status: 'indeterminate' };
+      }
+      return {
+        status: 'returned',
+        provider_succeeded: settled.result.success,
+        output: mcpResultPayload(settled.result),
+      };
+    } finally {
+      removeAbortListener();
+    }
   }
 
   private async snapshotFor(

--- a/apps/api/src/lib/capability-service.ts
+++ b/apps/api/src/lib/capability-service.ts
@@ -12,6 +12,8 @@ import {
   type McpCapabilityInvocationAdapterResult,
   type McpCapabilityInvocationRequest,
 } from './capability-providers/mcp.js';
+import type { GovernedCapabilityInvocationOptions } from './app-run-capability-bridge.js';
+import { APP_RUNS_ENABLED } from './env.js';
 
 export type CapabilityDiscoveryRequest = McpCapabilityDiscoveryRequest;
 export type CapabilityDiscoveryResult = McpCapabilityDiscoveryResult;
@@ -33,6 +35,23 @@ interface McpCapabilityProviderPort {
   invoke(request: McpCapabilityInvocationRequest): Promise<McpCapabilityInvocationAdapterResult>;
 }
 
+export interface GovernedCapabilityInvocationPort {
+  invoke(
+    request: McpCapabilityInvocationRequest,
+    options?: GovernedCapabilityInvocationOptions,
+  ): Promise<McpCapabilityInvocationAdapterResult>;
+}
+
+const lazyGovernedCapabilityPort: GovernedCapabilityInvocationPort = Object.freeze({
+  async invoke(
+    request: McpCapabilityInvocationRequest,
+    options?: GovernedCapabilityInvocationOptions,
+  ) {
+    const { postgresGovernedCapabilityExecutor } = await import('./app-run-capability-bridge.js');
+    return postgresGovernedCapabilityExecutor.invoke(request, options);
+  },
+});
+
 /**
  * Provider-neutral internal seam for discovery now and invocation in the next
  * cutover loops. The provider union is intentionally closed.
@@ -40,6 +59,8 @@ interface McpCapabilityProviderPort {
 export class CapabilityService {
   constructor(
     private readonly mcpProvider: McpCapabilityProviderPort = mcpCapabilityProvider,
+    private readonly governed: GovernedCapabilityInvocationPort = lazyGovernedCapabilityPort,
+    private readonly governedEnabled: () => boolean = () => APP_RUNS_ENABLED,
   ) {}
 
   async discover(request: CapabilityDiscoveryRequest): Promise<CapabilityDiscoveryResult> {
@@ -51,14 +72,19 @@ export class CapabilityService {
     throw new Error('Unsupported capability provider kind');
   }
 
-  async invoke(value: unknown): Promise<CapabilityInvocationResult> {
+  async invoke(
+    value: unknown,
+    options: GovernedCapabilityInvocationOptions = {},
+  ): Promise<CapabilityInvocationResult> {
     // Invocation inputs cross an execution boundary, so reject unsupported
     // non-JSON/authority-bearing fields before resolution or any provider call.
     const request = CapabilityInvocationRequestSchema.parse(value);
     let adapterResult: McpCapabilityInvocationAdapterResult;
     switch (request.provider.provider_kind) {
       case 'mcp':
-        adapterResult = await this.mcpProvider.invoke(request);
+        adapterResult = this.governedEnabled()
+          ? await this.governed.invoke(request, options)
+          : await this.mcpProvider.invoke(request);
         break;
       default:
         throw new Error('Unsupported capability provider kind');

--- a/apps/api/src/lib/capability-service.ts
+++ b/apps/api/src/lib/capability-service.ts
@@ -13,7 +13,7 @@ import {
   type McpCapabilityInvocationRequest,
 } from './capability-providers/mcp.js';
 import type { GovernedCapabilityInvocationOptions } from './app-run-capability-bridge.js';
-import { APP_RUNS_ENABLED } from './env.js';
+import { APP_RUN_LEGACY_MCP_CUTOVER_ENABLED } from './env.js';
 
 export type CapabilityDiscoveryRequest = McpCapabilityDiscoveryRequest;
 export type CapabilityDiscoveryResult = McpCapabilityDiscoveryResult;
@@ -60,7 +60,8 @@ export class CapabilityService {
   constructor(
     private readonly mcpProvider: McpCapabilityProviderPort = mcpCapabilityProvider,
     private readonly governed: GovernedCapabilityInvocationPort = lazyGovernedCapabilityPort,
-    private readonly governedEnabled: () => boolean = () => APP_RUNS_ENABLED,
+    private readonly legacyMcpCutoverEnabled: () => boolean =
+      () => APP_RUN_LEGACY_MCP_CUTOVER_ENABLED,
   ) {}
 
   async discover(request: CapabilityDiscoveryRequest): Promise<CapabilityDiscoveryResult> {
@@ -82,7 +83,7 @@ export class CapabilityService {
     let adapterResult: McpCapabilityInvocationAdapterResult;
     switch (request.provider.provider_kind) {
       case 'mcp':
-        adapterResult = this.governedEnabled()
+        adapterResult = this.legacyMcpCutoverEnabled()
           ? await this.governed.invoke(request, options)
           : await this.mcpProvider.invoke(request);
         break;

--- a/apps/api/src/lib/env.ts
+++ b/apps/api/src/lib/env.ts
@@ -114,7 +114,7 @@ export const APPS_ENABLED = process.env.DEFT_APPS_ENABLED === 'true';
 export const APP_DEVELOPER_PAIRING_ENABLED =
   APPS_ENABLED && process.env.DEFT_APP_DEVELOPER_PAIRING_ENABLED === 'true';
 
-// Governed App Runs remain a dormant, independent opt-in during Phase 3.
+// Governed App Runs remain a disabled-by-default, independent opt-in.
 // Exact "true" plus valid purpose-separated keyrings is required. A normal
 // legacy self-host boot never needs or parses the new secret document.
 export const APP_RUNS_ENABLED = process.env.DEFT_APP_RUNS_ENABLED === 'true';

--- a/apps/api/src/lib/env.ts
+++ b/apps/api/src/lib/env.ts
@@ -118,4 +118,22 @@ export const APP_DEVELOPER_PAIRING_ENABLED =
 // Exact "true" plus valid purpose-separated keyrings is required. A normal
 // legacy self-host boot never needs or parses the new secret document.
 export const APP_RUNS_ENABLED = process.env.DEFT_APP_RUNS_ENABLED === 'true';
+export const APP_RUN_LEGACY_MCP_CUTOVER_ENABLED =
+  process.env.DEFT_APP_RUN_LEGACY_MCP_CUTOVER_ENABLED === 'true';
+
+export function validateAppRunRolloutConfiguration(
+  appRunsEnabled: boolean,
+  legacyMcpCutoverEnabled: boolean,
+): void {
+  if (legacyMcpCutoverEnabled && !appRunsEnabled) {
+    throw new Error(
+      'DEFT_APP_RUN_LEGACY_MCP_CUTOVER_ENABLED=true requires DEFT_APP_RUNS_ENABLED=true',
+    );
+  }
+}
+
+validateAppRunRolloutConfiguration(
+  APP_RUNS_ENABLED,
+  APP_RUN_LEGACY_MCP_CUTOVER_ENABLED,
+);
 validateAppRunKeyringEnvironment(APP_RUNS_ENABLED, process.env.DEFT_APP_RUN_KEYRINGS);

--- a/apps/api/src/lib/mcp-runtime.ts
+++ b/apps/api/src/lib/mcp-runtime.ts
@@ -165,3 +165,58 @@ export async function getExecutableMcpConnection(
 
   return { connection };
 }
+
+/** Resolve the exact provider identity pinned into an App Run. Slug lookup is
+ * intentionally unavailable on this path: a renamed or replacement
+ * connection must never inherit an already-authorized Run. Actor assignment
+ * and token authority are rechecked by App Run live authorization immediately
+ * before this provider boundary. */
+export async function getExecutableMcpConnectionById(
+  orgId: string,
+  connectionId: string,
+  toolName: string,
+): Promise<ExecutableMcpConnectionResult> {
+  const [connection] = await db
+    .select()
+    .from(mcpConnections)
+    .where(and(
+      eq(mcpConnections.org_id, orgId),
+      eq(mcpConnections.id, connectionId),
+      eq(mcpConnections.is_active, true),
+    ))
+    .limit(1);
+  if (!connection) {
+    return {
+      connection: null,
+      error: 'Pinned MCP connection is unavailable',
+      reason: 'provider_unavailable',
+    };
+  }
+
+  if (!isMcpToolEnabled(connection.enabled_tools, connection.slug, toolName)) {
+    return {
+      connection: null,
+      error: 'Pinned MCP operation is unavailable',
+      reason: 'operation_unavailable',
+    };
+  }
+
+  const overrideRows = await db
+    .select({ tool_name: mcpToolOverrides.tool_name, is_disabled: mcpToolOverrides.is_disabled })
+    .from(mcpToolOverrides)
+    .where(and(
+      eq(mcpToolOverrides.org_id, orgId),
+      eq(mcpToolOverrides.mcp_connection_id, connection.id),
+    ));
+  if (overrideRows.some((row) => (
+    row.is_disabled && canonicalMcpToolName(row.tool_name) === toolName
+  ))) {
+    return {
+      connection: null,
+      error: 'Pinned MCP operation is unavailable',
+      reason: 'operation_unavailable',
+    };
+  }
+
+  return { connection };
+}

--- a/apps/api/src/lib/queues.ts
+++ b/apps/api/src/lib/queues.ts
@@ -46,6 +46,19 @@ export type FailJobOptions = {
   terminal?: boolean;
 };
 
+/** A handler can request a fenced pause without consuming its retry budget.
+ * This is reserved for operational gates where retrying immediately cannot
+ * make progress but the durable occurrence must remain resumable. */
+export class RetryLaterJobError extends Error {
+  constructor(
+    message: string,
+    readonly delayMs: number,
+  ) {
+    super(message);
+    this.name = 'RetryLaterJobError';
+  }
+}
+
 const DEFAULT_LEASE_MS = 60_000;
 const DEFAULT_RETENTION_MS = 7 * 24 * 60 * 60_000;
 const DEFAULT_WORKER_ID = `deft:${process.pid}:${crypto.randomUUID()}`;
@@ -258,6 +271,36 @@ export async function failJob(
     });
   }
   return true;
+}
+
+/** Return a live claimed job to pending without spending one max-attempt slot.
+ * The ownership token and lease fence prevent a stale worker from deferring a
+ * reclaimed occurrence. */
+export async function deferJob(
+  jobId: string,
+  lockToken: string,
+  error: string,
+  delayMs: number,
+): Promise<boolean> {
+  const normalizedDelayMs = Math.max(1_000, Math.floor(delayMs));
+  const result = await db.execute(sql`
+    UPDATE job_queue
+    SET status = 'pending',
+        attempts = GREATEST(attempts - 1, 0),
+        run_at = now() + (${normalizedDelayMs} * interval '1 millisecond'),
+        started_at = NULL,
+        completed_at = NULL,
+        error = ${error},
+        locked_by = NULL,
+        lock_token = NULL,
+        lock_expires_at = NULL
+    WHERE id = ${jobId}
+      AND status = 'running'
+      AND lock_token = ${lockToken}
+      AND lock_expires_at > now()
+    RETURNING id
+  `);
+  return resultRows(result).length === 1;
 }
 
 /** Atomically register at most one pending/running occurrence per cron key. */

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -110,6 +110,8 @@ async function shutdown(signal: NodeJS.Signals): Promise<void> {
     ]);
     const rejected = results.find((result): result is PromiseRejectedResult => result.status === 'rejected');
     if (rejected) throw rejected.reason;
+    const { shutdownAppRunRuntime } = await import('./lib/app-run-runtime.js');
+    await shutdownAppRunRuntime();
     const { closeDb } = await import('./lib/db.js');
     await closeDb();
   } catch (err) {

--- a/apps/api/src/workers/index.ts
+++ b/apps/api/src/workers/index.ts
@@ -2,11 +2,13 @@
 import {
   dequeueJob,
   completeJob,
+  deferJob,
   failJob,
   ensureCronJob,
   cleanupStaleJobs,
   pruneFinishedJobs,
   renewJobLease,
+  RetryLaterJobError,
   QUEUE_NAMES,
   type DequeuedJob,
   type QueueName,
@@ -413,6 +415,11 @@ async function processDequeuedJob(
     }
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
+    if (err instanceof RetryLaterJobError) {
+      const settled = await deferJob(job.id, job.lockToken, message, err.delayMs);
+      if (settled) console.warn(`[worker] Job ${job.name} deferred:`, message);
+      return;
+    }
     // Until every handler cooperatively cancels its I/O, retrying immediately
     // after a timeout can overlap with the still-running original promise.
     // Terminal-fail the occurrence; operators can inspect/replay it explicitly.

--- a/apps/api/src/workers/index.ts
+++ b/apps/api/src/workers/index.ts
@@ -254,6 +254,10 @@ async function getAgentJobHandler(jobName: string): Promise<JobHandler | null> {
       const mod = await import('./handlers/workflow-execute.js');
       return mod.handleWorkflowExecute;
     }
+    case 'app-run-attempt': {
+      const mod = await import('../lib/app-run-worker-handler.js');
+      return mod.handleAppRunAttempt;
+    }
     case 'certification-noop': {
       // Synthetic 60-person certification intentionally measures queue claim,
       // completion, and recovery without invoking a product side effect.
@@ -360,6 +364,10 @@ async function getScheduledJobHandler(jobName: string): Promise<JobHandler | nul
 
 export async function _getScheduledJobHandlerForTest(jobName: string): Promise<JobHandler | null> {
   return getScheduledJobHandler(jobName);
+}
+
+export async function _getAgentJobHandlerForTest(jobName: string): Promise<JobHandler | null> {
+  return getAgentJobHandler(jobName);
 }
 
 async function getHandler(queueName: string, jobName: string): Promise<JobHandler | null> {

--- a/apps/api/test/app-run-architecture.test.ts
+++ b/apps/api/test/app-run-architecture.test.ts
@@ -37,7 +37,7 @@ test('only the App Run secret boundary handles ciphertext and signing material',
   assert.deepEqual(violations, []);
 });
 
-test('the dormant foundation has no production execution consumer', async () => {
+test('App Run flag and key material stay confined to environment and the composition root', async () => {
   const consumers: string[] = [];
   for (const path of await typescriptFiles(sourceRoot)) {
     const sourcePath = relative(sourceRoot, path).replaceAll('\\', '/');
@@ -50,16 +50,38 @@ test('the dormant foundation has no production execution consumer', async () => 
   assert.deepEqual(consumers, []);
 });
 
-test('the governed engine stays unwired from production entrances', async () => {
-  const protectedEntrances = [
-    'lib/capability-service.ts',
-    'lib/capability-providers/mcp.ts',
-    'workers/index.ts',
-  ];
-  for (const sourcePath of protectedEntrances) {
-    const source = await readFile(join(sourceRoot, sourcePath), 'utf8');
-    assert.doesNotMatch(source, /\b(?:AppRunService|AppRunAttemptRunner|createAppRunAttemptJobHandler)\b/);
+test('C4 has one composed worker-owned attempt entrance without Capability Service cutover', async () => {
+  const capabilityService = await readFile(join(sourceRoot, 'lib/capability-service.ts'), 'utf8');
+  const worker = await readFile(join(sourceRoot, 'workers/index.ts'), 'utf8');
+  const runtime = await readFile(join(sourceRoot, 'lib/app-run-runtime.ts'), 'utf8');
+  const handler = await readFile(join(sourceRoot, 'lib/app-run-worker-handler.ts'), 'utf8');
+
+  assert.doesNotMatch(capabilityService, /\b(?:AppRunService|getAppRunRuntime|AppRunAttemptRunner)\b/);
+  assert.equal(worker.match(/case 'app-run-attempt'/g)?.length, 1);
+  assert.match(handler, /getAppRunRuntime/);
+  assert.match(runtime, /new PinnedMcpAppRunProviderExecutor/);
+  assert.match(runtime, /postgresAppRunAttemptQueue/);
+  assert.match(runtime, /new PostgresAppRunReceiptWriter/);
+  assert.match(runtime, /new PostgresAppRunAttentionProjector/);
+});
+
+test('only the MCP adapter calls the low-level client and governed execution is pinned by provider id', async () => {
+  const violations: string[] = [];
+  for (const path of await typescriptFiles(sourceRoot)) {
+    const sourcePath = relative(sourceRoot, path).replaceAll('\\', '/');
+    const source = await readFile(path, 'utf8');
+    if (sourcePath !== 'lib/capability-providers/mcp.ts' && /mcpClientManager\.executeTool/.test(source)) {
+      violations.push(sourcePath);
+    }
   }
+  assert.deepEqual(violations, []);
+
+  const provider = await readFile(join(sourceRoot, 'lib/capability-providers/mcp.ts'), 'utf8');
+  const executor = await readFile(join(sourceRoot, 'lib/app-run-provider-executor.ts'), 'utf8');
+  assert.match(provider, /resolvePinnedExecutable/);
+  assert.match(provider, /provider_instance_id/);
+  assert.doesNotMatch(executor, /connection_slug/);
+  assert.doesNotMatch(executor, /mcpClientManager/);
 });
 
 test('Run submission has one repository writer behind the advisory-lock service', async () => {
@@ -85,6 +107,8 @@ test('the App Run approval bridge has one safe compatibility writer and no execu
   assert.match(adapter, /safe_preview/);
   assert.doesNotMatch(adapter, /\b(?:executeTool|AppRunAttemptRunner|idempotency_key|raw_input|raw_output)\b/);
   assert.match(service, /approvalAdapter\.create/);
+  assert.match(service, /attemptScheduler\.scheduleInTransaction/);
+  assert.match(adapter, /attemptScheduler\.scheduleInTransaction/);
   assert.match(resolver, /row\.action === APP_RUN_APPROVAL_ACTION/);
 });
 

--- a/apps/api/test/app-run-architecture.test.ts
+++ b/apps/api/test/app-run-architecture.test.ts
@@ -37,21 +37,34 @@ test('only the App Run secret boundary handles ciphertext and signing material',
   assert.deepEqual(violations, []);
 });
 
-test('App Run flag and key material stay confined to environment and the composition root', async () => {
-  const allowedConsumers = new Set([
-    'lib/agent-actions.ts',
-    'lib/capability-service.ts',
-  ]);
+test('App Run engine flag and key material stay confined to environment and Run composition', async () => {
   const consumers: string[] = [];
   for (const path of await typescriptFiles(sourceRoot)) {
     const sourcePath = relative(sourceRoot, path).replaceAll('\\', '/');
     if (sourcePath.startsWith('lib/app-run-') || sourcePath === 'lib/env.ts') continue;
     const source = await readFile(path, 'utf8');
     if (/\b(?:AppRunSecretService|DEFT_APP_RUNS_ENABLED|APP_RUNS_ENABLED)\b/.test(source)) {
-      if (!allowedConsumers.has(sourcePath)) consumers.push(sourcePath);
+      consumers.push(sourcePath);
     }
   }
   assert.deepEqual(consumers, []);
+});
+
+test('legacy MCP cutover flag has only the two intake-boundary consumers', async () => {
+  const expectedConsumers = [
+    'lib/agent-actions.ts',
+    'lib/capability-service.ts',
+  ];
+  const consumers: string[] = [];
+  for (const path of await typescriptFiles(sourceRoot)) {
+    const sourcePath = relative(sourceRoot, path).replaceAll('\\', '/');
+    if (sourcePath === 'lib/env.ts') continue;
+    const source = await readFile(path, 'utf8');
+    if (/\b(?:DEFT_APP_RUN_LEGACY_MCP_CUTOVER_ENABLED|APP_RUN_LEGACY_MCP_CUTOVER_ENABLED)\b/.test(source)) {
+      consumers.push(sourcePath);
+    }
+  }
+  assert.deepEqual(consumers.sort(), expectedConsumers);
 });
 
 test('C5 selects one composed worker-owned attempt entrance through Capability Service', async () => {
@@ -62,7 +75,7 @@ test('C5 selects one composed worker-owned attempt entrance through Capability S
   const bridge = await readFile(join(sourceRoot, 'lib/app-run-capability-bridge.ts'), 'utf8');
   const legacyActions = await readFile(join(sourceRoot, 'lib/agent-actions.ts'), 'utf8');
 
-  assert.match(capabilityService, /governedEnabled\(\)/);
+  assert.match(capabilityService, /legacyMcpCutoverEnabled\(\)/);
   assert.match(capabilityService, /await this\.governed\.invoke/);
   assert.match(capabilityService, /await this\.mcpProvider\.invoke/);
   assert.doesNotMatch(capabilityService, /\b(?:AppRunService|getAppRunRuntime|AppRunAttemptRunner)\b/);
@@ -75,8 +88,10 @@ test('C5 selects one composed worker-owned attempt entrance through Capability S
   assert.match(bridge, /attemptRunner\.runImmediate/);
   assert.match(bridge, /legacy_action_id/);
   assert.doesNotMatch(bridge, /\.invoke\(request\)/);
-  assert.match(legacyActions, /APP_RUNS_ENABLED && action\.startsWith\('mcp__'\)/);
+  assert.match(legacyActions, /APP_RUN_LEGACY_MCP_CUTOVER_ENABLED && action\.startsWith\('mcp__'\)/);
   assert.match(legacyActions, /legacy_action_id:\s*actionId/);
+  assert.doesNotMatch(runtime, /APP_RUN_LEGACY_MCP_CUTOVER_ENABLED/);
+  assert.doesNotMatch(handler, /APP_RUN_LEGACY_MCP_CUTOVER_ENABLED/);
 });
 
 test('only the MCP adapter calls the low-level client and governed execution is pinned by provider id', async () => {

--- a/apps/api/test/app-run-architecture.test.ts
+++ b/apps/api/test/app-run-architecture.test.ts
@@ -38,24 +38,33 @@ test('only the App Run secret boundary handles ciphertext and signing material',
 });
 
 test('App Run flag and key material stay confined to environment and the composition root', async () => {
+  const allowedConsumers = new Set([
+    'lib/agent-actions.ts',
+    'lib/capability-service.ts',
+  ]);
   const consumers: string[] = [];
   for (const path of await typescriptFiles(sourceRoot)) {
     const sourcePath = relative(sourceRoot, path).replaceAll('\\', '/');
     if (sourcePath.startsWith('lib/app-run-') || sourcePath === 'lib/env.ts') continue;
     const source = await readFile(path, 'utf8');
     if (/\b(?:AppRunSecretService|DEFT_APP_RUNS_ENABLED|APP_RUNS_ENABLED)\b/.test(source)) {
-      consumers.push(sourcePath);
+      if (!allowedConsumers.has(sourcePath)) consumers.push(sourcePath);
     }
   }
   assert.deepEqual(consumers, []);
 });
 
-test('C4 has one composed worker-owned attempt entrance without Capability Service cutover', async () => {
+test('C5 selects one composed worker-owned attempt entrance through Capability Service', async () => {
   const capabilityService = await readFile(join(sourceRoot, 'lib/capability-service.ts'), 'utf8');
   const worker = await readFile(join(sourceRoot, 'workers/index.ts'), 'utf8');
   const runtime = await readFile(join(sourceRoot, 'lib/app-run-runtime.ts'), 'utf8');
   const handler = await readFile(join(sourceRoot, 'lib/app-run-worker-handler.ts'), 'utf8');
+  const bridge = await readFile(join(sourceRoot, 'lib/app-run-capability-bridge.ts'), 'utf8');
+  const legacyActions = await readFile(join(sourceRoot, 'lib/agent-actions.ts'), 'utf8');
 
+  assert.match(capabilityService, /governedEnabled\(\)/);
+  assert.match(capabilityService, /await this\.governed\.invoke/);
+  assert.match(capabilityService, /await this\.mcpProvider\.invoke/);
   assert.doesNotMatch(capabilityService, /\b(?:AppRunService|getAppRunRuntime|AppRunAttemptRunner)\b/);
   assert.equal(worker.match(/case 'app-run-attempt'/g)?.length, 1);
   assert.match(handler, /getAppRunRuntime/);
@@ -63,6 +72,11 @@ test('C4 has one composed worker-owned attempt entrance without Capability Servi
   assert.match(runtime, /postgresAppRunAttemptQueue/);
   assert.match(runtime, /new PostgresAppRunReceiptWriter/);
   assert.match(runtime, /new PostgresAppRunAttentionProjector/);
+  assert.match(bridge, /attemptRunner\.runImmediate/);
+  assert.match(bridge, /legacy_action_id/);
+  assert.doesNotMatch(bridge, /\.invoke\(request\)/);
+  assert.match(legacyActions, /APP_RUNS_ENABLED && action\.startsWith\('mcp__'\)/);
+  assert.match(legacyActions, /legacy_action_id:\s*actionId/);
 });
 
 test('only the MCP adapter calls the low-level client and governed execution is pinned by provider id', async () => {

--- a/apps/api/test/app-run-engine-db.test.ts
+++ b/apps/api/test/app-run-engine-db.test.ts
@@ -24,8 +24,16 @@ import {
 import { PostgresAppRunAttentionProjector } from '../src/lib/app-run-attention.js';
 import { AppRunOperationsService } from '../src/lib/app-run-operations.js';
 import { PostgresAppRunReceiptWriter } from '../src/lib/app-run-receipts.js';
-import { approveAction, rejectAction } from '../src/lib/agent-approval-resolver.js';
+import {
+  _setAppRunApprovalResolverForTest,
+  approveAction,
+  rejectAction,
+} from '../src/lib/agent-approval-resolver.js';
 import { createAppRunAttemptJobHandler } from '../src/lib/app-run-worker-handler.js';
+import {
+  postgresAppRunAttemptQueue,
+  type AppRunAttemptQueue,
+} from '../src/lib/app-run-scheduler.js';
 import {
   assertAppRunReferencedKeysAvailable,
   parseEnvironmentAppRunKeyrings,
@@ -270,7 +278,7 @@ function receiptRotationKeyProvider(
   return provider;
 }
 
-test('live authority revocation is sticky and the execution budget is reserved exactly once', async () => {
+test('live authority revocation is sticky and the execution budget is reserved exactly once', async (t) => {
   const providerId = `live-provider-${suffix}`;
   const snapshotId = `live-snapshot-${suffix}`;
   const employeeId = `live-employee-${suffix}`;
@@ -361,6 +369,8 @@ test('live authority revocation is sticky and the execution budget is reserved e
   });
   const liveTrusted = { ...trusted, execution_actor: executionActor };
   const setup = service();
+  _setAppRunApprovalResolverForTest(new PostgresAppRunApprovalResolver(setup.repository, live));
+  t.after(() => _setAppRunApprovalResolverForTest(null));
   const alwaysPolicy = {
     ...policy,
     review_requirement: 'always' as const,
@@ -1459,4 +1469,131 @@ test('the worker adapter accepts exact identity-only jobs and remains dependency
       data: { orgId: ORG_ID, runId: 'run-1', attemptId: 'attempt-1', input: 'secret' }, attempts: 1,
     }),
   );
+});
+
+test('released Runs create their exact attempt job atomically and approval rollback cannot strand authority', async () => {
+  const keys = keyProvider();
+  const secrets = new AppRunSecretService(keys);
+  const repository = new PostgresAppRunRepository();
+  const secretRepository = new AppRunSecretRepository(secrets);
+  const executor = new CountingExecutor();
+  const clock = () => new Date();
+  const runner = new AppRunAttemptRunner(
+    repository,
+    secretRepository,
+    secrets,
+    executor,
+    allowExecution,
+    clock,
+    60_000,
+    20_000,
+    undefined,
+    undefined,
+    postgresAppRunAttemptQueue,
+  );
+  const runs = new AppRunService(
+    repository,
+    secretRepository,
+    secrets,
+    keys,
+    allowAll,
+    clock,
+    postgresAppRunApprovalAdapter,
+    undefined,
+    undefined,
+    runner,
+  );
+  const governed = await runs.submit(trusted, submission({
+    idempotency_key: `atomic-job-${suffix}`,
+  }));
+  const scheduled = await client.query<{
+    attempt_id: string;
+    data: Record<string, unknown>;
+    dedupe_key: string;
+  }>(
+    `SELECT a.id AS attempt_id, q.data, q.dedupe_key
+       FROM app_run_attempts a JOIN job_queue q
+         ON q.org_id = a.org_id
+        AND q.name = 'app-run-attempt'
+        AND q.dedupe_key = 'app-run-attempt:' || a.id
+      WHERE a.org_id = $1 AND a.run_id = $2`,
+    [ORG_ID, governed.id],
+  );
+  assert.equal(scheduled.rowCount, 1);
+  assert.deepEqual(scheduled.rows[0]!.data, {
+    orgId: ORG_ID,
+    runId: governed.id,
+    attemptId: scheduled.rows[0]!.attempt_id,
+  });
+  assert.doesNotMatch(JSON.stringify(scheduled.rows[0]!.data), /raw-marker|recipient|retry-/);
+
+  const throwingQueue: AppRunAttemptQueue = {
+    async enqueue() { throw new Error('injected queue outage'); },
+  };
+  const rollbackRunner = new AppRunAttemptRunner(
+    repository,
+    secretRepository,
+    secrets,
+    executor,
+    allowExecution,
+    clock,
+    60_000,
+    20_000,
+    undefined,
+    undefined,
+    throwingQueue,
+  );
+  const approvalRuns = new AppRunService(
+    repository,
+    secretRepository,
+    secrets,
+    keys,
+    allowAll,
+    clock,
+    postgresAppRunApprovalAdapter,
+    undefined,
+    undefined,
+    rollbackRunner,
+  );
+  const reviewed = await approvalRuns.submit(trusted, submission({
+    idempotency_key: `atomic-approval-${suffix}`,
+    policy: {
+      risk_class: 'external_write',
+      review_requirement: 'always',
+      review_scope: 'per_invocation',
+      retry_class: 'unsafe_or_unknown',
+    },
+  }));
+  const [approval] = (await client.query<{ id: string }>(
+    `SELECT id FROM agent_actions WHERE org_id = $1 AND app_run_id = $2`,
+    [ORG_ID, reviewed.id],
+  )).rows;
+  const approvalResolver = new PostgresAppRunApprovalResolver(
+    repository,
+    { async authorizeApprovalInTransaction() { return true; } },
+    clock,
+    undefined,
+    undefined,
+    rollbackRunner,
+  );
+  await assert.rejects(
+    approvalResolver.approve(approval!.id, USER_ID),
+    /injected queue outage/,
+  );
+  const rolledBack = await client.query<{ run_state: string; action_state: string; attempts: string }>(
+    `SELECT r.state AS run_state, a.approval_status AS action_state,
+            (SELECT count(*) FROM app_run_attempts x
+              WHERE x.org_id = r.org_id AND x.run_id = r.id) AS attempts
+       FROM app_runs r JOIN agent_actions a
+         ON a.org_id = r.org_id AND a.app_run_id = r.id
+      WHERE r.org_id = $1 AND r.id = $2`,
+    [ORG_ID, reviewed.id],
+  );
+  assert.deepEqual(rolledBack.rows[0], {
+    run_state: 'pending_approval',
+    action_state: 'pending',
+    attempts: '0',
+  });
+
+  await client.query(`DELETE FROM job_queue WHERE org_id = $1 AND name = 'app-run-attempt'`, [ORG_ID]);
 });

--- a/apps/api/test/app-run-rollout-config.test.ts
+++ b/apps/api/test/app-run-rollout-config.test.ts
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+import { validateAppRunRolloutConfiguration } from '../src/lib/env.js';
+
+const apiRoot = fileURLToPath(new URL('../', import.meta.url));
+
+test('App Run rollout accepts the three safe engine and legacy MCP intake states', () => {
+  assert.doesNotThrow(() => validateAppRunRolloutConfiguration(false, false));
+  assert.doesNotThrow(() => validateAppRunRolloutConfiguration(true, false));
+  assert.doesNotThrow(() => validateAppRunRolloutConfiguration(true, true));
+});
+
+test('legacy MCP intake values other than exact lowercase true fail closed', () => {
+  const result = spawnSync(
+    process.execPath,
+    [
+      '--import',
+      'tsx',
+      '--eval',
+      "import('./src/lib/env.ts').then((env) => { if (env.APP_RUN_LEGACY_MCP_CUTOVER_ENABLED) process.exit(2); })",
+    ],
+    {
+      cwd: apiRoot,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        DEFT_APP_RUNS_ENABLED: 'false',
+        DEFT_APP_RUN_LEGACY_MCP_CUTOVER_ENABLED: 'TRUE',
+        DEFT_APP_RUN_KEYRINGS: '',
+      },
+    },
+  );
+
+  assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+});
+
+test('API startup rejects legacy MCP intake while the App Run engine is disabled', () => {
+  const result = spawnSync(
+    process.execPath,
+    ['--import', 'tsx', '--eval', "import('./src/lib/env.ts')"],
+    {
+      cwd: apiRoot,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        DEFT_APP_RUNS_ENABLED: 'false',
+        DEFT_APP_RUN_LEGACY_MCP_CUTOVER_ENABLED: 'true',
+        DEFT_APP_RUN_KEYRINGS: '',
+      },
+    },
+  );
+
+  assert.notEqual(result.status, 0);
+  assert.match(
+    `${result.stdout}\n${result.stderr}`,
+    /DEFT_APP_RUN_LEGACY_MCP_CUTOVER_ENABLED=true requires DEFT_APP_RUNS_ENABLED=true/,
+  );
+});

--- a/apps/api/test/app-run-rollout-transition-db.test.ts
+++ b/apps/api/test/app-run-rollout-transition-db.test.ts
@@ -1,0 +1,525 @@
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+import pg from 'pg';
+import {
+  APP_RUN_CONTRACT_VERSIONS,
+  createCapabilityProviderDiscoverySnapshot,
+} from '@deft/shared';
+
+type ChildPhase = 'seed' | 'engine-off-approval' | 'approve' | 'defer' | 'drain';
+
+type TransitionContext = Readonly<{
+  orgId: string;
+  userId: string;
+  employeeId: string;
+  providerId: string;
+  snapshotId: string;
+  snapshotDigest: string;
+  operationName: string;
+  suffix: string;
+  runId?: string;
+  actionId?: string;
+}>;
+
+const RESULT_PREFIX = 'DEFT_APP_RUN_TRANSITION_RESULT=';
+const childPhase = process.env.DEFT_APP_RUN_TRANSITION_CHILD_PHASE as ChildPhase | undefined;
+const databaseUrl = process.env.DEFT_TEST_DATABASE_URL
+  ?? (process.env.CI === 'true' ? process.env.DATABASE_URL : undefined);
+
+if (!databaseUrl) {
+  throw new Error('App Run rollout transition tests require DEFT_TEST_DATABASE_URL');
+}
+if (
+  process.env.CI !== 'true'
+  && !/(?:phase3|test|ci|acceptance)/i.test(new URL(databaseUrl).pathname)
+) {
+  throw new Error('App Run rollout transition tests require an explicitly disposable database');
+}
+
+function fixedKey(byte: number): string {
+  return Buffer.alloc(32, byte).toString('base64');
+}
+
+const keyrings = JSON.stringify({
+  schema_version: APP_RUN_CONTRACT_VERSIONS.keyring,
+  run_encryption: { current: 'enc-v1', keys: { 'enc-v1': fixedKey(1) } },
+  receipt_signing: { current: 'sig-v1', keys: { 'sig-v1': fixedKey(2) } },
+  fingerprint: { current: 'fp-v1', keys: { 'fp-v1': fixedKey(3) } },
+});
+
+function transitionContext(): TransitionContext {
+  const raw = process.env.DEFT_APP_RUN_TRANSITION_CONTEXT;
+  if (!raw) throw new Error('Missing App Run rollout transition context');
+  return JSON.parse(raw) as TransitionContext;
+}
+
+async function readState(
+  client: pg.Client,
+  context: TransitionContext,
+): Promise<Record<string, unknown>> {
+  const result = await client.query<{
+    run_state: string;
+    release_kind: string | null;
+    budget_reserved_count: number | null;
+    action_state: string;
+    employee_budget: number;
+    attempts: string;
+    jobs: string;
+    native_receipts: string;
+    legacy_receipts: string;
+  }>(
+    `SELECT r.state AS run_state,
+            r.execution_release_kind AS release_kind,
+            r.budget_reserved_count,
+            a.approval_status AS action_state,
+            e.daily_action_count AS employee_budget,
+            (SELECT count(*) FROM app_run_attempts x
+              WHERE x.org_id = r.org_id AND x.run_id = r.id) AS attempts,
+            (SELECT count(*) FROM job_queue q
+              WHERE q.org_id = r.org_id AND q.name = 'app-run-attempt'
+                AND q.data->>'runId' = r.id) AS jobs,
+            (SELECT count(*) FROM app_run_receipts n
+              WHERE n.org_id = r.org_id AND n.run_id = r.id) AS native_receipts,
+            (SELECT count(*) FROM action_receipts l
+              WHERE l.org_id = r.org_id AND l.action_id = a.id) AS legacy_receipts
+       FROM app_runs r
+       JOIN agent_actions a ON a.org_id = r.org_id AND a.app_run_id = r.id
+       JOIN agent_employees e ON e.org_id = r.org_id AND e.id = $3
+      WHERE r.org_id = $1 AND r.id = $2 AND a.id = $4`,
+    [context.orgId, context.runId, context.employeeId, context.actionId],
+  );
+  assert.equal(result.rowCount, 1);
+  return result.rows[0]!;
+}
+
+async function claimExactAppRunJob(
+  client: pg.Client,
+  context: TransitionContext,
+): Promise<{
+  id: string;
+  name: string;
+  data: Record<string, unknown>;
+  attempts: number;
+  cronKey: null;
+  lockedBy: string;
+  lockToken: string;
+  lockExpiresAt: Date;
+}> {
+  const lockToken = randomUUID();
+  const lockedBy = `transition:${process.pid}`;
+  const result = await client.query<{
+    id: string;
+    name: string;
+    data: Record<string, unknown>;
+    attempts: number;
+    lock_expires_at: Date;
+  }>(
+    `UPDATE job_queue
+        SET status = 'running', attempts = attempts + 1,
+            started_at = now(), completed_at = NULL, error = NULL,
+            locked_by = $3, lock_token = $4,
+            lock_expires_at = now() + interval '5 minutes'
+      WHERE id = (
+        SELECT id FROM job_queue
+         WHERE org_id = $1 AND name = 'app-run-attempt'
+           AND data->>'runId' = $2 AND status = 'pending'
+         ORDER BY created_at ASC LIMIT 1 FOR UPDATE SKIP LOCKED
+      )
+      RETURNING id, name, data, attempts, lock_expires_at`,
+    [context.orgId, context.runId, lockedBy, lockToken],
+  );
+  assert.equal(result.rowCount, 1);
+  const row = result.rows[0]!;
+  return {
+    id: row.id,
+    name: row.name,
+    data: row.data,
+    attempts: row.attempts,
+    cronKey: null,
+    lockedBy,
+    lockToken,
+    lockExpiresAt: row.lock_expires_at,
+  };
+}
+
+async function runChildPhase(phase: ChildPhase): Promise<void> {
+  const context = transitionContext();
+  const client = new pg.Client({ connectionString: databaseUrl });
+  await client.connect();
+  let runtimeLoaded = false;
+  try {
+    if (phase === 'seed') {
+      const { getAppRunRuntime } = await import('../src/lib/app-run-runtime.js');
+      const runtime = await getAppRunRuntime();
+      runtimeLoaded = true;
+      const initiatingActor = { actor_type: 'human' as const, user_id: context.userId };
+      const executionActor = {
+        actor_type: 'agent_employee' as const,
+        agent_employee_id: context.employeeId,
+      };
+      const policy = {
+        risk_class: 'external_write' as const,
+        review_requirement: 'always' as const,
+        review_scope: 'per_invocation' as const,
+        retry_class: 'unsafe_or_unknown' as const,
+      };
+      const authorizationSnapshot = await runtime.liveAuthorization.capture({
+        org_id: context.orgId,
+        authenticated_subject: initiatingActor,
+        execution_actor: executionActor,
+        provider_instance_id: context.providerId,
+        provider_snapshot_id: context.snapshotId,
+        operation_name: context.operationName,
+        policy,
+      });
+      const run = await runtime.service.submit({
+        org_id: context.orgId,
+        initiating_actor: initiatingActor,
+        execution_actor: executionActor,
+      }, {
+        schema_version: APP_RUN_CONTRACT_VERSIONS.run,
+        org_id: context.orgId,
+        initiating_actor: initiatingActor,
+        execution_actor: executionActor,
+        origin: { origin_kind: 'legacy_connector', connection_id: context.providerId },
+        operation: {
+          provider: {
+            org_id: context.orgId,
+            provider_kind: 'mcp',
+            provider_instance_id: context.providerId,
+          },
+          operation_name: context.operationName,
+        },
+        provider_snapshot_digest: context.snapshotDigest,
+        policy,
+        retention_class: 'standard',
+        idempotency_key: `rollout-transition:${context.suffix}`,
+        input: { transition_marker: context.suffix },
+        authorization_snapshot: authorizationSnapshot,
+        safe_preview: {
+          schema_version: APP_RUN_CONTRACT_VERSIONS.run,
+          title: 'Certify rollout drain transition',
+          resource_refs: [],
+        },
+      });
+      const action = await client.query<{ id: string }>(
+        `SELECT id FROM agent_actions
+          WHERE org_id = $1 AND app_run_id = $2 AND action = 'app_run_invoke'`,
+        [context.orgId, run.id],
+      );
+      assert.equal(action.rowCount, 1);
+      console.log(`${RESULT_PREFIX}${JSON.stringify({
+        runId: run.id,
+        actionId: action.rows[0]!.id,
+        runState: run.state,
+      })}`);
+      return;
+    }
+
+    if (!context.runId || !context.actionId) {
+      throw new Error('Run and action identities are required after the seed phase');
+    }
+
+    if (phase === 'engine-off-approval') {
+      const { approveAction } = await import('../src/lib/agent-approval-resolver.js');
+      let errorCode: string | null = null;
+      try {
+        await approveAction(context.actionId, context.userId);
+      } catch (error) {
+        errorCode = typeof error === 'object' && error !== null && 'code' in error
+          ? String((error as { code: unknown }).code)
+          : null;
+      }
+      console.log(`${RESULT_PREFIX}${JSON.stringify({
+        errorCode,
+        state: await readState(client, context),
+      })}`);
+      return;
+    }
+
+    if (phase === 'approve') {
+      const { approveAction } = await import('../src/lib/agent-approval-resolver.js');
+      runtimeLoaded = true;
+      const result = await approveAction(context.actionId, context.userId);
+      console.log(`${RESULT_PREFIX}${JSON.stringify({
+        approvalStatus: result.status,
+        state: await readState(client, context),
+      })}`);
+      return;
+    }
+
+    const { QUEUE_NAMES } = await import('../src/lib/queues.js');
+    const { _processDequeuedJobForTest } = await import('../src/workers/index.js');
+    const claimed = await claimExactAppRunJob(client, context);
+
+    if (phase === 'defer') {
+      await _processDequeuedJobForTest(QUEUE_NAMES.AGENT_JOBS, claimed);
+      const queue = await client.query<{ status: string; attempts: number; error: string | null }>(
+        'SELECT status, attempts, error FROM job_queue WHERE id = $1',
+        [claimed.id],
+      );
+      console.log(`${RESULT_PREFIX}${JSON.stringify({
+        queue: queue.rows[0],
+        state: await readState(client, context),
+      })}`);
+      return;
+    }
+
+    const { mcpClientManager } = await import('@deft/mcp');
+    const originalExecuteTool = mcpClientManager.executeTool;
+    let providerCalls = 0;
+    mcpClientManager.executeTool = async () => {
+      providerCalls += 1;
+      const rawResult = {
+        content: [{ type: 'text', text: 'rollout transition complete' }],
+        structuredContent: { transition_marker: context.suffix },
+      };
+      return {
+        success: true,
+        content: rawResult.content,
+        structuredContent: rawResult.structuredContent,
+        rawResult,
+        durationMs: 1,
+      };
+    };
+    try {
+      runtimeLoaded = true;
+      await _processDequeuedJobForTest(QUEUE_NAMES.AGENT_JOBS, claimed);
+      const { _getAgentJobHandlerForTest } = await import('../src/workers/index.js');
+      const registered = await _getAgentJobHandlerForTest('app-run-attempt');
+      assert.ok(registered);
+      await registered({
+        id: claimed.id,
+        name: claimed.name,
+        data: claimed.data,
+        attempts: claimed.attempts + 1,
+      });
+    } finally {
+      mcpClientManager.executeTool = originalExecuteTool;
+    }
+    const queue = await client.query<{ status: string; attempts: number }>(
+      'SELECT status, attempts FROM job_queue WHERE id = $1',
+      [claimed.id],
+    );
+    console.log(`${RESULT_PREFIX}${JSON.stringify({
+      providerCalls,
+      queue: queue.rows[0],
+      state: await readState(client, context),
+    })}`);
+  } finally {
+    await client.end();
+    if (runtimeLoaded) {
+      const { shutdownAppRunRuntime } = await import('../src/lib/app-run-runtime.js');
+      await shutdownAppRunRuntime();
+    }
+    const { closeDb } = await import('../src/lib/db.js');
+    await closeDb();
+  }
+}
+
+function spawnPhase(
+  phase: ChildPhase,
+  context: TransitionContext,
+  engineEnabled: boolean,
+  intakeEnabled: boolean,
+): Record<string, any> {
+  const scriptPath = fileURLToPath(import.meta.url);
+  const apiRoot = fileURLToPath(new URL('../', import.meta.url));
+  const result = spawnSync(process.execPath, ['--import', 'tsx', scriptPath], {
+    cwd: apiRoot,
+    encoding: 'utf8',
+    maxBuffer: 8 * 1024 * 1024,
+    env: {
+      ...process.env,
+      DATABASE_URL: databaseUrl,
+      DEFT_TEST_DATABASE_URL: databaseUrl,
+      DEFT_APP_RUNS_ENABLED: engineEnabled ? 'true' : 'false',
+      DEFT_APP_RUN_LEGACY_MCP_CUTOVER_ENABLED: intakeEnabled ? 'true' : 'false',
+      DEFT_APP_RUN_KEYRINGS: engineEnabled ? keyrings : '',
+      DEFT_APP_RUN_TRANSITION_CHILD_PHASE: phase,
+      DEFT_APP_RUN_TRANSITION_CONTEXT: JSON.stringify(context),
+    },
+  });
+  assert.equal(
+    result.status,
+    0,
+    `Phase ${phase} failed.\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`,
+  );
+  const line = result.stdout
+    .split(/\r?\n/)
+    .find((candidate) => candidate.startsWith(RESULT_PREFIX));
+  assert.ok(line, `Phase ${phase} returned no result marker.\n${result.stdout}`);
+  return JSON.parse(line.slice(RESULT_PREFIX.length)) as Record<string, any>;
+}
+
+async function cleanupFixture(client: pg.Client, context: TransitionContext): Promise<void> {
+  await client.query('BEGIN');
+  try {
+    await client.query("SELECT set_config('deft.app_run_maintenance', 'on', true)");
+    await client.query('DELETE FROM action_receipts WHERE org_id = $1', [context.orgId]);
+    await client.query('DELETE FROM agent_actions WHERE org_id = $1', [context.orgId]);
+    await client.query('DELETE FROM job_queue WHERE org_id = $1', [context.orgId]);
+    await client.query('DELETE FROM notifications WHERE org_id = $1', [context.orgId]);
+    await client.query('DELETE FROM attention_items WHERE org_id = $1', [context.orgId]);
+    await client.query('DELETE FROM app_runs WHERE org_id = $1', [context.orgId]);
+    await client.query('DELETE FROM capability_provider_snapshots WHERE org_id = $1', [context.orgId]);
+    await client.query('DELETE FROM agent_employees WHERE org_id = $1', [context.orgId]);
+    await client.query('DELETE FROM mcp_connections WHERE org_id = $1', [context.orgId]);
+    await client.query('DELETE FROM org_members WHERE org_id = $1', [context.orgId]);
+    await client.query('DELETE FROM orgs WHERE id = $1', [context.orgId]);
+    await client.query('DELETE FROM users WHERE id = $1', [context.userId]);
+    await client.query('COMMIT');
+  } catch (error) {
+    await client.query('ROLLBACK');
+    throw error;
+  }
+}
+
+if (childPhase) {
+  await runChildPhase(childPhase);
+} else {
+  test('accepted approval survives intake shutoff, engine pause, and drain-only restart exactly once', async () => {
+    const suffix = randomUUID().replaceAll('-', '').slice(0, 12);
+    const context: TransitionContext = {
+      orgId: `app-run-transition-org-${suffix}`,
+      userId: `app-run-transition-user-${suffix}`,
+      employeeId: `app-run-transition-employee-${suffix}`,
+      providerId: `app-run-transition-provider-${suffix}`,
+      snapshotId: `app-run-transition-snapshot-${suffix}`,
+      snapshotDigest: '',
+      operationName: 'send_transition_marker',
+      suffix,
+    };
+    const client = new pg.Client({ connectionString: databaseUrl });
+    await client.connect();
+    try {
+      await client.query(
+        'INSERT INTO orgs (id, name, slug) VALUES ($1, $2, $3)',
+        [context.orgId, 'App Run Transition Test', context.orgId],
+      );
+      await client.query(
+        `INSERT INTO users (id, email, name, kind, is_agent, email_verified)
+         VALUES ($1, $2, 'App Run Transition User', 'human', false, true)`,
+        [context.userId, `${context.userId}@test.local`],
+      );
+      await client.query(
+        `INSERT INTO org_members (id, org_id, user_id, role, is_active)
+         VALUES ($1, $2, $3, 'owner', true)`,
+        [`app-run-transition-member-${suffix}`, context.orgId, context.userId],
+      );
+      await client.query(
+        `INSERT INTO mcp_connections
+          (id, org_id, name, slug, server_url, transport, auth_type, is_active,
+           default_trust_tier, enabled_tools, created_by)
+         VALUES ($1, $2, 'Transition provider', $1,
+           'https://api.example.test/mcp', 'streamable-http', 'none', true,
+           'full', $3, $4)`,
+        [context.providerId, context.orgId, [context.operationName], context.userId],
+      );
+      await client.query(
+        `INSERT INTO agent_employees
+          (id, org_id, user_id, name, slug, role, system_prompt,
+           mcp_connection_ids, trust_level, max_daily_actions,
+           daily_action_count, unhealthy, is_active, is_deleted, created_by)
+         VALUES ($1, $2, $3, 'Transition employee', $1, 'custom', 'Test', $4,
+           'autonomous', 5, 0, false, true, false, $3)`,
+        [context.employeeId, context.orgId, context.userId, [context.providerId]],
+      );
+      const snapshot = await createCapabilityProviderDiscoverySnapshot({
+        adapter_contract_version: 'deft.capability.mcp-adapter.v1',
+        provider: {
+          org_id: context.orgId,
+          provider_kind: 'mcp',
+          provider_instance_id: context.providerId,
+        },
+        captured_at: new Date().toISOString(),
+        operations: [{
+          identity: {
+            provider: {
+              org_id: context.orgId,
+              provider_kind: 'mcp',
+              provider_instance_id: context.providerId,
+            },
+            operation_name: context.operationName,
+          },
+          description: 'Persist one deterministic rollout marker',
+          input_schema: { type: 'object' },
+        }],
+      });
+      const fixture = { ...context, snapshotDigest: snapshot.snapshot_digest };
+      await client.query(
+        `INSERT INTO capability_provider_snapshots
+          (id, org_id, provider_kind, provider_instance_id,
+           adapter_contract_version, snapshot_digest, safe_snapshot, captured_at)
+         VALUES ($1, $2, 'mcp', $3, $4, $5, $6::jsonb, $7)`,
+        [fixture.snapshotId, fixture.orgId, fixture.providerId,
+          snapshot.adapter_contract_version, snapshot.snapshot_digest,
+          JSON.stringify(snapshot), snapshot.captured_at],
+      );
+
+      const seeded = spawnPhase('seed', fixture, true, true);
+      const active = {
+        ...fixture,
+        runId: String(seeded.runId),
+        actionId: String(seeded.actionId),
+      };
+      assert.equal(seeded.runState, 'pending_approval');
+
+      const blocked = spawnPhase('engine-off-approval', active, false, false);
+      assert.equal(blocked.errorCode, 'APP_RUNS_DISABLED');
+      assert.deepEqual(blocked.state, {
+        run_state: 'pending_approval',
+        release_kind: null,
+        budget_reserved_count: null,
+        action_state: 'pending',
+        employee_budget: 0,
+        attempts: '0',
+        jobs: '0',
+        native_receipts: '0',
+        legacy_receipts: '0',
+      });
+
+      const approved = spawnPhase('approve', active, true, false);
+      assert.equal(approved.approvalStatus, 'approved');
+      assert.deepEqual(approved.state, {
+        run_state: 'pending_approval',
+        release_kind: 'approved',
+        budget_reserved_count: 1,
+        action_state: 'approved',
+        employee_budget: 1,
+        attempts: '1',
+        jobs: '1',
+        native_receipts: '1',
+        legacy_receipts: '0',
+      });
+
+      const deferred = spawnPhase('defer', active, false, false);
+      assert.equal(deferred.queue.status, 'pending');
+      assert.equal(deferred.queue.attempts, 0);
+      assert.match(deferred.queue.error, /App Runs are disabled/);
+      assert.equal(deferred.state.employee_budget, 1);
+      assert.equal(deferred.state.run_state, 'pending_approval');
+
+      const drained = spawnPhase('drain', active, true, false);
+      assert.equal(drained.providerCalls, 1);
+      assert.deepEqual(drained.queue, { status: 'completed', attempts: 1 });
+      assert.deepEqual(drained.state, {
+        run_state: 'succeeded',
+        release_kind: 'approved',
+        budget_reserved_count: 1,
+        action_state: 'approved',
+        employee_budget: 1,
+        attempts: '1',
+        jobs: '1',
+        native_receipts: '2',
+        legacy_receipts: '0',
+      });
+    } finally {
+      await cleanupFixture(client, context);
+      await client.end();
+    }
+  });
+}

--- a/apps/api/test/capability-immediate-execution-db.test.ts
+++ b/apps/api/test/capability-immediate-execution-db.test.ts
@@ -17,11 +17,11 @@ import { closeDb } from '../src/lib/db.js';
 import { executeToolCall } from '../src/lib/agent-context.js';
 import { executeAction, executeActionDirect } from '../src/lib/agent-actions.js';
 import { approveAction } from '../src/lib/agent-approval-resolver.js';
-import { APP_RUNS_ENABLED } from '../src/lib/env.js';
+import { APP_RUN_LEGACY_MCP_CUTOVER_ENABLED } from '../src/lib/env.js';
 import { shutdownAppRunRuntime } from '../src/lib/app-run-runtime.js';
 
-const legacyTest = APP_RUNS_ENABLED ? test.skip : test;
-const governedTest = APP_RUNS_ENABLED ? test : test.skip;
+const legacyTest = APP_RUN_LEGACY_MCP_CUTOVER_ENABLED ? test.skip : test;
+const governedTest = APP_RUN_LEGACY_MCP_CUTOVER_ENABLED ? test : test.skip;
 
 const DATABASE_URL = process.env.DEFT_TEST_DATABASE_URL
   ?? (process.env.CI === 'true' ? process.env.DATABASE_URL : undefined);
@@ -30,9 +30,9 @@ if (!DATABASE_URL) {
 }
 if (
   process.env.CI !== 'true'
-  && !/(?:test|ci|acceptance|phase2)/i.test(new URL(DATABASE_URL).pathname)
+  && !/(?:test|ci|acceptance|phase[23])/i.test(new URL(DATABASE_URL).pathname)
 ) {
-  throw new Error('Capability execution DB tests refuse a database without a test/CI/phase2 name');
+  throw new Error('Capability execution DB tests refuse a database without a test/CI/phase name');
 }
 const suffix = randomUUID().replaceAll('-', '').slice(0, 12);
 const ORG_ID = `capability-immediate-org-${suffix}`;

--- a/apps/api/test/capability-immediate-execution-db.test.ts
+++ b/apps/api/test/capability-immediate-execution-db.test.ts
@@ -17,6 +17,11 @@ import { closeDb } from '../src/lib/db.js';
 import { executeToolCall } from '../src/lib/agent-context.js';
 import { executeAction, executeActionDirect } from '../src/lib/agent-actions.js';
 import { approveAction } from '../src/lib/agent-approval-resolver.js';
+import { APP_RUNS_ENABLED } from '../src/lib/env.js';
+import { shutdownAppRunRuntime } from '../src/lib/app-run-runtime.js';
+
+const legacyTest = APP_RUNS_ENABLED ? test.skip : test;
+const governedTest = APP_RUNS_ENABLED ? test : test.skip;
 
 const DATABASE_URL = process.env.DEFT_TEST_DATABASE_URL
   ?? (process.env.CI === 'true' ? process.env.DATABASE_URL : undefined);
@@ -65,8 +70,10 @@ before(async () => {
   );
   await client.query(
     `INSERT INTO org_members (id, org_id, user_id, role, is_active)
-     VALUES ($1, $2, $3, 'owner', true)`,
-    [randomUUID(), ORG_ID, APPROVER_USER_ID],
+     VALUES
+       ($1, $2, $3, 'owner', true),
+       ($4, $2, $5, 'member', true)`,
+    [randomUUID(), ORG_ID, APPROVER_USER_ID, randomUUID(), USER_ID],
   );
   await client.query(
     `INSERT INTO mcp_connections
@@ -92,6 +99,11 @@ beforeEach(async () => {
   await client.query('DELETE FROM agent_action_approvers WHERE org_id = $1', [ORG_ID]);
   await client.query('DELETE FROM agent_actions WHERE org_id = $1', [ORG_ID]);
   await client.query('DELETE FROM mcp_tool_overrides WHERE mcp_connection_id = $1', [CONNECTION_ID]);
+  await client.query('DELETE FROM job_queue WHERE org_id = $1', [ORG_ID]);
+  await client.query(
+    'UPDATE org_members SET is_active = true WHERE org_id = $1 AND user_id = $2',
+    [ORG_ID, USER_ID],
+  );
   await client.query(
     `UPDATE mcp_connections
      SET is_active = true, enabled_tools = $2::text[], server_url = $3,
@@ -116,6 +128,7 @@ after(async () => {
   await client.query('DELETE FROM action_receipts WHERE org_id = $1', [ORG_ID]);
   await client.query('DELETE FROM agent_action_approvers WHERE org_id = $1', [ORG_ID]);
   await client.query('DELETE FROM agent_actions WHERE org_id = $1', [ORG_ID]);
+  await client.query('DELETE FROM job_queue WHERE org_id = $1', [ORG_ID]);
   await client.query('DELETE FROM mcp_tool_overrides WHERE mcp_connection_id = $1', [CONNECTION_ID]);
   await client.query('DELETE FROM agent_employees WHERE id = $1', [EMPLOYEE_ID]);
   await client.query('DELETE FROM mcp_connections WHERE id = $1', [CONNECTION_ID]);
@@ -123,6 +136,7 @@ after(async () => {
   await client.query('DELETE FROM users WHERE id = ANY($1::text[])', [[USER_ID, APPROVER_USER_ID]]);
   await client.query('DELETE FROM orgs WHERE id = $1', [ORG_ID]);
   await client.end();
+  await shutdownAppRunRuntime();
   await closeDb();
 });
 
@@ -195,7 +209,13 @@ async function budgetCount(): Promise<number> {
   return result.rows[0]!.daily_action_count;
 }
 
-function stubDiscovery(t: TestContext) {
+function stubDiscovery(
+  t: TestContext,
+  options: Readonly<{
+    isWrite?: boolean;
+    approvalTier?: 'auto-execute' | 'quick-approve' | 'full-review';
+  }> = {},
+) {
   const original = mcpClientManager.getCachedToolDiscovery;
   const calls: MCPConnectionConfig[] = [];
   const discovered: MCPToolDiscovery = {
@@ -206,8 +226,8 @@ function stubDiscovery(t: TestContext) {
       inputSchema: { type: 'object', properties: {} },
       connectionId: CONNECTION_ID,
       connectionSlug: CONNECTION_SLUG,
-      isWrite: true,
-      approvalTier: 'auto-execute',
+      isWrite: options.isWrite ?? true,
+      approvalTier: options.approvalTier ?? 'auto-execute',
       annotations: { destructiveHint: false },
       rawTool: {
         name: OPERATION_NAME,
@@ -282,7 +302,7 @@ async function receiptRows(actionId: string) {
   return result.rows;
 }
 
-test('immediate MCP success preserves exact structured output, citation, config, and one call', async (t) => {
+legacyTest('immediate MCP success preserves exact structured output, citation, config, and one call', async (t) => {
   const rawResult = {
     content: [{ type: 'text', text: 'sent' }],
     structuredContent: { report_id: 'report-1' },
@@ -334,7 +354,7 @@ test('immediate MCP success preserves exact structured output, citation, config,
   assert.equal(budget.rows[0]?.daily_action_count, 0);
 });
 
-test('immediate MCP compatibility output survives an unavailable strict projection', async (t) => {
+legacyTest('immediate MCP compatibility output survives an unavailable strict projection', async (t) => {
   const rawResult = {
     content: [{ type: 'text', text: 'provider completed the effect' }],
     structuredContent: { unsupported_counter: 1n },
@@ -357,7 +377,7 @@ test('immediate MCP compatibility output survives an unavailable strict projecti
   assert.equal(calls.length, 1);
 });
 
-test('immediate MCP tool and transport failures retain exact payloads and resolved citations', async (t) => {
+legacyTest('immediate MCP tool and transport failures retain exact payloads and resolved citations', async (t) => {
   const rawError = {
     content: [{ type: 'text', text: 'invalid report' }],
     structuredContent: { code: 'INVALID_REPORT' },
@@ -406,7 +426,7 @@ test('immediate MCP tool and transport failures retain exact payloads and resolv
   assert.equal(toolCalls.length, 2);
 });
 
-test('immediate MCP authorization denials preserve messages, ordering, and zero calls', async (t) => {
+legacyTest('immediate MCP authorization denials preserve messages, ordering, and zero calls', async (t) => {
   const calls = stubExecution(t, {
     success: true,
     content: [],
@@ -453,7 +473,7 @@ test('immediate MCP authorization denials preserve messages, ordering, and zero 
   assert.equal(calls.length, 0);
 });
 
-test('immediate MCP live connection, allowlist, override, and tenant denials make zero calls', async (t) => {
+legacyTest('immediate MCP live connection, allowlist, override, and tenant denials make zero calls', async (t) => {
   const calls = stubExecution(t, {
     success: true,
     content: [],
@@ -504,7 +524,7 @@ test('immediate MCP live connection, allowlist, override, and tenant denials mak
   assert.equal(calls.length, 0);
 });
 
-test('malformed names and invalid targets still throw before provider execution', async (t) => {
+legacyTest('malformed names and invalid targets still throw before provider execution', async (t) => {
   const calls = stubExecution(t, {
     success: true,
     content: [],
@@ -530,7 +550,7 @@ test('malformed names and invalid targets still throw before provider execution'
   assert.equal(calls.length, 0);
 });
 
-test('governed MCP actions preserve exact success and provider-failure persistence', async (t) => {
+legacyTest('governed MCP actions preserve exact success and provider-failure persistence', async (t) => {
   const successPayload = {
     content: [{ type: 'text', text: 'sent' }],
     structuredContent: { report_id: 'report-action' },
@@ -623,7 +643,7 @@ test('governed MCP actions preserve exact success and provider-failure persisten
   assert.equal(await budgetCount(), 2);
 });
 
-test('governed MCP action denials preserve policy and budget ordering with zero calls', async (t) => {
+legacyTest('governed MCP action denials preserve policy and budget ordering with zero calls', async (t) => {
   const calls = stubExecution(t, {
     success: true,
     content: [],
@@ -715,7 +735,7 @@ test('governed MCP action denials preserve policy and budget ordering with zero 
   assert.equal(calls.length, 0);
 });
 
-test('direct MCP actions preserve auto execution and stricter quick/full re-gating', async (t) => {
+legacyTest('direct MCP actions preserve auto execution and stricter quick/full re-gating', async (t) => {
   const discoveryCalls = stubDiscovery(t);
   const rawResult = {
     content: [{ type: 'text', text: 'sent' }],
@@ -799,7 +819,7 @@ test('direct MCP actions preserve auto execution and stricter quick/full re-gati
   assert.equal(discoveryCalls.length, 3);
 });
 
-test('reviewed MCP actions preserve quick/full resolution, receipts, revocation, and replay', async (t) => {
+legacyTest('reviewed MCP actions preserve quick/full resolution, receipts, revocation, and replay', async (t) => {
   const discoveryCalls = stubDiscovery(t);
   const successPayload = { content: [{ type: 'text', text: 'reviewed send' }] };
   const calls = stubExecution(t, {
@@ -910,4 +930,298 @@ test('reviewed MCP actions preserve quick/full resolution, receipts, revocation,
   assert.equal((await receiptRows(revokedActionId)).length, 1);
 
   assert.equal(discoveryCalls.length, 3);
+});
+
+async function appRunLedger(actionId?: string) {
+  const where = actionId
+    ? `AND r.safe_preview #>> '{fields,legacy_action_id}' = $2`
+    : `AND NOT (r.safe_preview->'fields' ? 'legacy_action_id')`;
+  const values = actionId ? [ORG_ID, actionId] : [ORG_ID];
+  const result = await client.query<{
+    runs: string;
+    attempts: string;
+    native_receipts: string;
+    jobs: string;
+    state: string | null;
+    safe_rows: string;
+  }>(
+    `SELECT count(DISTINCT r.id)::text AS runs,
+            count(DISTINCT a.id)::text AS attempts,
+            count(DISTINCT rr.id)::text AS native_receipts,
+            count(DISTINCT q.id)::text AS jobs,
+            max(r.state)::text AS state,
+            concat_ws(' ',
+              string_agg(DISTINCT r.safe_preview::text, ' '),
+              string_agg(DISTINCT e.payload::text, ' '),
+              string_agg(DISTINCT rr.envelope::text, ' '),
+              string_agg(DISTINCT q.data::text, ' ')
+            ) AS safe_rows
+       FROM app_runs r
+       LEFT JOIN app_run_attempts a ON a.org_id = r.org_id AND a.run_id = r.id
+       LEFT JOIN app_run_events e ON e.org_id = r.org_id AND e.run_id = r.id
+       LEFT JOIN app_run_receipts rr ON rr.org_id = r.org_id AND rr.run_id = r.id
+       LEFT JOIN job_queue q ON q.org_id = r.org_id
+         AND q.dedupe_key = 'app-run-attempt:' || a.id
+      WHERE r.org_id = $1 ${where}`,
+    values,
+  );
+  return result.rows[0]!;
+}
+
+governedTest('flag-on immediate safe MCP calls preserve exact output with one governed attempt and no budget debit', async (t) => {
+  stubDiscovery(t, { isWrite: false, approvalTier: 'auto-execute' });
+  await client.query(
+    `UPDATE mcp_connections SET default_trust_tier = 'auto' WHERE id = $1`,
+    [CONNECTION_ID],
+  );
+  const rawResult = {
+    content: [{ type: 'text', text: 'read result' }],
+    structuredContent: { report_id: 'read-report-1' },
+    _meta: { trace_id: 'governed-read' },
+  };
+  const calls = stubExecution(t, {
+    success: true,
+    content: rawResult.content,
+    structuredContent: rawResult.structuredContent,
+    meta: rawResult._meta,
+    rawResult,
+    durationMs: 13,
+  });
+  const params = { recipient: `safe-read-${suffix}@example.test` };
+
+  const actual = await executeToolCall(
+    PREFIXED_NAME,
+    params,
+    ORG_ID,
+    USER_ID,
+    undefined,
+    EMPLOYEE_ID,
+  );
+  assert.equal(actual.result, rawResult);
+  assert.equal(calls.length, 1);
+  assert.equal(await budgetCount(), 0);
+  const ledger = await appRunLedger();
+  assert.deepEqual(
+    { runs: ledger.runs, attempts: ledger.attempts, receipts: ledger.native_receipts, jobs: ledger.jobs, state: ledger.state },
+    { runs: '1', attempts: '1', receipts: '1', jobs: '1', state: 'succeeded' },
+  );
+  assert.doesNotMatch(ledger.safe_rows, new RegExp(`safe-read-${suffix}|recipient`, 'i'));
+});
+
+governedTest('flag-on post-effect output outside the retained contract is returned once without unsafe persistence or recall', async (t) => {
+  stubDiscovery(t, { isWrite: false, approvalTier: 'auto-execute' });
+  await client.query(
+    `UPDATE mcp_connections SET default_trust_tier = 'auto' WHERE id = $1`,
+    [CONNECTION_ID],
+  );
+  const rawResult = {
+    content: [{ type: 'text', text: 'provider completed' }],
+    structuredContent: { unsupported_counter: 1n },
+  };
+  const calls = stubExecution(t, {
+    success: true,
+    content: rawResult.content,
+    structuredContent: rawResult.structuredContent,
+    rawResult,
+    durationMs: 4,
+  });
+  const before = Number((await client.query<{ count: string }>(
+    `SELECT count(*) FROM app_runs WHERE org_id = $1`,
+    [ORG_ID],
+  )).rows[0]!.count);
+
+  const actual = await executeToolCall(PREFIXED_NAME, {}, ORG_ID, USER_ID, undefined, EMPLOYEE_ID);
+  assert.equal(actual.result, rawResult);
+  assert.equal(calls.length, 1);
+  const latest = await client.query<{ state: string; outputs: string }>(
+    `SELECT r.state,
+            (SELECT count(*) FROM app_run_secret_payloads p
+              WHERE p.org_id = r.org_id AND p.run_id = r.id AND p.payload_kind = 'output') AS outputs
+       FROM app_runs r WHERE r.org_id = $1
+      ORDER BY r.created_at DESC, r.id DESC LIMIT 1`,
+    [ORG_ID],
+  );
+  assert.deepEqual(latest.rows[0], { state: 'succeeded', outputs: '0' });
+  assert.equal(Number((await client.query<{ count: string }>(
+    `SELECT count(*) FROM app_runs WHERE org_id = $1`,
+    [ORG_ID],
+  )).rows[0]!.count), before + 1);
+});
+
+governedTest('flag-on result delivery rechecks live membership after the provider effect', async (t) => {
+  stubDiscovery(t, { isWrite: false, approvalTier: 'auto-execute' });
+  await client.query(
+    `UPDATE mcp_connections SET default_trust_tier = 'auto' WHERE id = $1`,
+    [CONNECTION_ID],
+  );
+  const original = mcpClientManager.executeTool;
+  let release!: () => void;
+  let entered!: () => void;
+  const providerEntered = new Promise<void>((resolve) => { entered = resolve; });
+  const providerRelease = new Promise<void>((resolve) => { release = resolve; });
+  let calls = 0;
+  mcpClientManager.executeTool = async () => {
+    calls += 1;
+    entered();
+    await providerRelease;
+    return {
+      success: true,
+      content: [{ type: 'text', text: 'membership-sensitive-result' }],
+      rawResult: { content: [{ type: 'text', text: 'membership-sensitive-result' }] },
+      durationMs: 6,
+    };
+  };
+  t.after(() => { mcpClientManager.executeTool = original; });
+  const before = Number((await client.query<{ count: string }>(
+    `SELECT count(*) FROM app_runs WHERE org_id = $1`,
+    [ORG_ID],
+  )).rows[0]!.count);
+
+  const pending = executeToolCall(PREFIXED_NAME, {}, ORG_ID, USER_ID, undefined, EMPLOYEE_ID);
+  await providerEntered;
+  await client.query(
+    'UPDATE org_members SET is_active = false WHERE org_id = $1 AND user_id = $2',
+    [ORG_ID, USER_ID],
+  );
+  release();
+
+  await assert.rejects(pending, /Access to the App Run is denied/);
+  assert.equal(calls, 1);
+  const latest = await client.query<{
+    state: string;
+    attempts: string;
+    receipts: string;
+    safe_rows: string;
+  }>(
+    `SELECT r.state,
+            (SELECT count(*) FROM app_run_attempts a
+              WHERE a.org_id = r.org_id AND a.run_id = r.id)::text AS attempts,
+            (SELECT count(*) FROM app_run_receipts rr
+              WHERE rr.org_id = r.org_id AND rr.run_id = r.id)::text AS receipts,
+            concat_ws(' ', r.safe_preview::text,
+              (SELECT string_agg(e.payload::text, ' ') FROM app_run_events e
+                WHERE e.org_id = r.org_id AND e.run_id = r.id)) AS safe_rows
+       FROM app_runs r WHERE r.org_id = $1
+      ORDER BY r.created_at DESC, r.id DESC LIMIT 1`,
+    [ORG_ID],
+  );
+  assert.deepEqual(
+    { state: latest.rows[0]!.state, attempts: latest.rows[0]!.attempts, receipts: latest.rows[0]!.receipts },
+    { state: 'succeeded', attempts: '1', receipts: '1' },
+  );
+  assert.doesNotMatch(latest.rows[0]!.safe_rows, /membership-sensitive-result/);
+  assert.equal(Number((await client.query<{ count: string }>(
+    `SELECT count(*) FROM app_runs WHERE org_id = $1`,
+    [ORG_ID],
+  )).rows[0]!.count), before + 1);
+});
+
+governedTest('flag-on approved MCP action retries converge on one Run, one attempt, one call, and one budget debit', async (t) => {
+  stubDiscovery(t, { isWrite: true, approvalTier: 'auto-execute' });
+  await client.query(
+    `UPDATE mcp_connections SET default_trust_tier = 'auto' WHERE id = $1`,
+    [CONNECTION_ID],
+  );
+  const rawResult = {
+    content: [{ type: 'text', text: 'sent once' }],
+    structuredContent: { report_id: 'governed-action-1' },
+  };
+  const calls = stubExecution(t, {
+    success: true,
+    content: rawResult.content,
+    structuredContent: rawResult.structuredContent,
+    rawResult,
+    durationMs: 19,
+  });
+  const params = { recipient: `governed-action-${suffix}@example.test` };
+  const actionId = await insertApprovedAction({ params });
+
+  const results = await Promise.all(Array.from({ length: 8 }, () => executeAction(
+    actionId,
+    PREFIXED_NAME,
+    params,
+    ORG_ID,
+    USER_ID,
+    { agentEmployeeId: EMPLOYEE_ID },
+  )));
+  assert.ok(results.every((result) => result.success));
+  for (const result of results) assert.deepEqual(result.result, rawResult);
+  assert.equal(calls.length, 1);
+  assert.equal(await budgetCount(), 1);
+  const ledger = await appRunLedger(actionId);
+  assert.deepEqual(
+    { runs: ledger.runs, attempts: ledger.attempts, receipts: ledger.native_receipts, jobs: ledger.jobs, state: ledger.state },
+    { runs: '1', attempts: '1', receipts: '1', jobs: '1', state: 'succeeded' },
+  );
+  assert.doesNotMatch(ledger.safe_rows, new RegExp(`governed-action-${suffix}|recipient`, 'i'));
+});
+
+governedTest('flag-on reviewed MCP approval preserves legacy receipts and replays without another provider call', async (t) => {
+  stubDiscovery(t, { isWrite: true, approvalTier: 'quick-approve' });
+  const rawResult = { content: [{ type: 'text', text: 'reviewed once' }] };
+  const calls = stubExecution(t, {
+    success: true,
+    content: rawResult.content,
+    rawResult,
+    durationMs: 7,
+  });
+  const actionId = await queueReviewedAction('quick');
+
+  const resolutions = await Promise.all([
+    approveAction(actionId, APPROVER_USER_ID),
+    approveAction(actionId, APPROVER_USER_ID),
+  ]);
+  assert.deepEqual(resolutions.map((result) => result.status), ['approved', 'approved']);
+  assert.equal(calls.length, 1);
+  assert.equal(await budgetCount(), 1);
+  assert.equal((await receiptRows(actionId)).length, 1);
+  assert.equal((await approveAction(actionId, APPROVER_USER_ID)).status, 'approved');
+  assert.equal(calls.length, 1);
+  const ledger = await appRunLedger(actionId);
+  assert.deepEqual(
+    { runs: ledger.runs, attempts: ledger.attempts, receipts: ledger.native_receipts, state: ledger.state },
+    { runs: '1', attempts: '1', receipts: '1', state: 'succeeded' },
+  );
+});
+
+governedTest('flag-on ambiguous MCP transport outcome becomes inspectable unknown and is never retried', async (t) => {
+  stubDiscovery(t, { isWrite: true, approvalTier: 'auto-execute' });
+  await client.query(
+    `UPDATE mcp_connections SET default_trust_tier = 'auto' WHERE id = $1`,
+    [CONNECTION_ID],
+  );
+  const calls = stubExecution(t, {
+    success: false,
+    content: null,
+    error: 'connection reset after send',
+    durationMs: 5,
+  });
+  const actionId = await insertApprovedAction({ params: {} });
+
+  const result = await executeAction(
+    actionId,
+    PREFIXED_NAME,
+    {},
+    ORG_ID,
+    USER_ID,
+    { agentEmployeeId: EMPLOYEE_ID },
+  );
+  assert.equal(result.success, false);
+  assert.match(result.error ?? '', /outcome is unknown/);
+  assert.equal(calls.length, 1);
+  assert.equal(await budgetCount(), 1);
+  const ledger = await appRunLedger(actionId);
+  assert.deepEqual(
+    { runs: ledger.runs, attempts: ledger.attempts, receipts: ledger.native_receipts, state: ledger.state },
+    { runs: '1', attempts: '1', receipts: '1', state: 'unknown_outcome' },
+  );
+  assert.equal((await executeAction(
+    actionId,
+    PREFIXED_NAME,
+    {},
+    ORG_ID,
+    USER_ID,
+    { agentEmployeeId: EMPLOYEE_ID },
+  )).success, false);
+  assert.equal(calls.length, 1);
 });

--- a/apps/api/test/capability-service.test.ts
+++ b/apps/api/test/capability-service.test.ts
@@ -10,6 +10,7 @@ import type {
   MCPToolOverride,
 } from '@deft/mcp';
 import { CapabilityService } from '../src/lib/capability-service.js';
+import { PinnedMcpAppRunProviderExecutor } from '../src/lib/app-run-provider-executor.js';
 import {
   discoverMcpToolsForConnections,
   mcpProviderDescriptionForAgent,
@@ -752,4 +753,92 @@ test('strict invocation inputs fail before resolution and pre-call/runtime throw
     /Invalid MCP connection target:/,
   );
   assert.equal(executeCalls, 1);
+});
+
+test('pinned App Run execution resolves the exact provider once and preserves returned MCP payloads', async () => {
+  const resolutionCalls: unknown[][] = [];
+  const executionCalls: unknown[][] = [];
+  const rawResult = {
+    content: [{ type: 'text', text: 'sent' }],
+    structuredContent: { message_id: 'message-pinned' },
+  };
+  const runtime: McpCapabilityRuntime = {
+    resolveExecutable: async () => ({ connection }),
+    resolvePinnedExecutable: async (...args) => {
+      resolutionCalls.push(args);
+      return { connection };
+    },
+    executeTool: async (...args) => {
+      executionCalls.push(args);
+      return {
+        success: true,
+        content: rawResult.content,
+        structuredContent: rawResult.structuredContent,
+        rawResult,
+        durationMs: 9,
+      };
+    },
+  };
+  const executor = new PinnedMcpAppRunProviderExecutor(providerForRuntime(runtime));
+  const result = await executor.execute({
+    org_id: connection.org_id,
+    provider_kind: 'mcp',
+    provider_instance_id: connection.id,
+    operation_name: 'send_email',
+    input: { recipient: 'ada@example.test' },
+  });
+
+  assert.deepEqual(resolutionCalls, [[connection.org_id, connection.id, 'send_email']]);
+  assert.equal(executionCalls.length, 1);
+  assert.deepEqual(result, {
+    status: 'returned',
+    provider_succeeded: true,
+    output: rawResult,
+  });
+});
+
+test('pinned App Run execution fails closed for unbound idempotency and ambiguous transport outcomes', async () => {
+  let resolutions = 0;
+  let calls = 0;
+  let release: (() => void) | null = null;
+  const pending = new Promise<void>((resolve) => { release = resolve; });
+  const runtime: McpCapabilityRuntime = {
+    resolveExecutable: async () => ({ connection }),
+    resolvePinnedExecutable: async () => {
+      resolutions++;
+      return { connection };
+    },
+    executeTool: async () => {
+      calls++;
+      if (calls === 1) {
+        return { success: false, content: null, error: 'socket reset', durationMs: 2 };
+      }
+      await pending;
+      return { success: true, content: [], rawResult: { content: [] }, durationMs: 2 };
+    },
+  };
+  const executor = new PinnedMcpAppRunProviderExecutor(providerForRuntime(runtime));
+  const base = {
+    org_id: connection.org_id,
+    provider_kind: 'mcp' as const,
+    provider_instance_id: connection.id,
+    operation_name: 'send_email',
+    input: {},
+  };
+
+  assert.deepEqual(await executor.execute({ ...base, provider_idempotency_key: 'unbound' }), {
+    status: 'not_attempted',
+    error_code: 'APP_RUN_PROVIDER_UNAVAILABLE',
+  });
+  assert.equal(resolutions, 0);
+  assert.equal(calls, 0);
+  assert.deepEqual(await executor.execute(base), { status: 'indeterminate' });
+
+  const controller = new AbortController();
+  const aborted = executor.execute({ ...base, signal: controller.signal });
+  while (calls < 2) await new Promise((resolve) => setImmediate(resolve));
+  controller.abort();
+  assert.deepEqual(await aborted, { status: 'indeterminate' });
+  release!();
+  assert.equal(calls, 2);
 });

--- a/apps/api/test/capability-service.test.ts
+++ b/apps/api/test/capability-service.test.ts
@@ -793,7 +793,12 @@ test('pinned App Run execution resolves the exact provider once and preserves re
   assert.deepEqual(result, {
     status: 'returned',
     provider_succeeded: true,
-    output: rawResult,
+    output: {
+      schema_version: 'deft.app_run.mcp_result.v1',
+      legacy_output: rawResult,
+      duration_ms: 9,
+    },
+    duration_ms: 9,
   });
 });
 
@@ -841,4 +846,73 @@ test('pinned App Run execution fails closed for unbound idempotency and ambiguou
   assert.deepEqual(await aborted, { status: 'indeterminate' });
   release!();
   assert.equal(calls, 2);
+});
+
+test('Capability Service selects exactly one flag path and never shadow-calls or falls back', async () => {
+  const request = {
+    org_id: connection.org_id,
+    actor: { user_id: 'user_ada' },
+    provider: {
+      provider_kind: 'mcp' as const,
+      connection_slug: connection.slug,
+      operation_name: 'send_email',
+    },
+    input: { recipient: 'ada@example.test' },
+  };
+  const legacyResult = {
+    provider: {
+      provider_kind: 'mcp' as const,
+      requested_provider_key: connection.slug,
+      resolved_provider: {
+        org_id: connection.org_id,
+        provider_kind: 'mcp' as const,
+        provider_instance_id: connection.id,
+      },
+    },
+    provider_display_name: connection.name,
+    operation_name: 'send_email',
+    provider_call_attempted: true,
+    provider_succeeded: true,
+    legacy_output: { path: 'legacy' },
+    duration_ms: 1,
+  };
+  const governedResult = { ...legacyResult, legacy_output: { path: 'governed' } };
+  let legacyCalls = 0;
+  let governedCalls = 0;
+  let governedOptions: unknown;
+  const legacyPort = {
+    async discover() { return { provider_kind: 'mcp' as const, tools: [], snapshot: null }; },
+    async invoke() { legacyCalls++; return legacyResult; },
+  };
+  const governedPort = {
+    async invoke(_request: unknown, options: unknown) {
+      governedCalls++;
+      governedOptions = options;
+      return governedResult;
+    },
+  };
+
+  const disabled = new CapabilityService(legacyPort, governedPort, () => false);
+  assert.deepEqual((await disabled.invoke(request)).legacy_output, { path: 'legacy' });
+  assert.deepEqual({ legacyCalls, governedCalls }, { legacyCalls: 1, governedCalls: 0 });
+
+  const enabled = new CapabilityService(legacyPort, governedPort, () => true);
+  assert.deepEqual((await enabled.invoke(request, {
+    legacy_action_id: 'action-1',
+    idempotency_key: 'occurrence-1',
+  })).legacy_output, { path: 'governed' });
+  assert.deepEqual({ legacyCalls, governedCalls }, { legacyCalls: 1, governedCalls: 1 });
+  assert.deepEqual(governedOptions, {
+    legacy_action_id: 'action-1',
+    idempotency_key: 'occurrence-1',
+  });
+
+  const failing = new CapabilityService(legacyPort, {
+    async invoke() {
+      governedCalls++;
+      throw new Error('governed failure');
+    },
+  }, () => true);
+  await assert.rejects(failing.invoke(request), /governed failure/);
+  assert.equal(legacyCalls, 1);
 });

--- a/apps/api/test/capability-service.test.ts
+++ b/apps/api/test/capability-service.test.ts
@@ -848,7 +848,7 @@ test('pinned App Run execution fails closed for unbound idempotency and ambiguou
   assert.equal(calls, 2);
 });
 
-test('Capability Service selects exactly one flag path and never shadow-calls or falls back', async () => {
+test('engine-on MCP intake modes select exactly one Capability Service path without fallback', async () => {
   const request = {
     org_id: connection.org_id,
     actor: { user_id: 'user_ada' },
@@ -892,12 +892,12 @@ test('Capability Service selects exactly one flag path and never shadow-calls or
     },
   };
 
-  const disabled = new CapabilityService(legacyPort, governedPort, () => false);
-  assert.deepEqual((await disabled.invoke(request)).legacy_output, { path: 'legacy' });
+  const engineOnIntakeOff = new CapabilityService(legacyPort, governedPort, () => false);
+  assert.deepEqual((await engineOnIntakeOff.invoke(request)).legacy_output, { path: 'legacy' });
   assert.deepEqual({ legacyCalls, governedCalls }, { legacyCalls: 1, governedCalls: 0 });
 
-  const enabled = new CapabilityService(legacyPort, governedPort, () => true);
-  assert.deepEqual((await enabled.invoke(request, {
+  const engineOnIntakeOn = new CapabilityService(legacyPort, governedPort, () => true);
+  assert.deepEqual((await engineOnIntakeOn.invoke(request, {
     legacy_action_id: 'action-1',
     idempotency_key: 'occurrence-1',
   })).legacy_output, { path: 'governed' });

--- a/apps/api/test/worker-queue-reliability.test.ts
+++ b/apps/api/test/worker-queue-reliability.test.ts
@@ -7,6 +7,7 @@ import {
   dequeueJob,
   enqueue,
   ensureCronJob,
+  RetryLaterJobError,
   type QueueName,
 } from '../src/lib/queues.js';
 import {
@@ -78,6 +79,27 @@ test('timeout aborts the handler and late resolution cannot complete the termina
   assert.equal(row?.attempts, 1, 'timeout must not enqueue an overlapping retry');
   assert.match(row?.error ?? '', /timed out/);
   assert.ok(row?.completed_at instanceof Date);
+});
+
+test('operational pauses preserve a durable occurrence without spending retry budget', async () => {
+  const name = `deferred:${crypto.randomUUID()}`;
+  await enqueue(TEST_QUEUE, name, {}, { maxAttempts: 1 });
+  const claim = await dequeueJob(TEST_QUEUE, { leaseMs: 10_000 });
+  assert.ok(claim);
+
+  await _processDequeuedJobForTest(TEST_QUEUE, claim, {
+    resolveHandler: async () => async () => {
+      throw new RetryLaterJobError('feature entrance disabled', 60_000);
+    },
+  });
+
+  const [row] = await rowsFor(name);
+  assert.equal(row?.status, 'pending');
+  assert.equal(row?.attempts, 0);
+  assert.equal(row?.completed_at, null);
+  assert.equal(row?.lock_token, null);
+  assert.match(row?.error ?? '', /feature entrance disabled/);
+  assert.ok((row?.run_at.getTime() ?? 0) > Date.now());
 });
 
 test('a terminally failed recurring occurrence schedules one successor', async () => {

--- a/apps/api/test/worker-scheduled-routing.test.ts
+++ b/apps/api/test/worker-scheduled-routing.test.ts
@@ -21,3 +21,10 @@ test('durable scheduled-message-send resolves to a real handler', async () => {
 
   assert.equal(typeof handler, 'function');
 });
+
+test('governed App Run attempts resolve through the agent-job worker registry', async () => {
+  const workers = await import('../src/workers/index.js');
+  const handler = await workers._getAgentJobHandlerForTest('app-run-attempt');
+
+  assert.equal(typeof handler, 'function');
+});

--- a/docs/app-run-operations.md
+++ b/docs/app-run-operations.md
@@ -1,9 +1,20 @@
 # Governed App Run operations
 
-Governed App Runs are a disabled-by-default self-host opt-in. Exact
-`DEFT_APP_RUNS_ENABLED=true` selects the Run-backed MCP capability entrance;
-every other value preserves the legacy entrance. App-origin execution remains
-disabled until a later phase supplies App grants and exact bindings.
+Governed App Runs are a disabled-by-default self-host opt-in with two controls.
+Exact `DEFT_APP_RUNS_ENABLED=true` enables key access, runtime composition, and
+draining of accepted work. Exact
+`DEFT_APP_RUN_LEGACY_MCP_CUTOVER_ENABLED=true` separately admits supported
+legacy MCP capability calls to that engine. Every other intake value preserves
+the legacy entrance. Intake-on with the engine off is invalid and API startup
+rejects it. App-origin execution remains disabled until a later phase supplies
+App grants and exact bindings.
+
+| Run engine | Legacy MCP intake | Operational state |
+|---|---|---|
+| Off | Off | Default legacy execution; no Run keys required; durable Run jobs defer |
+| On | Off | Decrypt, resume, and drain accepted Runs; new MCP calls stay legacy |
+| On | On | Default-off governed legacy MCP canary |
+| Off | On | Invalid startup configuration |
 
 This feature has two independent operational assets: the additive PostgreSQL
 Run ledger and `DEFT_APP_RUN_KEYRINGS`. Back them up, restore them, and rotate
@@ -21,8 +32,9 @@ node -e "const c=require('node:crypto');const k=()=>c.randomBytes(32).toString('
 Store the single-line result as the secret `DEFT_APP_RUN_KEYRINGS`; do not put
 it in source control, logs, tickets, or a database row. Set
 `DEFT_APP_RUNS_ENABLED=true` only after the supported upgrades through
-`0.3.0-preview.21` are applied. A process restart is required after either
-environment value changes.
+`0.3.0-preview.21` are applied. Leave legacy MCP intake false while validating
+startup and draining behavior; enable it only for a certified canary. A process
+restart is required after any Run environment value changes.
 
 Startup rejects malformed documents, reused key material, missing current key
 IDs, non-32-byte keys, and a keyring that omits any version still referenced by
@@ -72,10 +84,11 @@ For a restore:
    enabling App Runs.
 3. Boot with `DEFT_APP_RUNS_ENABLED=false` first and complete database and
    application health checks.
-4. Set the restored keyring and exact enable flag, restart, and require the
-   referenced-key inventory to pass.
+4. Set the restored keyring and engine flag with legacy MCP intake still off,
+   restart, and require the referenced-key inventory to pass.
 5. Inspect pending, running, and `unknown_outcome` Runs before accepting new
-   provider work. Never blindly retry an unknown outcome.
+   provider work. Never blindly retry an unknown outcome. Enable legacy MCP
+   intake only after that inspection and the release's canary gate pass.
 
 If the database survives but a referenced key does not, keep App Runs disabled.
 Encryption-key loss prevents retained input/result recovery; signing-key loss
@@ -84,20 +97,27 @@ matching. None can be reconstructed from database contents.
 
 ## Disable and rollback
 
-Turning the flag off is a safe entrance rollback on the Phase 3 execution
-floor. New calls use the legacy Capability Service path. Already-durable
-`app-run-attempt` jobs remain pending, do not call a provider, and do not spend
-their queue retry allowance. Pending App Run approvals also remain governed and
-cannot execute through the legacy action path. Re-enable the same keyring to
-resume them.
+The normal entrance rollback is to set
+`DEFT_APP_RUN_LEGACY_MCP_CUTOVER_ENABLED=false` while keeping
+`DEFT_APP_RUNS_ENABLED=true`. New MCP calls return to the legacy Capability
+Service path while already accepted Runs, attempts, and approvals retain their
+governed identity and may drain. There is no shadow call or legacy fallback for
+accepted governed work.
 
-The source-level execution rollback floor is `944b265f` or a later released
-image containing that commit. Images below that floor do not understand the
-pause contract for `app-run-attempt` jobs and must not be used while governed
-work is active. To move below the floor:
+Set the engine false only after intake is false. Engine-off defers durable
+`app-run-attempt` jobs without calling a provider or spending queue retry
+allowance; pending App Run approvals remain governed. Re-enable the same
+keyring and engine to resume them. Engine-off/intake-on is rejected rather than
+silently falling through.
 
-1. Quiesce traffic that can create MCP capability calls while still running the
-   Phase 3 floor with the flag and keyring available.
+Local C5 and closeout commit hashes are review checkpoints, not an operational
+rollback floor. The floor is the first immutable released image whose release
+record explicitly contains this split-control and job-pause contract. Until
+that artifact and its supported predecessor are recorded, do not treat the
+legacy MCP canary as production-supported. To move below the recorded floor:
+
+1. On the current floor, turn legacy MCP intake off but leave the engine and
+   keyring available; quiesce traffic that could create more governed work.
 2. Resolve or cancel pending approvals and let known work settle. Reconcile
    `unknown_outcome` without another provider call.
 3. Confirm there are no nonterminal Runs, pending App Run approvals, or active
@@ -114,9 +134,9 @@ work is active. To move below the floor:
     GROUP BY status;
    ```
 
-4. Set the flag false, restart on the Phase 3 floor, verify legacy execution,
-   and only then deploy an older image. Preserve the additive tables and
-   keyring backup; do not down-migrate or delete them.
+4. Set the engine false, restart on the current floor, verify legacy execution
+   and job deferral, and only then deploy the supported older image. Preserve
+   the additive tables and keyring backup; do not down-migrate or delete them.
 
 If any query is nonzero, remain on the Phase 3 floor. An in-flight process loss
 after a provider call may correctly produce `unknown_outcome`; that is an

--- a/docs/app-run-operations.md
+++ b/docs/app-run-operations.md
@@ -1,0 +1,132 @@
+# Governed App Run operations
+
+Governed App Runs are a disabled-by-default self-host opt-in. Exact
+`DEFT_APP_RUNS_ENABLED=true` selects the Run-backed MCP capability entrance;
+every other value preserves the legacy entrance. App-origin execution remains
+disabled until a later phase supplies App grants and exact bindings.
+
+This feature has two independent operational assets: the additive PostgreSQL
+Run ledger and `DEFT_APP_RUN_KEYRINGS`. Back them up, restore them, and rotate
+them together. Losing a referenced key is data loss even when the database is
+intact.
+
+## Generate the first keyring
+
+Generate three independent random 32-byte keys on a trusted operator machine:
+
+```bash
+node -e "const c=require('node:crypto');const k=()=>c.randomBytes(32).toString('base64');console.log(JSON.stringify({schema_version:'deft.app_run_keyring.v1',run_encryption:{current:'enc-v1',keys:{'enc-v1':k()}},receipt_signing:{current:'sig-v1',keys:{'sig-v1':k()}},fingerprint:{current:'fp-v1',keys:{'fp-v1':k()}}}))"
+```
+
+Store the single-line result as the secret `DEFT_APP_RUN_KEYRINGS`; do not put
+it in source control, logs, tickets, or a database row. Set
+`DEFT_APP_RUNS_ENABLED=true` only after the supported upgrades through
+`0.3.0-preview.21` are applied. A process restart is required after either
+environment value changes.
+
+Startup rejects malformed documents, reused key material, missing current key
+IDs, non-32-byte keys, and a keyring that omits any version still referenced by
+an active fingerprint, retained encrypted payload, or App Run receipt. This
+check completes before a governed provider effect can start.
+
+## Rotate without losing reads
+
+Rotate one purpose at a time:
+
+1. Back up PostgreSQL and the current keyring secret as one recovery point.
+2. Generate a new independent 32-byte key and a new portable ID such as
+   `enc-v2`, `sig-v2`, or `fp-v2`.
+3. Add the new entry to that purpose's `keys` object and make only its ID
+   `current`. Keep every old entry unchanged.
+4. Restart one candidate process. It must pass the referenced-key startup
+   inventory before receiving traffic.
+5. Complete the normal health and governed-call smoke checks, then roll the
+   same document to the remaining processes.
+
+New writes use the current key. Old entries are read/verify-only, so rotation
+does not rewrite old ciphertext or signatures. Mixed processes are safe only
+while the document contains both old and new keys.
+
+Do not retire an encryption key until its encrypted payloads have expired and
+the retention purge has completed. Do not retire a fingerprint key until every
+Run in its fixed idempotency horizon has expired. Receipt signing references
+are retained for as long as their receipts; Phase 3 has no destructive receipt
+retirement workflow, so a referenced signing key must remain configured.
+
+To test a proposed retirement, remove only the candidate entry in a non-serving
+process with a restored production backup. Startup must succeed. A missing
+reference fails with `APP_RUN_KEY_VERSION_UNAVAILABLE`; restore the entry and do
+not enable traffic. Never discover retirement safety by deleting the only copy.
+
+## Backup, restore, and disaster recovery
+
+Use the normal database backup flow in [Self-hosting](./self-hosting.md#backups),
+and export the exact keyring secret into the same encrypted backup set. Record
+which key IDs were current. Keep at least one offline recovery copy under the
+same access controls as the deployment secrets.
+
+For a restore:
+
+1. Restore PostgreSQL and uploads using the normal self-host procedure.
+2. Restore the keyring document from the matching recovery point before
+   enabling App Runs.
+3. Boot with `DEFT_APP_RUNS_ENABLED=false` first and complete database and
+   application health checks.
+4. Set the restored keyring and exact enable flag, restart, and require the
+   referenced-key inventory to pass.
+5. Inspect pending, running, and `unknown_outcome` Runs before accepting new
+   provider work. Never blindly retry an unknown outcome.
+
+If the database survives but a referenced key does not, keep App Runs disabled.
+Encryption-key loss prevents retained input/result recovery; signing-key loss
+prevents receipt verification; fingerprint-key loss prevents safe replay
+matching. None can be reconstructed from database contents.
+
+## Disable and rollback
+
+Turning the flag off is a safe entrance rollback on the Phase 3 execution
+floor. New calls use the legacy Capability Service path. Already-durable
+`app-run-attempt` jobs remain pending, do not call a provider, and do not spend
+their queue retry allowance. Pending App Run approvals also remain governed and
+cannot execute through the legacy action path. Re-enable the same keyring to
+resume them.
+
+The source-level execution rollback floor is `944b265f` or a later released
+image containing that commit. Images below that floor do not understand the
+pause contract for `app-run-attempt` jobs and must not be used while governed
+work is active. To move below the floor:
+
+1. Quiesce traffic that can create MCP capability calls while still running the
+   Phase 3 floor with the flag and keyring available.
+2. Resolve or cancel pending approvals and let known work settle. Reconcile
+   `unknown_outcome` without another provider call.
+3. Confirm there are no nonterminal Runs, pending App Run approvals, or active
+   App Run jobs:
+
+   ```sql
+   SELECT state, count(*) FROM app_runs
+    WHERE state NOT IN ('succeeded','failed','cancelled','expired','unknown_outcome')
+    GROUP BY state;
+   SELECT count(*) FROM agent_actions
+    WHERE action = 'app_run_invoke' AND approval_status = 'pending';
+   SELECT status, count(*) FROM job_queue
+    WHERE name = 'app-run-attempt' AND status IN ('pending','running')
+    GROUP BY status;
+   ```
+
+4. Set the flag false, restart on the Phase 3 floor, verify legacy execution,
+   and only then deploy an older image. Preserve the additive tables and
+   keyring backup; do not down-migrate or delete them.
+
+If any query is nonzero, remain on the Phase 3 floor. An in-flight process loss
+after a provider call may correctly produce `unknown_outcome`; that is an
+operator reconciliation case, not permission to retry.
+
+## Hosted-service boundary
+
+A future SaaS deployment may replace the environment provider with a KMS-backed
+implementation of the same purpose-separated key-provider interface. It must
+retain opaque versions, tenant/Run/purpose binding, current-plus-read-only
+rotation, pre-effect reference inventory, auditable access, backup/restore, and
+regional disaster-recovery behavior. No KMS or hosted dependency is required
+for self-hosted Phase 3.

--- a/docs/decisions/2026-08-30-governed-app-runs-rollout.md
+++ b/docs/decisions/2026-08-30-governed-app-runs-rollout.md
@@ -1,6 +1,7 @@
 # ADR: Additive Governed App Runs and staged secret rollout
 
-- Status: Accepted; dormant foundation implementation begun after Phase 2 merge
+- Status: Accepted; governed legacy-connector cutover implemented behind an
+  exact disabled-by-default opt-in, pending release artifact certification
 - Date: 2026-08-30
 - Depends on: Capability Service squash merge `9ba7b7c8` from PR #270
 - Supersedes: the big-bang sequencing implied by the earlier App Protocol v2
@@ -269,6 +270,62 @@ explicit safe field set, are tenant-scoped and bounded, and have no provider
 executor dependency. Repair may append missing events, receipts, and Attention,
 but never invokes or retries an external effect.
 
+### Production runtime and compatibility cutover
+
+The production composition root owns one key provider, secret repository,
+tenant-safe Run repository, live authorizer, access authorizer, approval
+resolver, receipt writer, Attention projector, pinned MCP executor, attempt
+runner, and operations service. The existing PostgreSQL queue carries only
+tenant, Run, and exact attempt identity. No job contains decrypted input or a
+provider callback.
+
+Capability Service selects exactly one entrance from the exact process-start
+flag: legacy while disabled, governed while enabled. There is no shadow call and
+no fallback after selecting the governed path. Existing MCP approval policy
+remains the compatibility gate. Auto-safe reads may enter directly; every write
+or stricter operation must present the exact approved `agent_actions` occurrence
+as host-owned evidence. That action identity also supplies the stable replay
+identity, so concurrent approval or action retries converge on one Run, attempt,
+provider call, budget reservation, native receipt, and legacy receipt.
+
+The compatibility Run records `review_requirement: policy` because the existing
+action lifecycle has already satisfied the current host policy before the Run
+is created. The Run-native `always` adapter remains the direct App Run contract
+for future bound callers; Phase 3 does not manufacture a second approval for an
+already reviewed legacy occurrence. Provider metadata cannot declare a write
+safe, and `origin = app` remains rejected.
+
+Employee budgets move at the durable first-attempt boundary. A governed denial
+that occurs before any attempt is authorized does not consume a slot; a selected
+external effect reserves exactly one slot even under concurrency. Safe reads do
+not debit the action counter. Flag-off behavior and its historical ordering are
+unchanged.
+
+The authorized caller can receive the exact provider response transiently and,
+when representable and retained, replay it through the access-controlled result
+method. Generic Runs, jobs, events, receipts, Attention, metrics, and logs never
+contain it. Live membership is checked again before delivery; revocation after
+the provider effect withholds the response without changing a known terminal
+outcome into a retry.
+
+### Operational disable and rollback floor
+
+Exact flag-off stops new governed entrances. An already-durable attempt job is
+returned to pending under its existing lease fence without spending queue retry
+allowance or calling the provider. Re-enabling the same keyring resumes it.
+Pending governed approvals also cannot fall through to legacy execution.
+
+The source-level execution rollback floor is `944b265f`. A released image that
+contains that commit may safely run with the entrance disabled and preserved
+pending jobs. An image below that floor may treat an App Run job as unknown or
+exhaust it, so downgrade below the floor requires quiescing new calls and proving
+there are no nonterminal Runs, pending `app_run_invoke` approvals, or active
+`app-run-attempt` jobs. Additive Run tables and the matching keyring backup are
+preserved across rollback; they are never down-migrated as part of the gate.
+
+Detailed generation, rotation, retirement, backup/restore, disaster recovery,
+and rollback steps live in `docs/app-run-operations.md`.
+
 ## Consequences
 
 - Phase 3 is larger than a local refactor and may span more than one release.
@@ -281,7 +338,8 @@ but never invokes or retries an external effect.
   separate rollback-floor gate.
 - Self-hosts gain explicit key configuration only when enabling App Runs;
   existing deployments continue to boot with the legacy contract while the
-  feature is off.
+  feature is off. This remains self-host opt-in and disabled by default; a
+  hosted KMS is a future provider, not a Phase 3 dependency.
 
 ## Acceptance evidence
 

--- a/docs/decisions/2026-08-30-governed-app-runs-rollout.md
+++ b/docs/decisions/2026-08-30-governed-app-runs-rollout.md
@@ -1,7 +1,8 @@
 # ADR: Additive Governed App Runs and staged secret rollout
 
-- Status: Accepted; governed legacy-connector cutover implemented behind an
-  exact disabled-by-default opt-in, pending release artifact certification
+- Status: Accepted; Run engine/draining and governed legacy-connector intake
+  implemented behind separate exact disabled-by-default controls, pending
+  release artifact certification
 - Date: 2026-08-30
 - Depends on: Capability Service squash merge `9ba7b7c8` from PR #270
 - Supersedes: the big-bang sequencing implied by the earlier App Protocol v2
@@ -37,7 +38,7 @@ schema, migration, approval, provider-call, receipt, worker, and rollback risk.
 An external-effect shadow comparison is unsafe, and a rollback could strand
 ciphertext an older image cannot read. Rejected.
 
-### Add a dormant Run subsystem and cut over behind a fail-closed flag
+### Add a durable Run subsystem and cut over behind fail-closed controls
 
 Add new tables and a deep App Run service, preserve `agent_actions` as a linked
 approval adapter, and keep current execution active until parity and release
@@ -185,9 +186,12 @@ Phase 3 is delivered as additive merge trains rather than one stacked PR:
 
 1. contracts, key readers, and dormant schema;
 2. Run lifecycle, attempts, and recovery using fake providers;
-3. approval and legacy compatibility behind `DEFT_APP_RUNS_ENABLED=false`;
+3. approval and legacy compatibility while all production entrances remain
+   disabled;
 4. operations, retention, rotation, and release certification; and
-5. an explicit decision to widen opt-in after parity, never an implicit default.
+5. an independent engine/drain control plus a default-off legacy MCP intake
+   control, followed by an explicit decision to widen opt-in after parity,
+   never an implicit default.
 
 The Phase 2 PR remained unchanged while this plan was prepared. The Phase 3
 planning branch is now rebased onto the exact squash merge. The upgrade manifest
@@ -265,10 +269,11 @@ database writes.
 Receipts and Attention are projections over the Run ledger, not alternate
 execution authorities. Native receipts contain only validated safe facts and a
 digest of any encrypted result envelope; signing-key references are inventoried
-inside the secret boundary. Operator list/metrics/audit surfaces select an
-explicit safe field set, are tenant-scoped and bounded, and have no provider
-executor dependency. Repair may append missing events, receipts, and Attention,
-but never invokes or retries an external effect.
+inside the secret boundary. The bounded operations service is an internal,
+production-denied repair primitive with no route or UI. Present operator access
+is the documented tenant-scoped SQL/runbook path. Repair may append missing
+events, receipts, and Attention, but never invokes or retries an external
+effect.
 
 ### Production runtime and compatibility cutover
 
@@ -279,14 +284,17 @@ runner, and operations service. The existing PostgreSQL queue carries only
 tenant, Run, and exact attempt identity. No job contains decrypted input or a
 provider callback.
 
-Capability Service selects exactly one entrance from the exact process-start
-flag: legacy while disabled, governed while enabled. There is no shadow call and
-no fallback after selecting the governed path. Existing MCP approval policy
-remains the compatibility gate. Auto-safe reads may enter directly; every write
-or stricter operation must present the exact approved `agent_actions` occurrence
-as host-owned evidence. That action identity also supplies the stable replay
-identity, so concurrent approval or action retries converge on one Run, attempt,
-provider call, budget reservation, native receipt, and legacy receipt.
+The existing `DEFT_APP_RUNS_ENABLED` control owns key access, runtime
+composition, and draining. The separate exact default-false
+`DEFT_APP_RUN_LEGACY_MCP_CUTOVER_ENABLED` control selects the Capability Service
+entrance: legacy while intake is off, governed while intake is on. Intake cannot
+start while the engine is off. There is no shadow call and no fallback after
+selecting the governed path. Existing MCP approval policy remains the
+compatibility gate. Auto-safe reads may enter directly; every write or stricter
+operation must present the exact approved `agent_actions` occurrence as
+host-owned evidence. That action identity also supplies the stable replay
+identity, so concurrent approval or action retries converge on one Run,
+attempt, provider call, budget reservation, native receipt, and legacy receipt.
 
 The compatibility Run records `review_requirement: policy` because the existing
 action lifecycle has already satisfied the current host policy before the Run
@@ -298,8 +306,9 @@ safe, and `origin = app` remains rejected.
 Employee budgets move at the durable first-attempt boundary. A governed denial
 that occurs before any attempt is authorized does not consume a slot; a selected
 external effect reserves exactly one slot even under concurrency. Safe reads do
-not debit the action counter. Flag-off behavior and its historical ordering are
-unchanged.
+not debit the action counter. The legacy employee budget path is skipped only
+when legacy MCP intake actually selects the governed entrance; engine-on with
+intake-off preserves the historical ordering.
 
 The authorized caller can receive the exact provider response transiently and,
 when representable and retained, replay it through the access-controlled result
@@ -310,18 +319,22 @@ outcome into a retry.
 
 ### Operational disable and rollback floor
 
-Exact flag-off stops new governed entrances. An already-durable attempt job is
-returned to pending under its existing lease fence without spending queue retry
-allowance or calling the provider. Re-enabling the same keyring resumes it.
-Pending governed approvals also cannot fall through to legacy execution.
+Turning legacy MCP intake off stops new governed admission while the enabled
+engine continues to drain accepted work. Turning the engine off after intake is
+off returns already-durable attempt jobs to pending under their lease fence
+without spending queue retry allowance or calling the provider. Pending
+governed approvals cannot fall through to legacy execution. Engine-off with
+intake-on is an invalid startup state.
 
-The source-level execution rollback floor is `944b265f`. A released image that
-contains that commit may safely run with the entrance disabled and preserved
-pending jobs. An image below that floor may treat an App Run job as unknown or
-exhaust it, so downgrade below the floor requires quiescing new calls and proving
-there are no nonterminal Runs, pending `app_run_invoke` approvals, or active
-`app-run-attempt` jobs. Additive Run tables and the matching keyring backup are
-preserved across rollback; they are never down-migrated as part of the gate.
+Source commits such as the original C5 checkpoint are review evidence only.
+The operational execution rollback floor is the first immutable released image
+whose release record names the final split-control contract. An image below
+that floor may treat an App Run job as unknown or exhaust it, so downgrade below
+the floor requires disabling intake, draining/quiescing governed work, and
+proving there are no nonterminal Runs, pending `app_run_invoke` approvals, or
+active `app-run-attempt` jobs. Additive Run tables and the matching keyring
+backup are preserved across rollback; they are never down-migrated as part of
+the gate.
 
 Detailed generation, rotation, retirement, backup/restore, disaster recovery,
 and rollback steps live in `docs/app-run-operations.md`.
@@ -332,7 +345,9 @@ and rollback steps live in `docs/app-run-operations.md`.
 - Old and new execution can coexist in code, but exactly one is selected for an
   invocation; they are never both called.
 - The linked legacy approval row remains temporarily necessary for native UI
-  compatibility.
+  compatibility. `app_runs` is canonical; after native App approval/Run UI and
+  Phase 6 parity are certified, no new App-origin path may depend on this dual
+  ledger or on legacy receipt creation.
 - New App Run tables can be rolled back by using an older image because that
   image ignores them, but any change to existing ciphertext writers has a
   separate rollback-floor gate.
@@ -357,7 +372,9 @@ and rollback steps live in `docs/app-run-operations.md`.
   events, receipts, metrics, Attention, and trace output. Separate tests prove
   exact output is available only through the authorized invocation/result path
   during its retention window.
-- Flag-off tests preserve every Phase 2 compatibility path; flag-on golden tests
-  certify legacy outcomes without external shadow execution.
+- Engine-off/intake-off and engine-on/intake-off tests preserve Phase 2
+  compatibility; engine-on/intake-on golden tests certify governed legacy
+  outcomes without external shadow execution; engine-off/intake-on fails
+  startup.
 - Self-host, backup/restore, rotation, rollback-floor, image, browser approval,
   security, and operator-recovery checks pass before opt-in is widened.

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -392,7 +392,7 @@ semi-autonomous runtime should show up as a shared coworker in Deft.
 | `JWT_SECRET` | Yes | Signs access tokens | none |
 | `JWT_REFRESH_SECRET` | Yes | Signs refresh tokens | none |
 | `ENCRYPTION_KEY` | Production | Encrypts provider keys at rest; at least 32 chars | dev value |
-| `DEFT_APP_RUNS_ENABLED` | No | Exact `true` enables the dormant Governed App Run foundation; invalid or missing keyrings then fail startup | `false` |
+| `DEFT_APP_RUNS_ENABLED` | No | Exact `true` routes supported MCP capability calls through Governed App Runs; invalid or missing keyrings then fail startup | `false` |
 | `DEFT_APP_RUN_KEYRINGS` | Only when App Runs enabled | Single-line versioned JSON document containing separate 32-byte base64 Run-encryption, receipt-signing, and fingerprint keyrings | none |
 | `DATABASE_URL` | No for Compose | External Postgres URL for non-Compose installs | derived |
 | `NEXT_PUBLIC_APP_URL` | Recommended | Public web URL and invite-link base | `http://localhost:3000` |
@@ -411,12 +411,11 @@ semi-autonomous runtime should show up as a shared coworker in Deft.
 | `R2_ENDPOINT` / `R2_ACCESS_KEY` / `R2_SECRET_KEY` / `R2_BUCKET` | No | Cloudflare R2 uploads | local uploads volume |
 | `METRICS_SCRAPE_TOKEN` | No | Bearer token for `/api/metrics` and `/health/queue`; unset disables detailed telemetry | none |
 
-### Dormant Governed App Run keyrings
+### Opt-in Governed App Run keyrings
 
-The App Run foundation has no production execution consumer in this release and
-stays off by default. Existing self-hosts do not need to set either App Run
-variable. If you are developing the later governed execution phases, generate
-three independent 32-byte keys with this Node.js command:
+Governed App Runs stay off by default. Existing self-hosts do not need either
+variable and retain the legacy connector execution path. Operators who opt in
+must generate three independent 32-byte keys with this Node.js command:
 
 ```bash
 node -e "const c=require('node:crypto');const k=()=>c.randomBytes(32).toString('base64');console.log(JSON.stringify({schema_version:'deft.app_run_keyring.v1',run_encryption:{current:'enc-v1',keys:{'enc-v1':k()}},receipt_signing:{current:'sign-v1',keys:{'sign-v1':k()}},fingerprint:{current:'fp-v1',keys:{'fp-v1':k()}}}))"
@@ -426,9 +425,13 @@ Store the single-line output verbatim as `DEFT_APP_RUN_KEYRINGS`, then set
 `DEFT_APP_RUNS_ENABLED=true`. Add a new key ID and make it `current` to rotate;
 keep older entries configured for reads and verification. Back up this setting
 with the database. Removing a key that is still referenced by retained Run
-payloads, receipts, or fingerprints is unrecoverable data loss. The later
-execution rollout must add reference-inventory and retirement checks before this
-feature is exposed for normal use.
+payloads, receipts, or fingerprints is unrecoverable data loss. Startup checks
+that inventory before any governed effect can execute. App-origin execution is
+still disabled; this opt-in governs the current MCP compatibility entrances.
+
+Read [Governed App Run operations](./app-run-operations.md) before enabling the
+feature. It contains rotation, retirement, backup/restore, disaster recovery,
+flag-off drain behavior, and the exact rollback-floor rules.
 
 ## Backups
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -392,8 +392,9 @@ semi-autonomous runtime should show up as a shared coworker in Deft.
 | `JWT_SECRET` | Yes | Signs access tokens | none |
 | `JWT_REFRESH_SECRET` | Yes | Signs refresh tokens | none |
 | `ENCRYPTION_KEY` | Production | Encrypts provider keys at rest; at least 32 chars | dev value |
-| `DEFT_APP_RUNS_ENABLED` | No | Exact `true` routes supported MCP capability calls through Governed App Runs; invalid or missing keyrings then fail startup | `false` |
+| `DEFT_APP_RUNS_ENABLED` | No | Exact `true` enables the App Run runtime and draining; invalid or missing keyrings then fail startup | `false` |
 | `DEFT_APP_RUN_KEYRINGS` | Only when App Runs enabled | Single-line versioned JSON document containing separate 32-byte base64 Run-encryption, receipt-signing, and fingerprint keyrings | none |
+| `DEFT_APP_RUN_LEGACY_MCP_CUTOVER_ENABLED` | No | Exact `true` routes supported legacy MCP capability calls into App Runs; requires the Run engine to be enabled | `false` |
 | `DATABASE_URL` | No for Compose | External Postgres URL for non-Compose installs | derived |
 | `NEXT_PUBLIC_APP_URL` | Recommended | Public web URL and invite-link base | `http://localhost:3000` |
 | `NEXT_PUBLIC_API_URL` | Recommended | Public API URL seen by browser | `http://localhost:3001` |
@@ -413,25 +414,41 @@ semi-autonomous runtime should show up as a shared coworker in Deft.
 
 ### Opt-in Governed App Run keyrings
 
-Governed App Runs stay off by default. Existing self-hosts do not need either
-variable and retain the legacy connector execution path. Operators who opt in
-must generate three independent 32-byte keys with this Node.js command:
+Governed App Runs stay off by default. Existing self-hosts do not need any Run
+variable and retain the legacy connector execution path. The engine and legacy
+MCP intake are intentionally separate:
+
+| Run engine | Legacy MCP intake | Meaning |
+|---|---|---|
+| Off | Off | Default legacy behavior; no Run keyrings required |
+| On | Off | Run service can decrypt, resume, and drain accepted work; new MCP calls remain legacy |
+| On | On | Exact default-off legacy MCP canary enters App Runs |
+| Off | On | Invalid; API startup rejects the configuration |
+
+Operators preparing the engine must generate three independent 32-byte keys
+with this Node.js command:
 
 ```bash
 node -e "const c=require('node:crypto');const k=()=>c.randomBytes(32).toString('base64');console.log(JSON.stringify({schema_version:'deft.app_run_keyring.v1',run_encryption:{current:'enc-v1',keys:{'enc-v1':k()}},receipt_signing:{current:'sign-v1',keys:{'sign-v1':k()}},fingerprint:{current:'fp-v1',keys:{'fp-v1':k()}}}))"
 ```
 
 Store the single-line output verbatim as `DEFT_APP_RUN_KEYRINGS`, then set
-`DEFT_APP_RUNS_ENABLED=true`. Add a new key ID and make it `current` to rotate;
-keep older entries configured for reads and verification. Back up this setting
-with the database. Removing a key that is still referenced by retained Run
-payloads, receipts, or fingerprints is unrecoverable data loss. Startup checks
-that inventory before any governed effect can execute. App-origin execution is
-still disabled; this opt-in governs the current MCP compatibility entrances.
+`DEFT_APP_RUNS_ENABLED=true` while leaving
+`DEFT_APP_RUN_LEGACY_MCP_CUTOVER_ENABLED=false`. Add a new key ID and make it
+`current` to rotate; keep older entries configured for reads and verification.
+Back up this setting with the database. Removing a key that is still referenced
+by retained Run payloads, receipts, or fingerprints is unrecoverable data loss.
+Startup checks that inventory before any governed effect can execute.
+
+Enable the separate legacy intake flag only for a certified canary. To stop new
+governed MCP admission without stranding accepted work, turn the intake flag
+off and leave the engine on until the Run ledger and queue are quiescent.
+App-origin execution remains disabled until the later App grant and binding
+phase; neither Phase 3 flag creates App authority.
 
 Read [Governed App Run operations](./app-run-operations.md) before enabling the
 feature. It contains rotation, retirement, backup/restore, disaster recovery,
-flag-off drain behavior, and the exact rollback-floor rules.
+split-control drain/pause behavior, and the exact rollback-floor rules.
 
 ## Backups
 

--- a/docs/superpowers/audits/2026-08-30-app-platform-phase-3-certification.md
+++ b/docs/superpowers/audits/2026-08-30-app-platform-phase-3-certification.md
@@ -1,0 +1,78 @@
+# App Platform Phase 3 local certification
+
+- Date: 2026-08-30
+- Runtime candidate: `944b265f`
+- Result: local code acceptance passed; release-only infrastructure gates remain
+- Rollout decision: disabled by default, self-host opt-in only; do not widen
+  further until the external gates below pass on a released image
+
+## Verified matrix
+
+| Boundary | Evidence | Result |
+|---|---|---|
+| Shared capability and App Run contracts | `@deft/shared` tests | 55 passed |
+| Fresh-schema/upgrade representation and additive migrations `.17`–`.21` | `@deft/db` upgrade contract tests | 23 passed |
+| Key configuration, AEAD/AAD, rotation, fingerprints, receipt signing, retirement refusal | App Run secret tests | passed |
+| Capability Service, pinned MCP adapter, one-path flag selection, no shadow/fallback | focused API tests | passed |
+| Architecture and leakage boundaries | App Run and Capability architecture tests | passed |
+| Trust, approval matrix, connector network/credential safety, provider-text boundary | focused API tests | passed |
+| Worker registry, lifecycle, lease fencing, retry exhaustion, and flag-off defer | focused worker and queue tests | passed |
+| Run lifecycle, concurrency, release, live authority, budgets, crash recovery, ancestry, receipts, Attention, operations, and atomic jobs | disposable-database engine tests | 20 passed |
+| Exact flag-off Phase 2 immediate/action/approval compatibility | same disposable fixture with flag false | 10 passed; 6 governed cases skipped |
+| Exact flag-on safe read, unrepresentable result, post-effect membership revocation, concurrent action replay, reviewed approval replay, and ambiguous transport | same disposable fixture with valid keyrings and flag true | 6 passed; 10 legacy cases skipped |
+| API discovery routes and legacy approval resolver assertions | disposable-database focused group | passed with the stale-fixture caveat below |
+| Repository TypeScript | `pnpm typecheck` | passed for all participating workspaces |
+| Production source build | `pnpm build` | API and optimized Next.js build passed; 43 web routes generated |
+
+The consolidated runs reported 55 shared tests, 23 upgrade tests, 104 focused
+non-database API tests, 69 selected flag-off database tests, and 6 selected
+flag-on database tests with no assertion failures. Exact provider results,
+inputs, retry keys, ciphertext, and key material remained outside safe ledgers
+in the explicit leakage assertions.
+
+## Rollback and operations decision
+
+`docs/app-run-operations.md` is the operator contract. It covers initial key
+generation, additive current-key rotation, read/verify overlap, reference-based
+retirement refusal, database-plus-keyring backup/restore, disaster recovery,
+flag-off pause behavior, downgrade queries, and the future hosted KMS seam.
+
+The source-level execution rollback floor is `944b265f`. Exact flag-off on that
+floor routes new calls through the unchanged legacy path and defers durable App
+Run jobs without spending attempts. Downgrade below that floor is not allowed
+until there are no nonterminal Runs, pending `app_run_invoke` approvals, or
+active `app-run-attempt` jobs.
+
+Existing connector ciphertext and legacy action-receipt writers remain
+unchanged. There was no in-place re-encryption, token migration, new hosted
+dependency, or default enablement.
+
+## Explicitly unverified release gates
+
+- The Docker daemon is not running on this host, so no production image,
+  Compose self-host smoke, rolling-image drill, or scripted backup/restore was
+  executed. The production source build passed.
+- Local PostgreSQL has no pgvector installation. Per the established test
+  constraint, `CREATE EXTENSION vector` and another `db:push-full` bootstrap
+  were not retried. Static fresh/upgrade convergence tests passed, and the
+  disposable database exercised the Phase 3 `.17`–`.21` objects, but a final
+  pgvector-backed fresh install and supported-upgrade drill remains a release
+  gate.
+- The disposable clone has no upgrade ledger and predates current Agent Channel
+  lease columns. The legacy approval-resolver assertions passed, but its
+  best-effort `approval.resolved` Agent Channel projection logged the missing
+  `claim_owner` column. A current-schema environment must rerun that projection
+  before release; the Phase 3 compatibility fixture's approval/receipt path was
+  clean.
+- No browser approval/Run-inspection pass was run. Phase 3 changes no web UI and
+  has no App Run operator UI; API/database compatibility and the production web
+  build passed. A released-image browser smoke with a deterministic MCP provider
+  remains a widening gate.
+- No actual downgrade to an older released image was performed. The source
+  rollback behavior and queue pause are tested; the image-level drill remains
+  blocked by Docker and by the absence of a released C5-floor image.
+
+These omissions do not invalidate the local implementation result. They do
+block default-on rollout, broad opt-in recommendation, and hosted-service
+enablement. Phase 3 should merge as additive guarded work, then complete the
+listed image/current-schema gates before a release announcement widens use.

--- a/docs/superpowers/audits/2026-08-30-app-platform-phase-3-certification.md
+++ b/docs/superpowers/audits/2026-08-30-app-platform-phase-3-certification.md
@@ -1,11 +1,12 @@
 # App Platform Phase 3 certification checkpoints
 
-- Date: 2026-08-30
+- Date: 2026-08-30; consolidated PR D gate 2026-08-31
 - Historical pre-split baseline: `5050b0f1` with C5 source checkpoint
   `944b265f`; useful review evidence, superseded for rollout certification
-- Current PR D control checkpoint: `5cf88c51` on PR C merge `9c8e9ac9`
-- Current result: split-control delta acceptance passed; consolidated PR D and
-  immutable release-artifact gates remain
+- Current PR D certification checkpoint: `fe66113f` on PR C merge `9c8e9ac9`;
+  split-control source checkpoint `5cf88c51`
+- Current result: consolidated local PR D gate passed; remote PR checks and the
+  immutable release-artifact gate remain
 - Rollout decision: off/off by default; merge alone does not make the legacy MCP
   canary supported
 
@@ -56,18 +57,44 @@ Phase 3 exposes no public operations route or UI. Present operator access is the
 bounded, tenant-scoped SQL and procedure contract in
 `docs/app-run-operations.md`.
 
-## Remaining PR D consolidated gate
+## Consolidated PR D local gate
 
-- Run engine off/intake off exact legacy parity.
-- Engine on/intake off durable-job drain/resume and engine-off defer without an
-  attempt debit.
-- Accepted-approval transition across intake-on, drain-only, and engine-off
-  process states with one Run, one provider effect, and no fallback.
-- Complete `apps/api/test/app-run-engine-db.test.ts` at the final PR D tip.
-- Focused worker, connector, trust, approval, keyring, leakage, and MCP-boundary
-  tests; participating typecheck; final diff inspection.
-- One production source build only if normal PR CI does not run the equivalent
-  build against the exact tip.
+The 2026-08-31 run used PostgreSQL 16 database
+`deft_phase3_prc_20260830_01`. It ended with zero App Runs, zero nonterminal
+Runs, zero active App Run jobs, and no transition or approval-resolver fixture
+residue.
+
+| Boundary | Evidence | Result |
+|---|---|---|
+| Engine off/intake off | shared immediate/action fixture | 10 legacy cases passed; 6 governed cases skipped |
+| Engine on/intake off | same fixture | 10 legacy cases passed; 6 governed cases skipped |
+| Engine on/intake on | same fixture | 6 governed cases passed; 10 legacy cases skipped |
+| Accepted approval across restart states | `app-run-rollout-transition-db.test.ts` using the production approval resolver, runtime, worker, and provider adapter | 1 passed; one Run, one attempt, one budget reservation, one provider call, no legacy receipt/fallback |
+| Complete App Run engine database suite | `app-run-engine-db.test.ts` at `fe66113f` | 20 passed |
+| Shared contract, architecture, rollout configuration, keyring, Capability Service, connector, trust, worker routing, leakage, and MCP boundary | focused serial group | 117 passed |
+| Approval and worker defer/retry compatibility | focused database group | 27 passed |
+| Participating TypeScript packages | repository `pnpm typecheck` | passed for web, API, shared, and App Kit |
+| Diff and residue hygiene | `git diff --check`, bounded full-delta inspection, and database residue queries | passed |
+
+The transition proof starts with intake and engine enabled, persists a pending
+approval, proves engine-off approval fails closed, approves after restart in
+drain-only mode, proves engine-off returns the durable job to pending without a
+retry debit, and resumes it in drain-only mode. A replay through the registered
+handler does not call the provider again.
+
+No browser, fresh-schema, pgvector retry, Docker image, or self-host smoke was
+run locally because this delta changes no UI or migration and those checks are
+explicit release-candidate gates. The one production source build is delegated
+to normal PR CI against the exact pushed tip; run it locally only if that CI job
+does not execute.
+
+## Remaining PR D remote gate
+
+- Inspect the committed audit delta and open PR D from the exact checkpoint.
+- Require normal PR CI, including the production source build, API tests,
+  typecheck, upgrade/image jobs, and security checks, to pass.
+- Keep the branch unmerged until human review; passing PR D does not satisfy the
+  separate release-artifact gate below.
 
 ## Remaining release-artifact gates
 

--- a/docs/superpowers/audits/2026-08-30-app-platform-phase-3-certification.md
+++ b/docs/superpowers/audits/2026-08-30-app-platform-phase-3-certification.md
@@ -1,78 +1,90 @@
-# App Platform Phase 3 local certification
+# App Platform Phase 3 certification checkpoints
 
 - Date: 2026-08-30
-- Runtime candidate: `944b265f`
-- Result: local code acceptance passed; release-only infrastructure gates remain
-- Rollout decision: disabled by default, self-host opt-in only; do not widen
-  further until the external gates below pass on a released image
+- Historical pre-split baseline: `5050b0f1` with C5 source checkpoint
+  `944b265f`; useful review evidence, superseded for rollout certification
+- Current PR D control checkpoint: `5cf88c51` on PR C merge `9c8e9ac9`
+- Current result: split-control delta acceptance passed; consolidated PR D and
+  immutable release-artifact gates remain
+- Rollout decision: off/off by default; merge alone does not make the legacy MCP
+  canary supported
 
-## Verified matrix
+## Current split-control delta
 
 | Boundary | Evidence | Result |
 |---|---|---|
-| Shared capability and App Run contracts | `@deft/shared` tests | 55 passed |
-| Fresh-schema/upgrade representation and additive migrations `.17`–`.21` | `@deft/db` upgrade contract tests | 23 passed |
-| Key configuration, AEAD/AAD, rotation, fingerprints, receipt signing, retirement refusal | App Run secret tests | passed |
-| Capability Service, pinned MCP adapter, one-path flag selection, no shadow/fallback | focused API tests | passed |
-| Architecture and leakage boundaries | App Run and Capability architecture tests | passed |
-| Trust, approval matrix, connector network/credential safety, provider-text boundary | focused API tests | passed |
-| Worker registry, lifecycle, lease fencing, retry exhaustion, and flag-off defer | focused worker and queue tests | passed |
-| Run lifecycle, concurrency, release, live authority, budgets, crash recovery, ancestry, receipts, Attention, operations, and atomic jobs | disposable-database engine tests | 20 passed |
-| Exact flag-off Phase 2 immediate/action/approval compatibility | same disposable fixture with flag false | 10 passed; 6 governed cases skipped |
-| Exact flag-on safe read, unrepresentable result, post-effect membership revocation, concurrent action replay, reviewed approval replay, and ambiguous transport | same disposable fixture with valid keyrings and flag true | 6 passed; 10 legacy cases skipped |
-| API discovery routes and legacy approval resolver assertions | disposable-database focused group | passed with the stale-fixture caveat below |
-| Repository TypeScript | `pnpm typecheck` | passed for all participating workspaces |
-| Production source build | `pnpm build` | API and optimized Next.js build passed; 43 web routes generated |
+| Three safe flag states, malformed intake, and invalid engine-off/intake-on startup | real isolated environment imports plus pure configuration checks | 3 passed |
+| Capability Service one-path selection, no shadow call, and no governed-to-legacy fallback | focused unit tests | passed |
+| Engine versus intake consumers | architecture scan plus runtime/handler assertions | passed |
+| Capability, architecture, and rollout configuration group | focused API tests | 27 passed |
+| Engine on/intake off | shared immediate/action disposable-database fixture | 10 legacy cases passed; 6 governed cases skipped |
+| Engine on/intake on | same fixture, provider stubs, and parity assertions | 6 governed cases passed; 10 legacy cases skipped |
+| API TypeScript | `pnpm --filter @deft/api typecheck` | passed |
+| Diff hygiene at the code checkpoint | `git diff --check` and bounded inspection | passed |
 
-The consolidated runs reported 55 shared tests, 23 upgrade tests, 104 focused
-non-database API tests, 69 selected flag-off database tests, and 6 selected
-flag-on database tests with no assertion failures. Exact provider results,
-inputs, retry keys, ciphertext, and key material remained outside safe ledgers
-in the explicit leakage assertions.
+The engine flag remains the only runtime/keyring/worker drain control. The
+legacy intake flag is consumed only by Capability Service and the legacy
+employee-budget bridge. A governed selection calls no legacy fallback even when
+the governed path throws. No UI, migration, token, connector-ciphertext, hosted
+dependency, or App-origin authority changed in the split.
 
-## Rollback and operations decision
+## Historical evidence retained through ancestry
 
-`docs/app-run-operations.md` is the operator contract. It covers initial key
-generation, additive current-key rotation, read/verify overlap, reference-based
-retirement refusal, database-plus-keyring backup/restore, disaster recovery,
-flag-off pause behavior, downgrade queries, and the future hosted KMS seam.
+The pre-split certification at `5050b0f1` covered shared App Run contracts,
+additive migrations `.17`–`.21`, key separation and rotation, lifecycle and
+crash recovery, live authority and budgets, approval ownership, ancestry,
+receipts, Attention, provider pinning, worker registration, leakage boundaries,
+repository typecheck, and a production source build. PR C independently passed
+required CI after merge-train reconstruction, including a real pgvector fresh
+schema, supported upgrade, production image, self-host smoke, browser smoke,
+CodeQL, dependency checks, API tests, typecheck, and build.
 
-The source-level execution rollback floor is `944b265f`. Exact flag-off on that
-floor routes new calls through the unchanged legacy path and defers durable App
-Run jobs without spending attempts. Downgrade below that floor is not allowed
-until there are no nonterminal Runs, pending `app_run_invoke` approvals, or
-active `app-run-attempt` jobs.
+That evidence remains valid for unchanged trust/data boundaries. It does not
+prove the newer control matrix, worker drain transition, or final PR D tip;
+those belong to the consolidated delta run and release gate below.
 
-Existing connector ciphertext and legacy action-receipt writers remain
-unchanged. There was no in-place re-encryption, token migration, new hosted
-dependency, or default enablement.
+## Execution and UI ownership
 
-## Explicitly unverified release gates
+`app_runs` is canonical execution state. `agent_actions` is the current
+approval-inbox projection for the legacy compatibility entrance, and legacy
+action receipts remain historical compatibility. After native App approval/Run
+UI and Phase 6 parity are certified, no new App-origin path may depend on this
+dual ledger.
 
-- The Docker daemon is not running on this host, so no production image,
-  Compose self-host smoke, rolling-image drill, or scripted backup/restore was
-  executed. The production source build passed.
-- Local PostgreSQL has no pgvector installation. Per the established test
-  constraint, `CREATE EXTENSION vector` and another `db:push-full` bootstrap
-  were not retried. Static fresh/upgrade convergence tests passed, and the
-  disposable database exercised the Phase 3 `.17`–`.21` objects, but a final
-  pgvector-backed fresh install and supported-upgrade drill remains a release
-  gate.
-- The disposable clone has no upgrade ledger and predates current Agent Channel
-  lease columns. The legacy approval-resolver assertions passed, but its
-  best-effort `approval.resolved` Agent Channel projection logged the missing
-  `claim_owner` column. A current-schema environment must rerun that projection
-  before release; the Phase 3 compatibility fixture's approval/receipt path was
-  clean.
-- No browser approval/Run-inspection pass was run. Phase 3 changes no web UI and
-  has no App Run operator UI; API/database compatibility and the production web
-  build passed. A released-image browser smoke with a deterministic MCP provider
-  remains a widening gate.
-- No actual downgrade to an older released image was performed. The source
-  rollback behavior and queue pause are tested; the image-level drill remains
-  blocked by Docker and by the absence of a released C5-floor image.
+`AppRunOperationsService` is an internal, production-denied repair primitive.
+Phase 3 exposes no public operations route or UI. Present operator access is the
+bounded, tenant-scoped SQL and procedure contract in
+`docs/app-run-operations.md`.
 
-These omissions do not invalidate the local implementation result. They do
-block default-on rollout, broad opt-in recommendation, and hosted-service
-enablement. Phase 3 should merge as additive guarded work, then complete the
-listed image/current-schema gates before a release announcement widens use.
+## Remaining PR D consolidated gate
+
+- Run engine off/intake off exact legacy parity.
+- Engine on/intake off durable-job drain/resume and engine-off defer without an
+  attempt debit.
+- Accepted-approval transition across intake-on, drain-only, and engine-off
+  process states with one Run, one provider effect, and no fallback.
+- Complete `apps/api/test/app-run-engine-db.test.ts` at the final PR D tip.
+- Focused worker, connector, trust, approval, keyring, leakage, and MCP-boundary
+  tests; participating typecheck; final diff inspection.
+- One production source build only if normal PR CI does not run the equivalent
+  build against the exact tip.
+
+## Remaining release-artifact gates
+
+- Build and identify the immutable merged candidate image and its supported
+  predecessor; record both digests and migration ledgers.
+- Prove a current pgvector-backed fresh install and supported upgrade through
+  `.21` on release-capable infrastructure.
+- Run deterministic-provider canary and approval/browser smoke without claiming
+  a public Run UI.
+- Back up and restore database, uploads/App artifacts where applicable, and all
+  Run keyrings at consistent points; exercise rotation and referenced-key
+  retirement refusal.
+- Disable intake, drain and quiesce governed work, then perform the actual
+  supported image rollback drill.
+- Record the first released image containing the final split-control contract as
+  the operational rollback floor.
+
+Until those gates pass, App origin remains disabled, the legacy MCP canary stays
+default-off and unsupported for production widening, and no local source hash
+is an operational rollback floor.

--- a/docs/superpowers/plans/2026-08-29-full-surface-app-platform.md
+++ b/docs/superpowers/plans/2026-08-29-full-surface-app-platform.md
@@ -2,9 +2,9 @@
 
 | Field | Value |
 |---|---|
-| **Status** | Canonical capability map and threat model; Phases 0–2 merged and Phase 3 closeout pending |
+| **Status** | Canonical capability map and threat model; Phase 3 PR C merged and guarded PR D closeout in progress; release gate pending |
 | **Date** | 2026-08-29; execution rebaseline 2026-08-30 |
-| **Baseline inspected** | `origin/master` at `399cd030`; local Phase 3 closeout baseline `5050b0f1` is unreleased |
+| **Baseline inspected** | `origin/master` at PR C merge `9c8e9ac9`; PR D is replayed from that exact merge and remains unreleased |
 | **North star** | A Deft user can ask Codex to build a useful application, install it into their Deft workspace, and have it participate natively in the human UI, search and knowledge, tasks and chat, Defty, employee agents, human MCP, automation, approvals, runs, receipts, and audit. |
 | **First delivery principle** | Build one safe participation protocol in stages; do not turn `deft.module.json` into an arbitrary plugin runtime. |
 | **Relationship to earlier work** | Supersedes the provisional App Protocol v2 implementation sequence while retaining its certified Module, Capability, App Run, and approval-boundary decisions as design input. Absorbs the useful resource-graph and solution-composition ideas from the modular work-management proposal. |
@@ -778,25 +778,27 @@ and the staged secret/rollback decision. Phase 3 is not one big-bang PR; migrati
 identifiers must be re-confirmed at the implementation boundary even though the
 planning branch is now rebased onto the Phase 2 merge.
 
-**Foundation status (2026-08-30):** PR A implements the frozen contracts,
-purpose-separated versioned key readers and cryptographic service, and additive
-tenant-bound Run/attempt/secret/event/receipt schema at upgrade slot `.17`.
-The App origin and all production execution consumers remain disabled; existing
-execution and legacy ciphertext writes are unchanged.
+**Implementation status (2026-08-30):** PRs A and B merged the frozen contracts,
+purpose-separated key service, additive schema, lifecycle, and fake-provider
+engine. Local C0–C5 checkpoints add release/budget evidence, live authority,
+approval compatibility, ancestry, receipts, Attention, operations, the pinned
+worker runtime, and an exact guarded Capability Service cutover. App origin
+remains disabled; existing connector ciphertext and legacy receipt writers are
+unchanged.
 
-- [ ] Add a versioned Secret Service with random nonces, AAD-bound ciphertext, current and decrypt-only keys, rotation, and explicit safe projections.
-- [ ] Add minimum-input rules, strict Run payload/blob limits, retention classes, terminal-state purge, and sanitized audit residue; permission widening cannot silently extend retention.
+- [x] Add a versioned Secret Service with random nonces, AAD-bound ciphertext, current and decrypt-only keys, rotation, and explicit safe projections.
+- [x] Add minimum-input rules, strict Run payload/blob limits, retention classes, terminal-state purge, and sanitized audit residue; permission widening cannot silently extend retention.
 - [ ] Stage encryption compatibility across releases: add legacy+v2 dual-read while retaining legacy writes, require the rollback-floor image to read v2 before enabling v2 writes, avoid in-place connector re-encryption during that window, then retire legacy only after tested backup/restore.
-- [ ] Add separate versioned receipt-signing and input/idempotency-fingerprint keyrings; never reuse encryption, signing, and fingerprint keys across purposes.
-- [ ] Add App Run, attempt, append-only event, App-native receipt, and attention schemas/tables/state machines.
-- [ ] Add idempotency replay/conflict, locks, timeouts, cancellation, retry classification, and `unknown_outcome` semantics.
-- [ ] Add bounded child-Run ancestry with inherited budgets/authorization and synchronous capability-cycle rejection.
-- [ ] Integrate the existing approval inbox through one linked `app_run_invoke` action while making the App Run the execution source of truth.
-- [ ] Add the closed `app | core | legacy_connector` execution-origin union; legacy origins persist `grant_source: legacy_connection_policy` and cannot appear in the App catalog.
-- [ ] Enforce the actor/App-grant intersection for App origins and the exact current legacy policy for compatibility origins before approval and again immediately before execution.
-- [ ] Recheck membership, employee health/budget, token scope, connector, schema digest, provider, assignment, grants/policy source, and bound authorization versions at execution.
-- [ ] Add sanitized receipts, metrics, operator inspection, and migration adapters for existing action receipts.
-- [ ] Wrap App Run invocation behind a disabled-by-default flag, certify it, and retain a bounded rollback path until parity is proven.
+- [x] Add separate versioned receipt-signing and input/idempotency-fingerprint keyrings; never reuse encryption, signing, and fingerprint keys across purposes.
+- [x] Add App Run, attempt, append-only event, App-native receipt, and attention schemas/tables/state machines.
+- [x] Add idempotency replay/conflict, locks, timeouts, cancellation, retry classification, and `unknown_outcome` semantics.
+- [x] Add bounded child-Run ancestry with inherited budgets/authorization and synchronous capability-cycle rejection.
+- [x] Integrate the existing approval inbox through one linked `app_run_invoke` action while making the App Run the execution source of truth.
+- [x] Add the closed `app | core | legacy_connector` execution-origin union; legacy origins persist `grant_source: legacy_connection_policy` and cannot appear in the App catalog.
+- [x] Enforce the actor/App-grant intersection for App origins and the exact current legacy policy for compatibility origins before approval and again immediately before execution.
+- [x] Recheck membership, employee health/budget, token scope, connector, schema digest, provider, assignment, grants/policy source, and bound authorization versions at execution.
+- [x] Add sanitized receipts, metrics, operator inspection, and compatibility adapters without rewriting existing action receipts.
+- [x] Wrap App Run invocation behind a disabled-by-default flag and retain a bounded rollback path; immutable release certification remains the D2 gate.
 
 **Acceptance evidence:** auto and reviewed calls create one Run and at most one provider call; capability cycles stop before a second call and child Runs cannot reset budgets; no pseudo-App grant exists; legacy Runs are not App-discoverable; `always` review cannot be bypassed by an Autonomous employee; payload limits and terminal purge preserve only the declared sanitized residue; restart/replay, encryption/signer/fingerprint rotation, supported-image rollback, low-entropy guessing resistance, unknown-outcome, and ciphertext-leakage tests pass.
 

--- a/docs/superpowers/plans/2026-08-29-full-surface-app-platform.md
+++ b/docs/superpowers/plans/2026-08-29-full-surface-app-platform.md
@@ -783,8 +783,10 @@ purpose-separated key service, additive schema, lifecycle, and fake-provider
 engine. PR C (#273) merged release/budget evidence, live authority, approval
 compatibility, ancestry, receipts, Attention, and internal repair invariants.
 PR D now contains the pinned worker runtime plus separate exact default-off Run
-engine/drain and legacy MCP intake controls. App origin remains disabled;
-existing connector ciphertext and legacy receipt writers are unchanged.
+engine/drain and legacy MCP intake controls. Its local consolidated gate and
+cross-process approval/drain transition passed at `fe66113f`; remote PR and
+immutable release-artifact gates remain. App origin remains disabled; existing
+connector ciphertext and legacy receipt writers are unchanged.
 
 - [x] Add a versioned Secret Service with random nonces, AAD-bound ciphertext, current and decrypt-only keys, rotation, and explicit safe projections.
 - [x] Add minimum-input rules, strict Run payload/blob limits, retention classes, terminal-state purge, and sanitized audit residue; permission widening cannot silently extend retention.

--- a/docs/superpowers/plans/2026-08-29-full-surface-app-platform.md
+++ b/docs/superpowers/plans/2026-08-29-full-surface-app-platform.md
@@ -780,11 +780,11 @@ planning branch is now rebased onto the Phase 2 merge.
 
 **Implementation status (2026-08-30):** PRs A and B merged the frozen contracts,
 purpose-separated key service, additive schema, lifecycle, and fake-provider
-engine. Local C0–C5 checkpoints add release/budget evidence, live authority,
-approval compatibility, ancestry, receipts, Attention, operations, the pinned
-worker runtime, and an exact guarded Capability Service cutover. App origin
-remains disabled; existing connector ciphertext and legacy receipt writers are
-unchanged.
+engine. PR C (#273) merged release/budget evidence, live authority, approval
+compatibility, ancestry, receipts, Attention, and internal repair invariants.
+PR D now contains the pinned worker runtime plus separate exact default-off Run
+engine/drain and legacy MCP intake controls. App origin remains disabled;
+existing connector ciphertext and legacy receipt writers are unchanged.
 
 - [x] Add a versioned Secret Service with random nonces, AAD-bound ciphertext, current and decrypt-only keys, rotation, and explicit safe projections.
 - [x] Add minimum-input rules, strict Run payload/blob limits, retention classes, terminal-state purge, and sanitized audit residue; permission widening cannot silently extend retention.
@@ -797,8 +797,8 @@ unchanged.
 - [x] Add the closed `app | core | legacy_connector` execution-origin union; legacy origins persist `grant_source: legacy_connection_policy` and cannot appear in the App catalog.
 - [x] Enforce the actor/App-grant intersection for App origins and the exact current legacy policy for compatibility origins before approval and again immediately before execution.
 - [x] Recheck membership, employee health/budget, token scope, connector, schema digest, provider, assignment, grants/policy source, and bound authorization versions at execution.
-- [x] Add sanitized receipts, metrics, operator inspection, and compatibility adapters without rewriting existing action receipts.
-- [x] Wrap App Run invocation behind a disabled-by-default flag and retain a bounded rollback path; immutable release certification remains the D2 gate.
+- [x] Add sanitized receipts, metrics, Attention, internal bounded inspection/repair primitives, and compatibility adapters without rewriting existing action receipts or claiming a public Operations surface.
+- [x] Separate disabled-by-default Run engine/drain and legacy MCP intake controls, reject intake without the engine, and retain a bounded drain-first rollback path; immutable release certification remains the D2 gate.
 
 **Acceptance evidence:** auto and reviewed calls create one Run and at most one provider call; capability cycles stop before a second call and child Runs cannot reset budgets; no pseudo-App grant exists; legacy Runs are not App-discoverable; `always` review cannot be bypassed by an Autonomous employee; payload limits and terminal purge preserve only the declared sanitized residue; restart/replay, encryption/signer/fingerprint rotation, supported-image rollback, low-entropy guessing resistance, unknown-outcome, and ciphertext-leakage tests pass.
 

--- a/docs/superpowers/plans/2026-08-30-app-platform-phase-3-closeout-loops.md
+++ b/docs/superpowers/plans/2026-08-30-app-platform-phase-3-closeout-loops.md
@@ -377,6 +377,27 @@ boundaries.
 - No repeated fresh-schema bootstrap locally.
 - No unrelated Hermes or full API certification outside normal CI.
 
+### Completed evidence (2026-08-31)
+
+- The shared immediate/action fixture passed in all three supported modes:
+  off/off 10 legacy cases, on/off 10 legacy cases, and on/on 6 governed cases.
+- Cross-process transition test `app-run-rollout-transition-db.test.ts` passed
+  at `fe66113f`. It uses the production approval resolver, runtime composition,
+  worker settlement, and provider adapter to prove one pending approval survives
+  intake shutoff, engine pause, and drain-only restart with one attempt, one
+  budget reservation, one provider call, and no legacy fallback.
+- The complete App Run engine database suite passed 20/20 at that checkpoint.
+- The focused shared contract, Capability Service, architecture, rollout,
+  keyring, connector, trust, leakage, worker-routing, and MCP-boundary group
+  passed 117/117. The focused approval and worker-reliability database group
+  passed 27/27.
+- Repository typecheck passed for every participating package. Final diff and
+  database residue checks passed; the fixture left zero Runs, nonterminal Runs,
+  active App Run jobs, or test identities.
+- The production source build remains assigned to normal PR CI against the exact
+  pushed tip, as allowed by item 9. The explicit local exclusions above were not
+  repeated.
+
 ## Loop 7 — Open, review, and merge PR D default-off
 
 ### Work

--- a/docs/superpowers/plans/2026-08-30-app-platform-phase-3-closeout-loops.md
+++ b/docs/superpowers/plans/2026-08-30-app-platform-phase-3-closeout-loops.md
@@ -2,12 +2,12 @@
 
 | Field | Value |
 |---|---|
-| **Status** | In execution; Loops 0–1 complete, Loop 2 next |
+| **Status** | In execution; Loops 0–5 complete, Loop 6 consolidated delta certification next |
 | **Date** | 2026-08-30 |
 | **Architecture source** | `docs/superpowers/plans/2026-08-29-full-surface-app-platform.md` |
 | **Delivery source** | `docs/superpowers/plans/2026-08-30-full-surface-app-platform-delivery-plan.md` |
-| **Merged base** | `origin/master` at `399cd030` |
-| **Local closeout baseline** | clean worktree at `5050b0f1`; local-only and unreleased |
+| **Merged base** | PR C merge on `origin/master` at `9c8e9ac9` |
+| **Local closeout baseline** | PR D C4–D2 replay at `ee513a35`, plus split-control checkpoint `5cf88c51`; local-only and unreleased |
 | **Outcome** | Merge and release the guarded Phase 3 execution substrate with Run draining separated from legacy MCP intake, then hand Phase 4 one immutable supported baseline. |
 
 ## Decision
@@ -29,8 +29,9 @@ trains.
 
 ## Current immutable facts
 
-- `origin/master` includes the Phase 3 foundation and fake-provider engine.
-- The Phase 3 worktree is clean on a linear local-only chain:
+- `origin/master` includes the Phase 3 foundation, engine, and PR C trust/data
+  completion through merge `9c8e9ac9`.
+- The original Phase 3 source worktree carried this historical local chain:
   - `4c4f48c1` — C0 engine/cutover hardening;
   - `e6274c41` — C1 live authority and budget evidence;
   - `c3670207` — C2 approval compatibility projection;
@@ -38,8 +39,10 @@ trains.
   - `ffdab418` — C4 runtime/worker composition;
   - `944b265f` — C5 legacy capability cutover;
   - `5050b0f1` — local certification documentation.
-- None of the local hashes is merged, released, or an operational rollback
-  floor.
+- PR C replayed C0–C3 and merged as #273. Original hashes remain historical;
+  PR D was rebuilt from the merge as `1e4ac5a7` (C4), `bd28ff6f` (C5), and
+  `ee513a35` (historical certification), then added split controls at
+  `5cf88c51`. No PR D hash is released or an operational rollback floor.
 - Before Loop 0, the revised delivery and closeout plans plus the intended
   canonical-plan header/pointer edits existed only in the dirty main worktree.
   The dirty main copy of the canonical plan predates newer Phase 1–3 evidence,
@@ -48,9 +51,9 @@ trains.
 - Additive migrations `.19`–`.21` are implemented and tested. Preserve them;
   rewriting their history provides no functional value and invalidates useful
   evidence.
-- The current single `DEFT_APP_RUNS_ENABLED` value controls Run runtime/key
-  availability and selects new legacy MCP intake. That coupling prevents a safe
-  drain-only mode and must be split before PR D closes.
+- `DEFT_APP_RUNS_ENABLED` now controls Run runtime/key availability and draining;
+  `DEFT_APP_RUN_LEGACY_MCP_CUTOVER_ENABLED` independently controls new legacy
+  MCP admission. The invalid off/on state is rejected at startup.
 - App origin, system origin, and automation origin remain fail-closed.
 - The current local host lacks pgvector and a running Docker release
   environment. Do not retry those known local limitations; run their gates once
@@ -282,6 +285,19 @@ comments unless a focused test proves a behavior defect.
 - Engine off/intake on fails startup.
 - All unspecified/malformed values fail closed.
 
+### Completed evidence
+
+- Split-control implementation checkpoint: `5cf88c51`.
+- Capability Service, architecture, and rollout configuration: 27 passed.
+- Real isolated startup rejects off/on; malformed uppercase intake fails closed.
+- API typecheck passed.
+- Shared disposable fixture with engine on/intake off: 10 legacy cases passed,
+  6 governed cases skipped.
+- Same fixture with engine on/intake on: 6 governed cases passed, 10 legacy
+  cases skipped.
+- Runtime and worker-handler source remain engine-controlled and have no intake
+  flag dependency. Dynamic drain/defer certification remains in Loop 6.
+
 ## Loop 5 — Correct closeout truth and ownership
 
 **Outcome:** documentation describes the shipped boundary rather than local
@@ -304,6 +320,16 @@ checkpoint assumptions.
 - Documentation/link checks when available.
 - `git diff --check`.
 - No database, browser, Docker, or build rerun for prose-only changes.
+
+### Completed record
+
+- The four-state matrix, drain-first rollback sequence, dual-ledger exit,
+  internal-only Operations boundary, App-origin deferral, and future immutable
+  released-image floor are recorded in the environment example, self-hosting
+  guide, operations runbook, ADR, canonical/delivery/Phase 3 plans, and
+  certification audit.
+- Compose already passes `.env` to services, so no duplicate variable wiring is
+  required.
 
 ## Loop 6 — Run one PR D delta certification
 
@@ -413,8 +439,8 @@ backup/restore and image rollback. Do not use the known deficient local host.
    all required keyrings at consistent points.
 10. Rotate encryption, fingerprint, and signing keys; prove retained payload/
     receipt reads and referenced-key retirement refusal.
-11. Prove flag-off pause and flag-on resume without attempt debit or duplicate
-    provider dispatch.
+11. Prove intake-off drain, engine-off pause, and engine-on resume without
+    attempt debit or duplicate provider dispatch.
 12. Use the frozen quiescence query to prove no nonterminal Runs, pending
    compatibility approvals, or active Run jobs remain, then perform the actual
    supported rollback drill between the recorded immutable source and target

--- a/docs/superpowers/plans/2026-08-30-app-platform-phase-3-governed-runs-loops.md
+++ b/docs/superpowers/plans/2026-08-30-app-platform-phase-3-governed-runs-loops.md
@@ -1,9 +1,10 @@
 # App Platform Phase 3: Governed App Runs and Secret Service loops
 
-**Status:** accepted and in progress; PR A (#271) and PR B (#272) merged the
-dormant Loops 0–4 foundation and fake-provider engine. C0 is complete at local
-checkpoint `4c4f48c1`; C1 live authorization/budget, C2 approval compatibility,
-and C3 operational safety are stacked on it pending review and publication.
+**Status:** local implementation and certification complete through D2; PR A
+(#271) and PR B (#272) merged the dormant foundation and fake-provider engine.
+C0–C5 are preserved as local review checkpoints through governed-cutover commit
+`944b265f`. External released-image, current-schema pgvector, browser, and
+self-host drills remain publication gates recorded in the certification audit.
 
 **Rebaseline record:** Phase 2 PR #270 merged with every required check green;
 the foundation selected `.17`, PR B selected `.18`, and the post-engine audit
@@ -135,11 +136,26 @@ worker, and Capability Service entrance.
 Loops 5–7 integrate approvals, Capability Service, existing actors, receipts,
 Attention, ancestry, and operator inspection behind a fail-closed flag.
 
+**Implemented rebaseline:** C1–C3 delivered Loop 5 and Loop 7 boundaries before
+C4 composed the production runtime. C5 then selected the Run-backed path in
+Capability Service. Existing legacy approval policy remains the compatibility
+gate, so an approved legacy occurrence supplies host evidence and stable replay
+identity rather than creating a duplicate App Run approval. Auto-safe reads use
+the same Run engine without an employee action debit. App-origin calls remain
+denied.
+
 ### Milestone D: release certification
 
 Loops 8–9 prove key rotation, supported upgrades, rollback, self-host operation,
 parity, and leakage safety. Widening the flag remains a separate explicit
 decision.
+
+**Final Phase 3 decision:** remain disabled by default and self-host opt-in. The
+source-level rollback floor is C5 commit `944b265f`; downgrading below it is
+allowed only after governed work is quiescent. Full operations are documented
+in `docs/app-run-operations.md`; verified evidence and release-only omissions
+are recorded in
+`docs/superpowers/audits/2026-08-30-app-platform-phase-3-certification.md`.
 
 ## Invariants
 

--- a/docs/superpowers/plans/2026-08-30-app-platform-phase-3-governed-runs-loops.md
+++ b/docs/superpowers/plans/2026-08-30-app-platform-phase-3-governed-runs-loops.md
@@ -1,10 +1,10 @@
 # App Platform Phase 3: Governed App Runs and Secret Service loops
 
-**Status:** local implementation and certification complete through D2; PR A
-(#271) and PR B (#272) merged the dormant foundation and fake-provider engine.
-C0–C5 are preserved as local review checkpoints through governed-cutover commit
-`944b265f`. External released-image, current-schema pgvector, browser, and
-self-host drills remain publication gates recorded in the certification audit.
+**Status:** PR A (#271), PR B (#272), and trust/data PR C (#273) are merged.
+Runtime/cutover PR D is replayed from PR C's merge, and its split-control code
+checkpoint is `5cf88c51`; consolidated delta and release-artifact certification
+remain. Original C0–C5 hashes are historical review checkpoints, not supported
+release floors.
 
 **Rebaseline record:** Phase 2 PR #270 merged with every required check green;
 the foundation selected `.17`, PR B selected `.18`, and the post-engine audit
@@ -134,7 +134,8 @@ worker, and Capability Service entrance.
 ### Milestone C: compatibility integration
 
 Loops 5–7 integrate approvals, Capability Service, existing actors, receipts,
-Attention, ancestry, and operator inspection behind a fail-closed flag.
+Attention, ancestry, and internal bounded inspection/repair behind fail-closed
+controls.
 
 **Implemented rebaseline:** C1–C3 delivered Loop 5 and Loop 7 boundaries before
 C4 composed the production runtime. C5 then selected the Run-backed path in
@@ -150,11 +151,13 @@ Loops 8–9 prove key rotation, supported upgrades, rollback, self-host operatio
 parity, and leakage safety. Widening the flag remains a separate explicit
 decision.
 
-**Final Phase 3 decision:** remain disabled by default and self-host opt-in. The
-source-level rollback floor is C5 commit `944b265f`; downgrading below it is
-allowed only after governed work is quiescent. Full operations are documented
-in `docs/app-run-operations.md`; verified evidence and release-only omissions
-are recorded in
+**Current Phase 3 decision:** remain disabled by default and self-host opt-in.
+The Run engine/drain and legacy MCP intake controls are independent; App origin
+remains denied. No local hash is an operational rollback floor. The first
+immutable released image containing the final split-control contract becomes
+the floor only after the release gate records it. Full operations are
+documented in `docs/app-run-operations.md`; verified evidence and release-only
+omissions are recorded in
 `docs/superpowers/audits/2026-08-30-app-platform-phase-3-certification.md`.
 
 ## Invariants
@@ -249,8 +252,9 @@ service interface. They do not receive decrypted input or a provider callback.
   unknown-key, rotation, and constant-time verification tests pass.
 - Low-entropy retry/input values cannot be verified by an offline database-only
   guessing attack.
-- Production startup fails only when App Runs are enabled without valid Run
-  keyrings; flag-off deployments retain the existing environment contract.
+- Production startup fails when the Run engine is enabled without valid Run
+  keyrings or when legacy MCP intake is enabled without the engine; the default
+  off/off deployment retains the existing environment contract.
 - Architecture tests prove only the secret repository handles Run ciphertext and
   only the signer handles signing key material.
 
@@ -410,7 +414,7 @@ service interface. They do not receive decrypted input or a provider callback.
   adapter or changed only under a separately approved migration decision.
 - No App-origin invocation succeeds.
 
-## Loop 7: Ancestry, receipts, Attention, and operator inspection
+## Loop 7: Ancestry, receipts, Attention, and internal inspection
 
 ### Work
 
@@ -422,8 +426,9 @@ service interface. They do not receive decrypted input or a provider callback.
   Do not migrate legacy receipt rows in place.
 - Publish idempotent Run Attention events for approval, failure,
   `unknown_outcome`, and repair gaps using the existing Attention service.
-- Add safe operator inspection and reconciliation surfaces plus bounded metrics.
-  Raw ciphertext and retry keys are never operator-list fields or metric labels.
+- Add safe internal inspection and reconciliation primitives plus bounded
+  metrics. Expose no production route or UI. Raw ciphertext and retry keys are
+  never selected fields or metric labels.
 - Add reconciliation reports for missing terminal events/receipts/Attention.
 
 ### Exit evidence
@@ -486,10 +491,10 @@ service interface. They do not receive decrypted input or a provider callback.
 - No raw input, retry key, ciphertext, provider secret, full output, or
   signing/fingerprint material appears in any generic/list or observability
   surface; the exact result is confined to its explicitly authorized response.
-- Every flag-on governed provider effect has a Run and attempt; every reviewed
+- Every intake-on governed provider effect has a Run and attempt; every reviewed
   Run has one linked approval adapter; every terminal governed effect has a
-  receipt or a visible repair gap. Flag-off legacy execution remains explicitly
-  outside that claim.
+  receipt or a visible repair gap. Intake-off legacy execution remains
+  explicitly outside that claim, including while the engine drains older work.
 - Unknown outcomes are inspectable and never auto-retried.
 - The flag/default, rollback floor, key versions, unverified requirements, and
   remaining legacy-encryption work are reported explicitly.
@@ -500,15 +505,15 @@ service interface. They do not receive decrypted input or a provider callback.
    schema, no execution cutover.
 2. **PR B — engine:** Loops 3–4; lifecycle, idempotency, retention, attempts, fake
    providers, and recovery.
-3. **PR C0 — engine cutover gate:** additive `.19`, execution-release and budget
-   evidence, exact-attempt jobs, lease heartbeat, provider-result taxonomy, and
-   horizon-safe replay; the engine remains unwired.
-4. **C1–C5 — integration train:** live authorization/budget, safe approval
-   adapter, receipts/Attention/operator/ancestry, pinned provider runtime and
-   worker, then an explicit guarded cutover. Each slice must be independently
-   green and may be its own PR.
-5. **D1–D2 — certification:** release/rotation/rollback evidence and the
-   explicit opt-in decision.
+3. **PR C — trust and data completion (#273):** C0–C3 additive `.19`–`.21`,
+   execution release, live authorization/budget, safe approval projection,
+   receipts, Attention, ancestry, and internal repair invariants.
+4. **PR D — guarded runtime and closeout:** C4–C5 production composition,
+   pinned provider/worker, independent engine and legacy-intake controls, and
+   consolidated delta certification.
+5. **Release gate:** immutable image, current-schema/pgvector, backup/restore,
+   rotation, rollback, deterministic-provider, and browser evidence before the
+   opt-in is called supported.
 
 Do not hold all merge trains for one final merge. Merge each independently green,
 then rebase the next train onto its merge commit. This preserves reviewability,

--- a/docs/superpowers/plans/2026-08-30-full-surface-app-platform-delivery-plan.md
+++ b/docs/superpowers/plans/2026-08-30-full-surface-app-platform-delivery-plan.md
@@ -2,10 +2,10 @@
 
 | Field | Value |
 |---|---|
-| **Status** | Proposed execution plan; Phases 0–2 merged, Phase 3 closeout pending |
+| **Status** | Active execution plan; Phases 0–2 and Phase 3 PR C merged, guarded PR D closeout in progress |
 | **Date** | 2026-08-30 |
 | **Architecture source** | `docs/superpowers/plans/2026-08-29-full-surface-app-platform.md` |
-| **Execution baseline** | Phase 1 `bdb137ee`; Phase 2 `9ba7b7c8`; merged Phase 3 engine `399cd030`; existing local Phase 3 certification baseline `5050b0f1` (not the final closeout tip) |
+| **Execution baseline** | Phase 1 `bdb137ee`; Phase 2 `9ba7b7c8`; Phase 3 PR C merge `9c8e9ac9`; PR D replay `ee513a35` plus split-control checkpoint `5cf88c51` (unreleased) |
 | **North star** | A community member can ask Codex to build any feasible Deft App, install it on an ordinary self-hosted workspace, and have it participate through governed resources, knowledge, agents, capabilities, experiences, automation, runtimes, sync, and public ingress as required by that App. |
 
 ## Decision
@@ -80,12 +80,15 @@ trusted API, web, or worker processes.
 - **Phase 3 PR A/B:** dormant App Run contracts, schema, secrets, lifecycle,
   attempts, replay, failure classification, and fake-provider engine merged
   through `399cd030`.
+- **Phase 3 PR C (#273):** C0–C3 trust/data completion merged at `9c8e9ac9`,
+  preserving additive `.19`–`.21`, release/budget evidence, approval ownership,
+  ancestry, receipts, Attention, and internal repair invariants.
 
-The remaining chain is local-only and unreleased:
-`4c4f48c1` (C0) -> `e6274c41` (C1) -> `c3670207` (C2) ->
-`d5192c55` (C3) -> `ffdab418` (C4) -> `944b265f` (C5) ->
-`5050b0f1` (certification docs). None of those hashes is a supported rollback
-floor. The rollback floor is the eventual merged and released image revision.
+The remaining PR D chain is local-only and unreleased: `1e4ac5a7` (C4 replay)
+-> `bd28ff6f` (C5 replay) -> `ee513a35` (historical certification replay) ->
+`5cf88c51` (split controls). Original C0–D2 hashes remain historical review
+evidence. None of these hashes is a supported rollback floor; the floor is the
+eventual immutable released image revision recorded by the release gate.
 
 No completed phase is restarted or redesigned. Later work must consume these
 deep services rather than create parallel execution, package, or authorization
@@ -93,8 +96,9 @@ paths.
 
 ### Phase 3 closeout gate
 
-The local C0–D2 work through `5050b0f1` is treated as completion and hardening
-of the merged engine, not as an App-facing feature.
+The historical C0–D2 work through `5050b0f1` is preserved as review evidence,
+not treated as proof of the newer split-control contract or as an App-facing
+feature. PR D's new checkpoint and consolidated matrix own closeout evidence.
 
 Before it merges:
 
@@ -112,17 +116,15 @@ Before it merges:
    one exists.
 4. Keep `origin = app`, system/automation origins, and broad rollout fail-closed
    until later phases provide their host-owned authority sources.
-5. Keep the exact flag-on legacy MCP path default-off, with no shadow provider
+5. Keep the exact legacy MCP intake path default-off, with no shadow provider
    call and no fallback after a governed attempt begins.
-6. Separate rollout controls for Run runtime/key availability, App-origin
-   entrance, and legacy-connector cutover. Document supported combinations,
-   prerequisites, compatible image floor, owner, and retirement/permanent
-   status. Enabling community Apps must not implicitly migrate all existing MCP
-   traffic.
-7. Because the split controls change code/startup contracts beyond
-   `5050b0f1`, create a new closeout checkpoint and rerun the flag-combination,
-   startup, queue-deferral, keyring, rollback, and compatibility delta before
-   PR D is certified.
+6. Keep Run runtime/key availability separate from legacy-connector cutover;
+   reject intake-on/engine-off and document the three safe combinations. Add an
+   App-origin control only with Phase 5's real grants/bindings entrance.
+   Enabling community Apps must not implicitly migrate all existing MCP traffic.
+7. Split-control checkpoint `5cf88c51` supersedes `5050b0f1` for rollout
+   evidence. Complete its flag-combination, startup, queue-deferral, keyring,
+   rollback, and compatibility delta before PR D is certified.
 
 Recommended review shape:
 
@@ -138,7 +140,8 @@ and recertify the changed delta rather than treating old hashes as evidence.
 
 Merge evidence is limited to changed boundaries plus one consolidated delta
 matrix: shared contracts, final upgrade representation, App Run database suite,
-one flag-off and one flag-on disposable-database fixture, focused
+engine-off/intake-off, engine-on/intake-off, and engine-on/intake-on modes in one
+disposable-database fixture, focused
 approval/trust/connector/worker/crypto/architecture tests, repository typecheck,
 and one production source build. Browser testing is required only if web code
 changes. Production-image, current-schema, backup/restore, rollback, and

--- a/docs/superpowers/plans/2026-08-30-full-surface-app-platform-delivery-plan.md
+++ b/docs/superpowers/plans/2026-08-30-full-surface-app-platform-delivery-plan.md
@@ -86,9 +86,10 @@ trusted API, web, or worker processes.
 
 The remaining PR D chain is local-only and unreleased: `1e4ac5a7` (C4 replay)
 -> `bd28ff6f` (C5 replay) -> `ee513a35` (historical certification replay) ->
-`5cf88c51` (split controls). Original C0–D2 hashes remain historical review
-evidence. None of these hashes is a supported rollback floor; the floor is the
-eventual immutable released image revision recorded by the release gate.
+`5cf88c51` (split controls) -> `a6f2eed2` (closeout contract) -> `fe66113f`
+(restart-transition certification). Original C0–D2 hashes remain historical
+review evidence. None of these hashes is a supported rollback floor; the floor
+is the eventual immutable released image revision recorded by the release gate.
 
 No completed phase is restarted or redesigned. Later work must consume these
 deep services rather than create parallel execution, package, or authorization


### PR DESCRIPTION
## Summary

Adds the guarded production composition and worker path for governed App Runs, then separates the Run engine/drain control from the exact default-off legacy MCP intake control. The cutover has one Capability Service entrance, no shadow provider call or fallback, and preserves the current legacy path unless explicitly enabled. App origin remains fail-closed; this PR is infrastructure for later connected Apps, not an App-facing rollout.

## Type

- [ ] Bug fix
- [x] New feature
- [x] Refactor
- [ ] Docs only
- [ ] CI / tooling

## Test plan

- Three supported flag modes against one disposable PostgreSQL 16 database:
  - engine off / intake off: 10 legacy cases passed, 6 governed skipped
  - engine on / intake off: 10 legacy cases passed, 6 governed skipped
  - engine on / intake on: 6 governed cases passed, 10 legacy skipped
- Cross-process approval/drain transition: 1 passed; one Run, one attempt, one budget reservation, one provider call, no legacy fallback
- Complete `app-run-engine-db.test.ts`: 20 passed
- Shared contract, Capability Service, architecture, rollout, keyring, connector, trust, leakage, worker routing, and MCP boundary group: 117 passed
- Approval and worker reliability database group: 27 passed
- `pnpm typecheck`: passed for all participating packages
- `git diff --check` and disposable-database residue checks: passed

The local host's previously documented missing pgvector extension was not retried. UI, migration, schema, package/dependency, token/scope, and deployment surfaces are unchanged, so browser, fresh-schema, Docker, and self-host drills remain assigned to the release-candidate gate. Normal PR CI owns the exact-tip production build.

## Rollout and rollback

- Default: engine off, legacy MCP intake off.
- Safe drain-only mode: engine on, intake off.
- Intake on while engine off is rejected at startup.
- Disable intake before disabling the engine; durable jobs pause without retry debit and resume when the engine returns.
- Merge does not make this canary supported or establish an operational rollback floor. The immutable release-artifact gate remains required.

## Checklist

- [x] `pnpm -r typecheck` passes
- [x] If touching the API: relevant tests under `apps/api/test/` pass
- [x] If touching the schema: migration is idempotent and added to the journal (not applicable; no schema change)
- [x] If touching the agent: action goes through the approval flow where required
- [x] No secrets, keys, or `.env` content committed

## Related issues

Continues Phase 3 after merged PR #273. Merge order: #273, then this PR. Do not widen rollout until the separate release-artifact gate passes.