### PR TITLE
fix(apps): constrain provider idempotency keys

### DIFF
--- a/apps/api/src/lib/app-run-attempt-runner.ts
+++ b/apps/api/src/lib/app-run-attempt-runner.ts
@@ -49,11 +49,15 @@ export type AppRunImmediateExecution = Readonly<{
   provider_result?: AppRunProviderExecutionResult;
 }>;
 
-function providerIdempotencyKey(runId: string): string {
-  return createHash('sha256')
+export function appRunProviderIdempotencyKey(runId: string): string {
+  const digest = createHash('sha256')
     .update('deft.app_run.provider_idempotency.v1\0')
     .update(runId)
     .digest('base64url');
+  // The frozen provider interface requires an alphanumeric first character.
+  // Preserve every already-valid v1 key byte-for-byte and distinguish the
+  // corrected form by length only when base64url begins with "-" or "_".
+  return /^[A-Za-z0-9]/.test(digest) ? digest : `d${digest}`;
 }
 
 function boundedLeaseMs(value: number): number {
@@ -127,7 +131,7 @@ export class AppRunAttemptRunner implements AppRunAttemptScheduler {
     }
 
     const stableProviderKey = claimed.run.retry_class === 'idempotent_with_key'
-      ? providerIdempotencyKey(runId)
+      ? appRunProviderIdempotencyKey(runId)
       : undefined;
     const stopHeartbeat = this.#startLeaseHeartbeat(claimed);
     let result: AppRunProviderExecutionResult;
@@ -384,7 +388,7 @@ export class AppRunAttemptRunner implements AppRunAttemptScheduler {
     const attemptNumber = (last?.attempt_number ?? 0) + 1;
     if (attemptNumber > run.attempt_limit) return null;
     const providerKey = run.retry_class === 'idempotent_with_key'
-      ? providerIdempotencyKey(run.id)
+      ? appRunProviderIdempotencyKey(run.id)
       : null;
     const providerFingerprint = providerKey
       ? this.secrets.fingerprintText('idempotency', providerKey)

--- a/apps/api/test/app-run-attempt-runner.test.ts
+++ b/apps/api/test/app-run-attempt-runner.test.ts
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { SandboxEmailSendInputSchema } from '@deft/app-kit';
+import { appRunProviderIdempotencyKey } from '../src/lib/app-run-attempt-runner.js';
+
+test('provider idempotency keys remain stable and satisfy the frozen interface', () => {
+  const formerlyInvalid = [
+    appRunProviderIdempotencyKey('00000000-0000-4000-8000-000000000000'),
+    appRunProviderIdempotencyKey('00000000-0000-4000-8000-000000000012'),
+  ];
+  assert.deepEqual(formerlyInvalid, [
+    'd-mcO2as3SSMVRkJ3PyFG9uFOVBfN-MPqGrDGmim-aFQ',
+    'd_4RiSOcIU8xRmFwghSICpZM0kU1mtv-Ri_kgI5vZqGU',
+  ]);
+  assert.equal(
+    appRunProviderIdempotencyKey('00000000-0000-4000-8000-000000000001'),
+    'B2exXALhKKYyYOXb5sg0Deb9T9RaewglbbbUxXGO1OE',
+    'already-valid v1 keys must remain byte-identical',
+  );
+  for (const idempotencyKey of formerlyInvalid) {
+    assert.doesNotThrow(() => SandboxEmailSendInputSchema.parse({
+      to: 'recipient@example.test',
+      subject: 'Contract-safe key',
+      body_text: 'The generated key must satisfy the frozen provider schema.',
+      idempotency_key: idempotencyKey,
+    }));
+  }
+});


### PR DESCRIPTION
## Summary
- keep every already-valid Phase 5 provider idempotency key byte-identical
- prefix only base64url digests whose first character violates the frozen provider contract
- add exact hyphen, underscore, and compatibility vectors

## Evidence
- reproduced the lifecycle failure before the fix on a disposable clone: human_mcp returned indeterminate and only 3 of 4 effects occurred
- focused regression: 1/1
- Phase 5 lifecycle DB proof: 1/1
- App Run engine DB suite: 21/21
- Phase 5 package/provider checks: 5/5
- App Kit contract suite: 16/16
- API typecheck: passed

No schema, migration, environment, UI, token, private-interface, or package-digest change.
