### PR TITLE
ci(apps): certify immutable Phase 5 candidate

### DIFF
--- a/.github/workflows/app-platform-phase5-certification.yml
+++ b/.github/workflows/app-platform-phase5-certification.yml
@@ -1,0 +1,121 @@
+name: App Platform Phase 5 Certification
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: app-platform-phase5-certification
+  cancel-in-progress: false
+
+env:
+  PHASE5_CANDIDATE_SHA: 161ca65fcb79cdb76fee315b2ba9974ff145a47e
+  PHASE4_BASELINE_SHA: ec79592e669bdf915fad8a5d2480f0625d819a4c
+  PREDECESSOR_IMAGE: ghcr.io/maneek21/deft@sha256:e565cc64ee22b5b9f6f99973e3762b639c27e026dc8824852145035acdacf788
+  PREDECESSOR_COMMIT: 6d39e0e0413c82d36c9481849ae582fdf805d1a6
+
+jobs:
+  certify:
+    name: Immutable non-publishing release-host gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - name: Checkout certification orchestration
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Checkout exact Phase 5 candidate
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ env.PHASE5_CANDIDATE_SHA }}
+          path: .cert/phase5-candidate
+          fetch-depth: 1
+
+      - name: Checkout exact Phase 4 baseline
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ env.PHASE4_BASELINE_SHA }}
+          path: .cert/phase4-baseline
+          fetch-depth: 1
+
+      - name: Verify immutable source identities
+        shell: bash
+        run: |
+          set -euo pipefail
+          certifier_sha="$(git rev-parse HEAD)"
+          candidate_sha="$(git -C .cert/phase5-candidate rev-parse HEAD)"
+          baseline_sha="$(git -C .cert/phase4-baseline rev-parse HEAD)"
+          [[ "$candidate_sha" == "$PHASE5_CANDIDATE_SHA" ]]
+          [[ "$baseline_sha" == "$PHASE4_BASELINE_SHA" ]]
+          {
+            echo "CERTIFIER_SHA=$certifier_sha"
+            echo "PHASE5_ROOT=$GITHUB_WORKSPACE/.cert/phase5-candidate"
+            echo "PHASE4_ROOT=$GITHUB_WORKSPACE/.cert/phase4-baseline"
+            echo "DEFT_APP_PLATFORM_EVIDENCE_DIR=$RUNNER_TEMP/deft-phase5-evidence"
+          } >> "$GITHUB_ENV"
+
+      - uses: pnpm/action-setup@v6.0.10
+        with:
+          version: 11.10.0
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - uses: docker/setup-buildx-action@v4
+
+      - name: Install certifier dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Chromium for desktop and mobile evidence
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Install exact Phase 4 dependencies
+        working-directory: .cert/phase4-baseline
+        run: pnpm install --frozen-lockfile
+
+      - name: Run immutable Phase 5 host certification
+        env:
+          CERTIFIER_ROOT: ${{ github.workspace }}
+          PHASE5_ROOT: ${{ env.PHASE5_ROOT }}
+          PHASE4_ROOT: ${{ env.PHASE4_ROOT }}
+          EVIDENCE_DIR: ${{ env.DEFT_APP_PLATFORM_EVIDENCE_DIR }}
+        run: bash scripts/ci/certify-app-platform-phase5.sh
+
+      - name: Upload safe certification evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-platform-phase5-safe-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ env.DEFT_APP_PLATFORM_EVIDENCE_DIR }}/safe
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 90
+
+      - name: Upload exact candidate image archive
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-platform-phase5-image-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ env.DEFT_APP_PLATFORM_EVIDENCE_DIR }}/candidate-image.tar.zst
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 90
+
+      - name: Confirm isolated resource cleanup
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker info >/dev/null
+          prefix="deft-p5-cert-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          if docker ps -a --format '{{.Names}}' | grep -Fx "$prefix-source"; then exit 1; fi
+          if docker ps -a --format '{{.Names}}' | grep -Fx "$prefix-restore"; then exit 1; fi
+          if docker ps -a --format '{{.Names}}' | grep -Fx "$prefix-app"; then exit 1; fi
+          if docker network ls --format '{{.Name}}' | grep -Fx "$prefix-network"; then exit 1; fi
+          if docker volume ls --format '{{.Name}}' | grep -Fx "$prefix-source-data"; then exit 1; fi
+          if docker volume ls --format '{{.Name}}' | grep -Fx "$prefix-restore-data"; then exit 1; fi

--- a/apps/api/test/phase5-predecessor-read-probe.ts
+++ b/apps/api/test/phase5-predecessor-read-probe.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { closeDb } from "../src/lib/db.js";
+import {
+  employeeModuleActor,
+  getModuleRecord,
+} from "../src/lib/module-service.js";
+
+function required(name: string): string {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+async function main(): Promise<void> {
+  const orgId = required("DEFT_PROBE_ORG_ID");
+  const employeeId = required("DEFT_PROBE_EMPLOYEE_ID");
+  const recordId = required("DEFT_PROBE_RECORD_ID");
+  try {
+    const record = await getModuleRecord(
+      employeeModuleActor({
+        orgId,
+        employeeId,
+        trustLevel: "standard",
+        source: "runtime",
+      }),
+      recordId,
+    );
+    assert.equal(record.data.name, "Ada Lovelace");
+    assert.equal(record.data.email, "ada@phase4.test");
+    process.stdout.write(
+      `${JSON.stringify({
+        schema: "deft.app_platform.phase5.predecessor_read.v1",
+        result: "passed",
+        resource: {
+          org_id: orgId,
+          record_id: record.id,
+          revision: record.revision,
+          name: record.data.name,
+        },
+      })}\n`,
+    );
+  } finally {
+    await closeDb();
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});

--- a/docs/superpowers/audits/2026-09-01-app-platform-phase-5-release-certification.md
+++ b/docs/superpowers/audits/2026-09-01-app-platform-phase-5-release-certification.md
@@ -3,7 +3,8 @@
 - Date: 2026-09-01
 - Candidate branch: `codex/app-platform-phase5-cutover`
 - Phase 4 immutable baseline: `ec79592e669bdf915fad8a5d2480f0625d819a4c`
-- Status: **local candidate passed; immutable release-host gate pending**
+- Merged candidate: `161ca65fcb79cdb76fee315b2ba9974ff145a47e` (`#280`)
+- Status: **local candidate and exact-merge CI passed; immutable non-publishing release-host gate pending**
 
 ## Certified local claim
 
@@ -100,11 +101,17 @@ evidence. No Phase 5 requirement is being inferred from those unrelated tests.
   not retried; the real extension remains a release-host requirement.
 - Docker Desktop is installed, but its engine is unavailable through the local
   Docker inference socket. Docker image construction was not retried.
-- No immutable candidate image or release commit exists before PR C is merged.
+- PR C is merged and its exact merge commit passed CI and security. That CI
+  image was ephemeral, so it does not provide the durable image digest,
+  matched recovery set, predecessor read, or restored-key continuity required
+  by this gate.
 
 ## Immutable release-host gate
 
-After PR C merges, certify the exact merged commit on the release host:
+Run the manual, read-only
+`.github/workflows/app-platform-phase5-certification.yml` lane. It checks out
+the exact merged Phase 5 commit independently of the later certifier commit,
+publishes nothing, and certifies:
 
 1. Record the immutable commit and candidate image digest.
 2. Create a fresh pgvector-backed schema and run the supported upgrade from the
@@ -115,6 +122,10 @@ After PR C merges, certify the exact merged commit on the release host:
 5. Read the upgraded data with the supported predecessor image, restore the
    candidate, and prove the accepted Run/receipt remains coherent.
 6. Archive the exact evidence and remove release-host disposable resources.
+
+The workflow may update this audit to PASS only after its immutable GitHub run,
+safe evidence artifact, candidate archive digest, browser evidence, and cleanup
+result are inspected. Adding the workflow does not itself satisfy the gate.
 
 Known Phase 4 release assets for that pass:
 

--- a/docs/superpowers/plans/2026-08-31-app-platform-phase-5-connected-grants-loops.md
+++ b/docs/superpowers/plans/2026-08-31-app-platform-phase-5-connected-grants-loops.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |---|---|
-| Status | Loop 7 local candidate complete; immutable release-host gate waits for PR C merge |
+| Status | PR C merged at `161ca65f`; Loop 7 local and exact-merge CI passed; immutable non-publishing release-host certification remains |
 | Base candidate | Merged Phase 4 commit `ec79592e669bdf915fad8a5d2480f0625d819a4c` |
 | Outcome | One installed App can request, receive, expose, and invoke one exact governed capability through the same host-owned path on every interactive actor surface |
 | Proof | Campaign resource + selected Contact resource -> approved sandbox MCP email -> one App Run, provider call, receipt, and result identity |

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "selfhost:smoke": "tsx scripts/selfhost-smoke.ts",
     "selfhost:upgrade": "tsx scripts/selfhost-upgrade.ts",
     "test:upgrade": "pnpm --filter @deft/db test:upgrade && tsx --test scripts/selfhost-upgrade.test.ts",
-    "test:release-workflow": "node --test scripts/release-workflow.test.mjs",
+    "test:release-workflow": "node --test scripts/release-workflow.test.mjs scripts/app-platform-certification-workflow.test.mjs",
     "test:public-env": "node --test scripts/inject-public-env.test.mjs",
     "typecheck": "pnpm -r --parallel typecheck"
   },

