### PR TITLE
fix(apps): build Phase 4 kit in certification

### DIFF
--- a/.github/workflows/app-platform-phase5-certification.yml
+++ b/.github/workflows/app-platform-phase5-certification.yml
@@ -97,7 +97,7 @@ jobs:
           retention-days: 90
 
       - name: Upload exact candidate image archive
-        if: always()
+        if: success()
         uses: actions/upload-artifact@v4
         with:
           name: app-platform-phase5-image-${{ github.run_id }}-${{ github.run_attempt }}

--- a/scripts/app-platform-certification-workflow.test.mjs
+++ b/scripts/app-platform-certification-workflow.test.mjs
@@ -86,6 +86,7 @@ test('certification uses real pgvector and proves matched backup, restore, and k
 });
 
 test('certification carries the Phase 4 and Phase 5 probes plus browser evidence', () => {
+  assert.match(orchestrator, /pnpm --filter @deft\/app-kit build/);
   assert.match(orchestrator, /resource-participation-apps-db\.test\.ts/);
   assert.match(orchestrator, /app-origin-run-lifecycle-db\.test\.ts/);
   assert.match(orchestrator, /app-platform-phase5-browser-smoke\.mjs/);

--- a/scripts/ci/certify-app-platform-phase5.sh
+++ b/scripts/ci/certify-app-platform-phase5.sh
@@ -86,6 +86,7 @@ docker exec "$source_container" psql -U postgres -d "$database_name" -Atc \
 
 (
   cd "$phase4_root"
+  pnpm --filter @deft/app-kit build
   DATABASE_URL="$source_url_host" pnpm db:push-full
   DATABASE_URL="$source_url_host" DEFT_TEST_DATABASE_URL="$source_url_host" \
     JWT_SECRET=phase5-cert-jwt-not-for-prod \


### PR DESCRIPTION
## Failure evidence
Release-host run [33462875234](https://github.com/Maneek21/Deft/actions/runs/33462875234) reached real pgvector schema setup, then the exact Phase 4 DB proof failed because `@deft/app-kit/dist/index.js` did not exist in the clean checkout.

## Fix
- build the exact Phase 4 App Kit before invoking its direct DB proof
- pin that prerequisite in the workflow architecture test
- upload the image archive only after a successful certification, while safe failure evidence remains `always()`

## Focused validation
- release-workflow tests: 6/6
- App Kit build: pass
- shell parse: pass
- workflow YAML parse: pass
- `git diff --check`: pass