### PR TITLE
feat(apps): add Phase 6 connected authoring flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - name: Verify bundled module provenance
         run: pnpm module:verify
+      - name: Test App Kit authoring contracts
+        run: pnpm --filter @deft/app-kit test
       - name: Verify release publishing contract
         run: pnpm test:release-workflow
       - name: Verify deterministic Hermes integration bundle

--- a/apps/api/src/lib/app-grant-service.ts
+++ b/apps/api/src/lib/app-grant-service.ts
@@ -1,9 +1,8 @@
 import { createHash } from 'node:crypto';
 import { appGrantSnapshots } from '@deft/db/schema';
 import {
-  SANDBOX_EMAIL_SEND_PRIVATE_CONTRACT,
+  projectDeftAppRequestedAuthority,
   type DeftAppManifest,
-  type DeftAppManifestV1,
 } from '@deft/app-kit';
 import { db } from './db.js';
 
@@ -49,16 +48,6 @@ export function digestAppGrantValue(value: unknown): `sha256:${string}` {
   return `sha256:${createHash('sha256').update(json, 'utf8').digest('hex')}`;
 }
 
-function v1RequestedRequirements(manifest: DeftAppManifestV1) {
-  return {
-    dependencies: manifest.dependencies,
-    resources: manifest.resource_requirements,
-    capabilities: manifest.capability_requirements,
-    connectors: manifest.connector_requirements,
-    actions: manifest.actions,
-  };
-}
-
 export function buildRequestedAppGrantProjection(input: {
   organization_id: string;
   app_installation_id: string;
@@ -68,31 +57,10 @@ export function buildRequestedAppGrantProjection(input: {
   package_digest: string;
 }): RequestedAppGrantProjection {
   const protocol = input.manifest.compatibility.app_protocol;
-  const requirements = protocol === '1'
-    ? v1RequestedRequirements(input.manifest as DeftAppManifestV1)
-    : { dependencies: [], resources: [], capabilities: [], connectors: [], actions: [] };
-  const resourceRights = protocol === '1'
-    ? (input.manifest as DeftAppManifestV1).resource_requirements.map((requirement) => ({
-        requirement_key: requirement.key,
-        source: requirement.source,
-        resource_type: requirement.resource_type,
-        fields: requirement.fields,
-        right: 'read',
-      }))
-    : [];
-  const classification = {
-    authority_state: 'requested_only',
-    executable: false,
-    provider_access: false,
-    review_required: protocol === '1',
-    actions: protocol === '1'
-      ? (input.manifest as DeftAppManifestV1).actions.map((action) => ({
-          action_key: action.key,
-          capability_requirement_key: action.capability_requirement_key,
-          host_policy: SANDBOX_EMAIL_SEND_PRIVATE_CONTRACT.host_policy,
-        }))
-      : [],
-  };
+  const portable = projectDeftAppRequestedAuthority(input.manifest);
+  const requirements = portable.requirements;
+  const resourceRights = portable.resource_rights;
+  const classification = portable.classification;
   const canonicalSnapshot = canonicalizeAppGrantValue({
     snapshot_version: APP_GRANT_SNAPSHOT_VERSION,
     snapshot_kind: 'requested',

--- a/apps/api/src/routes/app-developer.ts
+++ b/apps/api/src/routes/app-developer.ts
@@ -1,6 +1,10 @@
 import { Hono } from 'hono';
 import { z } from 'zod';
-import { APP_LIMITS } from '@deft/app-kit';
+import {
+  APP_LIMITS,
+  DEFT_APP_DEVELOPER_COMPATIBILITY,
+  resolveDeftAppDeveloperProtocolFlow,
+} from '@deft/app-kit';
 import { activateAppInstallation, inspectAppPackageJson, stageAppPackage } from '../lib/app-service.js';
 import { claimAppDeveloperSession, exchangeAppDeveloperPairing } from '../lib/app-developer-pairing.js';
 import { AppError, isAppError } from '../lib/app-errors.js';
@@ -21,7 +25,12 @@ function fail(c: any, error: unknown) {
   return c.json({ error: 'Developer request failed', code: 'INTERNAL_ERROR' }, 500);
 }
 
-appDeveloperRoutes.get('/status', (c) => c.json({ app_protocol: '0', audience: 'app-developer', single_use_install: true }));
+appDeveloperRoutes.get('/status', (c) => c.json({
+  app_protocol: '0',
+  audience: 'app-developer',
+  single_use_install: true,
+  compatibility: DEFT_APP_DEVELOPER_COMPATIBILITY,
+}));
 
 appDeveloperRoutes.post('/pair/exchange', async (c) => {
   try {
@@ -42,20 +51,18 @@ appDeveloperRoutes.post('/install', async (c) => {
       return c.json({ error: 'App package is too large', code: 'APP_INVALID_PACKAGE' }, 413);
     }
     const inspected = await inspectAppPackageJson(packageJson);
-    if (inspected.manifest.compatibility.app_protocol !== '0') {
-      throw new AppError(
-        `App Protocol v${inspected.manifest.compatibility.app_protocol} packages must use the workspace review flow`,
-        'APP_REVIEW_REQUIRED',
-        409,
-        {
-          app_protocol: inspected.manifest.compatibility.app_protocol,
-          required_flow: 'workspace_review',
-        },
-      );
+    const installFlow = resolveDeftAppDeveloperProtocolFlow(
+      DEFT_APP_DEVELOPER_COMPATIBILITY,
+      inspected.manifest.compatibility.app_protocol,
+    );
+    if (installFlow.package_format !== inspected.package.package_format) {
+      throw new AppError('App package format does not match its developer install flow', 'APP_INVALID_PACKAGE', 400);
     }
     const actor = await claimAppDeveloperSession(token);
     const staged = await stageAppPackage(actor, packageJson);
-    const app = await activateAppInstallation(actor, staged.id, staged.package_digest);
+    const app = installFlow.install_mode === 'stage_and_activate'
+      ? await activateAppInstallation(actor, staged.id, staged.package_digest)
+      : staged;
     return c.json({ app }, 201);
   } catch (error) {
     return fail(c, error);

--- a/apps/api/src/scripts/run-api-tests.ts
+++ b/apps/api/src/scripts/run-api-tests.ts
@@ -30,6 +30,12 @@ if (!runningInCi && process.env.DATABASE_URL === configuredDatabaseUrl) {
   process.exit(1);
 }
 
+// The API suite is the contract gate for both supported developer install
+// flows. Force the otherwise opt-in feature flags in the disposable test
+// process so pairing coverage cannot silently turn into skipped tests.
+process.env.DEFT_APPS_ENABLED = 'true';
+process.env.DEFT_APP_DEVELOPER_PAIRING_ENABLED = 'true';
+
 const pnpmCli = process.env.npm_execpath;
 if (!pnpmCli) {
   console.error('[run-api-tests] Run this script through pnpm so npm_execpath is available');

--- a/apps/api/test/app-grant-service.test.ts
+++ b/apps/api/test/app-grant-service.test.ts
@@ -3,7 +3,7 @@ import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
-import { DeftAppManifestV0Schema } from '@deft/app-kit';
+import { DeftAppManifestV0Schema, projectDeftAppRequestedAuthority } from '@deft/app-kit';
 import { buildRequestedAppGrantProjection } from '../src/lib/app-grant-service.js';
 import {
   connectedAppActionBindingMatches,
@@ -41,6 +41,10 @@ test('Protocol v1 staging projection is deterministic and explicitly non-executa
   assert.equal(first.classification.provider_access, false);
   assert.equal(first.classification.review_required, true);
   assert.doesNotMatch(JSON.stringify(first.canonical_snapshot), /deft\.private\.v1:/);
+  const portable = projectDeftAppRequestedAuthority(built.package.manifest);
+  assert.deepEqual((first.canonical_snapshot as any).requirements, portable.requirements);
+  assert.deepEqual(first.resource_rights, portable.resource_rights);
+  assert.deepEqual(first.classification, portable.classification);
 });
 
 test('Protocol v0 staging projection is an empty compatibility request', () => {

--- a/apps/api/test/app-platform-sandbox-provider.test.ts
+++ b/apps/api/test/app-platform-sandbox-provider.test.ts
@@ -1,0 +1,150 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { mkdir, mkdtemp, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { resolve } from 'node:path';
+import test from 'node:test';
+import {
+  DEFT_APP_KIT_VERSION,
+  SANDBOX_EMAIL_SEND_CONFORMANCE_VECTORS,
+  SANDBOX_EMAIL_SEND_PRIVATE_CONTRACT,
+} from '@deft/app-kit';
+import { MCPClientManager } from '@deft/mcp';
+
+const repositoryRoot = resolve(import.meta.dirname, '..', '..', '..');
+const providerSource = resolve(repositoryRoot, 'examples', 'app-platform-sandbox-email-provider');
+const proofBundlePath = resolve(repositoryRoot, 'examples', 'app-platform-connected-proof-bundle.json');
+
+function runPnpm(args: string[], cwd: string) {
+  const npmExecPath = process.env.npm_execpath
+    ?? (process.platform === 'win32' && process.env.APPDATA
+      ? resolve(process.env.APPDATA, 'npm', 'node_modules', 'pnpm', 'bin', 'pnpm.cjs')
+      : null);
+  const result = npmExecPath
+    ? spawnSync(process.execPath, [npmExecPath, ...args], { cwd, encoding: 'utf8' })
+    : spawnSync('pnpm', args, { cwd, encoding: 'utf8' });
+  assert.equal(
+    result.status,
+    0,
+    [result.error?.message, result.stdout, result.stderr].filter(Boolean).join('\n'),
+  );
+  return result;
+}
+
+test('packed standalone sandbox provider conforms through the official stdio transport', async () => {
+  const temporaryRoot = await mkdtemp(resolve(tmpdir(), 'deft-app-provider-'));
+  const artifacts = resolve(temporaryRoot, 'artifacts');
+  const consumer = resolve(temporaryRoot, 'consumer');
+  const previous = {
+    selfHosted: process.env.DEFT_SELF_HOSTED,
+    unsafeStdio: process.env.DEFT_MCP_ENABLE_UNSAFE_STDIO,
+    allowlist: process.env.MCP_STDIO_ALLOWED_COMMANDS,
+  };
+  const manager = new MCPClientManager();
+  try {
+    await mkdir(artifacts, { recursive: true });
+    await mkdir(consumer, { recursive: true });
+    runPnpm(['--dir', providerSource, 'pack', '--pack-destination', artifacts, '--json'], repositoryRoot);
+    const archives = (await readdir(artifacts)).filter((entry) => entry.endsWith('.tgz'));
+    assert.equal(archives.length, 1);
+    const archive = resolve(artifacts, archives[0]!);
+    const proofBundle = JSON.parse(await readFile(proofBundlePath, 'utf8')) as any;
+    const providerPin = proofBundle.providers.sandbox_email;
+    assert.equal(proofBundle.schema, 'deft.app_platform.connected_proof_bundle.v1');
+    assert.equal(proofBundle.app_kit.version, DEFT_APP_KIT_VERSION);
+    assert.equal(archives[0], providerPin.artifact.filename);
+    assert.equal((await stat(archive)).size, providerPin.artifact.byte_length);
+    assert.equal(
+      `sha256:${createHash('sha256').update(await readFile(archive)).digest('hex')}`,
+      providerPin.artifact.digest,
+    );
+    const contactsLock = JSON.parse(await readFile(
+      resolve(repositoryRoot, proofBundle.dependencies.contacts.lock_path),
+      'utf8',
+    )) as any;
+    assert.equal(contactsLock.app_id, proofBundle.dependencies.contacts.app_id);
+    assert.equal(contactsLock.version, proofBundle.dependencies.contacts.version);
+    assert.equal(contactsLock.package_digest, proofBundle.dependencies.contacts.package_digest);
+    assert.equal(contactsLock.manifest_digest, proofBundle.dependencies.contacts.manifest_digest);
+
+    await writeFile(resolve(consumer, 'package.json'), JSON.stringify({
+      name: 'deft-sandbox-provider-consumer',
+      version: '1.0.0',
+      private: true,
+      dependencies: {
+        '@deft/app-platform-sandbox-email-provider': `file:${archive}`,
+      },
+    }, null, 2), 'utf8');
+    runPnpm(['--dir', consumer, 'install', '--ignore-workspace', '--offline'], repositoryRoot);
+
+    const serverPath = resolve(
+      consumer,
+      'node_modules',
+      '@deft',
+      'app-platform-sandbox-email-provider',
+      'server.mjs',
+    );
+    assert.match(await readFile(serverPath, 'utf8'), /server\/discover/);
+    process.env.DEFT_SELF_HOSTED = 'true';
+    process.env.DEFT_MCP_ENABLE_UNSAFE_STDIO = 'true';
+    process.env.MCP_STDIO_ALLOWED_COMMANDS = process.execPath;
+    const config = {
+      connectionId: 'phase6-packed-sandbox-provider',
+      connectionSlug: 'phase6_sandbox',
+      orgId: '00000000-0000-4000-8000-000000000006',
+      transport: 'stdio' as const,
+      command: process.execPath,
+      args: [serverPath],
+    };
+
+    const discovery = await manager.testToolDiscovery(config);
+    assert.equal(discovery.providerTools.length, 1);
+    assert.deepEqual(discovery.providerTools[0], {
+      name: 'send_email',
+      title: 'Send sandbox email',
+      description: 'Accept one deterministic sandbox email without network egress.',
+      inputSchema: SANDBOX_EMAIL_SEND_PRIVATE_CONTRACT.input_schema,
+      outputSchema: SANDBOX_EMAIL_SEND_PRIVATE_CONTRACT.output_schema,
+    });
+
+    const first = await manager.executeTool(
+      config,
+      'send_email',
+      { ...SANDBOX_EMAIL_SEND_CONFORMANCE_VECTORS.valid.input },
+    );
+    assert.equal(first.success, true, first.error);
+    assert.deepEqual(first.structuredContent, SANDBOX_EMAIL_SEND_CONFORMANCE_VECTORS.valid.output);
+    const replay = await manager.executeTool(
+      config,
+      'send_email',
+      { ...SANDBOX_EMAIL_SEND_CONFORMANCE_VECTORS.valid.input },
+    );
+    assert.equal(replay.success, true, replay.error);
+    assert.deepEqual(replay.structuredContent, first.structuredContent);
+
+    const conflict = await manager.executeTool(config, 'send_email', {
+      ...SANDBOX_EMAIL_SEND_CONFORMANCE_VECTORS.valid.input,
+      subject: 'Different input',
+    });
+    assert.equal(conflict.success, false);
+    assert.match(conflict.error ?? '', /idempotency key was reused with different input/i);
+
+    const invalid = await manager.executeTool(
+      config,
+      'send_email',
+      { ...SANDBOX_EMAIL_SEND_CONFORMANCE_VECTORS.invalid[0].input },
+    );
+    assert.equal(invalid.success, false);
+    assert.match(invalid.error ?? '', /valid email address/i);
+  } finally {
+    await manager.shutdown();
+    if (previous.selfHosted === undefined) delete process.env.DEFT_SELF_HOSTED;
+    else process.env.DEFT_SELF_HOSTED = previous.selfHosted;
+    if (previous.unsafeStdio === undefined) delete process.env.DEFT_MCP_ENABLE_UNSAFE_STDIO;
+    else process.env.DEFT_MCP_ENABLE_UNSAFE_STDIO = previous.unsafeStdio;
+    if (previous.allowlist === undefined) delete process.env.MCP_STDIO_ALLOWED_COMMANDS;
+    else process.env.MCP_STDIO_ALLOWED_COMMANDS = previous.allowlist;
+    await rm(temporaryRoot, { recursive: true, force: true });
+  }
+});

--- a/apps/api/test/app-platform-sandbox-provider.test.ts
+++ b/apps/api/test/app-platform-sandbox-provider.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
-import { spawnSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
-import { mkdir, mkdtemp, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises';
+import { spawnSync } from 'node:child_process';
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { resolve } from 'node:path';
 import test from 'node:test';
@@ -15,6 +15,24 @@ import { MCPClientManager } from '@deft/mcp';
 const repositoryRoot = resolve(import.meta.dirname, '..', '..', '..');
 const providerSource = resolve(repositoryRoot, 'examples', 'app-platform-sandbox-email-provider');
 const proofBundlePath = resolve(repositoryRoot, 'examples', 'app-platform-connected-proof-bundle.json');
+const packedPayloadFiles = ['README.md', 'package.json', 'server.mjs'] as const;
+
+async function packedPayloadProof(root: string) {
+  const schema = 'deft.app_platform.packed_payload.v1';
+  const files = await Promise.all(packedPayloadFiles.map(async (path) => {
+    const bytes = await readFile(resolve(root, path));
+    return {
+      path,
+      byte_length: bytes.length,
+      digest: `sha256:${createHash('sha256').update(bytes).digest('hex')}`,
+    };
+  }));
+  return {
+    schema,
+    files,
+    digest: `sha256:${createHash('sha256').update(JSON.stringify({ schema, files })).digest('hex')}`,
+  };
+}
 
 function runPnpm(args: string[], cwd: string) {
   const npmExecPath = process.env.npm_execpath
@@ -54,11 +72,6 @@ test('packed standalone sandbox provider conforms through the official stdio tra
     assert.equal(proofBundle.schema, 'deft.app_platform.connected_proof_bundle.v1');
     assert.equal(proofBundle.app_kit.version, DEFT_APP_KIT_VERSION);
     assert.equal(archives[0], providerPin.artifact.filename);
-    assert.equal((await stat(archive)).size, providerPin.artifact.byte_length);
-    assert.equal(
-      `sha256:${createHash('sha256').update(await readFile(archive)).digest('hex')}`,
-      providerPin.artifact.digest,
-    );
     const contactsLock = JSON.parse(await readFile(
       resolve(repositoryRoot, proofBundle.dependencies.contacts.lock_path),
       'utf8',
@@ -78,13 +91,14 @@ test('packed standalone sandbox provider conforms through the official stdio tra
     }, null, 2), 'utf8');
     runPnpm(['--dir', consumer, 'install', '--ignore-workspace', '--offline'], repositoryRoot);
 
-    const serverPath = resolve(
+    const installedProviderRoot = resolve(
       consumer,
       'node_modules',
       '@deft',
       'app-platform-sandbox-email-provider',
-      'server.mjs',
     );
+    assert.deepEqual(await packedPayloadProof(installedProviderRoot), providerPin.artifact.content);
+    const serverPath = resolve(installedProviderRoot, 'server.mjs');
     assert.match(await readFile(serverPath, 'utf8'), /server\/discover/);
     process.env.DEFT_SELF_HOSTED = 'true';
     process.env.DEFT_MCP_ENABLE_UNSAFE_STDIO = 'true';

--- a/apps/api/test/apps-v0-pairing-db.test.ts
+++ b/apps/api/test/apps-v0-pairing-db.test.ts
@@ -1,8 +1,24 @@
 import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
 import { after, before, test } from 'node:test';
 import { and, eq } from 'drizzle-orm';
 import { Hono } from 'hono';
-import { appDeveloperPairings, appInstallations } from '@deft/db/schema';
+import {
+  agentActions,
+  appActionBindings,
+  appDependencyLocks,
+  appDeveloperPairings,
+  appGrantSnapshots,
+  appInstallations,
+  appModuleBindings,
+  appRuns,
+  appVersions,
+  capabilityProviderSnapshots,
+  mcpConnections,
+  mcpTokens,
+  orgMembers,
+} from '@deft/db/schema';
+import { DEFT_APP_DEVELOPER_COMPATIBILITY } from '@deft/app-kit';
 import { db, closeDb } from '../src/lib/db.js';
 import { APP_DEVELOPER_PAIRING_ENABLED } from '../src/lib/env.js';
 import {
@@ -13,27 +29,62 @@ import {
 } from '../src/lib/app-developer-pairing.js';
 import { humanModuleActor } from '../src/lib/module-service.js';
 import { appDeveloperRoutes } from '../src/routes/app-developer.js';
-import { buildPhase5ConnectedAppPackage } from './fixtures/phase5-connected-app-package.js';
+import {
+  buildPhase5ConnectedAppPackage,
+  buildPhase5DependencyAppPackage,
+} from './fixtures/phase5-connected-app-package.js';
 
-const orgId = 'apps-v0-test-org';
-const userId = 'apps-v0-test-owner';
+const suffix = randomUUID().replaceAll('-', '');
+const orgId = `apps-pairing-${suffix}`;
+const userId = `apps-pairing-owner-${suffix}`;
+const memberId = `apps-pairing-member-${suffix}`;
 const actor = humanModuleActor({ orgId, userId, role: 'owner' });
 
+function routeApp() {
+  const app = new Hono();
+  app.route('/api/app-developer', appDeveloperRoutes);
+  return app;
+}
+
+async function sessionToken() {
+  const pairing = await createAppDeveloperPairing(actor);
+  const session = await exchangeAppDeveloperPairing(pairing.code);
+  return { pairing, token: session.token };
+}
+
+async function install(app: Hono, token: string, packageJson: string) {
+  return app.request('/api/app-developer/install', {
+    method: 'POST',
+    headers: {
+      authorization: `Bearer ${token}`,
+      'content-type': 'application/vnd.deft.app.package+json',
+    },
+    body: packageJson,
+  });
+}
+
 before(async () => {
+  assert.equal(
+    APP_DEVELOPER_PAIRING_ENABLED,
+    true,
+    'The disposable API runner must execute pairing coverage instead of skipping it',
+  );
   await db.execute(`
-    INSERT INTO orgs (id, name, slug) VALUES ('${orgId}', 'Apps v0 test', 'apps-v0-test') ON CONFLICT DO NOTHING;
-    INSERT INTO users (id, email, name) VALUES ('${userId}', 'apps-v0-pairing-owner@example.test', 'Apps owner') ON CONFLICT DO NOTHING;
+    INSERT INTO orgs (id, name, slug)
+      VALUES ('${orgId}', 'Apps pairing test', 'apps-pairing-${suffix}')
+      ON CONFLICT DO NOTHING;
+    INSERT INTO users (id, email, name)
+      VALUES ('${userId}', 'apps-pairing-${suffix}@example.test', 'Apps owner')
+      ON CONFLICT DO NOTHING;
     INSERT INTO org_members (id, org_id, user_id, role, is_active)
-      VALUES ('apps-v0-member', '${orgId}', '${userId}', 'owner', true)
+      VALUES ('${memberId}', '${orgId}', '${userId}', 'owner', true)
       ON CONFLICT (org_id, user_id) DO UPDATE SET role = 'owner', is_active = true;
   `);
 });
 
 after(async () => closeDb());
 
-test('developer pairing is expiring, single-use, audience-bound, and revocable', {
-  skip: !APP_DEVELOPER_PAIRING_ENABLED,
-}, async () => {
+test('developer pairing is expiring, single-use, audience-bound, manager-rechecked, and revocable', async () => {
   const pairing = await createAppDeveloperPairing(actor);
   assert.equal(pairing.audience, 'app-developer');
   const session = await exchangeAppDeveloperPairing(pairing.code);
@@ -44,55 +95,150 @@ test('developer pairing is expiring, single-use, audience-bound, and revocable',
   assert.equal(claimed.org_id, orgId);
   await assert.rejects(() => claimAppDeveloperSession(session.token), /already used|invalid/);
 
+  const managerRecheck = await sessionToken();
+  await db.update(orgMembers).set({ role: 'member' }).where(and(
+    eq(orgMembers.org_id, orgId),
+    eq(orgMembers.user_id, userId),
+  ));
+  await assert.rejects(() => claimAppDeveloperSession(managerRecheck.token), /owner|admin|manager|invalid/i);
+  await db.update(orgMembers).set({ role: 'owner', is_active: true }).where(and(
+    eq(orgMembers.org_id, orgId),
+    eq(orgMembers.user_id, userId),
+  ));
+
   const revokedPairing = await createAppDeveloperPairing(actor);
   const revokedSession = await exchangeAppDeveloperPairing(revokedPairing.code);
   await revokeAppDeveloperPairing(actor, revokedPairing.pairing_id);
   await assert.rejects(() => claimAppDeveloperSession(revokedSession.token), /revoked|invalid/);
 
   const expired = await createAppDeveloperPairing(actor);
-  await db.update(appDeveloperPairings).set({ expires_at: new Date(0) }).where(eq(appDeveloperPairings.id, expired.pairing_id));
+  await db.update(appDeveloperPairings).set({ expires_at: new Date(0) })
+    .where(eq(appDeveloperPairings.id, expired.pairing_id));
   await assert.rejects(() => exchangeAppDeveloperPairing(expired.code), /expired|invalid/);
 });
 
-test('developer install rejects Protocol v1 before consuming the session or staging', {
-  skip: !APP_DEVELOPER_PAIRING_ENABLED,
-}, async () => {
-  const routeApp = new Hono();
-  routeApp.route('/api/app-developer', appDeveloperRoutes);
-  const statusResponse = await routeApp.request('/api/app-developer/status');
-  assert.equal(statusResponse.status, 200);
-  assert.deepEqual(await statusResponse.json(), {
+test('developer status advertises additive exact v0/v1 flows without changing legacy fields', async () => {
+  const response = await routeApp().request('/api/app-developer/status');
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), {
     app_protocol: '0',
     audience: 'app-developer',
     single_use_install: true,
+    compatibility: DEFT_APP_DEVELOPER_COMPATIBILITY,
   });
+});
 
-  const pairing = await createAppDeveloperPairing(actor);
-  const session = await exchangeAppDeveloperPairing(pairing.code);
+test('Protocol v1 inspection precedes token claim and valid delivery stages at zero authority', async () => {
+  const app = routeApp();
+  const pairing = await sessionToken();
   const built = await buildPhase5ConnectedAppPackage();
-  const response = await routeApp.request('/api/app-developer/install', {
-    method: 'POST',
-    headers: {
-      authorization: `Bearer ${session.token}`,
-      'content-type': 'application/json',
-    },
-    body: built.json,
-  });
-  assert.equal(response.status, 409);
-  assert.deepEqual(await response.json(), {
-    error: 'App Protocol v1 packages must use the workspace review flow',
-    code: 'APP_REVIEW_REQUIRED',
-    details: {
-      app_protocol: '1',
-      required_flow: 'workspace_review',
-    },
-  });
+  const corrupt = JSON.parse(built.json) as any;
+  corrupt.manifest_digest = `sha256:${'0'.repeat(64)}`;
+  const rejected = await install(app, pairing.token, JSON.stringify(corrupt));
+  assert.equal(rejected.status, 400);
+  assert.equal((await rejected.json() as any).code, 'APP_INVALID_PACKAGE');
 
   const [persistedPairing] = await db.select().from(appDeveloperPairings)
-    .where(eq(appDeveloperPairings.id, pairing.pairing_id));
+    .where(eq(appDeveloperPairings.id, pairing.pairing.pairing_id));
   assert.equal(persistedPairing?.install_used_at, null);
   assert.equal((await db.select().from(appInstallations).where(and(
     eq(appInstallations.org_id, orgId),
     eq(appInstallations.app_id, built.package.manifest.id),
   ))).length, 0);
+
+  const accepted = await install(app, pairing.token, built.json);
+  assert.equal(accepted.status, 201);
+  const body = await accepted.json() as any;
+  assert.deepEqual(Object.keys(body), ['app']);
+  assert.equal(body.app.app_id, built.package.manifest.id);
+  assert.equal(body.app.state, 'staged');
+  assert.equal(body.app.active_version_id, null);
+  assert.equal(body.app.grant_epoch, 0);
+
+  const [installation] = await db.select().from(appInstallations).where(and(
+    eq(appInstallations.org_id, orgId),
+    eq(appInstallations.id, body.app.id),
+  ));
+  const [version] = await db.select().from(appVersions).where(and(
+    eq(appVersions.org_id, orgId),
+    eq(appVersions.installation_id, body.app.id),
+  ));
+  assert.equal(installation?.state, 'staged');
+  assert.equal(installation?.active_version_id, null);
+  assert.equal(installation?.active_grant_snapshot_id, null);
+  assert.equal(version?.state, 'staged');
+  assert.ok(version?.requested_grant_snapshot_id);
+  const grants = await db.select().from(appGrantSnapshots).where(and(
+    eq(appGrantSnapshots.org_id, orgId),
+    eq(appGrantSnapshots.app_installation_id, body.app.id),
+  ));
+  assert.equal(grants.length, 1);
+  assert.equal(grants[0]!.snapshot_kind, 'requested');
+  assert.equal(grants[0]!.classification.executable, false);
+  assert.equal(grants[0]!.classification.provider_access, false);
+
+  for (const [label, rows] of [
+    ['Module bindings', await db.select().from(appModuleBindings).where(and(
+      eq(appModuleBindings.org_id, orgId), eq(appModuleBindings.app_installation_id, body.app.id),
+    ))],
+    ['dependency locks', await db.select().from(appDependencyLocks).where(and(
+      eq(appDependencyLocks.org_id, orgId), eq(appDependencyLocks.app_installation_id, body.app.id),
+    ))],
+    ['action bindings', await db.select().from(appActionBindings).where(and(
+      eq(appActionBindings.org_id, orgId), eq(appActionBindings.app_installation_id, body.app.id),
+    ))],
+    ['App Runs', await db.select().from(appRuns).where(and(
+      eq(appRuns.org_id, orgId), eq(appRuns.origin_app_installation_id, body.app.id),
+    ))],
+  ] as const) {
+    assert.equal(rows.length, 0, label);
+  }
+  assert.equal((await db.select().from(agentActions).where(eq(agentActions.org_id, orgId))).length, 0);
+  assert.equal((await db.select().from(capabilityProviderSnapshots).where(
+    eq(capabilityProviderSnapshots.org_id, orgId),
+  )).length, 0);
+  assert.equal((await db.select().from(mcpConnections).where(eq(mcpConnections.org_id, orgId))).length, 0);
+  assert.equal((await db.select().from(mcpTokens).where(eq(mcpTokens.org_id, orgId))).length, 0);
+
+  const replay = await install(app, pairing.token, built.json);
+  assert.equal(replay.status, 403);
+  assert.equal((await db.select().from(appInstallations).where(and(
+    eq(appInstallations.org_id, orgId),
+    eq(appInstallations.app_id, built.package.manifest.id),
+  ))).length, 1);
+  assert.equal((await db.select().from(appVersions).where(and(
+    eq(appVersions.org_id, orgId),
+    eq(appVersions.installation_id, body.app.id),
+  ))).length, 1);
+});
+
+test('Protocol v0 keeps the exact stage-and-activate response and replay behavior', async () => {
+  const app = routeApp();
+  const pairing = await sessionToken();
+  const built = await buildPhase5DependencyAppPackage();
+  const accepted = await install(app, pairing.token, built.json);
+  assert.equal(accepted.status, 201);
+  const body = await accepted.json() as any;
+  assert.deepEqual(Object.keys(body), ['app']);
+  assert.equal(body.app.app_id, built.package.manifest.id);
+  assert.equal(body.app.state, 'active');
+  assert.ok(body.app.active_version_id);
+
+  const [installation] = await db.select().from(appInstallations).where(and(
+    eq(appInstallations.org_id, orgId),
+    eq(appInstallations.id, body.app.id),
+  ));
+  assert.equal(installation?.state, 'active');
+  assert.ok(installation?.active_version_id);
+  assert.equal((await db.select().from(appModuleBindings).where(and(
+    eq(appModuleBindings.org_id, orgId),
+    eq(appModuleBindings.app_installation_id, body.app.id),
+  ))).length, 1);
+
+  const replay = await install(app, pairing.token, built.json);
+  assert.equal(replay.status, 403);
+  assert.equal((await db.select().from(appInstallations).where(and(
+    eq(appInstallations.org_id, orgId),
+    eq(appInstallations.app_id, built.package.manifest.id),
+  ))).length, 1);
 });

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@
 
 ## Operator and integration guides
 
+- [Connected App author guide](connected-app-author-guide.md)
 - [Hermes native employee integration](../integrations/hermes/deft-platform/README.md)
 - [Legacy Hermes Agent Channel bridge rollback](hermes-agent-channel-service.md)
 - Public product capabilities: [FEATURES.md](../FEATURES.md)

--- a/docs/connected-app-author-guide.md
+++ b/docs/connected-app-author-guide.md
@@ -1,0 +1,276 @@
+# Connected App author guide
+
+This guide covers the Phase 6 PR A proof: an independent author can create,
+check, build, verify host compatibility, and locally stage one App Protocol v1
+connected App using packed public artifacts. The handoff ends at a staged App
+with zero authority.
+
+The current authoring artifact is `@deft/app-kit@0.1.0-alpha.1`. Use a packed
+tarball of that exact version; do not substitute a monorepo workspace link or
+import private Deft packages.
+
+## 1. Use the pinned proof artifacts
+
+The
+[machine-readable connected proof bundle](../examples/app-platform-connected-proof-bundle.json)
+is the source of truth for the proof inputs. It records the pinned Contacts App
+package digest and the separately packed sandbox-email provider artifact digest
+and retrieval path. Verify the artifacts against those recorded values rather
+than copying a digest from prose. The connected template depends on the exact
+Contacts App and does not bundle or copy its records.
+
+To create the App Kit tarball from a matching Deft checkout:
+
+```sh
+pnpm --dir packages/app-kit pack --pack-destination /absolute/path/to/artifacts
+```
+
+Then install it in a clean directory outside the repository:
+
+```sh
+mkdir connected-campaigns
+cd connected-campaigns
+pnpm init
+pnpm add --save-dev /absolute/path/to/artifacts/deft-app-kit-0.1.0-alpha.1.tgz
+```
+
+When a release or proof bundle already supplies the tarball, install that exact
+artifact instead of repacking it.
+
+## 2. Choose the template deliberately
+
+The declarative compatibility default is unchanged:
+
+```sh
+pnpm exec deft app init
+# Byte-identical alternative:
+pnpm exec deft app init --template declarative
+```
+
+It creates an App Protocol v0 manifest, one Module v1 manifest, `APP_BRIEF.md`,
+scoped `AGENTS.md` guidance, and `.gitignore`. Protocol v0 has no dependency,
+capability, connector, action, runtime, or connected permission vocabulary.
+
+Create the connected scaffold in a different empty directory:
+
+```sh
+pnpm exec deft app init --template connected
+```
+
+That command creates:
+
+- an App Protocol v1 manifest;
+- a Module v2 `campaigns` resource with a relation to Contacts;
+- the exact `org.deft.reference.resource-contacts-app` version `1.0.0`
+  dependency and its required `contacts.email` field;
+- the lineage-private `sandbox_email_send` version `1` capability request;
+- an existing-provider `mcp` connector requirement; and
+- one host-rendered, single-recipient `send_campaign_email` action binding.
+
+Malformed template arguments are rejected. `init` also refuses to replace an
+existing `deft.app.json`.
+
+### Safe changes to the connected scaffold
+
+Stay inside the published manifest and Module contracts. Dependencies and
+resource requirements use exact versions and fields. Resource relations refer
+to the dependency's records; they do not copy those records into the App. The
+only connected capability in v1 is the frozen sandbox-email interface, and its
+connector requirement selects only a provider kind, never an endpoint or
+credential.
+
+Action inputs may come only from a declared resource field, one selected
+declared relation target, or explicit typed user input. Do not add templates,
+JSONPath, arbitrary transforms, scripts, URLs, environment reads, secrets,
+provider configuration, automation, custom UI, sync, or public routes. An App
+id or publisher label cannot choose the private interface namespace; the host
+resolves it from immutable workspace App lineage.
+
+## 3. Check and build
+
+Run the deterministic author loop from the App directory:
+
+```sh
+pnpm exec deft app check
+pnpm exec deft app build
+```
+
+`check` reads `deft.app.json` and every referenced Module, rejects symlinked or
+non-regular artifacts, recomputes their digests, and validates/builds in memory.
+It does not write build output.
+
+`build` performs the same checks and writes:
+
+| Path | Meaning |
+|---|---|
+| `.deft/app.deftapp.json` | Integrity-checked package sent to the host |
+| `deft.app.lock.json` | Package, manifest, and artifact digests; `permissions` remains empty |
+| `.deft/requested-authority.json` | Deterministic author review of requested authority only |
+
+Rebuilding unchanged input produces byte-identical output.
+
+### Requested authority is not effective authority
+
+For v0, `.deft/requested-authority.json` contains empty requirement and resource
+right lists. For v1, it projects the declared dependencies, resources,
+capability, connector, and action; read-only requested resource fields; and the
+Deft-owned sandbox policy floor. Its classification is
+`authority_state: "requested_only"`, `executable: false`, and
+`provider_access: false`.
+
+The report deliberately omits organization, installation, version, grant,
+binding, connector, provider, token, secret, and private-lineage identities. It
+is not part of the installable package and is not accepted by the host as a
+grant. Editing or deleting it cannot widen the App; the next build regenerates
+it. The host inspects the package, reprojects the request, and owns every
+effective grant and binding.
+
+## 4. Check the host before pairing
+
+The host API must have both exact opt-ins enabled:
+
+```text
+DEFT_APPS_ENABLED=true
+DEFT_APP_DEVELOPER_PAIRING_ENABLED=true
+```
+
+Point the CLI at the API, not the web port:
+
+```sh
+pnpm exec deft app doctor --url http://localhost:3001
+```
+
+`DEFT_URL` supplies the same value when `--url` is omitted; the final default is
+`http://localhost:3001`.
+
+`doctor` validates the local source and then checks the developer-status
+contract. A compatible current host retains the legacy fields
+`app_protocol: "0"`, `audience: "app-developer"`, and
+`single_use_install: true`, and adds this exact flow information:
+
+| Local protocol | Package format | Advertised install mode |
+|---:|---|---|
+| v0 | `deft.app.package.v0` | `stage_and_activate` |
+| v1 | `deft.app.package.v1` | `stage_only` |
+
+The additive compatibility object must include `@deft/app-kit` version
+`0.1.0-alpha.1`. The legacy `app_protocol: "0"` scalar remains `"0"` even when
+the additive object advertises v1; do not use that scalar alone to infer v1
+support.
+
+A legacy host that omits the compatibility object is accepted for v0 only. A v1
+project fails with `Host supports only App Protocol v0 developer installs`.
+Wrong App Kit versions, missing protocol flows, and package-format mismatches
+also fail. `install-local` performs this same compatibility preflight before it
+reads or exchanges a pairing code.
+
+`doctor` checks App Kit/protocol/package compatibility only. It does not check
+connector health, simulate grants, activate an App, resolve relations, invoke a
+provider, or prove App Run readiness.
+
+## 5. Stage with a one-time pairing
+
+An active workspace owner or admin must create an expiring, revocable,
+single-use developer pairing and give its code to the author. The CLI cannot
+create a pairing or grant itself manager authority.
+
+```sh
+pnpm exec deft app install-local --url http://localhost:3001
+```
+
+At the prompt, enter the code once. The CLI rebuilds the package, completes the
+compatibility preflight, exchanges the code for an audience-bound temporary
+session, and submits the package. The host inspects the package before consuming
+that session and rechecks that the pairing owner is still an active owner or
+admin.
+
+The result depends on the protocol:
+
+| Protocol | Result of `install-local` | Authority result |
+|---:|---|---|
+| v0 | Stage and activate the declarative App | No connected authority exists in v0 |
+| v1 | Leave the installation/version in `staged` | Zero effective grant, dependency lock, action binding, connector change, provider call, approval, or App Run |
+
+For v1, stop at the staged result. Hand the installable package, lockfile,
+requested-authority report, exact App Kit artifact identity, and proof-bundle
+identity to the owner/admin. Review, dependency selection, provider binding,
+effective-grant creation, and activation are host-owned operations; none can be
+encoded in the App package or requested-authority report. This PR A authoring
+slice does not promise a connected lifecycle UI for that handoff.
+
+## 6. Run the proof-only sandbox provider
+
+The standalone
+[sandbox email provider](../examples/app-platform-sandbox-email-provider/README.md)
+implements the frozen interface independently from App Kit. It has no
+dependencies and no network egress. Pack and install it separately from the App
+and App Kit:
+
+```sh
+pnpm --dir examples/app-platform-sandbox-email-provider pack --pack-destination /absolute/path/to/artifacts
+
+mkdir sandbox-email-proof
+cd sandbox-email-proof
+pnpm init
+pnpm add /absolute/path/to/artifacts/deft-app-platform-sandbox-email-provider-0.1.0-alpha.1.tgz
+node node_modules/@deft/app-platform-sandbox-email-provider/server.mjs
+```
+
+The process reads one JSON-RPC message per line from stdin. Paste these lines to
+perform a direct discovery and call proof:
+
+```jsonl
+{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"manual-proof","version":"1.0.0"}}}
+{"jsonrpc":"2.0","method":"notifications/initialized"}
+{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}
+{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"send_email","arguments":{"to":"ada@example.test","subject":"Analytical Engines","body_text":"Hello Ada","idempotency_key":"campaign:one/contact:ada"}}}
+```
+
+The final response contains this deterministic structured result:
+
+```json
+{"message_id":"sandbox_a90928f63948386da7c8a7a4","status":"accepted"}
+```
+
+Repeating the exact call in the same process returns the same result. Reusing
+the key with different input is rejected. State exists only in process memory
+and disappears at exit. `accepted` means accepted by this in-memory proof; it
+does not mean an email was delivered.
+
+For a self-host proof only, install or mount the packed provider read-only, use
+an absolute pinned Node.js executable as the stdio command, and pass the
+read-only absolute `server.mjs` path as its sole argument. Stdio is host-code
+execution and requires all three exact controls:
+
+```text
+DEFT_SELF_HOSTED=true
+DEFT_MCP_ENABLE_UNSAFE_STDIO=true
+MCP_STDIO_ALLOWED_COMMANDS=/absolute/path/to/node
+```
+
+`MCP_STDIO_ALLOWED_COMMANDS` is a comma-separated exact-command allowlist. Do
+not allowlist a shell, PowerShell, `cmd`, `pnpm`, `npm`, `npx`, a package runner,
+or a broad directory. Configuring this proof provider does not bind it to an
+App, grant provider access, or make a staged App executable.
+
+## PR A boundaries
+
+- No self-grant: packages and reports request authority; only the host can
+  create effective grants, bindings, and activation state.
+- No App-origin execution: PR A ends at zero-authority staging and makes no
+  provider call, approval, App Run, or receipt promise.
+- No production email: the sandbox provider retains in-memory proof results and
+  performs no network egress.
+- No connected lifecycle UI: the author path is CLI/API proof and adds no
+  review, bind, activate, or operating UI promise.
+- No automation: the v1 sandbox action is human-initiated, single-recipient,
+  always reviewed by host policy, and forbidden in automation.
+- No external runtime promise: App Kit contains no MCP loader or hosted runtime,
+  and the standalone provider is not a general runtime, SMTP adapter, sync
+  engine, credential store, or public ingress service.
+
+Staging needs no App Run keyring because it creates no Run. Any later operator
+who separately enables reviewed App-origin execution must follow
+[Governed App Run operations](app-run-operations.md), including matching
+database/keyring backup and restore; that later execution lifecycle is outside
+this PR A guide.

--- a/docs/connected-app-author-guide.md
+++ b/docs/connected-app-author-guide.md
@@ -14,10 +14,13 @@ import private Deft packages.
 The
 [machine-readable connected proof bundle](../examples/app-platform-connected-proof-bundle.json)
 is the source of truth for the proof inputs. It records the pinned Contacts App
-package digest and the separately packed sandbox-email provider artifact digest
-and retrieval path. Verify the artifacts against those recorded values rather
-than copying a digest from prose. The connected template depends on the exact
-Contacts App and does not bundle or copy its records.
+package digest and the separately packed sandbox-email provider's canonical
+payload digest and retrieval path. The provider pin hashes the exact packed file
+paths, lengths, and contents; raw `.tgz` wrapper bytes are not the identity
+because tar metadata differs across operating systems. Verify the installed
+payload against the recorded values rather than copying a digest from prose.
+The connected template depends on the exact Contacts App and does not bundle or
+copy its records.
 
 To create the App Kit tarball from a matching Deft checkout:
 

--- a/docs/superpowers/plans/2026-09-01-app-platform-phase-6-and-track-a-loops.md
+++ b/docs/superpowers/plans/2026-09-01-app-platform-phase-6-and-track-a-loops.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |---|---|
-| Status | Planned; implementation is gated on a passing immutable Phase 5 release-host certification and merged audit |
+| Status | Loop 6.0 sealed from merged Phase 5 audit `c0da089d`; Phase 6 PR A implemented and locally validated, merge certification pending |
 | Architecture source | `docs/superpowers/plans/2026-08-29-full-surface-app-platform.md` |
 | Delivery source | `docs/superpowers/plans/2026-08-30-full-surface-app-platform-delivery-plan.md` |
 | Phase 6 outcome | An independent author can build, stage, install, operate, upgrade, disable, recover, and inspect a Tier 2 connected App using published contracts and tooling only |
@@ -83,6 +83,37 @@ connected kernel.
 
 **Stop condition:** do not merge Phase 6 behavior if Phase 5 restore, receipt,
 predecessor, browser, or cleanup evidence is missing.
+
+**Sealed dependency (2026-09-01):** Phase 5 product candidate `438a283a`,
+certifier `70a4b984`, definitive run `33469721507`, and audit merge `c0da089d`
+all passed. The safe artifact is
+`sha256:40689d1ab9c914477a2efa8efb8528d2a53a6019d400f18962a8ed119876d256`;
+the separately retained image artifact is
+`sha256:f28bc0188de4880dbb57b162246f97aaf9f4996545737537460c39703bfb680d`.
+Real pgvector `0.8.6`, 23 migrations through `0.3.0-preview.25`, matching
+source/restored continuity hash
+`sha256:de8535e3fcb94e312a640392910e40af3ec8e191c14c650cee3e952c65343eda`,
+9/9 verified receipts, predecessor read, desktop/mobile proof, and isolated
+cleanup are recorded in the Phase 5 audit.
+
+The unchanged kernel evidence reused by Phase 6 is frozen as follows:
+
+- Contacts v0 package:
+  `sha256:1471f0b94da9f6851bd978c315bc22a2dd0343b61a87477e4293b144c54248d8`.
+- Connected Campaigns v1 package:
+  `sha256:973ec7076daf7405a7a4d8b48509ef6f99b1b1cc4b787961104c73f23b7f770d`.
+- Connected Module v2 artifact:
+  `sha256:5dc2a978506eb2917a3a99021831d62d94112a60615292e4b32e03e480cff208`.
+- Existing v1 requested-grant snapshot:
+  `sha256:2464c10f3a480c8d5d7f75c7923f8231a311bcdeb6dbfb584c8a0d7449572bed`.
+- Supported predecessor:
+  `ghcr.io/maneek21/deft@sha256:e565cc64ee22b5b9f6f99973e3762b639c27e026dc8824852145035acdacf788`.
+- `DEFT_APPS_ENABLED`, developer pairing, App Runs, App-origin intake, and
+  legacy MCP cutover remain separate exact-`true`, default-off flags.
+
+Phase 6 ordinary development references these immutable proofs and reruns only
+changed contracts. Its final beta gate repeats the compound release evidence
+once from the exact merged candidate.
 
 ### Loop 6.1 — Shared authoring contract and connected template
 

--- a/docs/superpowers/plans/2026-09-01-app-platform-phase-6-and-track-a-loops.md
+++ b/docs/superpowers/plans/2026-09-01-app-platform-phase-6-and-track-a-loops.md
@@ -1,0 +1,386 @@
+# App Platform Phase 6 and Track A — efficient execution loops
+
+| Field | Value |
+|---|---|
+| Status | Planned; implementation is gated on a passing immutable Phase 5 release-host certification and merged audit |
+| Architecture source | `docs/superpowers/plans/2026-08-29-full-surface-app-platform.md` |
+| Delivery source | `docs/superpowers/plans/2026-08-30-full-surface-app-platform-delivery-plan.md` |
+| Phase 6 outcome | An independent author can build, stage, install, operate, upgrade, disable, recover, and inspect a Tier 2 connected App using published contracts and tooling only |
+| Track A outcome | An installed App can run bounded scheduled work through the same grants, AppAction, approval, AppRun, receipt, budget, and revocation path as an interactive action |
+| Claim after both | Connected App Platform beta with bounded governed automation |
+| Still excluded | Custom App UI, arbitrary runtimes, specialized sync, anonymous/public ingress, marketplace, billing, and the general full-surface App-platform claim |
+
+## Why this shape
+
+Phase 5 proves the internal connected kernel. Phase 6 must prove that the kernel
+is usable outside the monorepo and operable by a self-hosted administrator. It
+must not create a second author-only authority model, simulator-only execution
+engine, or test-only provider contract.
+
+The next privileged plane is the revised delivery plan's **Track A**, not a new
+linear Phase 7. Track A starts only after immutable Phase 6 evidence. Its first
+consumer is one bounded scheduled Campaign action; it does not introduce a
+general workflow language, event bus, arbitrary expressions, or compensation
+runtime.
+
+This plan uses five review trains:
+
+1. Phase 6 PR A — independent authoring and zero-authority staging.
+2. Phase 6 PR B — complete native lifecycle and operator inspection.
+3. Phase 6 PR C — conformance, independent trial, and beta certification.
+4. Track A PR A — dormant automation contracts, persistence, and service seam.
+5. Track A PR B — durable scheduling, proof App, management surface, adversarial
+   evidence, and release certification.
+
+Each train is independently reviewable and preserves a deny-by-default cutover.
+
+## Shared invariants
+
+- Preserve Protocol v0 package, lock, install, activation, digest, and rejection
+  bytes. Preserve Protocol v1 schema/package/lock/digest and frozen-interface
+  bytes when Track A adds an explicit Protocol v2 dispatch path.
+- Staging is not authority. A staged Protocol v1 package cannot discover or
+  call providers, create Runs, bind connectors, or activate itself.
+- One pure requested-authority projection is shared by author lockfiles and the
+  host's requested grant snapshot. Effective authority remains host-owned.
+- AppActionService remains the only App action orchestration seam.
+- AppRunService remains the only effect, approval, replay, attempt, result,
+  receipt, and unknown-outcome ledger.
+- CapabilityService remains the only production provider-call seam.
+- Every persisted identity and query is organization-scoped; actor, token,
+  membership, installation/version, grant, binding, provider, and idempotency
+  dimensions remain part of execution authority.
+- Connected proof artifacts use packed, version-matched public files from clean
+  directories. Workspace links and monorepo-private imports are forbidden.
+- Feature flags remain off by default. Migration and rollback evidence precede
+  behavior cutover.
+- No Contact, Campaign, email, or newsletter branch enters Deft core.
+
+## Phase 6 — Independent connected-App proof and beta
+
+### Loop 6.0 — Seal the Phase 5 dependency
+
+**Purpose:** start external-author work only from a release-host-certified
+connected kernel.
+
+- Require the exact Phase 5 candidate, certifier commit, workflow run, safe
+  artifact hashes, pgvector version, backup/restore continuity, predecessor
+  read, desktop/mobile connected proof, and isolated cleanup in the audit.
+- Freeze the Phase 6 base commit, current Protocol v0/v1 golden fixtures,
+  private sandbox interface, proof App digests, supported predecessor, flags,
+  and certification matrix.
+- Record existing gaps rather than redesigning completed Phase 4–5 contracts.
+
+**Stop condition:** do not merge Phase 6 behavior if Phase 5 restore, receipt,
+predecessor, browser, or cleanup evidence is missing.
+
+### Loop 6.1 — Shared authoring contract and connected template
+
+**Purpose:** make the existing Protocol v1 contract understandable and
+deterministic to an external author without granting authority.
+
+- Add one public pure `projectDeftAppRequestedAuthority`-style helper in App
+  Kit. It returns only requested requirements, read-only resource rights, and
+  Deft-owned classification; it never includes host IDs, connectors, tokens,
+  private lineage, or effective grants.
+- Make AppGrantService consume the same projection before adding host-owned
+  identities and digests only if the existing v1 requested snapshot canonical
+  bytes and digest remain exact. Otherwise leave the host projection in place
+  and share lower-level pure atoms rather than rewriting persisted history.
+- Add strict `deft app init --template declarative|connected`; keep declarative
+  as the compatibility default and reject malformed template arguments.
+- Generate the connected scaffold from code-owned template content, including
+  a Module v2 Campaign resource, exact Contacts dependency, one sandbox action,
+  an App brief, and scoped AGENTS guidance.
+- Keep Protocol v0 lock bytes unchanged. Protocol v1 lockfiles expose a clearly
+  named requested-authority projection and never label it effective authority.
+- Pin projection clone safety, deterministic canonical bytes, absence of
+  secrets/host IDs, and the exact host-policy floor in tests.
+
+**Evidence:** App Kit protocol/CLI tests, AppGrant projection parity, v0 golden
+digests, connected proof package determinism, and repository typecheck.
+
+### Loop 6.2 — Protocol v1 doctor and zero-authority local staging
+
+**Purpose:** let a local author deliver a connected package to Deft without
+crossing review, binding, or activation.
+
+- Keep the existing expiring, revocable, manager-rechecked, audience-bound,
+  single-use developer pairing contract.
+- Inspect the package before consuming the pairing token.
+- Preserve Protocol v0 stage-and-activate behavior exactly.
+- For Protocol v1, reuse `stageAppPackage` and stop in `staged` with no active
+  version, effective grant, dependency lock, action binding, connector change,
+  provider call, approval, or App Run.
+- Extend the additive developer status response with supported protocol flows
+  while retaining the legacy Protocol v0 scalar.
+- Make `doctor` compare the local package protocol with the exact flow advertised
+  by the host. A v0-only host rejects a v1 package before token consumption.
+- Add a thin public contract simulator for package/host-flow compatibility,
+  requested-authority review, closed input resolution, and deterministic fake
+  provider results. It must call the exact exported validators, input resolver,
+  and conformance vectors; it cannot duplicate host authorization, activation,
+  AppAction, or AppRun logic. Use a tiny HTTP fixture only for transport tests.
+
+**Evidence:** v0 pairing compatibility, v1 stage-only database proof,
+single-use/revocation tests, CLI host compatibility tests, zero executable
+authority assertions, and API/App Kit typecheck.
+
+### Loop 6.3 — Clean packed proof, standalone sandbox provider, and guide
+
+**Purpose:** prove that the authoring surface is public and version-matched,
+not an artifact of workspace links.
+
+- Pack the exact App Kit tarball and install it into clean temporary directories
+  outside the repository.
+- Run the installed binary to initialize, check, and build Contacts and
+  Campaigns twice; compare lock/package bytes and digests and prove resolution
+  stays under the temporary directory.
+- Reject undeclared files, workspace paths, and private imports in the tarball.
+- Keep contract/schema constants and conformance vectors in App Kit. Package a
+  separate narrow proof-only stdio sandbox provider artifact exposing only
+  `send_email`; do not make the portable App Kit own a Node/MCP runtime.
+- Keep the API fixture and external provider as independent implementations
+  against the same conformance vectors so the proof does not pass by sharing
+  implementation code.
+- Test real stdio discovery/call through the official MCP transport, exact
+  schemas, replay, conflicting idempotency, invalid input, and clean shutdown.
+- Publish the connected author guide: packed-kit quickstart, doctor/stage,
+  administrator review/bind/activate handoff, requested versus effective
+  authority, offline connector health, safe extension choices, backup/key
+  requirements, and explicit non-claims.
+- Enforce App Kit and flagged v1 pairing tests in CI.
+
+**Evidence:** clean packed-directory test, stdio provider integration test,
+documentation links, deterministic proof digests, and unchanged v0 fixtures.
+
+**PR A exit:** an external directory can create and stage the connected proof
+using only packed public artifacts, but cannot self-authorize or invoke it.
+
+### Loop 6.4 — Complete native lifecycle and operator inspection
+
+**Purpose:** remove the remaining monorepo/test-harness shortcuts from the
+supported administrator and author journey.
+
+- Project staged Protocol v1 version, requested authority, deterministic diff,
+  dependency requirements, provider requirement, and missing bindings in
+  Settings without leaking provider secrets.
+- Show exact compatible App Kit/protocol versions and local unsigned provenance
+  in Settings and `doctor`; never imply registry signature or hosted trust.
+- Add the supported staged-upgrade path and reload it after upgrade.
+- Make disable and re-enable explicit; re-enable revalidates live membership,
+  dependency, connector, provider schema, grant, binding, and authority version
+  rather than reviving stale authority.
+- Expose receipt verification and bounded safe Run/result metadata to an
+  authorized actor in the connected journey.
+- Exercise stage, review, bind, activate, open, search, cite, relate, invoke,
+  approve, inspect receipt, upgrade, disable, and re-enable with Campaign
+  referencing Contact rather than copying it.
+- Keep sending single-recipient, human-initiated, and sandboxed. Do not add a
+  domain send-log projection before Track A.
+
+**Evidence:** focused service/route tests, Settings component tests, one
+desktop/mobile connected lifecycle proof, and no unauthorized receipt or
+provider visibility.
+
+**PR B exit:** the complete connected lifecycle is supported through native
+surfaces with no manual database edits or private test harness calls.
+
+### Loop 6.5 — Conformance, failure, and operator ceilings
+
+**Purpose:** prove that published semantics survive real failure and parity
+conditions.
+
+- Close App-origin gaps for provider timeout, ambiguous outcome, result expiry,
+  post-provider finalization failure, approval/revocation race, restart,
+  restore, App disable, connector disable, membership removal, stale authority,
+  upgrade, and second-token/cross-actor isolation.
+- Run one shared equivalence harness across human UI, Defty, employee, and
+  human MCP. Equivalent authority shares binding/policy/Run/receipt semantics;
+  actor and token identity remain distinct replay boundaries.
+- Make queue backlog, pending approval, attempts/retry, retained ciphertext,
+  provider snapshots, action discovery, payload limits, retention, cleanup,
+  degraded mode, and referenced-key inventory observable with bounded safe
+  summaries.
+- Prove offline boot: the App/local resources open without network, while the
+  connector is reported unhealthy and invocation fails safely.
+- Prove the ordinary self-host operator path for key generation, validation,
+  durable storage, startup diagnostics, rotation, retirement, backup inclusion,
+  restore, and explicit lost-key behavior. Reuse exact Phase 3/5 evidence where
+  immutable; add only the missing operator-facing assertions.
+
+**Evidence:** focused adversarial tests plus the shared parity matrix; no new
+executor, approval ledger, retry loop, or provider route.
+
+### Loop 6.6 — Independent trial and immutable beta gate
+
+**Purpose:** earn the Connected App Platform beta claim from external evidence.
+
+- Give a clean Codex task only the packed kit, public contracts, guide, and a
+  disposable self-host endpoint. Record friction and change contracts only for
+  demonstrated blockers.
+- Build/install the independent App and separately packed sandbox provider with
+  no Deft core edits and no hosted account, registry, or managed runtime. Run
+  the public simulator before staging and retain its deterministic result.
+- Run one consolidated release gate: Phase 4–6 conformance, supported upgrade
+  from the Phase 3 release, fresh pgvector schema, exact candidate image,
+  Compose/self-host smoke, desktop/mobile lifecycle, offline provider behavior,
+  repository typecheck/build, database plus key backup/restore, predecessor
+  read, and cleanup.
+- Retain safe evidence and the exact candidate image separately. Publish
+  nothing unless separately authorized.
+
+**PR C exit:** the audit permits only the claim **Connected App Platform beta**.
+
+## Track A — Bounded governed automation
+
+### Loop A.0 — Freeze the first automated proof
+
+**Purpose:** add one useful unattended plane without inventing a workflow
+platform.
+
+- Require the immutable Phase 6 beta audit.
+- Preserve the Phase 5 sandbox interface and its
+  `automation_eligibility: forbidden` policy byte-for-byte. Freeze an additive
+  lineage-private interface
+  and code-owned policy version that permits only an
+  `approved_automation_definition` and still uses an exact AppAction binding.
+  An App or schedule cannot select, author, or lower that policy; owner/admin
+  acceptance is explicit.
+- Freeze timezone, DST, misfire, unique-fire, pause, resume, retry,
+  dead-letter, budget, loop/recursion, and kill-switch semantics.
+- Gate G scope is frozen to existing organization-scoped Module v2 Campaign and
+  Contact resources plus the lineage-private capability policy. The first proof
+  pins one exact Contact and does not consume Task, message, file, calendar,
+  private-context, audience-query, or new privacy adapters. Do not add an event
+  outbox without a concrete producer/consumer proof.
+
+### Loop A.1 — Dormant contracts and additive persistence
+
+**Purpose:** persist definitions and fires while unattended dispatch remains
+impossible.
+
+- Add strict Protocol v2 for one package-authored schedule/action request that
+  stages with zero authority. Keep v0/v1 canonical bytes and rejection shapes
+  unchanged. Continue rejecting expressions, scripts, arbitrary events,
+  dynamic provider selection, unresolved user input, and compensation code.
+- Distinguish that package request from a host-created, owner/admin-approved,
+  immutable definition instance. The instance pins the exact Campaign
+  ResourceRef, record revision and content digest, exact selected Contact
+  ResourceRef, binding and provider snapshot, schedule/timezone, budgets,
+  validity window, and authorization vector. Any widening or content/input
+  change creates a new definition and requires fresh approval.
+- Add only organization-scoped `app_automation_definitions` and
+  `app_automation_fires` tables with installation/version/grant/binding/
+  authority lineage, immutable input/revision/content/provider pins, canonical
+  schedule, state/epoch, validity and budget, unique fire identity, claim/lease
+  metadata, bounded attempts, and terminal reason.
+- Add composite foreign keys, immutable historical fields, bounded JSON/text,
+  unique fire constraints, and deny-by-default flags.
+- Stage/review definitions with zero execution authority. Upgrade, disable,
+  grant revocation, and connector disable invalidate future eligibility live.
+
+**Evidence:** contract/golden tests, migration fresh/upgrade parity,
+cross-tenant rejection, immutable lineage, and proof of zero unattended Runs.
+
+### Loop A.2 — One automation principal over the existing action path
+
+**Purpose:** reuse interactive governance rather than create a cron executor.
+
+- Introduce a closed automation execution principal derived from the exact
+  active definition, installation/version, effective grant, action binding,
+  and organization.
+- Resolve each eligible fire through AppActionService and AppRunService with
+  the same resource authorization, provider snapshot, approval policy, budget,
+  idempotency, receipt, result, and unknown-outcome semantics.
+- Automation never receives connector credentials or calls CapabilityService
+  directly.
+- Only the additive code-owned policy can replace per-fire review with explicit
+  owner/admin approval of the fully pinned definition. A schedule cannot lower
+  the review floor, reuse Phase 5's automation-forbidden binding, or execute
+  unresolved `user_input`.
+
+**Evidence:** immediate/action/scheduled parity, no bypass tests, actor lineage,
+receipt verification, and live revocation before claim and dispatch.
+
+**PR A exit:** automation can be declared and reviewed, but remains globally
+disabled until the scheduler cutover.
+
+### Loop A.3 — Durable schedule scan, claims, and recovery
+
+**Purpose:** make scheduled firing restart-safe and horizontally safe.
+
+- Reuse the existing durable job queue and worker ownership model.
+- Compute canonical next-fire instants with explicit timezone/DST behavior.
+- Insert one unique fire before enqueue; claim with lease/epoch fencing; create
+  the App Run idempotently; finalize the fire from the Run outcome.
+- Implement explicit misfire handling, bounded retry only where existing Run
+  policy permits it, dead-letter state, pause/resume, per-definition and
+  organization budgets, backlog ceilings, kill switches, and crash recovery.
+- A lost lease, restart, duplicate scan, clock boundary, or second worker cannot
+  produce a second provider call for the same logical fire.
+
+**Evidence:** deterministic time/DST fixtures, duplicate-worker claims,
+restart/lease expiry, queue outage, budget exhaustion, pause/disable race,
+unknown outcome, and dead-letter recovery.
+
+### Loop A.4 — Independent scheduled Campaign and management surface
+
+**Purpose:** prove the plane from a packed App rather than a core special case.
+
+- Extend the independent Campaign App with one bounded scheduled-send
+  declaration and deterministic authority diff.
+- Extend App Kit schema/types/lock, permission diff, `doctor`, connected
+  template, public simulator, and conformance together. The simulator exercises
+  deterministic timezone/DST/misfire and pinned-input outcomes using the exact
+  pure schedule/contract functions, never a duplicate scheduler or executor.
+- Add generic host-rendered list/detail controls for definition state,
+  schedule/timezone, next fire, last fire/Run, pause/resume, retry eligibility,
+  budget/dead-letter summary, and kill-switch status.
+- Keep provider/domain behavior in the App/provider. No Campaign-specific
+  scheduler or UI branch enters core.
+- Prove disabled or offline providers do not prevent workspace/App resource
+  access; pending work degrades visibly and safely.
+
+**Evidence:** clean packed build, native Settings journey, desktop/mobile
+management proof, and generic architecture test.
+
+### Loop A.5 — Adversarial and immutable automation gate
+
+**Purpose:** earn the bounded governed automation claim.
+
+- Exercise duplicate scans, DST folds/gaps, long downtime/misfire, pause and
+  kill races, grant/connector/App/member revocation, provider timeout,
+  ambiguous result, restart, restore, stale versions, budget exhaustion,
+  dead-letter retry, and cleanup.
+- Prove interactive and scheduled invocations share action binding, policy
+  floor, Run ancestry, result/receipt, and revocation semantics while retaining
+  distinct principal and idempotency scopes.
+- Run fresh/upgrade/backup/restore/predecessor, exact candidate image,
+  self-host/offline, typecheck/build, and browser certification once.
+- Record safe hashes, counts, bounded summaries, cleanup, and explicit
+  non-claims in the release audit.
+
+**PR B exit:** permit **bounded governed automation** for the certified schedule
+plane. Do not claim arbitrary workflow automation or the general full-surface
+platform.
+
+## Consolidated validation policy
+
+- During implementation, run only the smallest affected contract/service/DB/UI
+  checks.
+- Each PR runs repository CI and security once after its focused matrix passes.
+- Phase 6 PR C and Track A PR B each run one immutable release-host gate with
+  real pgvector, exact images, supported upgrade, backup/restore, predecessor,
+  browser evidence where UI changed, and cleanup.
+- Do not repeat Docker, fresh-schema, browser, or production builds in every
+  loop. Report a genuinely unavailable requirement instead of substituting a
+  weaker proof.
+
+## Program continuation
+
+Phase 6 plus Track A is a meaningful public beta, not the final vision. The
+general “build any feasible full-surface App” claim remains blocked until Track
+B isolated custom experiences, Track C operator-managed runtimes and specialized
+sync, Track D Public Gateway, all consumed Gate G items, compound independent
+proofs, and final security/performance/compatibility certification pass.

--- a/docs/superpowers/plans/2026-09-01-app-platform-phase-6-and-track-a-loops.md
+++ b/docs/superpowers/plans/2026-09-01-app-platform-phase-6-and-track-a-loops.md
@@ -34,6 +34,16 @@ This plan uses five review trains:
 
 Each train is independently reviewable and preserves a deny-by-default cutover.
 
+For speed, Phase 6 executes as three bounded review trains rather than seven
+serial handoffs. PR A freezes contracts first, then parallelizes the App Kit
+template, Protocol v1 stage-only API path, and packed proof/provider work before
+one integration pass. PR B freezes safe lifecycle response shapes first, then
+parallelizes API wiring, Settings reuse, and only the newly exposed adversarial
+cases. PR C is evidence-only: product changes are allowed only for a blocker
+demonstrated by the independent trial or immutable gate. A Phase 5 evidence
+coverage map is created in Loop 6.0 so unchanged kernel proofs are referenced,
+not rerun during ordinary implementation.
+
 ## Shared invariants
 
 - Preserve Protocol v0 package, lock, install, activation, digest, and rejection
@@ -92,8 +102,12 @@ deterministic to an external author without granting authority.
 - Generate the connected scaffold from code-owned template content, including
   a Module v2 Campaign resource, exact Contacts dependency, one sandbox action,
   an App brief, and scoped AGENTS guidance.
-- Keep Protocol v0 lock bytes unchanged. Protocol v1 lockfiles expose a clearly
-  named requested-authority projection and never label it effective authority.
+- Keep Protocol v0 and Protocol v1 lock bytes unchanged. Emit the clearly named
+  requested-authority projection as a separate deterministic author report;
+  never write it into the v1 lock or label it effective authority.
+- Assign the changed packed App Kit a unique prerelease version. Developer
+  status advertises an additive protocol/flow/tooling compatibility structure
+  while retaining the legacy `app_protocol: "0"` scalar exactly.
 - Pin projection clone safety, deterministic canonical bytes, absence of
   secrets/host IDs, and the exact host-policy floor in tests.
 
@@ -116,11 +130,12 @@ crossing review, binding, or activation.
   while retaining the legacy Protocol v0 scalar.
 - Make `doctor` compare the local package protocol with the exact flow advertised
   by the host. A v0-only host rejects a v1 package before token consumption.
-- Add a thin public contract simulator for package/host-flow compatibility,
-  requested-authority review, closed input resolution, and deterministic fake
-  provider results. It must call the exact exported validators, input resolver,
-  and conformance vectors; it cannot duplicate host authorization, activation,
-  AppAction, or AppRun logic. Use a tiny HTTP fixture only for transport tests.
+- Add a thin public contract checker for package/host-flow compatibility,
+  requested-authority review, static binding validation, and frozen provider
+  vectors. It must call the exact exported validators and conformance vectors;
+  it must not simulate live authorization, activation, relations, AppAction,
+  AppRun, or the database-bound input resolver. Use a tiny HTTP fixture only
+  for transport tests.
 
 **Evidence:** v0 pairing compatibility, v1 stage-only database proof,
 single-use/revocation tests, CLI host compatibility tests, zero executable
@@ -140,6 +155,13 @@ not an artifact of workspace links.
 - Keep contract/schema constants and conformance vectors in App Kit. Package a
   separate narrow proof-only stdio sandbox provider artifact exposing only
   `send_email`; do not make the portable App Kit own a Node/MCP runtime.
+- Freeze one public proof bundle containing the exact Contacts dependency and
+  the separately packed provider, including their digests and retrieval path.
+  The connected template never relies on an unpublished workspace package.
+- For the self-host proof only, mount the packed provider read-only and
+  explicitly allowlist its pinned `node` launcher. Document that narrow
+  operator wiring; do not broaden the production container into a generic
+  runtime or silently rely on a host workspace path.
 - Keep the API fixture and external provider as independent implementations
   against the same conformance vectors so the proof does not pass by sharing
   implementation code.
@@ -171,8 +193,9 @@ supported administrator and author journey.
 - Make disable and re-enable explicit; re-enable revalidates live membership,
   dependency, connector, provider schema, grant, binding, and authority version
   rather than reviving stale authority.
-- Expose receipt verification and bounded safe Run/result metadata to an
-  authorized actor in the connected journey.
+- Expose receipt verification and bounded safe Run/result metadata only after
+  verifying the receipt signature plus tenant and caller authorization; no
+  provider secret, ciphertext, or cross-actor metadata crosses the response.
 - Exercise stage, review, bind, activate, open, search, cite, relate, invoke,
   approve, inspect receipt, upgrade, disable, and re-enable with Campaign
   referencing Contact rather than copying it.
@@ -201,7 +224,9 @@ conditions.
 - Make queue backlog, pending approval, attempts/retry, retained ciphertext,
   provider snapshots, action discovery, payload limits, retention, cleanup,
   degraded mode, and referenced-key inventory observable with bounded safe
-  summaries.
+  summaries. Implement this as one manager-only projection over existing Run
+  operations, queue health, key inventory, and connected health—not a second
+  generic operations framework.
 - Prove offline boot: the App/local resources open without network, while the
   connector is reported unhealthy and invocation fails safely.
 - Prove the ordinary self-host operator path for key generation, validation,

--- a/examples/app-platform-connected-proof-bundle.json
+++ b/examples/app-platform-connected-proof-bundle.json
@@ -1,0 +1,34 @@
+{
+  "schema": "deft.app_platform.connected_proof_bundle.v1",
+  "app_kit": {
+    "package": "@deft/app-kit",
+    "version": "0.1.0-alpha.1",
+    "source_path": "packages/app-kit",
+    "pack_command": "pnpm --dir packages/app-kit pack --pack-destination <output-directory> --json"
+  },
+  "dependencies": {
+    "contacts": {
+      "app_id": "org.deft.reference.resource-contacts-app",
+      "version": "1.0.0",
+      "source_path": "examples/resource-participation-contacts-app",
+      "lock_path": "examples/resource-participation-contacts-app/deft.app.lock.json",
+      "package_digest": "sha256:1471f0b94da9f6851bd978c315bc22a2dd0343b61a87477e4293b144c54248d8",
+      "manifest_digest": "sha256:d25831fbc3b87881db689ce1cf2beeb2256324be9c7e4a3f780e70534513e1ed"
+    }
+  },
+  "providers": {
+    "sandbox_email": {
+      "package": "@deft/app-platform-sandbox-email-provider",
+      "version": "0.1.0-alpha.1",
+      "source_path": "examples/app-platform-sandbox-email-provider",
+      "pack_command": "pnpm --dir examples/app-platform-sandbox-email-provider pack --pack-destination <output-directory> --json",
+      "artifact": {
+        "filename": "deft-app-platform-sandbox-email-provider-0.1.0-alpha.1.tgz",
+        "byte_length": 15164,
+        "digest": "sha256:9650e78b52de6635b22e3bf6199001ee3dc84b371dba8704252bc9e23afb6b46"
+      },
+      "transport": "stdio",
+      "network_egress": false
+    }
+  }
+}

--- a/examples/app-platform-connected-proof-bundle.json
+++ b/examples/app-platform-connected-proof-bundle.json
@@ -24,8 +24,27 @@
       "pack_command": "pnpm --dir examples/app-platform-sandbox-email-provider pack --pack-destination <output-directory> --json",
       "artifact": {
         "filename": "deft-app-platform-sandbox-email-provider-0.1.0-alpha.1.tgz",
-        "byte_length": 15164,
-        "digest": "sha256:9650e78b52de6635b22e3bf6199001ee3dc84b371dba8704252bc9e23afb6b46"
+        "content": {
+          "schema": "deft.app_platform.packed_payload.v1",
+          "files": [
+            {
+              "path": "README.md",
+              "byte_length": 1322,
+              "digest": "sha256:942acfd4bc6275f6d192e5524e71b0a0fbc3749b28f37fdc01490fae31cdd423"
+            },
+            {
+              "path": "package.json",
+              "byte_length": 420,
+              "digest": "sha256:22e3e69107b59bd2ca29a9b7c669067ce9771ff4b5daf955ee5f1f20b85a5e14"
+            },
+            {
+              "path": "server.mjs",
+              "byte_length": 7167,
+              "digest": "sha256:d012d12a1cbcef05387a76b82ad550f59f6efdaabf4d56f71b10cdfedfb1302f"
+            }
+          ],
+          "digest": "sha256:afae01e8e248a6adfaa6503c675e4074356083b34b7ec126b2582425df2091a1"
+        }
       },
       "transport": "stdio",
       "network_egress": false

--- a/examples/app-platform-sandbox-email-provider/.gitattributes
+++ b/examples/app-platform-sandbox-email-provider/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf

--- a/examples/app-platform-sandbox-email-provider/README.md
+++ b/examples/app-platform-sandbox-email-provider/README.md
@@ -1,0 +1,28 @@
+# Deft App Platform sandbox email provider
+
+This package is the dependency-free, proof-only MCP provider used by Deft's
+connected App conformance path. It exposes exactly one stdio tool,
+`send_email`, and performs no network egress. Accepted messages exist only in
+the provider process memory and disappear when that process exits.
+
+The provider implements the frozen private sandbox-email schema independently
+from `@deft/app-kit`. Repeating the same `idempotency_key` and input returns the
+same deterministic result; reusing a key with different input is rejected.
+
+Pack it as a standalone artifact:
+
+```sh
+pnpm pack --pack-destination ./dist
+```
+
+For a self-hosted proof, install the tarball in an isolated directory, launch
+its `server.mjs` with a pinned Node.js executable, and add only that exact
+executable path to `MCP_STDIO_ALLOWED_COMMANDS`. Stdio is an explicitly unsafe
+self-host operator surface and still requires `DEFT_SELF_HOSTED=true` plus
+`DEFT_MCP_ENABLE_UNSAFE_STDIO=true`. Do not add a shell, package runner, or a
+broad executable directory to the allowlist.
+
+This is not an SMTP client, newsletter service, production email adapter,
+hosted runtime, credential store, or authorization boundary. Deft remains
+responsible for grants, review, execution policy, receipts, and tenant-scoped
+authorization.

--- a/examples/app-platform-sandbox-email-provider/package.json
+++ b/examples/app-platform-sandbox-email-provider/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@deft/app-platform-sandbox-email-provider",
+  "version": "0.1.0-alpha.1",
+  "description": "Dependency-free stdio MCP provider for the Deft connected App proof.",
+  "license": "AGPL-3.0-only",
+  "private": true,
+  "type": "module",
+  "bin": {
+    "deft-app-platform-sandbox-email-provider": "./server.mjs"
+  },
+  "files": [
+    "server.mjs",
+    "README.md"
+  ],
+  "engines": {
+    "node": ">=22.13.0"
+  }
+}

--- a/examples/app-platform-sandbox-email-provider/server.mjs
+++ b/examples/app-platform-sandbox-email-provider/server.mjs
@@ -1,0 +1,217 @@
+#!/usr/bin/env node
+
+import { createHash } from 'node:crypto';
+import { createInterface } from 'node:readline';
+
+const SERVER_INFO = Object.freeze({
+  name: 'deft-app-platform-sandbox-email-provider',
+  version: '0.1.0-alpha.1',
+});
+
+const MAX_REQUEST_BYTES = 1024 * 1024;
+const EMAIL_PATTERN = /^(?!\.)(?!.*\.\.)([A-Za-z0-9_'+\-\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\-]*\.)+[A-Za-z]{2,}$/;
+const SUBJECT_PATTERN = /^[^\u0000-\u001f\u007f-\u009f\u200b-\u200f\u2028-\u202e\u2060\u2066-\u2069\ufeff]+$/u;
+const BODY_TEXT_PATTERN = /^[^\u0000-\u0008\u000b-\u001f\u007f-\u009f\u200b-\u200f\u2028-\u202e\u2060\u2066-\u2069\ufeff]+$/u;
+const IDEMPOTENCY_KEY_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:/-]*$/;
+
+const INPUT_SCHEMA = Object.freeze({
+  type: 'object',
+  additionalProperties: false,
+  required: Object.freeze(['to', 'subject', 'body_text', 'idempotency_key']),
+  properties: Object.freeze({
+    to: Object.freeze({ type: 'string', format: 'email', maxLength: 320 }),
+    subject: Object.freeze({
+      type: 'string',
+      minLength: 1,
+      maxLength: 998,
+      pattern: '^[^\\u0000-\\u001f\\u007f-\\u009f\\u200b-\\u200f\\u2028-\\u202e\\u2060\\u2066-\\u2069\\ufeff]+$',
+    }),
+    body_text: Object.freeze({
+      type: 'string',
+      minLength: 1,
+      maxLength: 100_000,
+      pattern: '^[^\\u0000-\\u0008\\u000b-\\u001f\\u007f-\\u009f\\u200b-\\u200f\\u2028-\\u202e\\u2060\\u2066-\\u2069\\ufeff]+$',
+    }),
+    idempotency_key: Object.freeze({
+      type: 'string',
+      minLength: 1,
+      maxLength: 256,
+      pattern: '^[A-Za-z0-9][A-Za-z0-9._:/-]*$',
+    }),
+  }),
+});
+
+const OUTPUT_SCHEMA = Object.freeze({
+  type: 'object',
+  additionalProperties: false,
+  required: Object.freeze(['message_id', 'status']),
+  properties: Object.freeze({
+    message_id: Object.freeze({
+      type: 'string',
+      minLength: 1,
+      maxLength: 256,
+      pattern: '^[A-Za-z0-9][A-Za-z0-9._:@/-]*$',
+    }),
+    status: Object.freeze({ const: 'accepted' }),
+  }),
+});
+
+const SEND_EMAIL_TOOL = Object.freeze({
+  name: 'send_email',
+  title: 'Send sandbox email',
+  description: 'Accept one deterministic sandbox email without network egress.',
+  inputSchema: INPUT_SCHEMA,
+  outputSchema: OUTPUT_SCHEMA,
+  annotations: Object.freeze({
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  }),
+});
+
+const effects = new Map();
+
+function isObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function validateInput(value) {
+  if (!isObject(value)) return 'input must be an object';
+  const keys = Object.keys(value);
+  const expected = ['body_text', 'idempotency_key', 'subject', 'to'];
+  if (keys.length !== expected.length || !expected.every((key) => keys.includes(key))) {
+    return 'input must contain exactly to, subject, body_text, and idempotency_key';
+  }
+  if (typeof value.to !== 'string' || value.to.length > 320 || !EMAIL_PATTERN.test(value.to)) {
+    return 'to must be a valid email address of at most 320 characters';
+  }
+  if (
+    typeof value.subject !== 'string'
+    || value.subject.length < 1
+    || value.subject.length > 998
+    || !SUBJECT_PATTERN.test(value.subject)
+  ) {
+    return 'subject does not satisfy the sandbox email contract';
+  }
+  if (
+    typeof value.body_text !== 'string'
+    || value.body_text.length < 1
+    || value.body_text.length > 100_000
+    || !BODY_TEXT_PATTERN.test(value.body_text)
+  ) {
+    return 'body_text does not satisfy the sandbox email contract';
+  }
+  if (
+    typeof value.idempotency_key !== 'string'
+    || value.idempotency_key.length < 1
+    || value.idempotency_key.length > 256
+    || !IDEMPOTENCY_KEY_PATTERN.test(value.idempotency_key)
+  ) {
+    return 'idempotency_key does not satisfy the sandbox email contract';
+  }
+  return null;
+}
+
+function inputDigest(input) {
+  return createHash('sha256')
+    .update(`${input.to}\u0000${input.subject}\u0000${input.body_text}\u0000${input.idempotency_key}`)
+    .digest('hex');
+}
+
+function toolError(message) {
+  return {
+    content: [{ type: 'text', text: message }],
+    isError: true,
+  };
+}
+
+function sendEmail(input) {
+  const validationError = validateInput(input);
+  if (validationError) return toolError(`Invalid sandbox email input: ${validationError}`);
+
+  const digest = inputDigest(input);
+  const prior = effects.get(input.idempotency_key);
+  if (prior) {
+    if (prior.digest !== digest) {
+      return toolError('Sandbox email idempotency key was reused with different input');
+    }
+    return prior.response;
+  }
+
+  const output = Object.freeze({
+    message_id: `sandbox_${digest.slice(0, 24)}`,
+    status: 'accepted',
+  });
+  const response = Object.freeze({
+    content: Object.freeze([{ type: 'text', text: JSON.stringify(output) }]),
+    structuredContent: output,
+  });
+  effects.set(input.idempotency_key, { digest, response });
+  return response;
+}
+
+function result(id, value) {
+  return { jsonrpc: '2.0', id, result: value };
+}
+
+function error(id, code, message) {
+  return { jsonrpc: '2.0', id, error: { code, message } };
+}
+
+function handleRequest(message) {
+  if (!isObject(message) || message.jsonrpc !== '2.0' || typeof message.method !== 'string') {
+    return error(isObject(message) && 'id' in message ? message.id : null, -32600, 'Invalid Request');
+  }
+
+  if (message.method === 'notifications/initialized' || message.method === 'notifications/cancelled') {
+    return null;
+  }
+  if (!('id' in message)) return null;
+
+  if (message.method === 'server/discover') {
+    return error(message.id, -32601, 'Method not found');
+  }
+  if (message.method === 'initialize') {
+    const protocolVersion = isObject(message.params) && typeof message.params.protocolVersion === 'string'
+      ? message.params.protocolVersion
+      : null;
+    if (!protocolVersion) return error(message.id, -32602, 'Invalid initialize params');
+    return result(message.id, {
+      protocolVersion,
+      capabilities: { tools: {} },
+      serverInfo: SERVER_INFO,
+      instructions: 'Proof-only sandbox provider. It performs no network egress.',
+    });
+  }
+  if (message.method === 'ping') return result(message.id, {});
+  if (message.method === 'tools/list') return result(message.id, { tools: [SEND_EMAIL_TOOL] });
+  if (message.method === 'tools/call') {
+    if (!isObject(message.params) || message.params.name !== 'send_email') {
+      return result(message.id, toolError('Unknown sandbox provider tool'));
+    }
+    return result(message.id, sendEmail(message.params.arguments));
+  }
+  return error(message.id, -32601, 'Method not found');
+}
+
+function writeMessage(message) {
+  process.stdout.write(`${JSON.stringify(message)}\n`);
+}
+
+const lines = createInterface({ input: process.stdin, crlfDelay: Infinity });
+lines.on('line', (line) => {
+  if (Buffer.byteLength(line, 'utf8') > MAX_REQUEST_BYTES) {
+    writeMessage(error(null, -32600, 'Request exceeds the sandbox provider limit'));
+    return;
+  }
+  let message;
+  try {
+    message = JSON.parse(line);
+  } catch {
+    writeMessage(error(null, -32700, 'Parse error'));
+    return;
+  }
+  const response = handleRequest(message);
+  if (response) writeMessage(response);
+});

--- a/packages/app-kit/README.md
+++ b/packages/app-kit/README.md
@@ -1,25 +1,95 @@
 # `@deft/app-kit`
 
-Portable, deterministic authoring contract for declarative Deft apps.
+Portable, deterministic authoring and packaging contracts for declarative Deft
+Apps. The package includes the `deft` CLI, strict App Protocol v0 and v1
+validators, requested-authority projection helpers, developer-host
+compatibility helpers, and the frozen sandbox-email conformance vectors.
 
-App Protocol v0 composes one or more declarative Module v1 manifests into a
-single integrity-checked package. Parsing a package proves structure and
-artifact integrity only. Installation, authorization, permissions, tenant
-isolation, and full Module validation remain host responsibilities.
+Parsing or building an App proves package structure and artifact integrity only.
+Installation, authorization, effective grants, tenant isolation, dependency and
+connector selection, activation, execution, and full Module validation remain
+host responsibilities.
+
+## Install the packed kit
+
+From a Deft checkout, create the exact package artifact:
+
+```sh
+pnpm --dir packages/app-kit pack --pack-destination /absolute/path/to/artifacts
+```
+
+Install that tarball in a clean App directory rather than using a workspace
+link:
+
+```sh
+mkdir connected-campaigns
+cd connected-campaigns
+pnpm init
+pnpm add --save-dev /absolute/path/to/artifacts/deft-app-kit-0.1.0-alpha.1.tgz
+```
+
+The installed binary is available as `pnpm exec deft`.
+
+## Authoring loop
+
+```sh
+# Protocol v0; omitting --template remains the byte-identical default.
+pnpm exec deft app init --template declarative
+
+# Or, in a different empty directory, Protocol v1 connected scaffolding.
+pnpm exec deft app init --template connected
+
+pnpm exec deft app check
+pnpm exec deft app build
+pnpm exec deft app doctor --url http://localhost:3001
+pnpm exec deft app install-local --url http://localhost:3001
+```
+
+`init` accepts only `declarative` or `connected`. `check` validates and builds
+in memory without writing generated artifacts. `build` writes the deterministic
+package, lockfile, and requested-authority report:
+
+- `.deft/app.deftapp.json`
+- `deft.app.lock.json`
+- `.deft/requested-authority.json`
+
+The requested-authority report is non-authoritative review material. It contains
+only App-authored requirements, projected read requests, and Deft-owned policy
+classification. It contains no effective grant, host identity, connector or
+provider selection, token, secret, or private lineage identity. Editing it
+cannot affect installation or authority; a build overwrites it and the host
+derives its own validated view from the package.
+
+## Protocol and local-install behavior
+
+| Template | Protocol | `install-local` flow | Connected authority |
+|---|---:|---|---|
+| `declarative` | v0 | Stage and activate | None; v0 cannot request capabilities or connectors |
+| `connected` | v1 | Stage only | None until separate host review, binding, grant, and activation |
+
+Both `doctor` and `install-local` build the local source and compare its protocol
+and package format with the host's advertised compatibility contract. The host
+must advertise this exact App Kit version. A legacy status response without the
+additive compatibility object remains usable for v0 only; it rejects v1 with
+`Host supports only App Protocol v0 developer installs` before a pairing code is
+read or exchanged.
 
 App Protocol v1 is a closed connected contract. It adds exact App dependencies,
-Module resource/field requirements, one private sandbox-email capability, an
-existing MCP-connector requirement, and closed host-rendered action bindings.
-Staging grants zero authority: it does not create a connector or enable
-execution. Supported hosts may explicitly review and activate the single frozen
-connected contract; execution remains separately rollout-gated.
+Module resource and field requirements, one private sandbox-email capability,
+an existing MCP-connector requirement, and closed host-rendered action bindings.
+Staging grants zero authority and cannot create a connector, discover or invoke
+a provider, create an App Run, or activate the App.
 
-Private interface keys are always relative to the immutable workspace App
-lineage selected by the host. An App id, repository, publisher label, or other
+Private interface keys are relative to the immutable workspace App lineage
+selected by the host. An App id, repository, publisher label, or other
 package-authored text cannot choose that authority namespace.
 
-The v1 action source language is intentionally closed: declared resource
-fields, one selected declared relation target, or explicit typed user input.
-Templates, JSONPath, arbitrary transforms, scripts, URLs, environment values,
-secrets, automation, runtimes, sync, custom UI, and public ingress are not part
-of this protocol.
+The v1 action source language is intentionally closed: declared resource fields,
+one selected declared relation target, or explicit typed user input. Templates,
+JSONPath, arbitrary transforms, scripts, URLs, environment values, secrets,
+automation, runtimes, sync, custom UI, and public ingress are not part of this
+protocol.
+
+See the [connected App author guide](../../docs/connected-app-author-guide.md)
+for the packed-artifact workflow, compatibility handoff, sandbox-provider proof,
+and the Phase 6 PR A boundaries.

--- a/packages/app-kit/package.json
+++ b/packages/app-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deft/app-kit",
-  "version": "0.1.0-alpha.0",
+  "version": "0.1.0-alpha.1",
   "description": "Portable authoring and packaging contract for declarative Deft apps.",
   "license": "AGPL-3.0-only",
   "type": "module",
@@ -25,7 +25,7 @@
     "README.md"
   ],
   "dependencies": {
-    "zod": "^4.4.3"
+    "zod": "4.4.3"
   },
   "devDependencies": {
     "@types/node": "^26.2.0",

--- a/packages/app-kit/src/cli.ts
+++ b/packages/app-kit/src/cli.ts
@@ -5,10 +5,15 @@ import { createInterface } from 'node:readline/promises';
 import { stdin, stdout } from 'node:process';
 import {
   buildDeftAppPackage,
+  canonicalDeftAppRequestedAuthorityReportJson,
+  checkDeftAppDeveloperContract,
+  DEFT_APP_PACKAGE_FORMAT,
+  DEFT_APP_REQUESTED_AUTHORITY_REPORT_PATH,
   parseDeftAppManifest,
   prepareModuleArtifact,
   type DeftAppManifestInput,
   type DeftAppManifestV0Input,
+  type DeftAppManifestV1Input,
 } from './index.js';
 
 const cwd = process.cwd();
@@ -34,7 +39,22 @@ async function assertRegularUnslinkedFile(relativePath: string): Promise<string>
   return current;
 }
 
-async function initialize(): Promise<void> {
+type AppTemplate = 'declarative' | 'connected';
+
+function parseInitTemplate(): AppTemplate {
+  const args = process.argv.slice(4);
+  if (args.length === 0) return 'declarative';
+  if (
+    args.length !== 2
+    || args[0] !== '--template'
+    || (args[1] !== 'declarative' && args[1] !== 'connected')
+  ) {
+    throw new Error('Usage: deft app init [--template declarative|connected]');
+  }
+  return args[1];
+}
+
+async function initializeDeclarative(): Promise<void> {
   const manifestPath = resolve(cwd, 'deft.app.json');
   if (await exists(manifestPath)) throw new Error('deft.app.json already exists');
   const modulePath = 'modules/hello-workspace/deft.module.json';
@@ -91,6 +111,148 @@ async function initialize(): Promise<void> {
   console.log(`Initialized ${manifest.name} in ${cwd}`);
 }
 
+async function initializeConnected(): Promise<void> {
+  const manifestPath = resolve(cwd, 'deft.app.json');
+  if (await exists(manifestPath)) throw new Error('deft.app.json already exists');
+  const modulePath = 'modules/connected-campaigns/deft.module.json';
+  const moduleManifest = {
+    schema_version: '2',
+    id: 'community.example.connected-campaigns',
+    slug: 'connected-campaigns',
+    version: '1.0.0',
+    name: 'Connected Campaigns',
+    description: 'Campaign resources that reference Contacts owned by a dependency App.',
+    collections: [{
+      key: 'campaigns',
+      name: 'Campaigns',
+      singular_name: 'Campaign',
+      fields: [
+        { key: 'subject', label: 'Subject', type: 'text', required: true },
+        { key: 'body', label: 'Body', type: 'long_text', required: true },
+        {
+          key: 'contacts',
+          label: 'Contacts',
+          type: 'resource_ref',
+          target: { module_id: 'org.deft.reference.resource-contacts', resource_type: 'contacts' },
+          multiple: true,
+          display: 'label',
+        },
+      ],
+      views: [
+        { key: 'all', name: 'All campaigns', type: 'table', fields: ['subject', 'contacts'] },
+        { key: 'detail', name: 'Campaign details', type: 'detail', fields: ['subject', 'body', 'contacts'] },
+      ],
+      search: { title_field: 'subject', subtitle_fields: [], fields: ['subject', 'body'] },
+    }],
+    navigation: { default_collection: 'campaigns', default_view: 'all' },
+  };
+  const artifact = await prepareModuleArtifact({ path: modulePath, manifest: moduleManifest });
+  const manifest: DeftAppManifestV1Input = {
+    schema_version: '1',
+    id: 'community.example.connected-campaigns-app',
+    version: '1.0.0',
+    name: 'Connected Campaigns',
+    description: 'A connected Deft App that relates Campaigns to Contacts and requests sandbox email.',
+    license: 'AGPL-3.0-only',
+    compatibility: { app_protocol: '1' },
+    modules: [{
+      module_id: moduleManifest.id,
+      version: moduleManifest.version,
+      manifest_path: modulePath,
+      manifest_digest: artifact.digest,
+    }],
+    navigation: [{
+      key: 'campaigns', label: 'Campaigns', module_id: moduleManifest.id,
+      collection_key: 'campaigns', view_key: 'all',
+    }],
+    dependencies: [{
+      key: 'contacts_app',
+      app_id: 'org.deft.reference.resource-contacts-app',
+      version: '1.0.0',
+    }],
+    resource_requirements: [
+      {
+        key: 'campaign',
+        source: { kind: 'included_module', module_id: moduleManifest.id, version: moduleManifest.version },
+        resource_type: 'campaigns',
+        fields: ['subject', 'body', 'contacts'],
+      },
+      {
+        key: 'contact',
+        source: {
+          kind: 'dependency_module',
+          dependency_key: 'contacts_app',
+          module_id: 'org.deft.reference.resource-contacts',
+          version: '1.0.0',
+        },
+        resource_type: 'contacts',
+        fields: ['email'],
+      },
+    ],
+    capability_requirements: [{
+      key: 'send_email',
+      interface: {
+        kind: 'private', namespace: 'app_lineage', key: 'sandbox_email_send', version: '1',
+      },
+    }],
+    connector_requirements: [{ key: 'mail_provider', provider_kind: 'mcp' }],
+    actions: [{
+      key: 'send_campaign_email',
+      label: 'Send campaign email',
+      capability_requirement_key: 'send_email',
+      connector_requirement_key: 'mail_provider',
+      placement: { kind: 'resource_detail', resource_requirement_key: 'campaign' },
+      input_bindings: [
+        {
+          input_key: 'to',
+          source: {
+            kind: 'selected_relation_field',
+            source_resource_requirement_key: 'campaign',
+            relation_field_key: 'contacts',
+            target_resource_requirement_key: 'contact',
+            target_field_key: 'email',
+            selection: 'one',
+          },
+        },
+        {
+          input_key: 'subject',
+          source: { kind: 'resource_field', resource_requirement_key: 'campaign', field_key: 'subject' },
+        },
+        {
+          input_key: 'body_text',
+          source: { kind: 'resource_field', resource_requirement_key: 'campaign', field_key: 'body' },
+        },
+      ],
+    }],
+  };
+  await writeJson(resolve(cwd, modulePath), moduleManifest);
+  await writeJson(manifestPath, manifest);
+  await writeFile(resolve(cwd, 'APP_BRIEF.md'), [
+    '# App brief',
+    '',
+    'Describe the connected workspace outcome, the resources it relates, and why each requested authority is needed.',
+    '',
+  ].join('\n'), 'utf8');
+  await writeFile(resolve(cwd, 'AGENTS.md'), [
+    '# Connected Deft App',
+    '',
+    '- Build only through the published `@deft/app-kit` manifest, Module, and package contracts.',
+    '- Keep staging at zero authority. A workspace owner or admin reviews, binds, and activates requests.',
+    '- Never add credentials, provider endpoints, executable code, arbitrary mapping, policy overrides, or Deft core edits.',
+    '- Keep Contacts as an exact dependency and reference its records; do not copy them into Campaigns.',
+    '- The sandbox email action is single-recipient, human-initiated, and always requires host review.',
+    '- App Protocol v1 does not provide automation, custom UI, runtime, sync, or public ingress.',
+    '',
+  ].join('\n'), 'utf8');
+  await writeFile(resolve(cwd, '.gitignore'), '.deft/\n', 'utf8');
+  console.log(`Initialized ${manifest.name} in ${cwd}`);
+}
+
+async function initialize(template: AppTemplate): Promise<void> {
+  if (template === 'connected') return initializeConnected();
+  return initializeDeclarative();
+}
+
 async function buildProject(writeOutput: boolean) {
   const source = JSON.parse(await readFile(resolve(cwd, 'deft.app.json'), 'utf8')) as DeftAppManifestInput;
   const artifacts = [];
@@ -115,6 +277,11 @@ async function buildProject(writeOutput: boolean) {
       artifacts: built.package.artifacts.map(({ path, digest, byte_length, media_type }) => ({ path, digest, byte_length, media_type })),
       permissions: [],
     });
+    await writeFile(
+      resolve(cwd, DEFT_APP_REQUESTED_AUTHORITY_REPORT_PATH),
+      `${canonicalDeftAppRequestedAuthorityReportJson(manifest)}\n`,
+      'utf8',
+    );
   }
   return built;
 }
@@ -128,13 +295,51 @@ async function hostUrl(): Promise<string> {
   return (option('--url') ?? process.env.DEFT_URL ?? 'http://localhost:3001').replace(/\/$/, '');
 }
 
-async function doctor(): Promise<void> {
-  const url = await hostUrl();
+type DeveloperStatus = {
+  app_protocol?: string;
+  audience?: string;
+  single_use_install?: boolean;
+  compatibility?: unknown;
+};
+
+async function readDeveloperStatus(url: string): Promise<DeveloperStatus> {
   const response = await fetch(`${url}/api/app-developer/status`);
   if (!response.ok) throw new Error(`Deft App developer pairing is unavailable at ${url} (${response.status})`);
-  const status = await response.json() as { app_protocol?: string; audience?: string };
-  if (status.app_protocol !== '0' || status.audience !== 'app-developer') throw new Error('Host is not compatible with App Protocol v0');
-  console.log(`Compatible App Protocol v0 host: ${url}`);
+  const status = await response.json() as DeveloperStatus;
+  if (
+    status.app_protocol !== '0'
+    || status.audience !== 'app-developer'
+    || status.single_use_install !== true
+  ) {
+    throw new Error('Host does not implement the Deft App developer pairing contract');
+  }
+  return status;
+}
+
+async function compatibleFlow(url: string, built: Awaited<ReturnType<typeof buildProject>>) {
+  const status = await readDeveloperStatus(url);
+  const protocol = built.package.manifest.compatibility.app_protocol;
+  const flow = status.compatibility === undefined
+    ? (() => {
+        if (protocol !== '0') throw new Error('Host supports only App Protocol v0 developer installs');
+        return { package_format: DEFT_APP_PACKAGE_FORMAT, install_mode: 'stage_and_activate' as const };
+      })()
+    : (await checkDeftAppDeveloperContract({
+        package_json: built.json,
+        host_compatibility: status.compatibility,
+      })).install_flow;
+  if (flow.package_format !== built.package.package_format) {
+    throw new Error(`Host advertises an incompatible package format for App Protocol v${protocol}`);
+  }
+  return flow;
+}
+
+async function doctor(): Promise<void> {
+  const built = await buildProject(false);
+  const url = await hostUrl();
+  const flow = await compatibleFlow(url, built);
+  const protocol = built.package.manifest.compatibility.app_protocol;
+  console.log(`Compatible App Protocol v${protocol} ${flow.install_mode} host: ${url}`);
 }
 
 async function readPairingCode(): Promise<string> {
@@ -151,10 +356,7 @@ async function readPairingCode(): Promise<string> {
 async function installLocal(): Promise<void> {
   const url = await hostUrl();
   const built = await buildProject(true);
-  const protocol = built.package.manifest.compatibility.app_protocol;
-  if (protocol !== '0') {
-    throw new Error(`App Protocol v${protocol} packages must use the workspace review flow`);
-  }
+  const flow = await compatibleFlow(url, built);
   const code = await readPairingCode();
   if (!code) throw new Error('A one-time pairing code is required on stdin');
   const exchange = await fetch(`${url}/api/app-developer/pair/exchange`, {
@@ -169,13 +371,15 @@ async function installLocal(): Promise<void> {
   });
   if (!installed.ok) throw new Error(`Install failed (${installed.status}): ${await installed.text()}`);
   const result = await installed.json() as { app: { name: string; state: string } };
-  console.log(`Installed ${result.app.name} (${result.app.state})`);
+  console.log(flow.install_mode === 'stage_only'
+    ? `Staged ${result.app.name} (${result.app.state}) for workspace review.`
+    : `Installed ${result.app.name} (${result.app.state})`);
 }
 
 async function main(): Promise<void> {
   const [domain, command] = process.argv.slice(2);
   if (domain !== 'app') throw new Error('Usage: deft app <init|check|build|doctor|install-local>');
-  if (command === 'init') return initialize();
+  if (command === 'init') return initialize(parseInitTemplate());
   if (command === 'check') {
     const built = await buildProject(false);
     const protocol = built.package.manifest.compatibility.app_protocol;

--- a/packages/app-kit/src/index.ts
+++ b/packages/app-kit/src/index.ts
@@ -8,6 +8,87 @@ export const DEFT_APP_MANIFEST_SCHEMA_VERSION_V1 = '1' as const;
 export const DEFT_APP_PROTOCOL_VERSION_V1 = '1' as const;
 export const DEFT_APP_PACKAGE_FORMAT_V1 = 'deft.app.package.v1' as const;
 export const DEFT_MODULE_ARTIFACT_MEDIA_TYPE = 'application/vnd.deft.module+json' as const;
+export const DEFT_APP_KIT_PACKAGE_NAME = '@deft/app-kit' as const;
+export const DEFT_APP_KIT_VERSION = '0.1.0-alpha.1' as const;
+export const DEFT_APP_DEVELOPER_COMPATIBILITY_SCHEMA = 'deft.app_developer.compatibility.v1' as const;
+export const DEFT_APP_DEVELOPER_CONTRACT_CHECK_SCHEMA = 'deft.app_developer.contract_check.v1' as const;
+export const DEFT_APP_REQUESTED_AUTHORITY_REPORT_SCHEMA = 'deft.app.requested_authority.v1' as const;
+export const DEFT_APP_REQUESTED_AUTHORITY_REPORT_PATH = '.deft/requested-authority.json' as const;
+
+const DeftAppDeveloperProtocolV0FlowSchema = z.strictObject({
+  package_format: z.literal(DEFT_APP_PACKAGE_FORMAT),
+  install_mode: z.literal('stage_and_activate'),
+});
+
+const DeftAppDeveloperProtocolV1FlowSchema = z.strictObject({
+  package_format: z.literal(DEFT_APP_PACKAGE_FORMAT_V1),
+  install_mode: z.literal('stage_only'),
+});
+
+export const DeftAppDeveloperCompatibilitySchema = z.strictObject({
+  schema: z.literal(DEFT_APP_DEVELOPER_COMPATIBILITY_SCHEMA),
+  app_kit: z.strictObject({
+    package: z.literal(DEFT_APP_KIT_PACKAGE_NAME),
+    versions: z.array(z.string().min(1)).min(1),
+  }),
+  protocol_flows: z.strictObject({
+    '0': DeftAppDeveloperProtocolV0FlowSchema,
+    '1': DeftAppDeveloperProtocolV1FlowSchema,
+  }),
+}).superRefine((value, ctx) => {
+  if (new Set(value.app_kit.versions).size !== value.app_kit.versions.length) {
+    ctx.addIssue({ code: 'custom', path: ['app_kit', 'versions'], message: 'App Kit versions must be unique' });
+  }
+});
+
+export type DeftAppDeveloperCompatibility = z.infer<typeof DeftAppDeveloperCompatibilitySchema>;
+export type DeftAppDeveloperProtocol = keyof DeftAppDeveloperCompatibility['protocol_flows'];
+export type DeftAppDeveloperProtocolFlow =
+  DeftAppDeveloperCompatibility['protocol_flows'][DeftAppDeveloperProtocol];
+export type DeftAppDeveloperInstallMode = DeftAppDeveloperProtocolFlow['install_mode'];
+
+export const DEFT_APP_DEVELOPER_COMPATIBILITY = Object.freeze({
+  schema: DEFT_APP_DEVELOPER_COMPATIBILITY_SCHEMA,
+  app_kit: Object.freeze({
+    package: DEFT_APP_KIT_PACKAGE_NAME,
+    versions: Object.freeze([DEFT_APP_KIT_VERSION]),
+  }),
+  protocol_flows: Object.freeze({
+    '0': Object.freeze({
+      package_format: DEFT_APP_PACKAGE_FORMAT,
+      install_mode: 'stage_and_activate' as const,
+    }),
+    '1': Object.freeze({
+      package_format: DEFT_APP_PACKAGE_FORMAT_V1,
+      install_mode: 'stage_only' as const,
+    }),
+  }),
+});
+
+export function parseDeftAppDeveloperCompatibility(value: unknown): DeftAppDeveloperCompatibility {
+  return DeftAppDeveloperCompatibilitySchema.parse(value);
+}
+
+export function resolveDeftAppDeveloperProtocolFlow(
+  value: unknown,
+  protocol: string,
+): DeftAppDeveloperProtocolFlow {
+  const compatibility = parseDeftAppDeveloperCompatibility(value);
+  if (!compatibility.app_kit.versions.includes(DEFT_APP_KIT_VERSION)) {
+    throw new Error(`Host does not support ${DEFT_APP_KIT_PACKAGE_NAME} ${DEFT_APP_KIT_VERSION}`);
+  }
+  if (protocol !== DEFT_APP_PROTOCOL_VERSION && protocol !== DEFT_APP_PROTOCOL_VERSION_V1) {
+    throw new Error(`Host does not support App Protocol v${protocol}`);
+  }
+  return compatibility.protocol_flows[protocol];
+}
+
+export function resolveDeftAppDeveloperInstallFlow(
+  value: unknown,
+  protocol: string,
+): DeftAppDeveloperInstallMode {
+  return resolveDeftAppDeveloperProtocolFlow(value, protocol).install_mode;
+}
 
 export const APP_LIMITS = Object.freeze({
   manifest_bytes: 128 * 1024,
@@ -300,6 +381,46 @@ export const SANDBOX_EMAIL_SEND_PRIVATE_INTERFACE = Object.freeze({
       Object.freeze(['subject', 'body_text'] as const),
     ]),
   }),
+} as const);
+
+/**
+ * Public, inert conformance data for independently implemented proof
+ * providers. This contains no transport, provider loading, or execution code.
+ */
+export const SANDBOX_EMAIL_SEND_CONFORMANCE_VECTORS = Object.freeze({
+  schema: 'deft.app.sandbox_email_send.conformance.v1',
+  valid: Object.freeze({
+    input: Object.freeze({
+      to: 'ada@example.test',
+      subject: 'Analytical Engines',
+      body_text: 'Hello Ada',
+      idempotency_key: 'campaign:one/contact:ada',
+    }),
+    output: Object.freeze({
+      message_id: 'sandbox_a90928f63948386da7c8a7a4',
+      status: 'accepted' as const,
+    }),
+  }),
+  invalid: Object.freeze([
+    Object.freeze({
+      label: 'invalid_email',
+      input: Object.freeze({
+        to: 'not-email',
+        subject: 'Analytical Engines',
+        body_text: 'Hello Ada',
+        idempotency_key: 'campaign:invalid/contact:ada',
+      }),
+    }),
+    Object.freeze({
+      label: 'header_injection',
+      input: Object.freeze({
+        to: 'ada@example.test',
+        subject: 'Analytical Engines\r\nBcc: attacker@example.test',
+        body_text: 'Hello Ada',
+        idempotency_key: 'campaign:header/contact:ada',
+      }),
+    }),
+  ]),
 } as const);
 
 export const DeftAppDependencyRequirementV1Schema = z.strictObject({
@@ -683,6 +804,167 @@ export type DeftAppPackageV1 = z.infer<typeof DeftAppPackageV1Schema>;
 export type DeftAppPackage = z.infer<typeof DeftAppPackageSchema>;
 export type DeftAppPackageArtifactV0 = z.infer<typeof DeftAppPackageArtifactV0Schema>;
 export type AppDigest = z.infer<typeof AppDigestSchema>;
+
+const SandboxEmailHostPolicySchema = z.strictObject({
+  risk_class: z.literal(SANDBOX_EMAIL_SEND_PRIVATE_CONTRACT.host_policy.risk_class),
+  review_requirement: z.literal(SANDBOX_EMAIL_SEND_PRIVATE_CONTRACT.host_policy.review_requirement),
+  review_scope: z.literal(SANDBOX_EMAIL_SEND_PRIVATE_CONTRACT.host_policy.review_scope),
+  egress_class: z.literal(SANDBOX_EMAIL_SEND_PRIVATE_CONTRACT.host_policy.egress_class),
+  retry_class: z.literal(SANDBOX_EMAIL_SEND_PRIVATE_CONTRACT.host_policy.retry_class),
+  retention_class: z.literal(SANDBOX_EMAIL_SEND_PRIVATE_CONTRACT.host_policy.retention_class),
+  automation_eligibility: z.literal(
+    SANDBOX_EMAIL_SEND_PRIVATE_CONTRACT.host_policy.automation_eligibility,
+  ),
+  provider_idempotency_key_required: z.literal(
+    SANDBOX_EMAIL_SEND_PRIVATE_CONTRACT.host_policy.provider_idempotency_key_required,
+  ),
+});
+
+export const DeftAppRequestedAuthorityProjectionSchema = z.strictObject({
+  requirements: z.strictObject({
+    dependencies: z.array(DeftAppDependencyRequirementV1Schema).max(APP_LIMITS.dependencies),
+    resources: z.array(DeftAppResourceRequirementV1Schema).max(APP_LIMITS.resource_requirements),
+    capabilities: z.array(DeftAppCapabilityRequirementV1Schema).max(APP_LIMITS.capability_requirements),
+    connectors: z.array(DeftAppConnectorRequirementV1Schema).max(APP_LIMITS.connector_requirements),
+    actions: z.array(DeftAppActionBindingV1Schema).max(APP_LIMITS.actions),
+  }),
+  resource_rights: z.array(z.strictObject({
+    requirement_key: AppMachineKeyV1Schema,
+    source: DeftAppResourceRequirementV1Schema.shape.source,
+    resource_type: AppMachineKeyV1Schema,
+    fields: z.array(AppMachineKeyV1Schema).min(1).max(APP_LIMITS.resource_fields_per_requirement),
+    right: z.literal('read'),
+  })).max(APP_LIMITS.resource_requirements),
+  classification: z.strictObject({
+    authority_state: z.literal('requested_only'),
+    executable: z.literal(false),
+    provider_access: z.literal(false),
+    review_required: z.boolean(),
+    actions: z.array(z.strictObject({
+      action_key: AppAuthorityKeyV1Schema,
+      capability_requirement_key: AppAuthorityKeyV1Schema,
+      host_policy: SandboxEmailHostPolicySchema,
+    })).max(APP_LIMITS.actions),
+  }),
+});
+
+export const DeftAppRequestedAuthorityReportSchema = z.strictObject({
+  schema: z.literal(DEFT_APP_REQUESTED_AUTHORITY_REPORT_SCHEMA),
+  app: z.strictObject({
+    id: AppIdSchema,
+    version: AppSemverSchema,
+    protocol_version: z.union([
+      z.literal(DEFT_APP_PROTOCOL_VERSION),
+      z.literal(DEFT_APP_PROTOCOL_VERSION_V1),
+    ]),
+  }),
+  requested_authority: DeftAppRequestedAuthorityProjectionSchema,
+});
+
+export type DeftAppRequestedAuthorityProjection =
+  z.infer<typeof DeftAppRequestedAuthorityProjectionSchema>;
+export type DeftAppRequestedAuthorityReport = z.infer<typeof DeftAppRequestedAuthorityReportSchema>;
+
+/**
+ * Project only App-authored requested authority. Host identities, effective
+ * grants, connector/provider selection, tokens, and lineage never enter this
+ * portable report.
+ */
+export function projectDeftAppRequestedAuthority(
+  value: DeftAppManifestInput | DeftAppManifest,
+): DeftAppRequestedAuthorityProjection {
+  const manifest = parseDeftAppManifest(value);
+  const connected = manifest.schema_version === DEFT_APP_MANIFEST_SCHEMA_VERSION_V1
+    ? manifest
+    : null;
+  const projection = {
+    requirements: connected
+      ? {
+          dependencies: connected.dependencies,
+          resources: connected.resource_requirements,
+          capabilities: connected.capability_requirements,
+          connectors: connected.connector_requirements,
+          actions: connected.actions,
+        }
+      : { dependencies: [], resources: [], capabilities: [], connectors: [], actions: [] },
+    resource_rights: connected
+      ? connected.resource_requirements.map((requirement) => ({
+          requirement_key: requirement.key,
+          source: requirement.source,
+          resource_type: requirement.resource_type,
+          fields: requirement.fields,
+          right: 'read' as const,
+        }))
+      : [],
+    classification: {
+      authority_state: 'requested_only' as const,
+      executable: false as const,
+      provider_access: false as const,
+      review_required: connected !== null,
+      actions: connected
+        ? connected.actions.map((action) => ({
+            action_key: action.key,
+            capability_requirement_key: action.capability_requirement_key,
+            host_policy: SANDBOX_EMAIL_SEND_PRIVATE_CONTRACT.host_policy,
+          }))
+        : [],
+    },
+  };
+  return DeftAppRequestedAuthorityProjectionSchema.parse(canonicalizeJson(projection));
+}
+
+export function buildDeftAppRequestedAuthorityReport(
+  value: DeftAppManifestInput | DeftAppManifest,
+): DeftAppRequestedAuthorityReport {
+  const manifest = parseDeftAppManifest(value);
+  return DeftAppRequestedAuthorityReportSchema.parse({
+    schema: DEFT_APP_REQUESTED_AUTHORITY_REPORT_SCHEMA,
+    app: {
+      id: manifest.id,
+      version: manifest.version,
+      protocol_version: manifest.compatibility.app_protocol,
+    },
+    requested_authority: projectDeftAppRequestedAuthority(manifest),
+  });
+}
+
+export function canonicalDeftAppRequestedAuthorityReportJson(
+  value: DeftAppManifestInput | DeftAppManifest,
+): string {
+  return JSON.stringify(canonicalizeJson(buildDeftAppRequestedAuthorityReport(value)), null, 2);
+}
+
+/**
+ * Validate only portable authoring contracts. Package verification performs
+ * the static Module/resource/action binding checks; this helper does not
+ * inspect a workspace, resolve effective grants, or call a provider.
+ */
+export async function checkDeftAppDeveloperContract(input: {
+  package_json: string;
+  host_compatibility: unknown;
+}) {
+  const verified = await verifyDeftAppPackageJson(input.package_json);
+  const protocol = verified.package.manifest.compatibility.app_protocol;
+  const installFlow = resolveDeftAppDeveloperProtocolFlow(input.host_compatibility, protocol);
+  if (installFlow.package_format !== verified.package.package_format) {
+    throw new Error(`Host advertises an incompatible package format for App Protocol v${protocol}`);
+  }
+  return {
+    schema: DEFT_APP_DEVELOPER_CONTRACT_CHECK_SCHEMA,
+    package: {
+      format: verified.package.package_format,
+      digest: verified.digest,
+      protocol_version: protocol,
+    },
+    install_flow: installFlow,
+    requested_authority: buildDeftAppRequestedAuthorityReport(verified.package.manifest),
+    sandbox_email_conformance: {
+      schema: SANDBOX_EMAIL_SEND_CONFORMANCE_VECTORS.schema,
+      valid_input: SandboxEmailSendInputSchema.parse(SANDBOX_EMAIL_SEND_CONFORMANCE_VECTORS.valid.input),
+      expected_output: SandboxEmailSendOutputSchema.parse(SANDBOX_EMAIL_SEND_CONFORMANCE_VECTORS.valid.output),
+    },
+  };
+}
 
 function recordWithString(value: unknown, key: string): string | undefined {
   if (typeof value !== 'object' || value === null || Array.isArray(value)) return undefined;

--- a/packages/app-kit/test/cli.test.ts
+++ b/packages/app-kit/test/cli.test.ts
@@ -1,8 +1,9 @@
 import assert from 'node:assert/strict';
 import { mkdir, mkdtemp, readFile, readdir, writeFile } from 'node:fs/promises';
+import { createServer } from 'node:http';
 import { tmpdir } from 'node:os';
 import { resolve } from 'node:path';
-import { spawnSync } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 import test from 'node:test';
 
 const cli = resolve(import.meta.dirname, '..', 'dist', 'cli.js');
@@ -11,11 +12,48 @@ function run(project: string, ...args: string[]) {
   return spawnSync(process.execPath, [cli, 'app', ...args], { cwd: project, encoding: 'utf8' });
 }
 
+async function runAsync(project: string, input: string, ...args: string[]) {
+  return new Promise<{ status: number | null; stdout: string; stderr: string }>((resolveRun, reject) => {
+    const child = spawn(process.execPath, [cli, 'app', ...args], { cwd: project, stdio: 'pipe' });
+    const stdout: Buffer[] = [];
+    const stderr: Buffer[] = [];
+    child.stdout.on('data', (chunk) => stdout.push(Buffer.from(chunk)));
+    child.stderr.on('data', (chunk) => stderr.push(Buffer.from(chunk)));
+    child.once('error', reject);
+    child.once('close', (status) => resolveRun({
+      status,
+      stdout: Buffer.concat(stdout).toString('utf8'),
+      stderr: Buffer.concat(stderr).toString('utf8'),
+    }));
+    child.stdin.end(input);
+  });
+}
+
 test('external authoring loop initializes and builds deterministically without credentials', async () => {
   const project = await mkdtemp(resolve(tmpdir(), 'deft-app-kit-'));
   const initialized = run(project, 'init');
   assert.equal(initialized.status, 0, initialized.stderr);
   assert.equal((await readFile(resolve(project, 'AGENTS.md'), 'utf8')).includes('Do not edit Deft core'), true);
+
+  const explicitProject = await mkdtemp(resolve(tmpdir(), 'deft-app-kit-explicit-'));
+  const explicit = run(explicitProject, 'init', '--template', 'declarative');
+  assert.equal(explicit.status, 0, explicit.stderr);
+  for (const filename of [
+    'deft.app.json',
+    'modules/hello-workspace/deft.module.json',
+    'APP_BRIEF.md',
+    'AGENTS.md',
+    '.gitignore',
+  ]) {
+    assert.equal(
+      await readFile(resolve(explicitProject, filename), 'utf8'),
+      await readFile(resolve(project, filename), 'utf8'),
+      `${filename} must remain byte-identical for the compatibility default`,
+    );
+  }
+  const invalidTemplate = run(await mkdtemp(resolve(tmpdir(), 'deft-app-kit-invalid-')), 'init', '--template', 'runtime');
+  assert.notEqual(invalidTemplate.status, 0);
+  assert.equal(invalidTemplate.stderr.trim(), 'Usage: deft app init [--template declarative|connected]');
 
   const checked = run(project, 'check');
   assert.equal(checked.status, 0, checked.stderr);
@@ -26,6 +64,17 @@ test('external authoring loop initializes and builds deterministically without c
   assert.equal(first.status, 0, first.stderr);
   const firstPackage = await readFile(resolve(project, '.deft', 'app.deftapp.json'), 'utf8');
   const firstLock = await readFile(resolve(project, 'deft.app.lock.json'), 'utf8');
+  const requestedAuthority = JSON.parse(
+    await readFile(resolve(project, '.deft', 'requested-authority.json'), 'utf8'),
+  ) as any;
+  assert.equal(requestedAuthority.schema, 'deft.app.requested_authority.v1');
+  assert.deepEqual(requestedAuthority.requested_authority.requirements, {
+    actions: [], capabilities: [], connectors: [], dependencies: [], resources: [],
+  });
+  assert.deepEqual(requestedAuthority.requested_authority.resource_rights, []);
+  assert.deepEqual(requestedAuthority.requested_authority.classification.actions, []);
+  assert.equal(requestedAuthority.requested_authority.classification.executable, false);
+  assert.equal(requestedAuthority.requested_authority.classification.provider_access, false);
   const second = run(project, 'build');
   assert.equal(second.status, 0, second.stderr);
   assert.equal(await readFile(resolve(project, '.deft', 'app.deftapp.json'), 'utf8'), firstPackage);
@@ -40,6 +89,114 @@ test('external authoring loop initializes and builds deterministically without c
     } catch {
       // Directories are intentionally ignored.
     }
+  }
+});
+
+test('connected template emits a Module v2 dependency App and requested authority without a grant', async () => {
+  const project = await mkdtemp(resolve(tmpdir(), 'deft-connected-template-'));
+  const initialized = run(project, 'init', '--template', 'connected');
+  assert.equal(initialized.status, 0, initialized.stderr);
+
+  const moduleManifest = JSON.parse(
+    await readFile(resolve(project, 'modules', 'connected-campaigns', 'deft.module.json'), 'utf8'),
+  ) as any;
+  const manifest = JSON.parse(await readFile(resolve(project, 'deft.app.json'), 'utf8')) as any;
+  assert.equal(moduleManifest.schema_version, '2');
+  assert.deepEqual(moduleManifest.collections[0].fields.find((field: any) => field.key === 'contacts').target, {
+    module_id: 'org.deft.reference.resource-contacts',
+    resource_type: 'contacts',
+  });
+  assert.deepEqual(manifest.dependencies, [{
+    key: 'contacts_app',
+    app_id: 'org.deft.reference.resource-contacts-app',
+    version: '1.0.0',
+  }]);
+  assert.equal(manifest.actions[0].input_bindings[0].source.kind, 'selected_relation_field');
+  assert.match(await readFile(resolve(project, 'AGENTS.md'), 'utf8'), /staging at zero authority/i);
+
+  const checked = run(project, 'check');
+  assert.equal(checked.status, 0, checked.stderr);
+  const first = run(project, 'build');
+  assert.equal(first.status, 0, first.stderr);
+  const firstPackage = await readFile(resolve(project, '.deft', 'app.deftapp.json'), 'utf8');
+  const firstLock = await readFile(resolve(project, 'deft.app.lock.json'), 'utf8');
+  const firstReport = await readFile(resolve(project, '.deft', 'requested-authority.json'), 'utf8');
+  assert.deepEqual((JSON.parse(firstLock) as any).permissions, []);
+  const report = JSON.parse(firstReport) as any;
+  assert.equal(report.app.protocol_version, '1');
+  assert.equal(report.requested_authority.classification.authority_state, 'requested_only');
+  assert.equal(report.requested_authority.classification.executable, false);
+  assert.equal(report.requested_authority.classification.provider_access, false);
+  assert.equal(report.requested_authority.classification.review_required, true);
+  assert.equal(report.requested_authority.resource_rights.every((right: any) => right.right === 'read'), true);
+  assert.equal(JSON.stringify(report).includes('organization_id'), false);
+  assert.equal(JSON.stringify(report).includes('connector_id'), false);
+  assert.equal(JSON.stringify(report).includes('token'), false);
+
+  const second = run(project, 'build');
+  assert.equal(second.status, 0, second.stderr);
+  assert.equal(await readFile(resolve(project, '.deft', 'app.deftapp.json'), 'utf8'), firstPackage);
+  assert.equal(await readFile(resolve(project, 'deft.app.lock.json'), 'utf8'), firstLock);
+  assert.equal(await readFile(resolve(project, '.deft', 'requested-authority.json'), 'utf8'), firstReport);
+
+  const requests: Array<{ url: string; authorization?: string; body: string }> = [];
+  const host = createServer((request, response) => {
+    if (request.url === '/api/app-developer/status') {
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end(JSON.stringify({
+        app_protocol: '0',
+        audience: 'app-developer',
+        single_use_install: true,
+        compatibility: {
+          schema: 'deft.app_developer.compatibility.v1',
+          app_kit: { package: '@deft/app-kit', versions: ['0.1.0-alpha.1'] },
+          protocol_flows: {
+            '0': { package_format: 'deft.app.package.v0', install_mode: 'stage_and_activate' },
+            '1': { package_format: 'deft.app.package.v1', install_mode: 'stage_only' },
+          },
+        },
+      }));
+      return;
+    }
+    const chunks: Buffer[] = [];
+    request.on('data', (chunk) => chunks.push(Buffer.from(chunk)));
+    request.on('end', () => {
+      requests.push({
+        url: request.url ?? '',
+        ...(request.headers.authorization ? { authorization: request.headers.authorization } : {}),
+        body: Buffer.concat(chunks).toString('utf8'),
+      });
+      if (request.url === '/api/app-developer/pair/exchange') {
+        response.writeHead(200, { 'content-type': 'application/json' });
+        response.end(JSON.stringify({ token: 'deft_app_dev_test' }));
+      } else {
+        response.writeHead(201, { 'content-type': 'application/json' });
+        response.end(JSON.stringify({ app: { name: 'Connected Campaigns', state: 'staged' } }));
+      }
+    });
+  });
+  await new Promise<void>((resolveListen) => host.listen(0, '127.0.0.1', resolveListen));
+  const address = host.address();
+  if (!address || typeof address === 'string') throw new Error('Expected a TCP test server');
+  try {
+    const installed = await runAsync(
+      project,
+      'one-time-code\n',
+      'install-local',
+      '--url',
+      `http://127.0.0.1:${address.port}`,
+    );
+    assert.equal(installed.status, 0, installed.stderr);
+    assert.equal(installed.stdout.trim(), 'Staged Connected Campaigns (staged) for workspace review.');
+    assert.deepEqual(requests.map((request) => request.url), [
+      '/api/app-developer/pair/exchange',
+      '/api/app-developer/install',
+    ]);
+    assert.deepEqual(JSON.parse(requests[0]!.body), { code: 'one-time-code' });
+    assert.equal(requests[1]!.authorization, 'Bearer deft_app_dev_test');
+    assert.equal((JSON.parse(requests[1]!.body) as any).package_format, 'deft.app.package.v1');
+  } finally {
+    await new Promise<void>((resolveClose, reject) => host.close((error) => error ? reject(error) : resolveClose()));
   }
 });
 
@@ -154,19 +311,36 @@ test('external authoring loop checks and builds Protocol v1 deterministically wi
   assert.equal(await readFile(resolve(project, '.deft', 'app.deftapp.json'), 'utf8'), firstPackage);
   assert.equal(await readFile(resolve(project, 'deft.app.lock.json'), 'utf8'), firstLock);
 
-  const installLocal = spawnSync(
-    process.execPath,
-    [cli, 'app', 'install-local', '--url', 'http://127.0.0.1:1'],
-    {
-      cwd: project,
-      encoding: 'utf8',
-      input: 'pairing-code-must-not-be-read\n',
-    },
-  );
-  assert.notEqual(installLocal.status, 0);
-  assert.equal(
-    installLocal.stderr.trim(),
-    'App Protocol v1 packages must use the workspace review flow',
-  );
-  assert.doesNotMatch(installLocal.stderr, /Pairing failed|fetch failed|one-time pairing code/i);
+  let nonStatusRequests = 0;
+  const host = createServer((request, response) => {
+    if (request.url === '/api/app-developer/status') {
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end(JSON.stringify({
+        app_protocol: '0',
+        audience: 'app-developer',
+        single_use_install: true,
+      }));
+      return;
+    }
+    nonStatusRequests += 1;
+    response.writeHead(500).end();
+  });
+  await new Promise<void>((resolveListen) => host.listen(0, '127.0.0.1', resolveListen));
+  const address = host.address();
+  if (!address || typeof address === 'string') throw new Error('Expected a TCP test server');
+  try {
+    const installLocal = await runAsync(
+      project,
+      'pairing-code-must-not-be-read\n',
+      'install-local',
+      '--url',
+      `http://127.0.0.1:${address.port}`,
+    );
+    assert.notEqual(installLocal.status, 0);
+    assert.equal(installLocal.stderr.trim(), 'Host supports only App Protocol v0 developer installs');
+    assert.equal(nonStatusRequests, 0, 'Compatibility refusal must happen before pairing exchange');
+    assert.doesNotMatch(installLocal.stderr, /Pairing failed|fetch failed|one-time pairing code/i);
+  } finally {
+    await new Promise<void>((resolveClose, reject) => host.close((error) => error ? reject(error) : resolveClose()));
+  }
 });

--- a/packages/app-kit/test/developer-contract.test.ts
+++ b/packages/app-kit/test/developer-contract.test.ts
@@ -1,0 +1,171 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import test from 'node:test';
+import {
+  DEFT_APP_DEVELOPER_COMPATIBILITY,
+  DEFT_APP_KIT_VERSION,
+  SANDBOX_EMAIL_SEND_CONFORMANCE_VECTORS,
+  SandboxEmailSendInputSchema,
+  SandboxEmailSendOutputSchema,
+  buildDeftAppPackage,
+  buildDeftAppRequestedAuthorityReport,
+  canonicalDeftAppRequestedAuthorityReportJson,
+  checkDeftAppDeveloperContract,
+  parseDeftAppDeveloperCompatibility,
+  parseDeftAppManifestJson,
+  prepareModuleArtifact,
+  projectDeftAppRequestedAuthority,
+  resolveDeftAppDeveloperProtocolFlow,
+} from '../src/index.js';
+
+const repositoryRoot = resolve(import.meta.dirname, '..', '..', '..');
+
+async function exampleManifest(path: string) {
+  return parseDeftAppManifestJson(await readFile(resolve(repositoryRoot, path), 'utf8'));
+}
+
+async function examplePackage(path: string) {
+  const manifest = await exampleManifest(`${path}/deft.app.json`);
+  const artifacts = await Promise.all(manifest.modules.map(async (moduleReference) => prepareModuleArtifact({
+    path: moduleReference.manifest_path,
+    manifest: JSON.parse(await readFile(
+      resolve(repositoryRoot, path, moduleReference.manifest_path),
+      'utf8',
+    )) as unknown,
+  })));
+  return buildDeftAppPackage({ manifest, artifacts });
+}
+
+test('freezes one additive App Kit and protocol-flow compatibility contract', async () => {
+  const packageJson = JSON.parse(
+    await readFile(resolve(import.meta.dirname, '..', 'package.json'), 'utf8'),
+  ) as { version: string };
+  assert.equal(DEFT_APP_KIT_VERSION, packageJson.version);
+  assert.deepEqual(DEFT_APP_DEVELOPER_COMPATIBILITY, {
+    schema: 'deft.app_developer.compatibility.v1',
+    app_kit: { package: '@deft/app-kit', versions: ['0.1.0-alpha.1'] },
+    protocol_flows: {
+      '0': { package_format: 'deft.app.package.v0', install_mode: 'stage_and_activate' },
+      '1': { package_format: 'deft.app.package.v1', install_mode: 'stage_only' },
+    },
+  });
+  assert.equal(Object.isFrozen(DEFT_APP_DEVELOPER_COMPATIBILITY), true);
+  assert.equal(Object.isFrozen(DEFT_APP_DEVELOPER_COMPATIBILITY.app_kit.versions), true);
+  assert.equal(Object.isFrozen(DEFT_APP_DEVELOPER_COMPATIBILITY.protocol_flows['1']), true);
+  assert.deepEqual(
+    resolveDeftAppDeveloperProtocolFlow(DEFT_APP_DEVELOPER_COMPATIBILITY, '0'),
+    { package_format: 'deft.app.package.v0', install_mode: 'stage_and_activate' },
+  );
+  assert.deepEqual(
+    resolveDeftAppDeveloperProtocolFlow(DEFT_APP_DEVELOPER_COMPATIBILITY, '1'),
+    { package_format: 'deft.app.package.v1', install_mode: 'stage_only' },
+  );
+  assert.throws(
+    () => resolveDeftAppDeveloperProtocolFlow(DEFT_APP_DEVELOPER_COMPATIBILITY, '2'),
+    /does not support App Protocol v2/,
+  );
+  assert.throws(
+    () => resolveDeftAppDeveloperProtocolFlow({
+      ...DEFT_APP_DEVELOPER_COMPATIBILITY,
+      app_kit: { package: '@deft/app-kit', versions: ['0.1.0-alpha.0'] },
+    }, '1'),
+    /does not support @deft\/app-kit 0\.1\.0-alpha\.1/,
+  );
+  assert.throws(
+    () => parseDeftAppDeveloperCompatibility({
+      ...DEFT_APP_DEVELOPER_COMPATIBILITY,
+      provider_endpoint: 'https://attacker.example',
+    }),
+    /Unrecognized key/,
+  );
+});
+
+test('checks a connected package against only the public host and provider contracts', async () => {
+  const built = await examplePackage('examples/connected-resource-campaigns-app');
+  const checked = await checkDeftAppDeveloperContract({
+    package_json: built.json,
+    host_compatibility: DEFT_APP_DEVELOPER_COMPATIBILITY,
+  });
+  assert.equal(checked.schema, 'deft.app_developer.contract_check.v1');
+  assert.deepEqual(checked.package, {
+    format: 'deft.app.package.v1',
+    digest: built.digest,
+    protocol_version: '1',
+  });
+  assert.equal(checked.install_flow.install_mode, 'stage_only');
+  assert.equal(checked.requested_authority.requested_authority.classification.executable, false);
+  assert.deepEqual(
+    checked.sandbox_email_conformance.expected_output,
+    SANDBOX_EMAIL_SEND_CONFORMANCE_VECTORS.valid.output,
+  );
+});
+
+test('projects v0 as explicitly empty requested authority', async () => {
+  const manifest = await exampleManifest('examples/resource-participation-contacts-app/deft.app.json');
+  const projection = projectDeftAppRequestedAuthority(manifest);
+  assert.deepEqual(projection.requirements, {
+    dependencies: [], resources: [], capabilities: [], connectors: [], actions: [],
+  });
+  assert.deepEqual(projection.resource_rights, []);
+  assert.deepEqual(projection.classification, {
+    authority_state: 'requested_only',
+    executable: false,
+    provider_access: false,
+    review_required: false,
+    actions: [],
+  });
+});
+
+test('projects connected requested authority without host identity or effective grants', async () => {
+  const manifest = await exampleManifest('examples/connected-resource-campaigns-app/deft.app.json');
+  const first = projectDeftAppRequestedAuthority(manifest);
+  const replay = projectDeftAppRequestedAuthority(structuredClone(manifest));
+  assert.deepEqual(replay, first);
+  assert.equal(first.requirements.dependencies.length, 1);
+  assert.equal(first.requirements.actions.length, 1);
+  assert.equal(first.resource_rights.length, 2);
+  assert.equal(first.resource_rights.every((right) => right.right === 'read'), true);
+  assert.deepEqual(first.classification.actions[0]!.host_policy, {
+    risk_class: 'external_write',
+    review_requirement: 'always',
+    review_scope: 'per_invocation',
+    egress_class: 'email',
+    retry_class: 'idempotent_with_key',
+    retention_class: 'standard',
+    automation_eligibility: 'forbidden',
+    provider_idempotency_key_required: true,
+  });
+
+  first.requirements.dependencies.length = 0;
+  first.classification.actions[0]!.host_policy.retention_class = 'standard';
+  assert.equal(projectDeftAppRequestedAuthority(manifest).requirements.dependencies.length, 1);
+
+  const report = buildDeftAppRequestedAuthorityReport(manifest);
+  const json = canonicalDeftAppRequestedAuthorityReportJson(manifest);
+  assert.deepEqual(JSON.parse(json), report);
+  assert.equal(canonicalDeftAppRequestedAuthorityReportJson(structuredClone(manifest)), json);
+  for (const forbidden of [
+    '"organization_id":', '"installation_id":', '"version_id":', '"connector_id":',
+    '"provider_id":', '"token":', '"secret":', '"effective_grant":', '"lineage_id":',
+  ]) {
+    assert.equal(json.includes(forbidden), false, forbidden);
+  }
+});
+
+test('publishes provider-independent sandbox email conformance vectors', () => {
+  assert.equal(SandboxEmailSendInputSchema.safeParse(
+    SANDBOX_EMAIL_SEND_CONFORMANCE_VECTORS.valid.input,
+  ).success, true);
+  assert.equal(SandboxEmailSendOutputSchema.safeParse(
+    SANDBOX_EMAIL_SEND_CONFORMANCE_VECTORS.valid.output,
+  ).success, true);
+  assert.deepEqual(SANDBOX_EMAIL_SEND_CONFORMANCE_VECTORS.valid.output, {
+    message_id: 'sandbox_a90928f63948386da7c8a7a4',
+    status: 'accepted',
+  });
+  assert.equal(Object.isFrozen(SANDBOX_EMAIL_SEND_CONFORMANCE_VECTORS.valid.input), true);
+  for (const vector of SANDBOX_EMAIL_SEND_CONFORMANCE_VECTORS.invalid) {
+    assert.equal(SandboxEmailSendInputSchema.safeParse(vector.input).success, false, vector.label);
+  }
+});

--- a/packages/app-kit/test/packed-external.test.ts
+++ b/packages/app-kit/test/packed-external.test.ts
@@ -1,0 +1,93 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { cp, mkdir, mkdtemp, readFile, readdir, realpath, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { resolve } from 'node:path';
+import test from 'node:test';
+
+const packageRoot = resolve(import.meta.dirname, '..');
+const repositoryRoot = resolve(packageRoot, '..', '..');
+
+function run(command: string, args: string[], cwd: string) {
+  const result = spawnSync(command, args, { cwd, encoding: 'utf8' });
+  assert.equal(result.status, 0, [result.error?.message, result.stdout, result.stderr].filter(Boolean).join('\n'));
+  return result;
+}
+
+function runPnpm(args: string[], cwd: string) {
+  assert.ok(process.env.npm_execpath, 'Run App Kit tests through pnpm');
+  return run(process.execPath, [process.env.npm_execpath, ...args], cwd);
+}
+
+async function buildTwice(cli: string, project: string) {
+  const check = run(process.execPath, [cli, 'app', 'check'], project);
+  assert.match(check.stdout, /Valid App Protocol/);
+  run(process.execPath, [cli, 'app', 'build'], project);
+  const first = {
+    package: await readFile(resolve(project, '.deft', 'app.deftapp.json'), 'utf8'),
+    lock: await readFile(resolve(project, 'deft.app.lock.json'), 'utf8'),
+    report: await readFile(resolve(project, '.deft', 'requested-authority.json'), 'utf8'),
+  };
+  run(process.execPath, [cli, 'app', 'build'], project);
+  assert.equal(await readFile(resolve(project, '.deft', 'app.deftapp.json'), 'utf8'), first.package);
+  assert.equal(await readFile(resolve(project, 'deft.app.lock.json'), 'utf8'), first.lock);
+  assert.equal(await readFile(resolve(project, '.deft', 'requested-authority.json'), 'utf8'), first.report);
+  return first;
+}
+
+test('packed App Kit builds Contacts and connected Campaigns from a clean external install', async () => {
+  const temporaryRoot = await mkdtemp(resolve(tmpdir(), 'deft-packed-app-kit-'));
+  try {
+    const artifacts = resolve(temporaryRoot, 'artifacts');
+    const consumer = resolve(temporaryRoot, 'consumer');
+    await mkdir(artifacts, { recursive: true });
+    await mkdir(consumer, { recursive: true });
+    runPnpm(['--dir', packageRoot, 'pack', '--pack-destination', artifacts, '--json'], repositoryRoot);
+    const archives = (await readdir(artifacts)).filter((entry) => entry.endsWith('.tgz'));
+    assert.equal(archives.length, 1);
+    const archive = resolve(artifacts, archives[0]!);
+    await writeFile(resolve(consumer, 'package.json'), `${JSON.stringify({
+      name: 'deft-external-app-author',
+      version: '1.0.0',
+      private: true,
+      dependencies: { '@deft/app-kit': `file:${archive.replace(/\\/g, '/')}` },
+    }, null, 2)}\n`, 'utf8');
+    runPnpm(['--dir', consumer, 'install', '--ignore-workspace', '--offline'], repositoryRoot);
+
+    const installedRoot = await realpath(resolve(consumer, 'node_modules', '@deft', 'app-kit'));
+    assert.equal(installedRoot.startsWith(await realpath(consumer)), true);
+    const installedPackage = JSON.parse(await readFile(resolve(installedRoot, 'package.json'), 'utf8')) as any;
+    assert.equal(installedPackage.version, '0.1.0-alpha.1');
+    assert.equal(installedPackage.bin.deft, './dist/cli.js');
+    const installedFiles = await readdir(installedRoot, { recursive: true });
+    assert.equal(installedFiles.some((entry) => /^src(?:[\\/]|$)/.test(entry)), false);
+    assert.equal(installedFiles.some((entry) => /^test(?:[\\/]|$)/.test(entry)), false);
+    const installedText = (await Promise.all(installedFiles
+      .filter((entry) => /\.(?:js|d\.ts|md|json)$/.test(entry))
+      .map(async (entry) => {
+        try { return await readFile(resolve(installedRoot, entry), 'utf8'); }
+        catch { return ''; }
+      }))).join('\n');
+    assert.equal(installedText.includes(repositoryRoot), false);
+    assert.doesNotMatch(installedText, /from\s+['"]@deft\/(?:db|shared|mcp|api|web)/);
+
+    const cli = resolve(installedRoot, 'dist', 'cli.js');
+    const contacts = resolve(temporaryRoot, 'contacts');
+    await cp(resolve(repositoryRoot, 'examples', 'resource-participation-contacts-app'), contacts, {
+      recursive: true,
+    });
+    const contactsProof = await buildTwice(cli, contacts);
+    assert.equal((JSON.parse(contactsProof.lock) as any).package_digest,
+      'sha256:1471f0b94da9f6851bd978c315bc22a2dd0343b61a87477e4293b144c54248d8');
+
+    const campaigns = resolve(temporaryRoot, 'campaigns');
+    await mkdir(campaigns, { recursive: true });
+    run(process.execPath, [cli, 'app', 'init', '--template', 'connected'], campaigns);
+    const campaignsProof = await buildTwice(cli, campaigns);
+    assert.equal((JSON.parse(campaignsProof.lock) as any).schema, 'deft.app.lock.v1');
+    assert.deepEqual((JSON.parse(campaignsProof.lock) as any).permissions, []);
+    assert.equal((JSON.parse(campaignsProof.report) as any).requested_authority.classification.executable, false);
+  } finally {
+    await rm(temporaryRoot, { recursive: true, force: true });
+  }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -311,7 +311,7 @@ importers:
   packages/app-kit:
     dependencies:
       zod:
-        specifier: ^4.4.3
+        specifier: 4.4.3
         version: 4.4.3
     devDependencies:
       '@types/node':


### PR DESCRIPTION
## Summary

- publish @deft/app-kit 0.1.0-alpha.1 connected/declarative templates, exact host-flow compatibility, a portable requested-authority projection, and a public contract checker
- extend developer pairing so Protocol v1 packages are inspected before token claim and staged at zero authority while Protocol v0 remains stage-and-activate
- add clean packed external-author proofs, a separately packed no-egress stdio sandbox provider, a pinned proof bundle, and the connected App author guide
- enforce App Kit and non-skipping pairing coverage in CI

## Safety boundary

- Protocol v1 delivery stops in staged: no effective grant, dependency lock, action binding, connector mutation, provider call, approval, App Run, or activation
- requested-authority output is separate, non-authoritative review material and contains no host IDs, tokens, secrets, provider selection, or effective grants
- no UI, migration, production-email, automation, runtime, sync, or deployment surface is added
- Protocol v0 response shape, package bytes, stage-and-activate behavior, and the frozen requested-grant snapshot digest remain exact

## Validation

- pnpm --filter @deft/app-kit test — 23/23
- standalone packed provider through official MCP stdio transport — 1/1
- grant projection plus pairing/install database gate — 9/9
- pnpm typecheck
- git diff --check origin/master...HEAD

The disposable PostgreSQL database/instance and temporary packed artifacts were stopped and removed after validation.