--- a/scripts/app-platform-certification-workflow.test.mjs
+++ b/scripts/app-platform-certification-workflow.test.mjs
@@ -1,0 +1,112 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const workflow = readFileSync(
+  new URL('../.github/workflows/app-platform-phase5-certification.yml', import.meta.url),
+  'utf8',
+);
+const orchestrator = readFileSync(
+  new URL('./ci/certify-app-platform-phase5.sh', import.meta.url),
+  'utf8',
+);
+const executionSurface = `${workflow}\n${orchestrator}`;
+
+const CANDIDATE_COMMIT = '161ca65fcb79cdb76fee315b2ba9974ff145a47e';
+const PHASE4_BASELINE_COMMIT = 'ec79592e669bdf915fad8a5d2480f0625d819a4c';
+const PREDECESSOR_IMAGE = 'ghcr.io/maneek21/deft@sha256:e565cc64ee22b5b9f6f99973e3762b639c27e026dc8824852145035acdacf788';
+
+function occurrences(source, value) {
+  return source.split(value).length - 1;
+}
+
+test('Phase 5 certification is manual and read-only at the repository boundary', () => {
+  assert.match(workflow, /^on:\s*\r?\n\s+workflow_dispatch:/m);
+  assert.doesNotMatch(
+    workflow,
+    /^\s{2}(?:push|pull_request|pull_request_target|schedule|release):/m,
+  );
+  assert.match(workflow, /permissions:\s*\r?\n\s+contents:\s*read\b/);
+  for (const forbidden of [
+    /contents:\s*write/,
+    /packages:\s*write/,
+    /id-token:\s*write/,
+    /attestations:\s*write/,
+    /actions:\s*write/,
+  ]) assert.doesNotMatch(workflow, forbidden);
+});
+
+test('candidate, Phase 4 baseline, and predecessor image are immutable identities', () => {
+  assert.match(workflow, new RegExp(`PHASE5_CANDIDATE_SHA:\\s*${CANDIDATE_COMMIT}`));
+  assert.match(workflow, new RegExp(`PHASE4_BASELINE_SHA:\\s*${PHASE4_BASELINE_COMMIT}`));
+  assert.match(
+    workflow,
+    new RegExp(`PREDECESSOR_IMAGE:\\s*["']?${PREDECESSOR_IMAGE.replaceAll('.', '\\.')}`),
+  );
+  assert.equal(occurrences(workflow, CANDIDATE_COMMIT), 1);
+  assert.equal(occurrences(workflow, PHASE4_BASELINE_COMMIT), 1);
+  assert.equal(occurrences(workflow, PREDECESSOR_IMAGE), 1);
+  assert.match(workflow, /ref:\s*\$\{\{\s*env\.PHASE5_CANDIDATE_SHA\s*\}\}/);
+  assert.match(workflow, /ref:\s*\$\{\{\s*env\.PHASE4_BASELINE_SHA\s*\}\}/);
+});
+
+test('certification checks the exact candidate revision and builds without publishing', () => {
+  assert.match(workflow, /candidate_sha="\$\(git -C \.cert\/phase5-candidate rev-parse HEAD\)"/);
+  assert.match(workflow, /\[\[ "\$candidate_sha" == "\$PHASE5_CANDIDATE_SHA" \]\]/);
+  assert.match(workflow, /baseline_sha="\$\(git -C \.cert\/phase4-baseline rev-parse HEAD\)"/);
+  assert.match(workflow, /\[\[ "\$baseline_sha" == "\$PHASE4_BASELINE_SHA" \]\]/);
+  assert.match(workflow, /bash scripts\/ci\/certify-app-platform-phase5\.sh/);
+  assert.match(orchestrator, /git -C "\$phase5_root" rev-parse HEAD/);
+  assert.match(orchestrator, /docker buildx build --load/);
+  assert.match(orchestrator, /org\.opencontainers\.image\.revision/);
+  assert.match(orchestrator, /\[\[ "\$image_revision" == "\$phase5_sha" \]\]/);
+  for (const forbidden of [
+    /docker\s+push\b/,
+    /push:\s*true\b/,
+    /gh\s+release\b/,
+    /(?:oras|cosign)\s+(?:push|sign)\b/,
+    /softprops\/action-gh-release/,
+    /actions\/create-release/,
+  ]) assert.doesNotMatch(executionSurface, forbidden);
+});
+
+test('certification uses real pgvector and proves matched backup, restore, and key continuity', () => {
+  assert.match(orchestrator, /pgvector\/pgvector:pg16/);
+  assert.match(orchestrator, /CREATE EXTENSION(?: IF NOT EXISTS)? vector/i);
+  assert.match(orchestrator, /\bpg_dump\b/);
+  assert.match(orchestrator, /\bpg_restore\b/);
+  assert.match(orchestrator, /DEFT_APP_RUN_KEYRINGS/);
+  assert.match(orchestrator, /keyring_hash="\$\(sha256sum "\$keyring_path"/);
+  assert.match(
+    orchestrator,
+    /sha256sum "\$restored_keyring_path"[^\n]+== "\$keyring_hash"/,
+  );
+  assert.match(orchestrator, /source-snapshot\.json/);
+  assert.match(orchestrator, /restored-verification\.json/);
+});
+
+test('certification carries the Phase 4 and Phase 5 probes plus browser evidence', () => {
+  assert.match(orchestrator, /resource-participation-apps-db\.test\.ts/);
+  assert.match(orchestrator, /app-origin-run-lifecycle-db\.test\.ts/);
+  assert.match(orchestrator, /app-platform-phase5-browser-smoke\.mjs/);
+  assert.match(workflow, /DEFT_APP_PLATFORM_EVIDENCE_DIR/);
+  assert.match(orchestrator, /DEFT_APP_PLATFORM_BROWSER_EVIDENCE=/);
+  assert.match(orchestrator, /NEXT_PUBLIC_FEATURE_APPS=true/);
+  assert.match(orchestrator, /DEFT_APPS_ENABLED=true/);
+  assert.match(orchestrator, /DEFT_APP_RUNS_ENABLED=true/);
+  assert.match(orchestrator, /DEFT_APP_RUN_APP_ORIGIN_ENABLED=true/);
+});
+
+test('evidence uploads even on failure and disposable resources are always removed', () => {
+  assert.match(workflow, /actions\/upload-artifact@v4/);
+  assert.match(workflow, /if:\s*always\(\)/);
+  assert.match(workflow, /app-platform-phase5-certification/);
+  assert.match(orchestrator, /trap cleanup EXIT/);
+  assert.match(orchestrator, /docker\s+(?:rm|container\s+rm)\b/);
+  assert.match(orchestrator, /docker\s+volume\s+rm/);
+  assert.match(orchestrator, /docker\s+network\s+rm/);
+  assert.match(workflow, /Confirm isolated resource cleanup/);
+  assert.match(workflow, /docker ps -a/);
+  assert.match(workflow, /docker volume ls/);
+  assert.match(workflow, /docker network ls/);
+});

--- a/scripts/ci/app-platform-phase5-browser-smoke.mjs
+++ b/scripts/ci/app-platform-phase5-browser-smoke.mjs
@@ -1,0 +1,212 @@
+import assert from 'node:assert/strict';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { chromium } from 'playwright';
+
+const webUrl = (process.env.DEFT_WEB_URL || 'http://127.0.0.1:3000').replace(/\/$/, '');
+const email = process.env.DEFT_TEST_EMAIL || 'diego@testers-tomatoes.com';
+const password = process.env.DEFT_TEST_PASSWORD || 'tomato123';
+const requireConnected = process.env.DEFT_APP_PLATFORM_REQUIRE_CONNECTED === 'true';
+const evidenceDirectory = resolve(
+  process.env.DEFT_APP_PLATFORM_EVIDENCE_DIR || 'dist/app-platform-phase5-certification',
+);
+const evidencePath = resolve(
+  process.env.DEFT_APP_PLATFORM_BROWSER_EVIDENCE
+    || `${evidenceDirectory}/apps-browser-smoke.json`,
+);
+
+const viewports = Object.freeze([
+  Object.freeze({ name: 'desktop', width: 1440, height: 900 }),
+  Object.freeze({ name: 'mobile', width: 390, height: 844 }),
+]);
+
+function collectStrings(value, output) {
+  if (typeof value === 'string') {
+    if (value.length >= 8) output.add(value);
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) collectStrings(item, output);
+    return;
+  }
+  if (value && typeof value === 'object') {
+    for (const item of Object.values(value)) collectStrings(item, output);
+  }
+}
+
+function secretMarkers() {
+  const markers = new Set();
+  for (const name of [
+    'DEFT_TEST_PASSWORD',
+    'DEFT_APP_RUN_KEYRINGS',
+    'JWT_SECRET',
+    'JWT_REFRESH_SECRET',
+    'ENCRYPTION_KEY',
+  ]) {
+    const value = process.env[name];
+    if (!value) continue;
+    if (name === 'DEFT_APP_RUN_KEYRINGS') {
+      try {
+        collectStrings(JSON.parse(value), markers);
+      } catch {
+        // The API owns keyring validation. The smoke still checks that the raw
+        // value is absent without printing it into diagnostics.
+      }
+    }
+    if (value.length >= 8) markers.add(value);
+  }
+  if (!process.env.DEFT_TEST_PASSWORD && password.length >= 8) markers.add(password);
+
+  const extra = process.env.DEFT_APP_PLATFORM_SECRET_MARKERS;
+  if (extra) {
+    const parsed = JSON.parse(extra);
+    if (!Array.isArray(parsed) || parsed.some((item) => typeof item !== 'string')) {
+      throw new Error('DEFT_APP_PLATFORM_SECRET_MARKERS must be a JSON string array');
+    }
+    collectStrings(parsed, markers);
+  }
+  return [...markers];
+}
+
+async function login(page) {
+  await page.goto(`${webUrl}/login`, { waitUntil: 'domcontentloaded' });
+  await page.locator('#login-email').waitFor({ state: 'visible', timeout: 20_000 });
+  await page.locator('#login-email').fill(email);
+  await page.locator('#login-password').fill(password);
+  const loginResponse = page.waitForResponse(
+    (response) => response.request().method() === 'POST'
+      && response.url().includes('/api/auth/login'),
+    { timeout: 20_000 },
+  );
+  await page.getByRole('button', { name: 'Sign in', exact: true }).click();
+  const response = await loginResponse;
+  if (!response.ok()) {
+    throw new Error(`Demo login returned HTTP ${response.status()}`);
+  }
+  await page.waitForURL((url) => !url.pathname.startsWith('/login'), { timeout: 20_000 });
+}
+
+async function assertAppsSurface(page, viewport, markers, apiFailures) {
+  await page.setViewportSize({ width: viewport.width, height: viewport.height });
+  await page.goto(`${webUrl}/settings/apps`, { waitUntil: 'domcontentloaded' });
+  if (new URL(page.url()).pathname.startsWith('/login')) {
+    throw new Error(`${viewport.name} Apps surface redirected to login`);
+  }
+  await page.getByRole('heading', { name: 'Apps', exact: true }).first()
+    .waitFor({ state: 'visible', timeout: 20_000 });
+  await page.waitForFunction((mustShowConnected) => {
+    const text = document.body.innerText;
+    return mustShowConnected
+      ? text.includes('Connected Resource Campaigns') && text.includes('Effective authority')
+      : text.includes('No Apps installed') || document.querySelectorAll('article').length > 0;
+  }, requireConnected, { timeout: 20_000 });
+
+  const emptyState = await page.getByText('No Apps installed', { exact: true }).count() > 0;
+  const appCards = await page.locator('article').count();
+  assert.ok(emptyState || appCards > 0, 'Apps surface rendered neither its empty state nor an App card');
+  if (requireConnected) {
+    assert.equal(emptyState, false, 'connected proof unexpectedly rendered the empty Apps state');
+    const connectedCard = page.locator('article').filter({ hasText: 'Connected Resource Campaigns' });
+    await connectedCard.waitFor({ state: 'visible', timeout: 20_000 });
+    await connectedCard.getByText('active', { exact: true }).waitFor({ state: 'visible', timeout: 20_000 });
+    const connectedText = await connectedCard.innerText();
+    assert.match(connectedText, /Effective authority/);
+    assert.match(connectedText, /1 active binding/);
+    assert.match(connectedText, /Effective action bindings/);
+    assert.match(connectedText, /Recent Runs/);
+    assert.doesNotMatch(connectedText, /No App Runs yet\./);
+  }
+
+  const overflow = await page.evaluate(() => document.documentElement.scrollWidth - window.innerWidth);
+  assert.ok(overflow <= 2, `${viewport.name} Apps surface overflows by ${overflow}px`);
+
+  const [text, html] = await Promise.all([
+    page.locator('body').innerText(),
+    page.content(),
+  ]);
+  for (const [index, marker] of markers.entries()) {
+    assert.equal(text.includes(marker), false, `secret marker ${index + 1} is visible as Apps page text`);
+    assert.equal(html.includes(marker), false, `secret marker ${index + 1} is present in Apps page markup`);
+  }
+  assert.doesNotMatch(text, /deft_app_dev_[A-Za-z0-9_-]{16,}/, 'developer token is visible on Apps page');
+  assert.doesNotMatch(text, /hmac-sha256:[a-f0-9]{64}/i, 'receipt signature is visible on Apps page');
+
+  const relevantFailures = apiFailures.filter((failure) => failure.viewport === viewport.name);
+  assert.deepEqual(relevantFailures, [], `${viewport.name} Apps API requests failed`);
+
+  const screenshotPath = resolve(evidenceDirectory, `apps-${viewport.name}.png`);
+  await page.screenshot({ path: screenshotPath, fullPage: true });
+  return {
+    name: viewport.name,
+    width: viewport.width,
+    height: viewport.height,
+    state: emptyState ? 'empty' : 'installed',
+    connected_proof_required: requireConnected,
+    app_card_count: appCards,
+    horizontal_overflow_px: overflow,
+    screenshot: screenshotPath,
+  };
+}
+
+async function main() {
+  await mkdir(evidenceDirectory, { recursive: true });
+  await mkdir(dirname(evidencePath), { recursive: true });
+  const evidence = {
+    schema: 'deft.app_platform.phase5.browser_smoke.v1',
+    result: 'failed',
+    target: webUrl,
+    route: '/settings/apps',
+    completed_at: null,
+    viewports: [],
+    checks: {
+      authenticated_demo_login: false,
+      apps_surface_loaded: false,
+      secrets_absent_from_rendered_surface: false,
+      browser_errors_absent: false,
+    },
+  };
+  let browser;
+  try {
+    browser = await chromium.launch({ headless: true });
+    const context = await browser.newContext({ viewport: viewports[0] });
+    const page = await context.newPage();
+    const pageErrors = [];
+    const apiFailures = [];
+    let activeViewport = viewports[0].name;
+    page.on('pageerror', (error) => pageErrors.push(error.message));
+    page.on('response', (response) => {
+      if (response.url().includes('/api/apps') && response.status() >= 400) {
+        apiFailures.push({ viewport: activeViewport, status: response.status(), url: response.url() });
+      }
+    });
+
+    await login(page);
+    evidence.checks.authenticated_demo_login = true;
+    const markers = secretMarkers();
+    for (const viewport of viewports) {
+      activeViewport = viewport.name;
+      evidence.viewports.push(await assertAppsSurface(page, viewport, markers, apiFailures));
+    }
+    evidence.checks.apps_surface_loaded = true;
+    evidence.checks.secrets_absent_from_rendered_surface = true;
+    assert.deepEqual(pageErrors, [], `uncaught browser errors: ${pageErrors.join(' | ')}`);
+    evidence.checks.browser_errors_absent = true;
+    evidence.result = 'passed';
+    evidence.completed_at = new Date().toISOString();
+    console.log('APP_PLATFORM_BROWSER_SMOKE_PASSED');
+    console.log(`Evidence: ${evidencePath}`);
+  } catch (error) {
+    evidence.completed_at = new Date().toISOString();
+    evidence.error = error instanceof Error ? error.message : String(error);
+    throw error;
+  } finally {
+    await writeFile(evidencePath, `${JSON.stringify(evidence, null, 2)}\n`, 'utf8');
+    if (browser) await browser.close();
+  }
+}
+
+main().catch((error) => {
+  console.error('[FAIL] App Platform Phase 5 browser smoke');
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});

