### PR TITLE
fix(apps): restore Hello Workspace release compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ env vars. Patch versions (`0.X.Y`) are non-breaking fixes only.
 
 ## [Unreleased]
 
+## [0.3.0-preview.14] — 2026-08-31
+
+### Fixed
+
+- Declarative Apps built by the public App Kit are no longer rejected when a
+  valid included Module omits schema-defaulted fields such as
+  `required: false`. Package artifact integrity and host-side Module semantic
+  validation remain independently enforced.
+
 ## [0.3.0-preview.13] — 2026-08-27
 
 ### Added
@@ -386,7 +395,8 @@ The `0.1.0-alpha` tag was originally published under BSL 1.1. The current
 codebase has since been relicensed under [GNU AGPL v3.0 only](LICENSE); consult
 the license file present in the exact revision you use.
 
-[Unreleased]: https://github.com/Maneek21/Deft/compare/v0.3.0-preview.13...HEAD
+[Unreleased]: https://github.com/Maneek21/Deft/compare/v0.3.0-preview.14...HEAD
+[0.3.0-preview.14]: https://github.com/Maneek21/Deft/releases/tag/v0.3.0-preview.14
 [0.3.0-preview.13]: https://github.com/Maneek21/Deft/releases/tag/v0.3.0-preview.13
 [0.3.0-preview.12]: https://github.com/Maneek21/Deft/releases/tag/v0.3.0-preview.12
 [0.3.0-preview.11]: https://github.com/Maneek21/Deft/releases/tag/v0.3.0-preview.11

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ ARG NEXT_PUBLIC_API_URL=__DEFT_API_URL__
 ARG NEXT_PUBLIC_WS_URL=__DEFT_WS_URL__
 ARG NEXT_PUBLIC_FEATURE_HUDDLES=false
 ARG NEXT_PUBLIC_FEATURE_APPS=false
-ARG DEFT_RELEASE_VERSION=0.3.0-preview.13
+ARG DEFT_RELEASE_VERSION=0.3.0-preview.14
 ENV NEXT_PUBLIC_APP_URL=$NEXT_PUBLIC_APP_URL
 ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
 ENV NEXT_PUBLIC_WS_URL=$NEXT_PUBLIC_WS_URL
@@ -50,7 +50,7 @@ RUN pnpm --filter @deft/app-kit build && pnpm --filter @deft/web build
 
 # Stage 3: Production
 FROM node:22-alpine AS runner