--- a/scripts/ci/app-platform-phase5-certification-probe.test.ts
+++ b/scripts/ci/app-platform-phase5-certification-probe.test.ts
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict';
+import { resolve } from 'node:path';
+import test from 'node:test';
+
+import {
+  __test,
+  assembleContinuitySnapshot,
+  deterministicCertificationKeyring,
+  parseCliArgs,
+} from './app-platform-phase5-certification-probe.js';
+
+test('deterministic disposable keyring exactly matches the Phase 5 lifecycle fixture', () => {
+  const keyring = deterministicCertificationKeyring();
+  assert.deepEqual(keyring, {
+    schema_version: 'deft.app_run_keyring.v1',
+    run_encryption: {
+      current: 'enc-v1',
+      keys: { 'enc-v1': 'U7cF09jO6DwXGV6YBUf+TfwBMvSYW4qvCci2G0GsXtI=' },
+    },
+    receipt_signing: {
+      current: 'sig-v1',
+      keys: { 'sig-v1': 'kRH0f7E08kqSt1e6q0f4hV0Drytvclee4ZKGhNwNxUM=' },
+    },
+    fingerprint: {
+      current: 'fp-v1',
+      keys: { 'fp-v1': 'FEh1oMo2hracqpKl6OnCCR/fUdYCXNrNf/OY6umWLLc=' },
+    },
+  });
+});
+
+test('CLI modes require the exact output and expected-snapshot surfaces', () => {
+  assert.deepEqual(parseCliArgs(['keyring', '--output', 'keys.json']), {
+    mode: 'keyring', output: resolve('keys.json'),
+  });
+  assert.deepEqual(parseCliArgs(['snapshot', '--output', 'before.json']), {
+    mode: 'snapshot', output: resolve('before.json'),
+  });
+  assert.deepEqual(parseCliArgs([
+    'verify', '--expected-snapshot', 'before.json', '--output', 'after.json',
+  ]), {
+    mode: 'verify',
+    expectedSnapshot: resolve('before.json'),
+    output: resolve('after.json'),
+  });
+  assert.throws(() => parseCliArgs(['verify', '--output', 'after.json']), /USAGE_EXPECTED_SNAPSHOT_REQUIRED/);
+  assert.throws(() => parseCliArgs(['snapshot', '--expected-snapshot', 'before.json', '--output', 'after.json']), /USAGE_EXPECTED_SNAPSHOT_NOT_ALLOWED/);
+  assert.throws(() => parseCliArgs(['keyring', '--output', 'one', '--output', 'two']), /USAGE_UNKNOWN_OR_DUPLICATE_FLAG/);
+  assert.throws(() => parseCliArgs(['verify', '--expected-snapshot', 'same', '--output', 'same']), /USAGE_OUTPUT_OVERLAPS_INPUT/);
+});
+
+test('continuity hash is deterministic, metadata-bound, and contains no row values', () => {
+  const table = __test.tableSnapshot('app_runs', [{ id: 'run-1', private: 'not emitted' }]);
+  const input = {
+    pgvectorVersion: '0.8.1',
+    migrations: [{ version: '0.3.0-preview.25', checksum: 'sha256:migration' }],
+    tables: [table],
+  };
+  const first = assembleContinuitySnapshot(input);
+  const second = assembleContinuitySnapshot(structuredClone(input));
+  assert.deepEqual(first, second);
+  assert.match(first.continuity_sha256, /^sha256:[a-f0-9]{64}$/);
+  assert.equal(JSON.stringify(first).includes('not emitted'), false);
+
+  const changed = assembleContinuitySnapshot({ ...input, pgvectorVersion: '0.8.2' });
+  assert.notEqual(changed.continuity_sha256, first.continuity_sha256);
+  assert.deepEqual(__test.parseContinuitySnapshot(first), first);
+  assert.throws(
+    () => __test.parseContinuitySnapshot({ ...first, continuity_sha256: `sha256:${'0'.repeat(64)}` }),
+    /EXPECTED_SNAPSHOT_HASH_INVALID/,
+  );
+});