-ARG DEFT_RELEASE_VERSION=0.3.0-preview.13
+ARG DEFT_RELEASE_VERSION=0.3.0-preview.14
 ARG VCS_REF=unknown
 ARG SOURCE_URL=https://github.com/Maneek21/Deft
 LABEL org.opencontainers.image.licenses="AGPL-3.0-only" \

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ BSL 1.1 license included in those revisions; relicensing this source tree does
 not retroactively change old tags or images.
 
 ```bash
-export DEFT_IMAGE=ghcr.io/maneek21/deft:0.3.0-preview.13
+export DEFT_IMAGE=ghcr.io/maneek21/deft:0.3.0-preview.14
 docker compose -f docker-compose.yml -f compose.prod.yml -f compose.release.yml pull
 docker compose -f docker-compose.yml -f compose.prod.yml -f compose.release.yml up -d postgres
 docker compose -f docker-compose.yml -f compose.prod.yml -f compose.release.yml run --rm init

--- a/apps/api/src/lib/agent-channel.ts
+++ b/apps/api/src/lib/agent-channel.ts
@@ -45,9 +45,9 @@ export const AGENT_CHANNEL_AUTONOMOUS_REQUIRED_RUNTIME_CAPABILITIES = [
   'accepted_event_rehydration_v1',
 ] as const;
 export type AgentChannelAdapterMode = 'supervised_runtime' | 'autonomous_platform';
-export const DEFT_RELEASE_VERSION = process.env.DEFT_RELEASE_VERSION || '0.3.0-preview.13';
+export const DEFT_RELEASE_VERSION = process.env.DEFT_RELEASE_VERSION || '0.3.0-preview.14';
 export const DEFT_BUILD_COMMIT = process.env.DEFT_BUILD_COMMIT || process.env.VCS_REF || 'unknown';
-export const DEFT_SCHEMA_HEAD = '0.3.0-preview.13';
+export const DEFT_SCHEMA_HEAD = '0.3.0-preview.14';
 export const AGENT_CHANNEL_DEFAULT_LEASE_MS = 120_000;
 export const AGENT_CHANNEL_MIN_LEASE_MS = 30_000;
 export const AGENT_CHANNEL_MAX_LEASE_MS = 600_000;

--- a/apps/api/src/lib/app-service.ts
+++ b/apps/api/src/lib/app-service.ts
@@ -12,7 +12,6 @@ import {
   type DeftAppPackageV0,
 } from '@deft/app-kit';
 import {
-  digestModuleManifest,
   parseDeftModuleManifest,
   type ModuleActor,
 } from '@deft/shared/modules';
@@ -115,9 +114,6 @@ export async function inspectAppPackageJson(value: string): Promise<InspectedApp
       const artifact = verified.package.artifacts.find((item) => item.path === reference.manifest_path);
       if (!artifact) throw new Error(`Missing artifact ${reference.manifest_path}`);
       const moduleManifest = parseDeftModuleManifest(JSON.parse(artifact.content) as unknown);
-      if ((await digestModuleManifest(moduleManifest)) !== reference.manifest_digest) {
-        throw new Error(`Module digest mismatch for ${reference.module_id}`);
-      }
       const collections = new Set(moduleManifest.collections.map((collection) => collection.key));
       for (const item of verified.package.manifest.navigation.filter((nav) => nav.module_id === reference.module_id)) {
         if (!collections.has(item.collection_key)) {

--- a/apps/api/test/apps-v0-inspection.test.ts
+++ b/apps/api/test/apps-v0-inspection.test.ts
@@ -4,7 +4,13 @@ import { buildDeftAppPackage, prepareModuleArtifact } from '@deft/app-kit';
 import { inspectAppPackageJson } from '../src/lib/app-service.js';
 import { AppError } from '../src/lib/app-errors.js';
 
-async function helloPackage() {
+async function helloPackage(options: { includeOmittedDefault?: boolean } = {}) {
+  const fields = [
+    { key: 'message', label: 'Message', type: 'text' as const, required: true },
+    ...(options.includeOmittedDefault
+      ? [{ key: 'occasion', label: 'Occasion', type: 'text' as const }]
+      : []),
+  ];
   const moduleManifest = {
     schema_version: '1',
     id: 'community.deft.hello-workspace',
@@ -14,7 +20,7 @@ async function helloPackage() {
     collections: [{
       key: 'greetings',
       name: 'Greetings',
-      fields: [{ key: 'message', label: 'Message', type: 'text', required: true }],
+      fields,
       views: [{ key: 'all', name: 'All greetings', type: 'table', fields: ['message'] }],
     }],
   };
@@ -54,6 +60,12 @@ test('API inspection uses the public package contract and grants zero permission
   assert.equal(inspected.package_digest, built.digest);
   assert.deepEqual(inspected.permissions, []);
   assert.equal(inspected.manifest.navigation[0]?.collection_key, 'greetings');
+});
+
+test('API inspection accepts public App Kit artifacts with omitted Module defaults', async () => {
+  const built = await helloPackage({ includeOmittedDefault: true });
+  const inspected = await inspectAppPackageJson(built.json);
+  assert.equal(inspected.package_digest, built.digest);
 });
 
 test('API inspection rejects navigation that is not backed by an included Module collection', async () => {

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -71,7 +71,7 @@ workflow and carry GitHub build provenance. Verify checksums and the image
 digest before deploying or installing the Hermes bundle:
 
 ```bash
-export TAG=v0.3.0-preview.13
+export TAG=v0.3.0-preview.14
 export VERSION="${TAG#v}"
 export IMAGE=ghcr.io/maneek21/deft
 export DIGEST="$(docker buildx imagetools inspect "$IMAGE:$VERSION" --format '{{json .Manifest.Digest}}' | tr -d '"')"

--- a/integrations/hermes/integration-manifest.json
+++ b/integrations/hermes/integration-manifest.json
@@ -1,8 +1,8 @@
 {
   "schema": "deft.hermes.integration.v2",
   "integration_version": "0.5.1",
-  "deft_release": "0.3.0-preview.13",
-  "deft_release_compatibility": "=0.3.0-preview.13",
+  "deft_release": "0.3.0-preview.14",
+  "deft_release_compatibility": "=0.3.0-preview.14",
   "agent_channel_protocols": [
     "deft.agent_channel.v2"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deft",
-  "version": "0.3.0-preview.13",
+  "version": "0.3.0-preview.14",
   "private": true,
   "license": "AGPL-3.0-only",
   "repository": {


### PR DESCRIPTION
## Summary
- accept public App Kit packages whose included Module manifests omit schema-defaulted fields
- preserve package artifact integrity and host-side Module semantic validation without comparing two different canonical forms
- add a cross-package regression test and prepare immutable `v0.3.0-preview.14` release metadata

## Release-gate finding
The `v0.3.0-preview.13` operational gate built Hello Workspace successfully with the public CLI, but the release API rejected install because Module parsing adds `required: false` before the redundant digest comparison. The package verifier had already bound the exact artifact bytes to the manifest digest. The failed single-use pairing was consumed, and no App installation was persisted.

## Verification
- red-before/green-after: `pnpm exec tsx --test apps/api/test/apps-v0-inspection.test.ts` (3/3)
- `pnpm --filter @deft/app-kit test` (8/8)
- `pnpm test:release-workflow` (10/10)
- `pnpm test:hermes-integration-bundle` (8/8)
- `pnpm typecheck`
- `pnpm build`
- `git diff --check`

## Boundaries
- no migration or persisted-data change
- no permission, token, pairing, connector, App Run, or rollout-control change
- published `v0.3.0-preview.13` remains immutable; this fix advances to preview.14