--- a/scripts/ci/app-platform-phase5-certification-probe.ts
+++ b/scripts/ci/app-platform-phase5-certification-probe.ts
@@ -1,0 +1,532 @@
+import { createHash } from 'node:crypto';
+import { chmod, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import { basename, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  APP_RUN_CONTRACT_VERSIONS,
+  canonicalCapabilityJson,
+} from '../../packages/shared/src/index.js';
+
+const KEYRING_PURPOSE = 'loop5-lifecycle';
+const SNAPSHOT_SCHEMA = 'deft.app_platform.phase5.continuity_snapshot.v1';
+const VERIFY_SCHEMA = 'deft.app_platform.phase5.restore_verification.v1';
+
+const CONTINUITY_TABLES = Object.freeze([
+  'agent_actions',
+  'app_action_bindings',
+  'app_dependency_locks',
+  'app_grant_snapshots',
+  'app_installations',
+  'app_module_bindings',
+  'app_run_attempts',
+  'app_run_events',
+  'app_run_receipts',
+  'app_run_secret_payloads',
+  'app_runs',
+  'app_versions',
+  'capability_provider_snapshots',
+  'module_installations',
+  'module_mutation_receipts',
+  'module_records',
+  'module_versions',
+  'resource_relation_edges',
+  'resource_relation_receipts',
+  'resource_relation_sets',
+] as const);
+
+const EXPECTED_APP_PACKAGE_DIGESTS = Object.freeze([
+  'sha256:1471f0b94da9f6851bd978c315bc22a2dd0343b61a87477e4293b144c54248d8',
+  'sha256:0f478f5a761590f1f5874c7a0d0dc3382436b5e7f44c0c6ad6591cd577476344',
+  'sha256:973ec7076daf7405a7a4d8b48509ef6f99b1b1cc4b787961104c73f23b7f770d',
+] as const);
+
+const EXPECTED_MODULE_MANIFEST_DIGEST =
+  'sha256:5dc2a978506eb2917a3a99021831d62d94112a60615292e4b32e03e480cff208';
+const EXPECTED_LATEST_MIGRATION = '0.3.0-preview.25';
+
+type CliOptions = Readonly<{
+  mode: 'keyring' | 'snapshot' | 'verify';
+  output: string;
+  expectedSnapshot?: string;
+}>;
+
+type QueryResult<Row extends Record<string, unknown>> = Readonly<{
+  rows: Row[];
+  rowCount: number | null;
+}>;
+
+type PgClient = {
+  connect(): Promise<void>;
+  query<Row extends Record<string, unknown>>(
+    text: string,
+    values?: unknown[],
+  ): Promise<QueryResult<Row>>;
+  end(): Promise<void>;
+};
+
+type PgModule = Readonly<{
+  Client: new (config: Readonly<{ connectionString: string }>) => PgClient;
+}>;
+
+export type ContinuityTableSnapshot = Readonly<{
+  table: string;
+  row_count: number;
+  sha256: string;
+}>;
+
+export type ContinuitySnapshot = Readonly<{
+  schema_version: typeof SNAPSHOT_SCHEMA;
+  continuity_sha256: string;
+  total_rows: number;
+  pgvector_version: string;
+  migration_count: number;
+  latest_migration: string;
+  migration_sha256: string;
+  tables: readonly ContinuityTableSnapshot[];
+}>;
+
+class CertificationProbeError extends Error {
+  constructor(readonly code: string) {
+    super(code);
+    this.name = 'CertificationProbeError';
+  }
+}
+
+function sha256(value: string | Buffer): string {
+  return `sha256:${createHash('sha256').update(value).digest('hex')}`;
+}
+
+function deterministicKey(purpose: string, keyId: string): string {
+  return createHash('sha256')
+    .update(`${KEYRING_PURPOSE}:${purpose}:${keyId}`)
+    .digest('base64');
+}
+
+export function deterministicCertificationKeyring() {
+  return {
+    schema_version: APP_RUN_CONTRACT_VERSIONS.keyring,
+    run_encryption: {
+      current: 'enc-v1',
+      keys: { 'enc-v1': deterministicKey('run_encryption', 'enc-v1') },
+    },
+    receipt_signing: {
+      current: 'sig-v1',
+      keys: { 'sig-v1': deterministicKey('receipt_signing', 'sig-v1') },
+    },
+    fingerprint: {
+      current: 'fp-v1',
+      keys: { 'fp-v1': deterministicKey('fingerprint', 'fp-v1') },
+    },
+  } as const;
+}
+
+export function parseCliArgs(argv: readonly string[]): CliOptions {
+  const [rawMode, ...rest] = argv;
+  if (rawMode !== 'keyring' && rawMode !== 'snapshot' && rawMode !== 'verify') {
+    throw new CertificationProbeError('USAGE_INVALID_MODE');
+  }
+
+  let output: string | undefined;
+  let expectedSnapshot: string | undefined;
+  for (let index = 0; index < rest.length; index += 2) {
+    const flag = rest[index];
+    const value = rest[index + 1];
+    if (!value || value.startsWith('--')) {
+      throw new CertificationProbeError('USAGE_MISSING_VALUE');
+    }
+    if (flag === '--output' && output === undefined) output = value;
+    else if (flag === '--expected-snapshot' && expectedSnapshot === undefined) {
+      expectedSnapshot = value;
+    } else {
+      throw new CertificationProbeError('USAGE_UNKNOWN_OR_DUPLICATE_FLAG');
+    }
+  }
+
+  if (!output) throw new CertificationProbeError('USAGE_OUTPUT_REQUIRED');
+  if (rawMode === 'verify' && !expectedSnapshot) {
+    throw new CertificationProbeError('USAGE_EXPECTED_SNAPSHOT_REQUIRED');
+  }
+  if (rawMode !== 'verify' && expectedSnapshot) {
+    throw new CertificationProbeError('USAGE_EXPECTED_SNAPSHOT_NOT_ALLOWED');
+  }
+  if (expectedSnapshot && resolve(expectedSnapshot) === resolve(output)) {
+    throw new CertificationProbeError('USAGE_OUTPUT_OVERLAPS_INPUT');
+  }
+  return {
+    mode: rawMode,
+    output: resolve(output),
+    ...(expectedSnapshot ? { expectedSnapshot: resolve(expectedSnapshot) } : {}),
+  };
+}
+
+async function writeJson(path: string, value: unknown, secret = false): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  const serialized = secret
+    ? canonicalCapabilityJson(value)
+    : `${JSON.stringify(value, null, 2)}\n`;
+  await writeFile(path, serialized, { encoding: 'utf8', mode: 0o600 });
+  await chmod(path, 0o600);
+}
+
+function databaseUrl(): string {
+  const value = process.env.DATABASE_URL ?? process.env.DEFT_TEST_DATABASE_URL;
+  if (!value) throw new CertificationProbeError('DATABASE_URL_REQUIRED');
+  return value;
+}
+
+function pgClient(): PgClient {
+  const requireFromApi = createRequire(new URL('../../apps/api/package.json', import.meta.url));
+  const pg = requireFromApi('pg') as PgModule;
+  return new pg.Client({ connectionString: databaseUrl() });
+}
+
+async function withClient<T>(run: (client: PgClient) => Promise<T>): Promise<T> {
+  const client = pgClient();
+  await client.connect();
+  try {
+    return await run(client);
+  } finally {
+    await client.end();
+  }
+}
+
+function tableSnapshot(table: string, rows: readonly unknown[]): ContinuityTableSnapshot {
+  return Object.freeze({
+    table,
+    row_count: rows.length,
+    sha256: sha256(canonicalCapabilityJson(rows)),
+  });
+}
+
+function snapshotBasis(snapshot: Omit<ContinuitySnapshot, 'continuity_sha256'>) {
+  return {
+    schema_version: snapshot.schema_version,
+    pgvector_version: snapshot.pgvector_version,
+    migration_count: snapshot.migration_count,
+    latest_migration: snapshot.latest_migration,
+    migration_sha256: snapshot.migration_sha256,
+    tables: snapshot.tables,
+  };
+}
+
+export function assembleContinuitySnapshot(input: Readonly<{
+  pgvectorVersion: string;
+  migrations: readonly unknown[];
+  tables: readonly ContinuityTableSnapshot[];
+}>): ContinuitySnapshot {
+  if (input.migrations.length === 0) {
+    throw new CertificationProbeError('MIGRATION_LEDGER_EMPTY');
+  }
+  const latest = input.migrations.at(-1);
+  if (!latest || typeof latest !== 'object' || !('version' in latest)) {
+    throw new CertificationProbeError('MIGRATION_LEDGER_INVALID');
+  }
+  const latestMigration = (latest as { version?: unknown }).version;
+  if (typeof latestMigration !== 'string' || !latestMigration) {
+    throw new CertificationProbeError('MIGRATION_LEDGER_INVALID');
+  }
+  if (latestMigration !== EXPECTED_LATEST_MIGRATION) {
+    throw new CertificationProbeError('PHASE5_MIGRATION_NOT_CURRENT');
+  }
+  const partial = {
+    schema_version: SNAPSHOT_SCHEMA,
+    total_rows: input.tables.reduce((total, table) => total + table.row_count, 0),
+    pgvector_version: input.pgvectorVersion,
+    migration_count: input.migrations.length,
+    latest_migration: latestMigration,
+    migration_sha256: sha256(canonicalCapabilityJson(input.migrations)),
+    tables: Object.freeze([...input.tables]),
+  } satisfies Omit<ContinuitySnapshot, 'continuity_sha256'>;
+  return Object.freeze({
+    ...partial,
+    continuity_sha256: sha256(canonicalCapabilityJson(snapshotBasis(partial))),
+  });
+}
+
+async function createContinuitySnapshot(client: PgClient): Promise<ContinuitySnapshot> {
+  const tables: ContinuityTableSnapshot[] = [];
+  for (const table of CONTINUITY_TABLES) {
+    const result = await client.query<{ value: unknown }>(
+      `SELECT to_jsonb(certification_row) AS value
+         FROM (SELECT * FROM "${table}" ORDER BY id) AS certification_row`,
+    );
+    tables.push(tableSnapshot(table, result.rows.map((row) => row.value)));
+  }
+
+  const vector = await client.query<{ extversion: string }>(
+    "SELECT extversion FROM pg_extension WHERE extname = 'vector'",
+  );
+  if (vector.rows.length !== 1 || !vector.rows[0]?.extversion) {
+    throw new CertificationProbeError('PGVECTOR_EXTENSION_MISSING');
+  }
+  const migrations = await client.query<{ value: unknown }>(
+    `SELECT to_jsonb(certification_migration) AS value
+       FROM (
+         SELECT * FROM deft_schema_migrations ORDER BY applied_at, version
+       ) AS certification_migration`,
+  );
+  return assembleContinuitySnapshot({
+    pgvectorVersion: vector.rows[0].extversion,
+    migrations: migrations.rows.map((row) => row.value),
+    tables,
+  });
+}
+
+function isSha256(value: unknown): value is string {
+  return typeof value === 'string' && /^sha256:[a-f0-9]{64}$/.test(value);
+}
+
+function parseContinuitySnapshot(value: unknown): ContinuitySnapshot {
+  if (!value || typeof value !== 'object') {
+    throw new CertificationProbeError('EXPECTED_SNAPSHOT_INVALID');
+  }
+  const candidate = value as Partial<ContinuitySnapshot>;
+  if (
+    candidate.schema_version !== SNAPSHOT_SCHEMA
+    || !isSha256(candidate.continuity_sha256)
+    || typeof candidate.pgvector_version !== 'string'
+    || typeof candidate.migration_count !== 'number'
+    || typeof candidate.latest_migration !== 'string'
+    || !isSha256(candidate.migration_sha256)
+    || !Array.isArray(candidate.tables)
+  ) throw new CertificationProbeError('EXPECTED_SNAPSHOT_INVALID');
+
+  const tables = candidate.tables.map((raw) => {
+    if (
+      !raw || typeof raw !== 'object'
+      || typeof raw.table !== 'string'
+      || !Number.isInteger(raw.row_count) || raw.row_count < 0
+      || !isSha256(raw.sha256)
+    ) throw new CertificationProbeError('EXPECTED_SNAPSHOT_INVALID');
+    return Object.freeze({ table: raw.table, row_count: raw.row_count, sha256: raw.sha256 });
+  });
+  const parsed = Object.freeze({
+    schema_version: SNAPSHOT_SCHEMA,
+    continuity_sha256: candidate.continuity_sha256,
+    total_rows: tables.reduce((total, table) => total + table.row_count, 0),
+    pgvector_version: candidate.pgvector_version,
+    migration_count: candidate.migration_count,
+    latest_migration: candidate.latest_migration,
+    migration_sha256: candidate.migration_sha256,
+    tables,
+  }) satisfies ContinuitySnapshot;
+  const recomputed = sha256(canonicalCapabilityJson(snapshotBasis(parsed)));
+  if (recomputed !== parsed.continuity_sha256) {
+    throw new CertificationProbeError('EXPECTED_SNAPSHOT_HASH_INVALID');
+  }
+  return parsed;
+}
+
+async function generateKeyring(output: string): Promise<void> {
+  const keyring = deterministicCertificationKeyring();
+  await writeJson(output, keyring, true);
+  const serialized = canonicalCapabilityJson(keyring);
+  console.log(JSON.stringify({
+    schema_version: 'deft.app_platform.phase5.disposable_keyring.v1',
+    result: 'written',
+    output: basename(output),
+    sha256: sha256(serialized),
+    warning: 'deterministic_disposable_certification_keys_only',
+    key_ids: {
+      run_encryption: keyring.run_encryption.current,
+      receipt_signing: keyring.receipt_signing.current,
+      fingerprint: keyring.fingerprint.current,
+    },
+  }));
+}
+
+async function writeSnapshot(output: string): Promise<void> {
+  const snapshot = await withClient(createContinuitySnapshot);
+  await writeJson(output, snapshot);
+  console.log(JSON.stringify(snapshot));
+}
+
+async function verifyProofArtifacts(client: PgClient): Promise<void> {
+  const apps = await client.query<{ package_digest: string }>(
+    'SELECT DISTINCT package_digest FROM app_versions WHERE package_digest = ANY($1::text[])',
+    [[...EXPECTED_APP_PACKAGE_DIGESTS]],
+  );
+  const foundApps = new Set(apps.rows.map((row) => row.package_digest));
+  if (EXPECTED_APP_PACKAGE_DIGESTS.some((digest) => !foundApps.has(digest))) {
+    throw new CertificationProbeError('PROOF_APP_DIGEST_MISSING');
+  }
+  const modules = await client.query<{ manifest_digest: string }>(
+    'SELECT DISTINCT manifest_digest FROM module_versions WHERE manifest_digest = $1',
+    [EXPECTED_MODULE_MANIFEST_DIGEST],
+  );
+  if (modules.rows.length === 0) {
+    throw new CertificationProbeError('PROOF_MODULE_DIGEST_MISSING');
+  }
+}
+
+async function verifyRestore(expectedPath: string, output: string): Promise<void> {
+  const expected = parseContinuitySnapshot(JSON.parse(await readFile(expectedPath, 'utf8')) as unknown);
+  const restored = await withClient(createContinuitySnapshot);
+  if (restored.continuity_sha256 !== expected.continuity_sha256) {
+    throw new CertificationProbeError('RESTORED_CONTINUITY_MISMATCH');
+  }
+
+  type RunRow = { id: string; org_id: string; state: string };
+  type AttemptRow = { id: string };
+  type ReceiptRow = {
+    envelope: unknown;
+    envelope_digest: string;
+    signing_key_version: string;
+    signature_hmac: string;
+  };
+
+  let closeDb: (() => Promise<void>) | undefined;
+  let destroyKeys: (() => void) | undefined;
+  const client = pgClient();
+  await client.connect();
+  try {
+    const keyringModule = await import('../../apps/api/src/lib/app-run-keyrings.js');
+    const repositoryModule = await import('../../apps/api/src/lib/app-run-repository.js');
+    const secretRepositoryModule = await import('../../apps/api/src/lib/app-run-secret-repository.js');
+    const secretModule = await import('../../apps/api/src/lib/app-run-secrets.js');
+    const dbModule = await import('../../apps/api/src/lib/db.js');
+    closeDb = dbModule.closeDb;
+    const keys = keyringModule.parseEnvironmentAppRunKeyrings(process.env.DEFT_APP_RUN_KEYRINGS);
+    destroyKeys = () => keys.destroy();
+    const secrets = new secretModule.AppRunSecretService(keys);
+    const repository = new repositoryModule.PostgresAppRunRepository();
+    const secretRepository = new secretRepositoryModule.AppRunSecretRepository(secrets);
+    const inventoryAt = new Date();
+    keyringModule.assertAppRunReferencedKeysAvailable(keys, [
+      ...await repository.activeKeyReferences(inventoryAt),
+      ...await secretRepository.retainedKeyReferences(inventoryAt),
+      ...await secretRepository.receiptSigningKeyReferences(),
+    ]);
+
+    const runs = await client.query<RunRow>(
+      "SELECT id, org_id, state FROM app_runs WHERE origin_kind = 'app' ORDER BY id",
+    );
+    const succeeded = runs.rows.filter((run) => run.state === 'succeeded');
+    if (succeeded.length < 4) {
+      throw new CertificationProbeError('APP_ORIGIN_SUCCESS_PROOF_INCOMPLETE');
+    }
+
+    let inputsDecrypted = 0;
+    let outputsDecrypted = 0;
+    for (const run of succeeded) {
+      const input = await secretRepository.readInput(run.org_id, run.id);
+      if (input === null) throw new CertificationProbeError('APP_RUN_INPUT_NOT_RECOVERABLE');
+      inputsDecrypted += 1;
+
+      const attempts = await client.query<AttemptRow>(
+        `SELECT id FROM app_run_attempts
+          WHERE org_id = $1 AND run_id = $2 AND state = 'succeeded'
+          ORDER BY attempt_number DESC LIMIT 1`,
+        [run.org_id, run.id],
+      );
+      const attempt = attempts.rows[0];
+      if (!attempt) throw new CertificationProbeError('APP_RUN_SUCCESS_ATTEMPT_MISSING');
+      const result = await secretRepository.readOutput(run.org_id, run.id, attempt.id);
+      if (
+        !result || typeof result !== 'object' || Array.isArray(result)
+        || result.provider_succeeded !== true
+      ) throw new CertificationProbeError('APP_RUN_OUTPUT_NOT_RECOVERABLE');
+      outputsDecrypted += 1;
+    }
+
+    const receipts = await client.query<ReceiptRow>(
+      `SELECT envelope, envelope_digest, signing_key_version, signature_hmac
+         FROM app_run_receipts ORDER BY id`,
+    );
+    if (receipts.rows.length === 0) {
+      throw new CertificationProbeError('APP_RUN_RECEIPTS_MISSING');
+    }
+    let receiptsVerified = 0;
+    for (const receipt of receipts.rows) {
+      const digest = sha256(canonicalCapabilityJson(receipt.envelope));
+      if (
+        digest !== receipt.envelope_digest
+        || !secrets.verifyReceipt(
+          receipt.envelope,
+          receipt.signing_key_version,
+          receipt.signature_hmac,
+        )
+      ) throw new CertificationProbeError('APP_RUN_RECEIPT_INVALID');
+      receiptsVerified += 1;
+    }
+
+    await verifyProofArtifacts(client);
+    const report = Object.freeze({
+      schema_version: VERIFY_SCHEMA,
+      result: 'passed',
+      continuity: {
+        expected_sha256: expected.continuity_sha256,
+        restored_sha256: restored.continuity_sha256,
+        matched: true,
+        table_count: restored.tables.length,
+        total_rows: restored.total_rows,
+        pgvector_version: restored.pgvector_version,
+        migration_count: restored.migration_count,
+        latest_migration: restored.latest_migration,
+      },
+      referenced_key_inventory: {
+        checked: true,
+        run_encryption_versions: keys.keyIds('run_encryption').length,
+        receipt_signing_versions: keys.keyIds('receipt_signing').length,
+        fingerprint_versions: keys.keyIds('fingerprint').length,
+      },
+      app_origin_runs: {
+        total: runs.rows.length,
+        succeeded: succeeded.length,
+        inputs_decrypted: inputsDecrypted,
+        outputs_decrypted: outputsDecrypted,
+      },
+      receipts: {
+        total: receipts.rows.length,
+        verified: receiptsVerified,
+      },
+      proof_artifacts: {
+        app_package_digests_verified: EXPECTED_APP_PACKAGE_DIGESTS.length,
+        module_manifest_digests_verified: 1,
+      },
+    });
+    await writeJson(output, report);
+    console.log(JSON.stringify(report));
+  } finally {
+    try {
+      await client.end();
+    } finally {
+      destroyKeys?.();
+      await closeDb?.();
+    }
+  }
+}
+
+export async function main(argv = process.argv.slice(2)): Promise<void> {
+  const options = parseCliArgs(argv);
+  if (options.mode === 'keyring') return generateKeyring(options.output);
+  if (options.mode === 'snapshot') return writeSnapshot(options.output);
+  if (!options.expectedSnapshot) throw new CertificationProbeError('USAGE_EXPECTED_SNAPSHOT_REQUIRED');
+  return verifyRestore(options.expectedSnapshot, options.output);
+}
+
+const invokedPath = process.argv[1] ? resolve(process.argv[1]) : '';
+if (invokedPath && fileURLToPath(import.meta.url) === invokedPath) {
+  main().catch((error: unknown) => {
+    const code = error instanceof CertificationProbeError ? error.code : 'UNEXPECTED_FAILURE';
+    console.error(JSON.stringify({
+      schema_version: 'deft.app_platform.phase5.certification_error.v1',
+      result: 'failed',
+      error_code: code,
+    }));
+    process.exitCode = 1;
+  });
+}
+
+export const __test = Object.freeze({
+  SNAPSHOT_SCHEMA,
+  CONTINUITY_TABLES,
+  EXPECTED_APP_PACKAGE_DIGESTS,
+  EXPECTED_MODULE_MANIFEST_DIGEST,
+  EXPECTED_LATEST_MIGRATION,
+  parseContinuitySnapshot,
+  sha256,
+  tableSnapshot,
+});

--- a/scripts/ci/certify-app-platform-phase5.sh
+++ b/scripts/ci/certify-app-platform-phase5.sh
@@ -1,0 +1,281 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+phase5_sha="${PHASE5_CANDIDATE_SHA:?PHASE5_CANDIDATE_SHA is required}"
+phase4_sha="${PHASE4_BASELINE_SHA:?PHASE4_BASELINE_SHA is required}"
+predecessor_image="${PREDECESSOR_IMAGE:?PREDECESSOR_IMAGE is required}"
+predecessor_commit="${PREDECESSOR_COMMIT:?PREDECESSOR_COMMIT is required}"
+certifier_root="${CERTIFIER_ROOT:?CERTIFIER_ROOT is required}"
+phase5_root="${PHASE5_ROOT:?PHASE5_ROOT is required}"
+phase4_root="${PHASE4_ROOT:?PHASE4_ROOT is required}"
+evidence_root="${EVIDENCE_DIR:?EVIDENCE_DIR is required}"
+
+run_id="${GITHUB_RUN_ID:?GITHUB_RUN_ID is required}"
+run_attempt="${GITHUB_RUN_ATTEMPT:?GITHUB_RUN_ATTEMPT is required}"
+prefix="deft-p5-cert-${run_id}-${run_attempt}"
+network="${prefix}-network"
+source_container="${prefix}-source"
+restore_container="${prefix}-restore"
+app_container="${prefix}-app"
+source_volume="${prefix}-source-data"
+restore_volume="${prefix}-restore-data"
+candidate_tag="deft:phase5-cert-${run_id}-${run_attempt}"
+database_name="deft_phase4_phase5_release_test"
+postgres_password="phase5-cert-postgres"
+host_port=55432
+source_url_host="postgres://postgres:${postgres_password}@127.0.0.1:${host_port}/${database_name}"
+source_url_container="postgres://postgres:${postgres_password}@${source_container}:5432/${database_name}"
+restore_url_container="postgres://postgres:${postgres_password}@${restore_container}:5432/${database_name}"
+safe_dir="${evidence_root}/safe"
+recovery_dir="${RUNNER_TEMP:?RUNNER_TEMP is required}/deft-phase5-recovery-${run_id}-${run_attempt}"
+keyring_path="${recovery_dir}/app-run-keyrings.json"
+restored_keyring_path="${recovery_dir}/restored-app-run-keyrings.json"
+dump_path="${recovery_dir}/database.dump"
+candidate_archive="${evidence_root}/candidate-image.tar.zst"
+
+mkdir -p "$safe_dir" "$recovery_dir"
+chmod 700 "$recovery_dir"
+
+cleanup() {
+  set +e
+  docker rm -f "$app_container" "$restore_container" "$source_container" >/dev/null 2>&1
+  docker network rm "$network" >/dev/null 2>&1
+  docker volume rm "$restore_volume" "$source_volume" >/dev/null 2>&1
+  rm -f "$keyring_path" "$restored_keyring_path" "$dump_path"
+  rmdir "$recovery_dir" >/dev/null 2>&1
+}
+trap cleanup EXIT
+
+wait_for_postgres() {
+  local container="$1"
+  for attempt in $(seq 1 30); do
+    if docker exec "$container" pg_isready -U postgres -d "$database_name" >/dev/null 2>&1; then return 0; fi
+    if [[ "$attempt" == 30 ]]; then
+      docker logs "$container"
+      return 1
+    fi
+    sleep 2
+  done
+}
+
+run_candidate() {
+  docker run --rm --network "$network" \
+    -e DATABASE_URL="$1" \
+    -e DEFT_TEST_DATABASE_URL="$1" \
+    -e JWT_SECRET=phase5-cert-jwt-not-for-prod \
+    -e JWT_REFRESH_SECRET=phase5-cert-refresh-not-for-prod \
+    -e ENCRYPTION_KEY=phase5-cert-envelope-key-32bytes \
+    --entrypoint sh "$candidate_tag" -c "$2"
+}
+
+[[ "$(git -C "$phase5_root" rev-parse HEAD)" == "$phase5_sha" ]]
+[[ "$(git -C "$phase4_root" rev-parse HEAD)" == "$phase4_sha" ]]
+
+docker network create "$network" >/dev/null
+docker volume create "$source_volume" >/dev/null
+docker volume create "$restore_volume" >/dev/null
+docker run -d --name "$source_container" --network "$network" -p "${host_port}:5432" \
+  -v "${source_volume}:/var/lib/postgresql/data" \
+  -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD="$postgres_password" -e POSTGRES_DB="$database_name" \
+  pgvector/pgvector:pg16 >/dev/null
+wait_for_postgres "$source_container"
+docker exec "$source_container" psql -U postgres -d "$database_name" -v ON_ERROR_STOP=1 \
+  -c 'CREATE EXTENSION IF NOT EXISTS vector;'
+docker exec "$source_container" psql -U postgres -d "$database_name" -Atc \
+  "SELECT extversion FROM pg_extension WHERE extname = 'vector'" > "$safe_dir/pgvector-version.txt"
+
+(
+  cd "$phase4_root"
+  DATABASE_URL="$source_url_host" pnpm db:push-full
+  DATABASE_URL="$source_url_host" DEFT_TEST_DATABASE_URL="$source_url_host" \
+    JWT_SECRET=phase5-cert-jwt-not-for-prod \
+    JWT_REFRESH_SECRET=phase5-cert-refresh-not-for-prod \
+    ENCRYPTION_KEY=phase5-cert-envelope-key-32bytes \
+    pnpm --filter @deft/api exec tsx --test test/resource-participation-apps-db.test.ts
+)
+
+docker buildx build --load \
+  --tag "$candidate_tag" \
+  --iidfile "$safe_dir/candidate-buildkit-iid.txt" \
+  --metadata-file "$safe_dir/candidate-buildkit-metadata.json" \
+  --build-arg "VCS_REF=$phase5_sha" \
+  --build-arg NEXT_PUBLIC_APP_URL=http://127.0.0.1:3000 \
+  --build-arg NEXT_PUBLIC_API_URL=http://127.0.0.1:3001 \
+  --build-arg NEXT_PUBLIC_WS_URL=http://127.0.0.1:3001 \
+  --build-arg NEXT_PUBLIC_FEATURE_HUDDLES=true \
+  --build-arg NEXT_PUBLIC_FEATURE_APPS=true \
+  "$phase5_root"
+
+image_revision="$(docker image inspect "$candidate_tag" --format '{{index .Config.Labels "org.opencontainers.image.revision"}}')"
+[[ "$image_revision" == "$phase5_sha" ]]
+docker image inspect "$candidate_tag" > "$safe_dir/candidate-image-inspect.json"
+printf '%s\n' "$image_revision" > "$safe_dir/candidate-image-revision.txt"
+
+run_candidate "$source_url_container" 'pnpm db:upgrade && pnpm module:verify'
+run_candidate "$source_url_container" 'pnpm db:seed:demo'
+docker run --rm --network "$network" \
+  -v "${phase5_root}/examples:/app/examples:ro" \
+  -e DATABASE_URL="$source_url_container" \
+  -e DEFT_TEST_DATABASE_URL="$source_url_container" \
+  -e JWT_SECRET=phase5-cert-jwt-not-for-prod \
+  -e JWT_REFRESH_SECRET=phase5-cert-refresh-not-for-prod \
+  -e ENCRYPTION_KEY=phase5-cert-envelope-key-32bytes \
+  --entrypoint sh "$candidate_tag" \
+  -c 'pnpm --filter @deft/api exec tsx --test test/phase5-proof-package-determinism.test.ts test/phase5-sandbox-email-provider.test.ts test/app-origin-run-lifecycle-db.test.ts'
+
+docker run --rm --network "$network" \
+  -e DATABASE_URL="$source_url_container" \
+  -e DEFT_TEST_EMAIL=diego@testers-tomatoes.com \
+  -e DEFT_APPROVAL_SMOKE_MARKER="Phase 5 certification ${run_id}" \
+  --entrypoint sh "$candidate_tag" -c 'pnpm test:product-browser:seed'
+
+proof_email="$(docker exec "$source_container" psql -U postgres -d "$database_name" -qAtc "
+  WITH demo AS (
+    SELECT password_hash FROM users WHERE email = 'diego@testers-tomatoes.com'
+  )
+  UPDATE users AS proof
+     SET password_hash = demo.password_hash, email_verified = true
+    FROM demo
+   WHERE proof.email LIKE 'loop5-owner-%@example.test'
+   RETURNING proof.email")"
+[[ "$proof_email" == loop5-owner-*@example.test ]]
+
+docker run --rm --network "$network" \
+  -v "${certifier_root}/scripts/ci/app-platform-phase5-certification-probe.ts:/app/scripts/ci/app-platform-phase5-certification-probe.ts:ro" \
+  -v "${recovery_dir}:/recovery" \
+  -e DATABASE_URL="$source_url_container" -e DEFT_TEST_DATABASE_URL="$source_url_container" \
+  --entrypoint sh "$candidate_tag" \
+  -c 'pnpm exec tsx scripts/ci/app-platform-phase5-certification-probe.ts keyring --output /recovery/app-run-keyrings.json'
+chmod 600 "$keyring_path"
+keyring_hash="$(sha256sum "$keyring_path" | cut -d ' ' -f 1)"
+printf '%s\n' "$keyring_hash" > "$safe_dir/app-run-keyring.sha256"
+
+keyring_json="$(tr -d '\n' < "$keyring_path")"
+docker run --rm --network "$network" \
+  -v "${certifier_root}/scripts/ci/app-platform-phase5-certification-probe.ts:/app/scripts/ci/app-platform-phase5-certification-probe.ts:ro" \
+  -v "${safe_dir}:/evidence" \
+  -e DATABASE_URL="$source_url_container" -e DEFT_TEST_DATABASE_URL="$source_url_container" \
+  -e DEFT_APP_RUN_KEYRINGS="$keyring_json" \
+  --entrypoint sh "$candidate_tag" \
+  -c 'pnpm exec tsx scripts/ci/app-platform-phase5-certification-probe.ts snapshot --output /evidence/source-snapshot.json'
+
+docker exec "$source_container" pg_dump -U postgres -d "$database_name" -Fc > "$dump_path"
+chmod 600 "$dump_path"
+sha256sum "$dump_path" | cut -d ' ' -f 1 > "$safe_dir/database-dump.sha256"
+cp "$keyring_path" "$restored_keyring_path"
+chmod 600 "$restored_keyring_path"
+[[ "$(sha256sum "$restored_keyring_path" | cut -d ' ' -f 1)" == "$keyring_hash" ]]
+restored_keyring_json="$(tr -d '\n' < "$restored_keyring_path")"
+
+docker run -d --name "$restore_container" --network "$network" \
+  -v "${restore_volume}:/var/lib/postgresql/data" \
+  -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD="$postgres_password" -e POSTGRES_DB="$database_name" \
+  pgvector/pgvector:pg16 >/dev/null
+wait_for_postgres "$restore_container"
+docker exec "$restore_container" psql -U postgres -d "$database_name" -v ON_ERROR_STOP=1 \
+  -c 'CREATE EXTENSION IF NOT EXISTS vector;'
+docker exec -i "$restore_container" pg_restore -U postgres -d "$database_name" --clean --if-exists < "$dump_path"
+
+read -r probe_org probe_employee probe_record < <(
+  docker exec "$restore_container" psql -U postgres -d "$database_name" -At -F ' ' -c "
+    SELECT mr.org_id, ae.id, mr.id
+      FROM module_records mr
+      JOIN module_installations mi ON mi.id = mr.installation_id AND mi.org_id = mr.org_id
+      JOIN agent_employees ae ON ae.org_id = mr.org_id AND ae.is_active = true AND ae.is_deleted = false
+     WHERE mr.data->>'name' = 'Ada Lovelace'
+       AND mr.is_deleted = false
+       AND mi.agent_access IN ('read', 'write')
+     ORDER BY mr.created_at
+     LIMIT 1"
+)
+[[ -n "$probe_org" && -n "$probe_employee" && -n "$probe_record" ]]
+
+docker pull "$predecessor_image"
+predecessor_revision="$(docker image inspect "$predecessor_image" --format '{{index .Config.Labels "org.opencontainers.image.revision"}}')"
+[[ "$predecessor_revision" == "$predecessor_commit" ]]
+printf '%s\n' "$predecessor_image" > "$safe_dir/predecessor-image.txt"
+printf '%s\n' "$predecessor_revision" > "$safe_dir/predecessor-image-revision.txt"
+docker run --rm --network "$network" \
+  -v "${certifier_root}/apps/api/test/phase5-predecessor-read-probe.ts:/app/apps/api/test/phase5-predecessor-read-probe.ts:ro" \
+  -e DATABASE_URL="$restore_url_container" \
+  -e DEFT_PROBE_ORG_ID="$probe_org" \
+  -e DEFT_PROBE_EMPLOYEE_ID="$probe_employee" \
+  -e DEFT_PROBE_RECORD_ID="$probe_record" \
+  --entrypoint sh "$predecessor_image" \
+  -c 'pnpm --filter @deft/api exec tsx test/phase5-predecessor-read-probe.ts' \
+  > "$safe_dir/predecessor-read.json"
+
+docker run --rm --network "$network" \
+  -v "${certifier_root}/scripts/ci/app-platform-phase5-certification-probe.ts:/app/scripts/ci/app-platform-phase5-certification-probe.ts:ro" \
+  -v "${safe_dir}:/evidence" \
+  -e DATABASE_URL="$restore_url_container" -e DEFT_TEST_DATABASE_URL="$restore_url_container" \
+  -e JWT_SECRET=phase5-cert-jwt-not-for-prod \
+  -e JWT_REFRESH_SECRET=phase5-cert-refresh-not-for-prod \
+  -e ENCRYPTION_KEY=phase5-cert-envelope-key-32bytes \
+  -e DEFT_APPS_ENABLED=true \
+  -e DEFT_APP_RUNS_ENABLED=true \
+  -e DEFT_APP_RUN_APP_ORIGIN_ENABLED=true \
+  -e DEFT_APP_RUN_LEGACY_MCP_CUTOVER_ENABLED=false \
+  -e DEFT_APP_RUN_KEYRINGS="$restored_keyring_json" \
+  --entrypoint sh "$candidate_tag" \
+  -c 'pnpm exec tsx scripts/ci/app-platform-phase5-certification-probe.ts verify --expected-snapshot /evidence/source-snapshot.json --output /evidence/restored-verification.json'
+
+docker run -d --name "$app_container" --network "$network" -p 3000:3000 -p 3001:3001 \
+  -e DATABASE_URL="$restore_url_container" \
+  -e JWT_SECRET=phase5-cert-jwt-not-for-prod \
+  -e JWT_REFRESH_SECRET=phase5-cert-refresh-not-for-prod \
+  -e ENCRYPTION_KEY=phase5-cert-envelope-key-32bytes \
+  -e DEFT_APPS_ENABLED=true \
+  -e DEFT_APP_RUNS_ENABLED=true \
+  -e DEFT_APP_RUN_APP_ORIGIN_ENABLED=true \
+  -e DEFT_APP_RUN_LEGACY_MCP_CUTOVER_ENABLED=false \
+  -e DEFT_APP_RUN_KEYRINGS="$restored_keyring_json" \
+  -e NEXT_PUBLIC_APP_URL=http://127.0.0.1:3000 \
+  -e NEXT_PUBLIC_API_URL=http://127.0.0.1:3001 \
+  -e NEXT_PUBLIC_WS_URL=http://127.0.0.1:3001 \
+  -e NEXT_PUBLIC_FEATURE_APPS=true \
+  "$candidate_tag" >/dev/null
+for attempt in $(seq 1 45); do
+  if curl --fail --silent http://127.0.0.1:3001/health >/dev/null \
+    && curl --fail --silent http://127.0.0.1:3000/login >/dev/null; then break; fi
+  if [[ "$attempt" == 45 ]]; then docker logs "$app_container"; exit 1; fi
+  sleep 2
+done
+
+DEFT_WEB_URL=http://127.0.0.1:3000 \
+DEFT_TEST_EMAIL="$proof_email" \
+DEFT_TEST_PASSWORD=tomato123 \
+DEFT_APP_PLATFORM_REQUIRE_CONNECTED=true \
+DEFT_APP_RUN_KEYRINGS="$restored_keyring_json" \
+JWT_SECRET=phase5-cert-jwt-not-for-prod \
+JWT_REFRESH_SECRET=phase5-cert-refresh-not-for-prod \
+ENCRYPTION_KEY=phase5-cert-envelope-key-32bytes \
+DEFT_APP_PLATFORM_EVIDENCE_DIR="$safe_dir" \
+DEFT_APP_PLATFORM_BROWSER_EVIDENCE="$safe_dir/browser-evidence.json" \
+node "$certifier_root/scripts/ci/app-platform-phase5-browser-smoke.mjs"
+
+docker save "$candidate_tag" | zstd -T0 -10 -o "$candidate_archive"
+sha256sum "$candidate_archive" | cut -d ' ' -f 1 > "$safe_dir/candidate-image-archive.sha256"
+docker exec "$restore_container" psql -U postgres -d "$database_name" -Atc \
+  "SELECT version || '|' || kind FROM deft_schema_migrations ORDER BY applied_at, version" \
+  > "$safe_dir/migration-ledger.txt"
+
+CERTIFIER_SHA="${CERTIFIER_SHA:?CERTIFIER_SHA is required}" \
+PHASE5_CANDIDATE_SHA="$phase5_sha" PHASE4_BASELINE_SHA="$phase4_sha" \
+PREDECESSOR_IMAGE="$predecessor_image" IMAGE_REVISION="$image_revision" \
+node --input-type=module - "$safe_dir/certification-summary.json" <<'NODE'
+import { writeFileSync } from 'node:fs';
+const output = process.argv[2];
+writeFileSync(output, `${JSON.stringify({
+  schema: 'deft.app_platform.phase5.release_host.v1',
+  result: 'passed',
+  certifier_sha: process.env.CERTIFIER_SHA,
+  candidate_sha: process.env.PHASE5_CANDIDATE_SHA,
+  baseline_sha: process.env.PHASE4_BASELINE_SHA,
+  candidate_revision: process.env.IMAGE_REVISION,
+  predecessor_image: process.env.PREDECESSOR_IMAGE,
+  published: false,
+}, null, 2)}\n`, { mode: 0o644 });
+NODE
+
+echo 'Phase 5 immutable non-publishing certification passed.'


### PR DESCRIPTION
## Outcome
Adds the manual, non-publishing release-host certification lane required to close App Protocol v2 Phase 5 against immutable inputs.

## What it proves
- exact Phase 5 candidate `161ca65f` and Phase 4 baseline `ec79592e`
- real pgvector fresh/upgrade/backup/restore coverage
- AppRun key backup/restore continuity and receipt verification
- exact predecessor image compatibility
- connected Apps desktop/mobile browser proof
- exact locally-built candidate image provenance and retained archive
- isolated resource cleanup

## Safety
- `workflow_dispatch` only
- repository permissions are read-only
- no package, image, or release publishing
- safe evidence and the large image archive are retained separately
- the audit remains explicitly pending until this workflow is merged and passes on `master`

## Local evidence
- API/repository typecheck passed
- probe tests passed (3/3)
- release workflow tests passed (16/16 total; 6/6 new)
- shell parse, browser syntax, YAML parse, and `git diff --check` passed

Live Docker/pgvector/browser certification is intentionally delegated to this release-host workflow because local Docker and pgvector are unavailable.