### PR TITLE
feat(apps): complete connected lifecycle management

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,13 +30,14 @@ jobs:
         run: pnpm test:hermes-integration-bundle
       - name: Lint web
         run: pnpm --filter @deft/web lint
-      - name: Test web realtime lifecycle state
+      - name: Test focused web contracts
         run: >-
           pnpm --filter @deft/web exec tsx --test
           src/lib/huddle-state.test.ts
           src/lib/socket.test.ts
           src/lib/space-socket.test.ts
           src/lib/module-collection-nav.test.ts
+          src/lib/apps.test.ts
       - name: Type check API
         run: pnpm --filter @deft/api typecheck
       - name: Type check Web

--- a/apps/api/src/lib/app-action-service.ts
+++ b/apps/api/src/lib/app-action-service.ts
@@ -60,6 +60,7 @@ import type {
   AppRunPreparedInputPayload,
 } from './app-run-prepared-input.js';
 import type { AppRunSafeView } from './app-run-repository.js';
+import type { AppRunReceiptReader, AppRunVerifiedReceiptView } from './app-run-receipts.js';
 import { isMcpToolEnabled } from './mcp-tool-identity.js';
 import { readModuleRecordScalarFields } from './module-service.js';
 import { resourceAuthorizationService } from './resource-provider-adapters.js';
@@ -283,6 +284,24 @@ export interface AppActionRunReadPort {
   }>>;
 }
 
+export type AppActionReceiptBundle = Readonly<{
+  run: Readonly<{
+    id: string;
+    state: AppRunSafeView['state'];
+    operation_name: string;
+    safe_preview: AppRunSafeView['safe_preview'];
+    safe_outcome: AppRunSafeView['safe_outcome'];
+    risk_class: AppRunSafeView['risk_class'];
+    review_requirement: AppRunSafeView['review_requirement'];
+    review_scope: AppRunSafeView['review_scope'];
+    retry_class: AppRunSafeView['retry_class'];
+    retention_class: AppRunSafeView['retention_class'];
+    result_expires_at: string;
+    result_purged_at: string | null;
+  }>;
+  receipts: readonly AppRunVerifiedReceiptView[];
+}>;
+
 export interface AppActionFieldReaderPort {
   read(
     actor: ModuleActor,
@@ -342,6 +361,13 @@ const lazyRunReads: AppActionRunReadPort = Object.freeze({
   ) {
     const { getAppRunRuntime } = await import('./app-run-runtime.js');
     return (await getAppRunRuntime()).service.result(orgId, runId, actor);
+  },
+});
+
+const lazyReceiptReads: AppRunReceiptReader = Object.freeze({
+  async readVerified(orgId: string, runId: string) {
+    const { getAppRunRuntime } = await import('./app-run-runtime.js');
+    return (await getAppRunRuntime()).receiptReader.readVerified(orgId, runId);
   },
 });
 
@@ -866,6 +892,7 @@ export class AppActionService {
     private readonly fieldReader: AppActionFieldReaderPort = defaultFieldReader,
     private readonly runs: AppActionRunPort = lazyRuns,
     private readonly runReads: AppActionRunReadPort = lazyRunReads,
+    private readonly receiptReads: AppRunReceiptReader = lazyReceiptReads,
   ) {}
 
   async list(callerValue: AppActionCaller, input: Readonly<{ resource_ref: unknown }>): Promise<AppActionListResult> {
@@ -1147,6 +1174,30 @@ export class AppActionService {
     const caller = callerContext(callerValue);
     await this.#assertRunReadAuthority(caller);
     return this.runReads.result(caller.actor.org_id, runId, caller.authenticated_subject);
+  }
+
+  async inspectReceipts(callerValue: AppActionCaller, runId: string): Promise<AppActionReceiptBundle> {
+    const caller = callerContext(callerValue);
+    await this.#assertRunReadAuthority(caller);
+    const run = await this.runReads.inspect(caller.actor.org_id, runId, caller.authenticated_subject);
+    const receipts = await this.receiptReads.readVerified(caller.actor.org_id, runId);
+    return Object.freeze({
+      run: Object.freeze({
+        id: run.id,
+        state: run.state,
+        operation_name: run.operation_name,
+        safe_preview: run.safe_preview,
+        safe_outcome: run.safe_outcome,
+        risk_class: run.risk_class,
+        review_requirement: run.review_requirement,
+        review_scope: run.review_scope,
+        retry_class: run.retry_class,
+        retention_class: run.retention_class,
+        result_expires_at: run.result_expires_at.toISOString(),
+        result_purged_at: run.result_purged_at?.toISOString() ?? null,
+      }),
+      receipts: Object.freeze([...receipts]),
+    });
   }
 
   async #assertRunReadAuthority(caller: CallerContext): Promise<void> {

--- a/apps/api/src/lib/app-review-service.ts
+++ b/apps/api/src/lib/app-review-service.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto';
-import { and, desc, eq, sql } from 'drizzle-orm';
+import { and, desc, eq, inArray, sql } from 'drizzle-orm';
 import {
   appActionBindings,
   appDependencyLocks,
@@ -17,6 +17,8 @@ import {
 } from '@deft/db/schema';
 import {
   canonicalAppPrivateInterfaceIdentity,
+  DEFT_APP_DEVELOPER_COMPATIBILITY,
+  projectDeftAppRequestedAuthority,
   type DeftAppManifestV1,
   type DeftAppPackageV1,
   type DeftAppPrivateInterfaceDescriptorV1,
@@ -60,7 +62,6 @@ import {
 } from './module-service.js';
 import { getIO } from '../socket.js';
 import { compareAppSemver } from './app-service.js';
-import { safeRunSelection } from './app-run-repository.js';
 
 type ReviewExecutor = Pick<typeof db, 'select' | 'insert' | 'update' | 'execute'>;
 type Installation = typeof appInstallations.$inferSelect;
@@ -70,6 +71,42 @@ type Connection = typeof mcpConnections.$inferSelect;
 
 const REVIEW_VERSION = 'deft.app_grant_review.v1' as const;
 const DEPENDENCY_LOCK_VERSION = 'deft.app_dependency_lock.v1' as const;
+
+type ConnectedReviewTargetVersionCandidate = Pick<
+  Version,
+  'id' | 'version' | 'protocol_version' | 'state' | 'created_at'
+>;
+
+function selectConnectedReviewTargetVersion<TVersion extends ConnectedReviewTargetVersionCandidate>(
+  installation: Pick<Installation, 'state' | 'active_version_id'>,
+  versions: readonly TVersion[],
+): TVersion | null {
+  const activeVersion = installation.active_version_id
+    ? versions.find((version) => version.id === installation.active_version_id) ?? null
+    : null;
+  const stagedVersion = versions
+    .filter((version) => (
+      version.protocol_version === '1'
+      && version.state === 'staged'
+      && (!activeVersion || compareAppSemver(activeVersion.version, version.version) < 0)
+    ))
+    .sort((left, right) => (
+      compareAppSemver(right.version, left.version)
+      || right.created_at.getTime() - left.created_at.getTime()
+      || right.id.localeCompare(left.id)
+    ))[0] ?? null;
+  return stagedVersion
+    ?? (installation.state === 'disabled' && activeVersion?.protocol_version === '1' ? activeVersion : null);
+}
+
+function connectedReviewActivationKind(
+  installation: Pick<Installation, 'active_version_id'>,
+  target: Pick<Version, 'id'> | null,
+): 'initial' | 'upgrade' | 'reenable' | null {
+  if (!target) return null;
+  if (!installation.active_version_id) return 'initial';
+  return target.id !== installation.active_version_id ? 'upgrade' : 'reenable';
+}
 
 export type AppConnectorSelection = Readonly<{
   connector_requirement_key: string;
@@ -351,16 +388,31 @@ async function loadReviewContext(
   if (!['staged', 'active', 'disabled'].includes(installation.state)) {
     throw new AppError('App cannot be reviewed in its current state', 'APP_STATE_CONFLICT', 409);
   }
+  const versionCandidates = await executor.select({
+    id: appVersions.id,
+    version: appVersions.version,
+    protocol_version: appVersions.protocol_version,
+    state: appVersions.state,
+    created_at: appVersions.created_at,
+  }).from(appVersions).where(and(
+    eq(appVersions.org_id, actor.org_id),
+    eq(appVersions.installation_id, installation.id),
+  ));
+  const target = selectConnectedReviewTargetVersion(installation, versionCandidates);
+  if (!target || target.id !== request.app_version_id) {
+    throw appError('The server-selected App review target changed', 'APP_STALE');
+  }
   const [version] = await executor.select().from(appVersions).where(and(
     eq(appVersions.org_id, actor.org_id),
     eq(appVersions.installation_id, installation.id),
-    eq(appVersions.id, request.app_version_id),
+    eq(appVersions.id, target.id),
     eq(appVersions.package_digest, request.expected_package_digest),
   )).limit(1);
+  if (!version) throw appError('The server-selected App review target changed', 'APP_STALE');
   const isReactivation = installation.state === 'disabled'
-    && installation.active_version_id === version?.id
-    && version?.state === 'active';
-  if (!version || (version.state !== 'staged' && !isReactivation)) {
+    && installation.active_version_id === version.id
+    && version.state === 'active';
+  if (version.state !== 'staged' && !isReactivation) {
     throw appError('The staged App version changed before review', 'APP_STALE');
   }
   if (installation.active_version_id && installation.active_version_id !== version.id) {
@@ -863,6 +915,7 @@ export async function prepareConnectedAppReview(
   capability: AppReviewCapabilityPort = capabilityService,
 ): Promise<ConnectedAppReview> {
   assertHumanManager(actorValue);
+  await assertCurrentModuleManagerWithExecutor(db, actorValue);
   const context = await loadReviewContext(db, actorValue, installationId, request);
   const evidence = await discoverProviderEvidence(actorValue, context, capability);
   return buildReview(
@@ -1024,6 +1077,7 @@ export async function activateConnectedAppInstallation(
   testHooks?: { failBeforePointerSwap?: boolean },
 ): Promise<ConnectedAppReview> {
   assertHumanManager(actorValue);
+  await assertCurrentModuleManagerWithExecutor(db, actorValue);
   const before = await loadReviewContext(db, actorValue, installationId, request);
   const discovered = await discoverProviderEvidence(actorValue, before, capability);
   const postCommit: ModuleLifecyclePostCommit[] = [];
@@ -1242,6 +1296,7 @@ export async function getConnectedAppGrantManagement(
   installationId: string,
 ) {
   assertHumanManager(actorValue);
+  await assertCurrentModuleManagerWithExecutor(db, actorValue);
   const [installation] = await db.select().from(appInstallations).where(and(
     eq(appInstallations.org_id, actorValue.org_id),
     eq(appInstallations.id, installationId),
@@ -1252,12 +1307,16 @@ export async function getConnectedAppGrantManagement(
     version: appVersions.version,
     protocol_version: appVersions.protocol_version,
     state: appVersions.state,
+    manifest: appVersions.manifest,
+    package_format: sql<string>`${appVersions.package} ->> 'package_format'`,
+    provenance: appVersions.provenance,
     package_digest: appVersions.package_digest,
     manifest_digest: appVersions.manifest_digest,
     requested_grant_snapshot_id: appVersions.requested_grant_snapshot_id,
     staged_at: appVersions.staged_at,
     activated_at: appVersions.activated_at,
     superseded_at: appVersions.superseded_at,
+    created_at: appVersions.created_at,
   }).from(appVersions).where(and(
     eq(appVersions.org_id, actorValue.org_id),
     eq(appVersions.installation_id, installation.id),
@@ -1266,14 +1325,25 @@ export async function getConnectedAppGrantManagement(
     eq(appGrantSnapshots.org_id, actorValue.org_id),
     eq(appGrantSnapshots.app_installation_id, installation.id),
   )).orderBy(desc(appGrantSnapshots.created_at), desc(appGrantSnapshots.id));
-  const effectiveIds = snapshots
-    .filter((snapshot) => snapshot.snapshot_kind === 'effective')
-    .map((snapshot) => snapshot.id);
-  const dependencies = effectiveIds.length === 0
+  const reviewTargetVersion = selectConnectedReviewTargetVersion(installation, versions);
+  const activationKind = connectedReviewActivationKind(installation, reviewTargetVersion);
+  const requestedSnapshot = reviewTargetVersion?.requested_grant_snapshot_id
+    ? snapshots.find((snapshot) => (
+        snapshot.id === reviewTargetVersion.requested_grant_snapshot_id
+        && snapshot.snapshot_kind === 'requested'
+      )) ?? null
+    : null;
+  const requestedAuthority = reviewTargetVersion?.protocol_version === '1' && requestedSnapshot
+    ? projectDeftAppRequestedAuthority(reviewTargetVersion.manifest as DeftAppManifestV1)
+    : null;
+
+  const effective = await latestEffectiveSnapshot(db, installation);
+  const dependencies = !effective
     ? []
     : (await db.select().from(appDependencyLocks).where(and(
         eq(appDependencyLocks.org_id, actorValue.org_id),
         eq(appDependencyLocks.app_installation_id, installation.id),
+        eq(appDependencyLocks.grant_snapshot_id, effective.id),
       ))).map((lock) => ({
         id: lock.id,
         grant_snapshot_id: lock.grant_snapshot_id,
@@ -1286,11 +1356,12 @@ export async function getConnectedAppGrantManagement(
         ownership: lock.ownership,
         lock_digest: lock.lock_digest,
       }));
-  const bindings = effectiveIds.length === 0
+  const bindings = !effective
     ? []
     : (await db.select().from(appActionBindings).where(and(
         eq(appActionBindings.org_id, actorValue.org_id),
         eq(appActionBindings.app_installation_id, installation.id),
+        eq(appActionBindings.grant_snapshot_id, effective.id),
       ))).map((binding) => ({
         id: binding.id,
         grant_snapshot_id: binding.grant_snapshot_id,
@@ -1300,7 +1371,6 @@ export async function getConnectedAppGrantManagement(
         interface_identity: binding.interface_identity,
         provider_kind: binding.provider_kind,
         mcp_connection_id: binding.mcp_connection_id,
-        provider_snapshot_id: binding.provider_snapshot_id,
         operation_name: binding.operation_name,
         operation_schema_digest: binding.operation_schema_digest,
         connector_authorization_version: binding.connector_authorization_version,
@@ -1316,7 +1386,141 @@ export async function getConnectedAppGrantManagement(
           provider_idempotency_key_required: binding.provider_idempotency_key_required,
         },
       }));
-  const recentRuns = await db.select(safeRunSelection).from(appRuns).where(and(
+
+  const dependencyRequirements = requestedAuthority?.requirements.dependencies ?? [];
+  const dependencyInstallations = dependencyRequirements.length === 0
+    ? []
+    : await db.select().from(appInstallations).where(and(
+        eq(appInstallations.org_id, actorValue.org_id),
+        inArray(appInstallations.app_id, dependencyRequirements.map((item) => item.app_id)),
+      ));
+  const dependencyVersionIds = dependencyInstallations.flatMap(
+    (candidate) => candidate.active_version_id ? [candidate.active_version_id] : [],
+  );
+  const dependencyVersions = dependencyVersionIds.length === 0
+    ? []
+    : await db.select().from(appVersions).where(and(
+        eq(appVersions.org_id, actorValue.org_id),
+        inArray(appVersions.id, dependencyVersionIds),
+      ));
+  const projectedDependencies = dependencyRequirements.map((requirement) => {
+    const candidate = dependencyInstallations.find((item) => item.app_id === requirement.app_id) ?? null;
+    const version = candidate?.active_version_id
+      ? dependencyVersions.find((item) => item.id === candidate.active_version_id) ?? null
+      : null;
+    const status = !candidate || !version
+      ? 'missing' as const
+      : candidate.state !== 'active'
+        ? 'disabled' as const
+        : version.version !== requirement.version
+          ? 'version_mismatch' as const
+          : 'ready' as const;
+    return {
+      ...requirement,
+      status,
+      installation_id: candidate?.id ?? null,
+      active_version: version?.version ?? null,
+      lifecycle_epoch: candidate?.lifecycle_epoch ?? null,
+    };
+  });
+
+  const connectorRequirements = requestedAuthority?.requirements.connectors ?? [];
+  const connections = connectorRequirements.length === 0
+    ? []
+    : await db.select({
+        id: mcpConnections.id,
+        name: mcpConnections.name,
+        slug: mcpConnections.slug,
+        is_active: mcpConnections.is_active,
+        connection_error: mcpConnections.connection_error,
+        enabled_tools: mcpConnections.enabled_tools,
+        app_run_authorization_version: mcpConnections.app_run_authorization_version,
+      }).from(mcpConnections).where(eq(mcpConnections.org_id, actorValue.org_id));
+  const connectionIds = connections.map((connection) => connection.id);
+  const overrides = connectionIds.length === 0
+    ? []
+    : await db.select({
+        mcp_connection_id: mcpToolOverrides.mcp_connection_id,
+        tool_name: mcpToolOverrides.tool_name,
+        is_disabled: mcpToolOverrides.is_disabled,
+      }).from(mcpToolOverrides).where(and(
+        eq(mcpToolOverrides.org_id, actorValue.org_id),
+        inArray(mcpToolOverrides.mcp_connection_id, connectionIds),
+      ));
+  const manifest = reviewTargetVersion?.protocol_version === '1'
+    ? reviewTargetVersion.manifest as DeftAppManifestV1
+    : null;
+  const capabilityByKey = new Map(
+    (manifest?.capability_requirements ?? []).map((requirement) => [requirement.key, requirement]),
+  );
+  const projectedConnectors = connectorRequirements.map((requirement) => {
+    const requiredOperations = [...new Set((manifest?.actions ?? [])
+      .filter((action) => action.connector_requirement_key === requirement.key)
+      .flatMap((action) => {
+        const capability = capabilityByKey.get(action.capability_requirement_key);
+        const privateInterface = getConnectedAppPrivateInterface(capability?.interface);
+        return privateInterface ? [privateInterface.operation_name] : [];
+      }))].sort();
+    const candidates = connections.map((connection) => {
+      const disabledOperations = new Set(overrides
+        .filter((override) => override.mcp_connection_id === connection.id && override.is_disabled)
+        .map((override) => override.tool_name));
+      const eligible = connection.is_active
+        && !connection.connection_error
+        && requiredOperations.every((operation) => (
+          isMcpToolEnabled(connection.enabled_tools, connection.slug, operation)
+          && !disabledOperations.has(operation)
+        ));
+      return {
+        id: connection.id,
+        name: connection.name,
+        status: !connection.is_active
+          ? 'inactive' as const
+          : connection.connection_error
+            ? 'unhealthy' as const
+            : eligible
+              ? 'configured' as const
+              : 'operation_disabled' as const,
+        eligible_for_review: eligible,
+        authorization_version: connection.app_run_authorization_version,
+        provider_schema_check: 'pending_review' as const,
+      };
+    }).sort((left, right) => left.name.localeCompare(right.name) || left.id.localeCompare(right.id));
+    const current = bindings.find((binding) => binding.connector_requirement_key === requirement.key) ?? null;
+    const currentConnection = current
+      ? candidates.find((candidate) => candidate.id === current.mcp_connection_id) ?? null
+      : null;
+    return {
+      ...requirement,
+      required_operations: requiredOperations,
+      current_binding: current && currentConnection ? {
+        mcp_connection_id: current.mcp_connection_id,
+        name: currentConnection.name,
+        binding_digest: current.binding_digest,
+        authorization_version: current.connector_authorization_version,
+        configured: currentConnection.eligible_for_review,
+      } : null,
+      candidates,
+    };
+  });
+  const missingBindingKeys = projectedConnectors
+    .filter((requirement) => !requirement.current_binding?.configured)
+    .map((requirement) => requirement.key);
+
+  const recentRuns = await db.select({
+    id: appRuns.id,
+    state: appRuns.state,
+    operation_name: appRuns.operation_name,
+    risk_class: appRuns.risk_class,
+    review_requirement: appRuns.review_requirement,
+    safe_preview: appRuns.safe_preview,
+    safe_outcome: appRuns.safe_outcome,
+    result_expires_at: appRuns.result_expires_at,
+    result_purged_at: appRuns.result_purged_at,
+    terminal_at: appRuns.terminal_at,
+    created_at: appRuns.created_at,
+    updated_at: appRuns.updated_at,
+  }).from(appRuns).where(and(
     eq(appRuns.org_id, actorValue.org_id),
     eq(appRuns.origin_kind, 'app'),
     eq(appRuns.origin_app_installation_id, installation.id),
@@ -1331,8 +1535,21 @@ export async function getConnectedAppGrantManagement(
       lifecycle_epoch: installation.lifecycle_epoch,
       grant_epoch: installation.grant_epoch,
     },
+    compatibility: DEFT_APP_DEVELOPER_COMPATIBILITY,
     versions: versions.map((version) => ({
-      ...version,
+      id: version.id,
+      version: version.version,
+      protocol_version: version.protocol_version,
+      state: version.state,
+      manifest: version.manifest,
+      package_format: typeof version.package_format === 'string'
+        ? version.package_format
+        : null,
+      provenance: version.provenance,
+      provenance_trust: 'local_unsigned' as const,
+      package_digest: version.package_digest,
+      manifest_digest: version.manifest_digest,
+      requested_grant_snapshot_id: version.requested_grant_snapshot_id,
       staged_at: version.staged_at.toISOString(),
       activated_at: version.activated_at?.toISOString() ?? null,
       superseded_at: version.superseded_at?.toISOString() ?? null,
@@ -1346,14 +1563,45 @@ export async function getConnectedAppGrantManagement(
       resource_rights: snapshot.resource_rights,
       classification: snapshot.classification,
       snapshot_digest: snapshot.snapshot_digest,
-      reviewed_by_actor_type: snapshot.reviewed_by_actor_type,
-      reviewed_by_actor_id: snapshot.reviewed_by_actor_id,
       reviewed_at: snapshot.reviewed_at?.toISOString() ?? null,
       created_at: snapshot.created_at.toISOString(),
     })),
+    review_target: reviewTargetVersion && requestedSnapshot && requestedAuthority && activationKind ? {
+      activation_kind: activationKind,
+      app_version_id: reviewTargetVersion.id,
+      version: reviewTargetVersion.version,
+      protocol_version: '1' as const,
+      package_format: typeof reviewTargetVersion.package_format === 'string'
+        ? reviewTargetVersion.package_format
+        : null,
+      package_digest: reviewTargetVersion.package_digest,
+      manifest_digest: reviewTargetVersion.manifest_digest,
+      manifest: reviewTargetVersion.manifest,
+      provenance: reviewTargetVersion.provenance,
+      provenance_trust: 'local_unsigned' as const,
+      requested_snapshot_id: requestedSnapshot.id,
+      requested_snapshot_digest: requestedSnapshot.snapshot_digest,
+      requested_authority: requestedAuthority,
+      dependency_requirements: projectedDependencies,
+      connector_requirements: projectedConnectors,
+      missing_binding_keys: missingBindingKeys,
+      readiness: {
+        dependencies_ready: projectedDependencies.every((requirement) => requirement.status === 'ready'),
+        connector_candidates_ready: projectedConnectors.every(
+          (requirement) => requirement.candidates.some((candidate) => candidate.eligible_for_review),
+        ),
+      },
+    } : null,
     dependencies,
     action_bindings: bindings,
-    recent_runs: recentRuns,
+    recent_runs: recentRuns.map((run) => ({
+      ...run,
+      result_expires_at: run.result_expires_at.toISOString(),
+      result_purged_at: run.result_purged_at?.toISOString() ?? null,
+      terminal_at: run.terminal_at?.toISOString() ?? null,
+      created_at: run.created_at.toISOString(),
+      updated_at: run.updated_at.toISOString(),
+    })),
   };
 }
 
@@ -1374,6 +1622,7 @@ export async function inspectConnectedAppHealth(
   capability: AppReviewCapabilityPort = capabilityService,
 ): Promise<ConnectedAppHealth> {
   assertHumanManager(actorValue);
+  await assertCurrentModuleManagerWithExecutor(db, actorValue);
   const [installation] = await db.select().from(appInstallations).where(and(
     eq(appInstallations.org_id, actorValue.org_id),
     eq(appInstallations.id, installationId),

--- a/apps/api/src/lib/app-run-receipts.ts
+++ b/apps/api/src/lib/app-run-receipts.ts
@@ -8,7 +8,7 @@ import {
   type AppRunReceiptKind,
   type AppRunSafeMetadata,
 } from '@deft/shared';
-import { and, eq } from 'drizzle-orm';
+import { and, asc, eq } from 'drizzle-orm';
 import { AppRunError } from './app-run-errors.js';
 import { db } from './db.js';
 import type { AppRunSafeView, AppRunTransaction } from './app-run-repository.js';
@@ -27,6 +27,27 @@ export type AppRunReceiptWrite = Readonly<{
 
 export interface AppRunReceiptWriter {
   write(tx: AppRunTransaction, input: AppRunReceiptWrite): Promise<void>;
+}
+
+export type AppRunVerifiedReceiptView = Readonly<{
+  receipt_id: string;
+  receipt_kind: AppRunReceiptKind;
+  run_state: AppRunSafeView['state'];
+  occurred_at: string;
+  envelope_digest: string;
+  signing_key_version: string;
+  signed_at: string;
+  verified: true;
+}>;
+
+export interface AppRunReceiptReader {
+  readVerified(orgId: string, runId: string): Promise<readonly AppRunVerifiedReceiptView[]>;
+}
+
+export type AppRunStoredReceiptRow = typeof appRunReceipts.$inferSelect;
+
+export interface AppRunReceiptRowSource {
+  list(orgId: string, runId: string): Promise<readonly AppRunStoredReceiptRow[]>;
 }
 
 export const noOpAppRunReceiptWriter: AppRunReceiptWriter = Object.freeze({
@@ -48,6 +69,67 @@ function receiptId(orgId: string, runId: string, receiptKey: string): string {
     .update('\0')
     .update(receiptKey)
     .digest('hex')}`;
+}
+
+function verifiedReceiptView(
+  row: AppRunStoredReceiptRow,
+  expectedOrgId: string,
+  expectedRunId: string,
+  secrets: AppRunSecretService,
+): AppRunVerifiedReceiptView {
+  let envelope: ReturnType<typeof parseAppRunReceiptEnvelope>;
+  try {
+    envelope = parseAppRunReceiptEnvelope(row.envelope);
+  } catch {
+    throw new AppRunError('APP_RUN_REPAIR_REQUIRED');
+  }
+  const expectedReceiptId = receiptId(expectedOrgId, expectedRunId, row.receipt_key);
+  if (
+    row.org_id !== expectedOrgId
+    || row.run_id !== expectedRunId
+    || row.receipt_version !== APP_RUN_CONTRACT_VERSIONS.receipt
+    || row.id !== expectedReceiptId
+    || envelope.receipt_id !== row.id
+    || envelope.receipt_kind !== row.receipt_kind
+    || envelope.org_id !== expectedOrgId
+    || envelope.run_id !== expectedRunId
+    || (envelope.attempt_id ?? null) !== row.attempt_id
+    || envelope.occurred_at !== row.signed_at.toISOString()
+    || row.envelope_digest !== sha256(envelope)
+    || !secrets.verifyReceipt(envelope, row.signing_key_version, row.signature_hmac)
+  ) throw new AppRunError('APP_RUN_REPAIR_REQUIRED');
+
+  return Object.freeze({
+    receipt_id: row.id,
+    receipt_kind: envelope.receipt_kind,
+    run_state: envelope.run_state,
+    occurred_at: envelope.occurred_at,
+    envelope_digest: row.envelope_digest,
+    signing_key_version: row.signing_key_version,
+    signed_at: row.signed_at.toISOString(),
+    verified: true as const,
+  });
+}
+
+const postgresAppRunReceiptRows: AppRunReceiptRowSource = Object.freeze({
+  async list(orgId: string, runId: string) {
+    return db.select().from(appRunReceipts).where(and(
+      eq(appRunReceipts.org_id, orgId),
+      eq(appRunReceipts.run_id, runId),
+    )).orderBy(asc(appRunReceipts.signed_at), asc(appRunReceipts.id));
+  },
+});
+
+export class PostgresAppRunReceiptReader implements AppRunReceiptReader {
+  constructor(
+    private readonly secrets: AppRunSecretService,
+    private readonly rows: AppRunReceiptRowSource = postgresAppRunReceiptRows,
+  ) {}
+
+  async readVerified(orgId: string, runId: string): Promise<readonly AppRunVerifiedReceiptView[]> {
+    const rows = await this.rows.list(orgId, runId);
+    return Object.freeze(rows.map((row) => verifiedReceiptView(row, orgId, runId, this.secrets)));
+  }
 }
 
 export class PostgresAppRunReceiptWriter implements AppRunReceiptWriter {
@@ -156,14 +238,12 @@ export class PostgresAppRunReceiptWriter implements AppRunReceiptWriter {
       eq(appRunReceipts.run_id, runId),
       eq(appRunReceipts.receipt_key, receiptKey),
     )).limit(1);
-    return Boolean(
-      receipt
-      && receipt.envelope_digest === sha256(receipt.envelope)
-      && this.secrets.verifyReceipt(
-        receipt.envelope,
-        receipt.signing_key_version,
-        receipt.signature_hmac,
-      ),
-    );
+    if (!receipt) return false;
+    try {
+      verifiedReceiptView(receipt, orgId, runId, this.secrets);
+      return true;
+    } catch {
+      return false;
+    }
   }
 }

--- a/apps/api/src/lib/app-run-runtime.ts
+++ b/apps/api/src/lib/app-run-runtime.ts
@@ -7,7 +7,7 @@ import { parseEnvironmentAppRunKeyrings, type EnvironmentAppRunKeyProvider } fro
 import { PostgresAppRunLiveAuthorization } from './app-run-live-authorization.js';
 import { AppRunOperationsService } from './app-run-operations.js';
 import { PinnedMcpAppRunProviderExecutor } from './app-run-provider-executor.js';
-import { PostgresAppRunReceiptWriter } from './app-run-receipts.js';
+import { PostgresAppRunReceiptReader, PostgresAppRunReceiptWriter } from './app-run-receipts.js';
 import { PostgresAppRunRepository } from './app-run-repository.js';
 import { postgresAppRunAttemptQueue } from './app-run-scheduler.js';
 import { AppRunSecretRepository } from './app-run-secret-repository.js';
@@ -25,6 +25,7 @@ export type AppRunRuntime = Readonly<{
   service: AppRunService;
   attemptRunner: AppRunAttemptRunner;
   approvalResolver: PostgresAppRunApprovalResolver;
+  receiptReader: PostgresAppRunReceiptReader;
   operations: AppRunOperationsService;
 }>;
 
@@ -39,6 +40,7 @@ async function createAppRunRuntime(): Promise<AppRunRuntime> {
   const liveAuthorization = new PostgresAppRunLiveAuthorization();
   const accessAuthorization = new PostgresAppRunAuthorizer();
   const receipts = new PostgresAppRunReceiptWriter(secrets, secretRepository);
+  const receiptReader = new PostgresAppRunReceiptReader(secrets);
   const attention = new PostgresAppRunAttentionProjector();
   const clock = () => new Date();
   const attemptRunner = new AppRunAttemptRunner(
@@ -101,6 +103,7 @@ async function createAppRunRuntime(): Promise<AppRunRuntime> {
     service,
     attemptRunner,
     approvalResolver,
+    receiptReader,
     operations,
   });
 }

--- a/apps/api/src/routes/app-runs.ts
+++ b/apps/api/src/routes/app-runs.ts
@@ -30,6 +30,15 @@ appRunRoutes.get('/:runId/result', async (c) => {
   }
 });
 
+appRunRoutes.get('/:runId/receipts', async (c) => {
+  try {
+    const runId = RunIdSchema.parse(c.req.param('runId'));
+    return c.json(await appActionService.inspectReceipts(callerFromContext(c), runId));
+  } catch (error) {
+    return appHttpFailure(c, error, 'App Run', 'app-runs');
+  }
+});
+
 appRunRoutes.get('/:runId', async (c) => {
   try {
     const runId = RunIdSchema.parse(c.req.param('runId'));

--- a/apps/api/test/app-action-routes.test.ts
+++ b/apps/api/test/app-action-routes.test.ts
@@ -147,7 +147,11 @@ test('JWT App action routes are strict human:ui adapters over AppActionService',
 
 test('JWT App Run routes delegate actor-scoped reads and map safe Run errors', async (t) => {
   const service = appActionService as any;
-  const original = { inspectRun: service.inspectRun, result: service.result };
+  const original = {
+    inspectRun: service.inspectRun,
+    result: service.result,
+    inspectReceipts: service.inspectReceipts,
+  };
   t.after(() => Object.assign(service, original));
 
   const calls: Array<{ operation: string; caller: any; runId: string }> = [];
@@ -159,6 +163,13 @@ test('JWT App Run routes delegate actor-scoped reads and map safe Run errors', a
     calls.push({ operation: 'result', caller, runId });
     return { run: { id: runId, state: 'succeeded' }, value: { status: 'accepted' } };
   };
+  service.inspectReceipts = async (caller: any, runId: string) => {
+    calls.push({ operation: 'receipts', caller, runId });
+    return {
+      run: { id: runId, state: 'succeeded', operation_name: 'send_email' },
+      receipts: [{ receipt_id: 'receipt-1', verified: true }],
+    };
+  };
 
   const app = testApp();
   const inspected = await app.request('/api/app-runs/run-1');
@@ -167,9 +178,13 @@ test('JWT App Run routes delegate actor-scoped reads and map safe Run errors', a
   const result = await app.request('/api/app-runs/run-1/result');
   assert.equal(result.status, 200);
   assert.deepEqual((await result.json() as any).value, { status: 'accepted' });
+  const receipts = await app.request('/api/app-runs/run-1/receipts');
+  assert.equal(receipts.status, 200);
+  assert.deepEqual((await receipts.json() as any).receipts, [{ receipt_id: 'receipt-1', verified: true }]);
   assert.deepEqual(calls.map((call) => [call.operation, call.runId]), [
     ['inspect', 'run-1'],
     ['result', 'run-1'],
+    ['receipts', 'run-1'],
   ]);
   assert.ok(calls.every((call) => call.caller.actor.source === 'ui'));
 
@@ -179,6 +194,14 @@ test('JWT App Run routes delegate actor-scoped reads and map safe Run errors', a
   assert.deepEqual(await expired.json(), {
     error: 'The exact App Run result is no longer retained',
     code: 'APP_RUN_RESULT_EXPIRED',
+  });
+
+  service.inspectReceipts = async () => { throw new AppRunError('APP_RUN_REPAIR_REQUIRED'); };
+  const invalidReceipt = await app.request('/api/app-runs/run-1/receipts');
+  assert.equal(invalidReceipt.status, 409);
+  assert.deepEqual(await invalidReceipt.json(), {
+    error: 'The App Run requires local repair',
+    code: 'APP_RUN_REPAIR_REQUIRED',
   });
 
   const invalid = await app.request(`/api/app-runs/${'x'.repeat(513)}`);

--- a/apps/api/test/app-run-receipt-inspection.test.ts
+++ b/apps/api/test/app-run-receipt-inspection.test.ts
@@ -1,0 +1,293 @@
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import test, { after } from 'node:test';
+
+import { APP_RUN_CONTRACT_VERSIONS, canonicalCapabilityJson } from '@deft/shared';
+
+import {
+  AppActionService,
+  type AppActionRunReadPort,
+} from '../src/lib/app-action-service.js';
+import { closeDb } from '../src/lib/db.js';
+import { AppRunError } from '../src/lib/app-run-errors.js';
+import { parseEnvironmentAppRunKeyrings } from '../src/lib/app-run-keyrings.js';
+import {
+  PostgresAppRunReceiptReader,
+  type AppRunReceiptReader,
+  type AppRunStoredReceiptRow,
+} from '../src/lib/app-run-receipts.js';
+import { AppRunSecretService } from '../src/lib/app-run-secrets.js';
+import { humanModuleActor } from '../src/lib/module-service.js';
+
+after(async () => closeDb());
+
+const ORG_ID = 'receipt-inspection-org';
+const RUN_ID = 'receipt-inspection-run';
+const RECEIPT_KEY = 'approval:action-1';
+const OCCURRED_AT = '2026-09-01T12:00:00.000Z';
+
+function key(byte: number): string {
+  return Buffer.alloc(32, byte).toString('base64');
+}
+
+function keyringConfig(): string {
+  return JSON.stringify({
+    schema_version: APP_RUN_CONTRACT_VERSIONS.keyring,
+    run_encryption: { current: 'enc-v1', keys: { 'enc-v1': key(1) } },
+    receipt_signing: { current: 'sig-v1', keys: { 'sig-v1': key(2) } },
+    fingerprint: { current: 'fp-v1', keys: { 'fp-v1': key(3) } },
+  });
+}
+
+function receiptId(orgId = ORG_ID, runId = RUN_ID, receiptKey = RECEIPT_KEY): string {
+  return `app-run-receipt:${createHash('sha256')
+    .update('deft.app_run_receipt_id.v1\0')
+    .update(orgId)
+    .update('\0')
+    .update(runId)
+    .update('\0')
+    .update(receiptKey)
+    .digest('hex')}`;
+}
+
+function digest(value: unknown): string {
+  return `sha256:${createHash('sha256').update(canonicalCapabilityJson(value)).digest('hex')}`;
+}
+
+function storedReceipt(
+  secrets: AppRunSecretService,
+  envelopeOverrides: Record<string, unknown> = {},
+): AppRunStoredReceiptRow {
+  const envelope = {
+    schema_version: APP_RUN_CONTRACT_VERSIONS.receipt,
+    receipt_id: receiptId(),
+    receipt_kind: 'approval' as const,
+    org_id: ORG_ID,
+    run_id: RUN_ID,
+    run_state: 'pending_approval' as const,
+    actor: { actor_type: 'human' as const, user_id: 'forbidden-actor-id' },
+    operation: {
+      provider: {
+        org_id: ORG_ID,
+        provider_kind: 'mcp' as const,
+        provider_instance_id: 'forbidden-provider-instance',
+      },
+      operation_name: 'send_email',
+    },
+    policy: {
+      risk_class: 'external_write' as const,
+      review_requirement: 'always' as const,
+      review_scope: 'per_invocation' as const,
+      retry_class: 'idempotent_with_key' as const,
+    },
+    input_fingerprint: {
+      key_version: 'fp-v1',
+      fingerprint: `hmac-sha256:${'1'.repeat(64)}`,
+    },
+    output_envelope_digest: `sha256:${'2'.repeat(64)}`,
+    facts: { private_marker: 'forbidden-fact' },
+    occurred_at: OCCURRED_AT,
+    ...envelopeOverrides,
+  };
+  const signature = secrets.signReceipt(envelope);
+  return {
+    id: receiptId(),
+    org_id: ORG_ID,
+    run_id: RUN_ID,
+    attempt_id: null,
+    receipt_version: APP_RUN_CONTRACT_VERSIONS.receipt,
+    receipt_key: RECEIPT_KEY,
+    receipt_kind: 'approval',
+    envelope,
+    envelope_digest: digest(envelope),
+    signing_key_version: signature.key_version,
+    signature_hmac: signature.signature_hmac,
+    signed_at: new Date(OCCURRED_AT),
+    created_at: new Date(OCCURRED_AT),
+  };
+}
+
+test('receipt reader verifies every row and returns only the bounded safe projection', async () => {
+  const keys = parseEnvironmentAppRunKeyrings(keyringConfig());
+  const secrets = new AppRunSecretService(keys);
+  const row = storedReceipt(secrets);
+  const reader = new PostgresAppRunReceiptReader(secrets, {
+    async list(orgId, runId) {
+      assert.equal(orgId, ORG_ID);
+      assert.equal(runId, RUN_ID);
+      return [row];
+    },
+  });
+
+  const projected = await reader.readVerified(ORG_ID, RUN_ID);
+  assert.deepEqual(projected, [{
+    receipt_id: row.id,
+    receipt_kind: 'approval',
+    run_state: 'pending_approval',
+    occurred_at: OCCURRED_AT,
+    envelope_digest: row.envelope_digest,
+    signing_key_version: 'sig-v1',
+    signed_at: OCCURRED_AT,
+    verified: true,
+  }]);
+  const serialized = JSON.stringify(projected);
+  for (const forbidden of [
+    ORG_ID,
+    'forbidden-actor-id',
+    'forbidden-provider-instance',
+    'forbidden-fact',
+    row.signature_hmac,
+    'output_envelope_digest',
+    'input_fingerprint',
+  ]) assert.doesNotMatch(serialized, new RegExp(forbidden));
+
+  for (const invalid of [
+    { ...row, envelope_digest: `sha256:${'0'.repeat(64)}` },
+    { ...row, signature_hmac: `hmac-sha256:${'0'.repeat(64)}` },
+    storedReceipt(secrets, { run_id: 'different-run' }),
+  ]) {
+    const failClosed = new PostgresAppRunReceiptReader(secrets, {
+      async list() { return [row, invalid]; },
+    });
+    await assert.rejects(
+      () => failClosed.readVerified(ORG_ID, RUN_ID),
+      (error: unknown) => error instanceof AppRunError && error.code === 'APP_RUN_REPAIR_REQUIRED',
+    );
+  }
+  keys.destroy();
+});
+
+test('AppActionService authorizes through Run inspection before reading receipts and redacts the Run', async () => {
+  const order: string[] = [];
+  const forbiddenOrg = 'forbidden-org-id';
+  const forbiddenActor = 'forbidden-actor-id';
+  const forbiddenProvider = 'forbidden-provider-instance';
+  const runReads: AppActionRunReadPort = {
+    async inspect(orgId, runId, actor) {
+      order.push('inspect');
+      assert.equal(orgId, ORG_ID);
+      assert.equal(runId, RUN_ID);
+      assert.deepEqual(actor, { actor_type: 'human', user_id: 'receipt-reader-user' });
+      return {
+        id: RUN_ID,
+        org_id: forbiddenOrg,
+        contract_version: APP_RUN_CONTRACT_VERSIONS.run,
+        origin_kind: 'app',
+        initiating_actor_type: 'human',
+        initiating_actor_id: forbiddenActor,
+        execution_actor_type: 'human',
+        execution_actor_id: forbiddenActor,
+        provider_kind: 'mcp',
+        provider_instance_id: forbiddenProvider,
+        operation_name: 'send_email',
+        state: 'succeeded',
+        risk_class: 'external_write',
+        review_requirement: 'always',
+        review_scope: 'per_invocation',
+        retry_class: 'idempotent_with_key',
+        retention_class: 'standard',
+        safe_preview: { title: 'Send one sandbox message' },
+        safe_outcome: { success: true, provider_call_attempted: true, result_status: 'retained' },
+        root_run_id: RUN_ID,
+        parent_run_id: null,
+        depth: 0,
+        input_expires_at: new Date('2026-09-02T12:00:00.000Z'),
+        result_expires_at: new Date('2026-09-03T12:00:00.000Z'),
+        idempotency_expires_at: new Date('2026-09-04T12:00:00.000Z'),
+        attempt_limit: 3,
+        execution_release_kind: 'approved',
+        execution_released_at: new Date(OCCURRED_AT),
+        input_purged_at: null,
+        result_purged_at: null,
+        started_at: new Date(OCCURRED_AT),
+        terminal_at: new Date(OCCURRED_AT),
+        unknown_outcome_at: null,
+        reconciled_at: null,
+        cancelled_at: null,
+        cancel_requested_at: null,
+        created_at: new Date(OCCURRED_AT),
+        updated_at: new Date(OCCURRED_AT),
+      };
+    },
+    async result() { throw new Error('not used'); },
+  };
+  const receiptReads: AppRunReceiptReader = {
+    async readVerified(orgId, runId) {
+      order.push('receipts');
+      assert.equal(orgId, ORG_ID);
+      assert.equal(runId, RUN_ID);
+      return [{
+        receipt_id: receiptId(),
+        receipt_kind: 'approval',
+        run_state: 'pending_approval',
+        occurred_at: OCCURRED_AT,
+        envelope_digest: `sha256:${'3'.repeat(64)}`,
+        signing_key_version: 'sig-v1',
+        signed_at: OCCURRED_AT,
+        verified: true,
+      }];
+    },
+  };
+  const service = new AppActionService(
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    runReads,
+    receiptReads,
+  );
+  const caller = {
+    actor: humanModuleActor({
+      orgId: ORG_ID,
+      userId: 'receipt-reader-user',
+      role: 'member',
+      source: 'ui',
+    }),
+  };
+
+  const bundle = await service.inspectReceipts(caller, RUN_ID);
+  assert.deepEqual(order, ['inspect', 'receipts']);
+  assert.deepEqual(bundle.run, {
+    id: RUN_ID,
+    state: 'succeeded',
+    operation_name: 'send_email',
+    safe_preview: { title: 'Send one sandbox message' },
+    safe_outcome: { success: true, provider_call_attempted: true, result_status: 'retained' },
+    risk_class: 'external_write',
+    review_requirement: 'always',
+    review_scope: 'per_invocation',
+    retry_class: 'idempotent_with_key',
+    retention_class: 'standard',
+    result_expires_at: '2026-09-03T12:00:00.000Z',
+    result_purged_at: null,
+  });
+  const serialized = JSON.stringify(bundle);
+  for (const forbidden of [forbiddenOrg, forbiddenActor, forbiddenProvider]) {
+    assert.doesNotMatch(serialized, new RegExp(forbidden));
+  }
+
+  let receiptReadsAfterDenial = 0;
+  const denied = new AppActionService(
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    {
+      async inspect() { throw new AppRunError('APP_RUN_ACCESS_DENIED'); },
+      async result() { throw new Error('not used'); },
+    },
+    {
+      async readVerified() {
+        receiptReadsAfterDenial += 1;
+        return [];
+      },
+    },
+  );
+  await assert.rejects(
+    () => denied.inspectReceipts(caller, RUN_ID),
+    (error: unknown) => error instanceof AppRunError && error.code === 'APP_RUN_ACCESS_DENIED',
+  );
+  assert.equal(receiptReadsAfterDenial, 0);
+});

--- a/apps/api/test/apps-connected-grants-db.test.ts
+++ b/apps/api/test/apps-connected-grants-db.test.ts
@@ -36,6 +36,7 @@ import {
 } from '@deft/db/schema';
 import { AppError } from '../src/lib/app-errors.js';
 import { closeDb, db } from '../src/lib/db.js';
+import { ModuleError } from '../src/lib/module-errors.js';
 import {
   activateAppInstallation,
   disableAppInstallation,
@@ -768,10 +769,19 @@ test('explicit connected review activates atomically, rejects stale CAS, and re-
   ))[0]?.value, 0);
   const management = await getConnectedAppGrantManagement(actor, staged.id);
   assert.equal(management.installation.active_grant_snapshot_id, active!.active_grant_snapshot_id);
+  assert.equal(management.compatibility.app_kit.package, '@deft/app-kit');
+  assert.equal(management.compatibility.protocol_flows['1'].install_mode, 'stage_only');
+  assert.equal(management.review_target, null);
   assert.equal(management.snapshots.filter((item) => item.snapshot_kind === 'effective').length, 1);
   assert.equal(management.dependencies.length, 1);
+  assert.equal(management.dependencies[0]?.grant_snapshot_id, active!.active_grant_snapshot_id);
   assert.equal(management.action_bindings[0]?.operation_name, 'send_email');
+  assert.equal(management.action_bindings[0]?.grant_snapshot_id, active!.active_grant_snapshot_id);
   assert.deepEqual(management.recent_runs, []);
+  const managementJson = JSON.stringify(management);
+  for (const forbidden of ['server_url', 'access_token', 'refresh_token', 'reviewed_by_actor_id', 'provider_snapshot_id']) {
+    assert.equal(managementJson.includes(forbidden), false, `management projection leaked ${forbidden}`);
+  }
   const healthy = await inspectConnectedAppHealth(
     actor,
     staged.id,
@@ -815,6 +825,13 @@ test('explicit connected review activates atomically, rejects stale CAS, and re-
     enableAppInstallation(actor, staged.id, revoked!.lifecycle_epoch),
     (error: unknown) => error instanceof AppError && error.code === 'APP_REVIEW_REQUIRED',
   );
+  const disabledManagement = await getConnectedAppGrantManagement(actor, staged.id);
+  assert.equal(disabledManagement.review_target?.activation_kind, 'reenable');
+  assert.equal(disabledManagement.review_target?.app_version_id, active!.active_version_id);
+  assert.equal(disabledManagement.review_target?.readiness.dependencies_ready, true);
+  assert.equal(disabledManagement.review_target?.connector_requirements[0]?.current_binding?.configured, true);
+  assert.equal(disabledManagement.installation.lifecycle_epoch, revoked!.lifecycle_epoch);
+  assert.equal(disabledManagement.installation.grant_epoch, revoked!.grant_epoch);
 
   const reactivationRequest = {
     ...restoredRequest,
@@ -908,6 +925,14 @@ test('explicit connected review activates atomically, rejects stale CAS, and re-
     eq(orgMembers.user_id, OTHER_USER_ID),
   ));
   try {
+    await assert.rejects(
+      getConnectedAppGrantManagement(actor, staged.id),
+      (error: unknown) => error instanceof ModuleError && error.code === 'MODULE_ACCESS_DENIED',
+    );
+    await assert.rejects(
+      inspectConnectedAppHealth(actor, staged.id, { refresh_provider_schemas: false }),
+      (error: unknown) => error instanceof ModuleError && error.code === 'MODULE_ACCESS_DENIED',
+    );
     const accessResponse = await routeApp.request(`/api/apps/${dependency.id}/uninstall`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
@@ -1035,7 +1060,25 @@ test('reviewed v0-to-v1 upgrade atomically preserves App pointers, Module data, 
   assert.equal(relationBeforeUpgrade.revision, 1);
   assert.equal(relationBeforeUpgrade.target_resource_id, contact.record!.id);
 
-  const upgradeBuilt = await buildPhase5ConnectedAppPackage();
+  const olderUpgradeBuilt = await buildPhase5ConnectedAppPackage();
+  const olderUpgrade = await stageAppUpgrade(
+    actor,
+    predecessor.id,
+    olderUpgradeBuilt.json,
+    predecessor.lifecycle_epoch,
+  );
+  const [olderUpgradeVersion] = await db.select().from(appVersions).where(and(
+    eq(appVersions.org_id, orgId),
+    eq(appVersions.id, olderUpgrade.version_id),
+  ));
+  const [olderUpgradeRequest] = await db.select().from(appGrantSnapshots).where(and(
+    eq(appGrantSnapshots.org_id, orgId),
+    eq(appGrantSnapshots.id, olderUpgradeVersion!.requested_grant_snapshot_id!),
+  ));
+  assert.ok(olderUpgradeVersion);
+  assert.ok(olderUpgradeRequest);
+
+  const upgradeBuilt = await buildPhase5ConnectedAppPackage({ app_version: '3.0.1' });
   const upgrade = await stageAppUpgrade(
     actor,
     predecessor.id,
@@ -1052,6 +1095,15 @@ test('reviewed v0-to-v1 upgrade atomically preserves App pointers, Module data, 
   ));
   assert.ok(upgradeVersion);
   assert.ok(upgradeRequest);
+  const stagedUpgradeManagement = await getConnectedAppGrantManagement(actor, predecessor.id);
+  assert.equal(stagedUpgradeManagement.installation.active_version_id, predecessor.active_version_id);
+  assert.equal(stagedUpgradeManagement.review_target?.activation_kind, 'upgrade');
+  assert.equal(stagedUpgradeManagement.review_target?.app_version_id, upgradeVersion.id);
+  assert.equal(stagedUpgradeManagement.review_target?.package_digest, upgradeVersion.package_digest);
+  assert.equal(stagedUpgradeManagement.review_target?.requested_snapshot_digest, upgradeRequest.snapshot_digest);
+  assert.equal(stagedUpgradeManagement.review_target?.provenance_trust, 'local_unsigned');
+  assert.equal(stagedUpgradeManagement.review_target?.dependency_requirements[0]?.status, 'ready');
+  assert.equal(stagedUpgradeManagement.review_target?.missing_binding_keys.includes('mail_provider'), true);
   const connectionId = randomUUID();
   await db.insert(mcpConnections).values({
     id: connectionId,
@@ -1065,6 +1117,23 @@ test('reviewed v0-to-v1 upgrade atomically preserves App pointers, Module data, 
     created_by: userId,
   });
   const reviewProvider = await sandboxReviewCapability(orgId, connectionId);
+  const olderReviewRequest = {
+    app_version_id: olderUpgradeVersion.id,
+    expected_package_digest: olderUpgradeVersion.package_digest,
+    expected_requested_snapshot_digest: olderUpgradeRequest.snapshot_digest,
+    expected_lifecycle_epoch: predecessor.lifecycle_epoch,
+    expected_grant_epoch: predecessor.grant_epoch,
+    connector_selections: [{
+      connector_requirement_key: 'mail_provider',
+      mcp_connection_id: connectionId,
+    }],
+  };
+  const discoveryCallsBeforeOlderTarget = reviewProvider.discoveryCalls();
+  await assert.rejects(
+    prepareConnectedAppReview(actor, predecessor.id, olderReviewRequest, reviewProvider.capability),
+    (error: unknown) => error instanceof AppError && error.code === 'APP_STALE',
+  );
+  assert.equal(reviewProvider.discoveryCalls(), discoveryCallsBeforeOlderTarget);
   const reviewRequest = {
     app_version_id: upgradeVersion.id,
     expected_package_digest: upgradeVersion.package_digest,
@@ -1082,6 +1151,27 @@ test('reviewed v0-to-v1 upgrade atomically preserves App pointers, Module data, 
     reviewRequest,
     reviewProvider.capability,
   );
+  const discoveryCallsBeforeDemotion = reviewProvider.discoveryCalls();
+  await db.update(orgMembers).set({ role: 'member' }).where(and(
+    eq(orgMembers.org_id, orgId),
+    eq(orgMembers.user_id, userId),
+  ));
+  try {
+    await assert.rejects(
+      activateConnectedAppInstallation(actor, predecessor.id, {
+        ...reviewRequest,
+        expected_review_digest: review.review_digest,
+        accept_host_policy: true,
+      }, reviewProvider.capability),
+      (error: unknown) => error instanceof ModuleError && error.code === 'MODULE_ACCESS_DENIED',
+    );
+    assert.equal(reviewProvider.discoveryCalls(), discoveryCallsBeforeDemotion);
+  } finally {
+    await db.update(orgMembers).set({ role: 'owner' }).where(and(
+      eq(orgMembers.org_id, orgId),
+      eq(orgMembers.user_id, userId),
+    ));
+  }
   await assert.rejects(
     activateConnectedAppInstallation(actor, predecessor.id, {
       ...reviewRequest,
@@ -1246,7 +1336,7 @@ test('reviewed v0-to-v1 upgrade atomically preserves App pointers, Module data, 
   assert.deepEqual(retentionRefusal.details, { cascaded: false, data_preserved: true });
   assert.deepEqual(await snapshotGraph(), graphBeforeUninstallRefusals);
 
-  const identicalBuilt = await buildPhase5ConnectedAppPackage({ app_version: '3.0.1' });
+  const identicalBuilt = await buildPhase5ConnectedAppPackage({ app_version: '3.0.2' });
   const identical = await stageAppUpgrade(
     actor,
     predecessor.id,

--- a/apps/web/src/app/(app)/settings/apps/apps-client.tsx
+++ b/apps/web/src/app/(app)/settings/apps/apps-client.tsx
@@ -17,15 +17,26 @@ export function AppsClient() {
   useAppRealtime();
   useSetPageContext(<span className="text-[0.875rem] font-semibold">Settings · Apps</span>, []);
   const inputRef = useRef<HTMLInputElement>(null);
-  const [pending, setPending] = useState<{ source: string; inspection: AppInspection } | null>(null);
+  const [pending, setPending] = useState<{
+    source: string;
+    inspection: AppInspection;
+    upgradeTarget: AppInstallation | null;
+  } | null>(null);
+  const uploadTargetRef = useRef<AppInstallation | null>(null);
   const [busy, setBusy] = useState<string | null>(null);
   const [message, setMessage] = useState<{ tone: 'error' | 'success'; text: string } | null>(null);
   const [pairing, setPairing] = useState<{ code: string; expires_at: string } | null>(null);
   const canManage = user?.role === 'owner' || user?.role === 'admin';
 
-  const choosePackage = () => { setMessage(null); inputRef.current?.click(); };
+  const choosePackage = (upgradeTarget: AppInstallation | null = null) => {
+    uploadTargetRef.current = upgradeTarget;
+    setMessage(null);
+    inputRef.current?.click();
+  };
   const inspect = async (event: ChangeEvent<HTMLInputElement>) => {
     const file = event.currentTarget.files?.[0];
+    const upgradeTarget = uploadTargetRef.current;
+    uploadTargetRef.current = null;
     event.currentTarget.value = '';
     if (!file) return;
     setPending(null); setMessage(null);
@@ -35,7 +46,14 @@ export function AppsClient() {
       const source = await file.text();
       const response = await api.fetch('/api/apps/inspect', { method: 'POST', headers: { 'Content-Type': 'application/vnd.deft.app.package+json' }, body: source });
       if (!response.ok) throw new Error(await appApiError(response, 'Unable to inspect this App package.'));
-      setPending({ source, inspection: normalizeAppInspection(await response.json()) });
+      const inspection = normalizeAppInspection(await response.json());
+      if (upgradeTarget && inspection.manifest.id !== upgradeTarget.app_id) {
+        throw new Error(`This package is ${inspection.manifest.id}; choose an upgrade for ${upgradeTarget.app_id}.`);
+      }
+      if (upgradeTarget && inspection.manifest.compatibility.app_protocol !== '1') {
+        throw new Error('Connected App upgrades require an App Protocol v1 package.');
+      }
+      setPending({ source, inspection, upgradeTarget });
     } catch (reason) { setMessage({ tone: 'error', text: reason instanceof Error ? reason.message : 'Unable to inspect App.' }); }
   };
 
@@ -43,12 +61,19 @@ export function AppsClient() {
     if (!pending) return;
     setBusy('stage'); setMessage(null);
     try {
-      const response = await api.fetch('/api/apps/stage', { method: 'POST', headers: { 'Content-Type': 'application/vnd.deft.app.package+json' }, body: pending.source });
+      const path = pending.upgradeTarget
+        ? `/api/apps/${encodeURIComponent(pending.upgradeTarget.id)}/upgrades/stage?expected_lifecycle_epoch=${pending.upgradeTarget.lifecycle_epoch}`
+        : '/api/apps/stage';
+      const response = await api.fetch(path, { method: 'POST', headers: { 'Content-Type': 'application/vnd.deft.app.package+json' }, body: pending.source });
       if (!response.ok) throw new Error(await appApiError(response, 'Unable to stage this App.'));
       await refreshApps();
       const connected = pending.inspection.manifest.compatibility.app_protocol === '1';
       setPending(null);
-      setMessage({ tone: 'success', text: connected ? 'Connected App staged for explicit authority review.' : 'App staged with no permissions and no workspace navigation.' });
+      setMessage({ tone: 'success', text: pending.upgradeTarget
+        ? `${pending.inspection.manifest.name} ${pending.inspection.manifest.version} staged for explicit upgrade review.`
+        : connected
+          ? 'Connected App staged for explicit authority review.'
+          : 'App staged with no permissions and no workspace navigation.' });
     } catch (reason) { setMessage({ tone: 'error', text: reason instanceof Error ? reason.message : 'Unable to stage App.' }); }
     finally { setBusy(null); }
   };
@@ -87,7 +112,7 @@ export function AppsClient() {
   return <div className="flex h-full min-h-0 flex-1 flex-col overflow-hidden">
     <PageHeader title="Apps" description="Expand this workspace with local, declarative App packages." compact secondary={canManage ? <div className="flex gap-2 px-1">
       <button type="button" onClick={() => void createPairing()} disabled={busy !== null} className="deft-pill min-h-11"><KeyRound size={14} /> Pair Codex</button>
-      <button type="button" onClick={choosePackage} disabled={busy !== null} className="deft-pill min-h-11 text-white" style={{ background: 'var(--primary-container)' }}><FileUp size={14} /> Inspect package</button>
+      <button type="button" onClick={() => choosePackage()} disabled={busy !== null} className="deft-pill min-h-11 text-white" style={{ background: 'var(--primary-container)' }}><FileUp size={14} /> Inspect package</button>
     </div> : undefined} />
     <input ref={inputRef} type="file" accept="application/json,.json" onChange={(event) => void inspect(event)} className="sr-only" aria-label="Choose a Deft App package" />
     <div className="min-h-0 flex-1 overflow-y-auto px-4 pb-8 pt-3 md:px-6">
@@ -97,29 +122,30 @@ export function AppsClient() {
           <div className="flex items-start justify-between gap-3"><div><h2 className="text-sm font-semibold">One-time Codex pairing</h2><p className="mt-1 text-xs" style={{ color: 'var(--on-surface-variant)' }}>Enter this only in the CLI prompt. It expires at {new Date(pairing.expires_at).toLocaleTimeString()} and cannot be replayed.</p></div><button type="button" onClick={() => setPairing(null)} aria-label="Dismiss pairing"><X size={16} /></button></div>
           <div className="mt-3 flex items-center gap-2"><code className="rounded-lg px-3 py-2 text-base font-semibold tracking-widest" style={{ background: 'var(--surface-container-high)' }}>{pairing.code}</code><button type="button" className="deft-pill" onClick={() => void navigator.clipboard.writeText(pairing.code)}><Copy size={13} /> Copy</button></div>
         </section>}
-        {pending && <InspectionCard pending={pending.inspection} busy={busy === 'stage'} onCancel={() => setPending(null)} onStage={() => void stage()} />}
+        {pending && <InspectionCard pending={pending.inspection} upgradeTarget={pending.upgradeTarget} busy={busy === 'stage'} onCancel={() => setPending(null)} onStage={() => void stage()} />}
         {isLoading ? <div className="flex min-h-48 items-center justify-center"><Loader2 className="animate-spin" aria-label="Loading Apps" /></div>
           : error ? <EmptyState icon={<AppWindow size={20} />} title="Apps did not load" description={error instanceof Error ? error.message : 'Try again.'} action={{ label: 'Try again', onClick: () => void mutate() }} />
-          : apps.length === 0 ? <EmptyState icon={<AppWindow size={20} />} title="No Apps installed" description="Build a declarative App with the public kit, then inspect its package here." action={canManage ? { label: 'Inspect a package', onClick: choosePackage } : undefined} />
-          : <div className="grid gap-3 md:grid-cols-2">{apps.map((app) => <AppCard key={app.id} app={app} canManage={canManage} busy={busy === app.id} onActivate={() => void activate(app)} onDisable={() => void disable(app)} />)}</div>}
+          : apps.length === 0 ? <EmptyState icon={<AppWindow size={20} />} title="No Apps installed" description="Build a declarative App with the public kit, then inspect its package here." action={canManage ? { label: 'Inspect a package', onClick: () => choosePackage() } : undefined} />
+          : <div className="grid gap-3 md:grid-cols-2">{apps.map((app) => <AppCard key={app.id} app={app} canManage={canManage} busy={busy === app.id} onActivate={() => void activate(app)} onDisable={() => void disable(app)} onChooseUpgrade={() => choosePackage(app)} />)}</div>}
       </div>
     </div>
   </div>;
 }
 
-function InspectionCard({ pending, busy, onCancel, onStage }: { pending: AppInspection; busy: boolean; onCancel: () => void; onStage: () => void }) {
+function InspectionCard({ pending, upgradeTarget, busy, onCancel, onStage }: { pending: AppInspection; upgradeTarget: AppInstallation | null; busy: boolean; onCancel: () => void; onStage: () => void }) {
   const connectedManifest = isConnectedAppManifest(pending.manifest) ? pending.manifest : null;
   const connected = Boolean(connectedManifest);
   return <section className="rounded-xl p-4" style={{ background: 'var(--surface-container-low)', border: '1px solid var(--primary)' }}>
-    <div className="flex items-start gap-3"><ShieldCheck size={20} style={{ color: 'var(--status-green)' }} /><div className="min-w-0 flex-1"><h2 className="text-sm font-semibold">Review {pending.manifest.name}</h2><p className="mt-1 text-xs" style={{ color: 'var(--on-surface-variant)' }}>{pending.manifest.description ?? 'Declarative workspace App.'}</p></div></div>
-    <dl className="mt-4 grid gap-2 text-xs sm:grid-cols-2"><Fact label="Identity" value={`${pending.manifest.id}@${pending.manifest.version}`} /><Fact label="Protocol" value={`App v${pending.manifest.compatibility.app_protocol}`} /><Fact label="License" value={pending.manifest.license} /><Fact label="Source" value={pending.manifest.provenance ? `${pending.manifest.provenance.source_repository}@${pending.manifest.provenance.source_commit}` : 'Unsigned local package'} /><Fact label="Package digest" value={pending.package_digest} mono /></dl>
+    <div className="flex items-start gap-3"><ShieldCheck size={20} style={{ color: 'var(--status-green)' }} /><div className="min-w-0 flex-1"><h2 className="text-sm font-semibold">Review {pending.manifest.name}{upgradeTarget ? ' upgrade' : ''}</h2><p className="mt-1 text-xs" style={{ color: 'var(--on-surface-variant)' }}>{pending.manifest.description ?? 'Declarative workspace App.'}</p></div></div>
+    <dl className="mt-4 grid gap-2 text-xs sm:grid-cols-2"><Fact label="Identity" value={`${pending.manifest.id}@${pending.manifest.version}`} /><Fact label="Protocol" value={`App v${pending.manifest.compatibility.app_protocol}`} /><Fact label="Package format" value={pending.package_format} /><Fact label="License" value={pending.manifest.license} /><Fact label="Provenance" value={pending.manifest.provenance ? `Unsigned local · unverified ${pending.manifest.provenance.source_repository}@${pending.manifest.provenance.source_commit}` : 'Unsigned local package · no source attestation'} /><Fact label="Package digest" value={pending.package_digest} mono /></dl>
+    {upgradeTarget && <p className="mt-3 rounded-lg px-3 py-2 text-[11px]" style={{ background: 'var(--surface-container-high)', color: 'var(--on-surface-variant)' }}>This stages {pending.manifest.version} beside active {upgradeTarget.version}. The active version and authority remain unchanged until an owner completes the exact upgrade review.</p>}
     <div className="mt-4"><h3 className="text-xs font-semibold">Exact included Modules</h3><ul className="mt-2 space-y-1">{pending.manifest.modules.map((module) => <li key={`${module.module_id}@${module.version}`} className="rounded-md px-2 py-1.5 font-mono text-[10px]" style={{ background: 'var(--surface-container-high)', color: 'var(--on-surface-variant)' }}>{module.module_id}@{module.version} · {module.manifest_digest}</li>)}</ul></div>
     <div className="mt-4 rounded-lg p-3" style={{ background: 'var(--surface-container-high)' }}><p className="flex items-center gap-2 text-xs font-semibold"><Check size={14} style={{ color: 'var(--status-green)' }} /> {connected ? 'No authority before review' : 'No connected permissions'}</p><p className="mt-1 text-[11px]" style={{ color: 'var(--on-surface-variant)' }}>{connectedManifest ? `Staging grants no authority. Owners must bind ${connectedManifest.connector_requirements.length} connector requirement${connectedManifest.connector_requirements.length === 1 ? '' : 's'} and accept Deft’s host policy before activation.` : `Staging grants no authority and adds no navigation. Activation installs ${pending.manifest.modules.length} exact Module artifact${pending.manifest.modules.length === 1 ? '' : 's'}.`}</p></div>
-    <div className="mt-4 flex justify-end gap-2"><button type="button" className="deft-pill min-h-11" onClick={onCancel}>Cancel</button><button type="button" className="deft-pill min-h-11 text-white" style={{ background: 'var(--primary-container)' }} disabled={busy} onClick={onStage}>{busy && <Loader2 size={13} className="animate-spin" />} {connected ? 'Stage for review' : 'Stage with no rights'}</button></div>
+    <div className="mt-4 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end"><button type="button" className="deft-pill min-h-11" onClick={onCancel}>Cancel</button><button type="button" className="deft-pill min-h-11 text-white" style={{ background: 'var(--primary-container)' }} disabled={busy} onClick={onStage}>{busy && <Loader2 size={13} className="animate-spin" />} {upgradeTarget ? 'Stage upgrade for review' : connected ? 'Stage for review' : 'Stage with no rights'}</button></div>
   </section>;
 }
 
-function AppCard({ app, canManage, busy, onActivate, onDisable }: { app: AppInstallation; canManage: boolean; busy: boolean; onActivate: () => void; onDisable: () => void }) {
+function AppCard({ app, canManage, busy, onActivate, onDisable, onChooseUpgrade }: { app: AppInstallation; canManage: boolean; busy: boolean; onActivate: () => void; onDisable: () => void; onChooseUpgrade: () => void }) {
   const connected = app.manifest.compatibility.app_protocol === '1';
   const tone = app.state === 'active' ? 'var(--status-green)' : app.state === 'disabled' ? 'var(--outline)' : 'var(--status-amber)';
   return <article className={`flex min-h-56 flex-col rounded-xl p-4 ${connected ? 'md:col-span-2' : ''}`} style={{ background: 'var(--surface-container-low)', border: '1px solid var(--ghost-border)' }}>
@@ -127,7 +153,7 @@ function AppCard({ app, canManage, busy, onActivate, onDisable }: { app: AppInst
     <p className="mt-3 line-clamp-2 text-xs leading-5" style={{ color: 'var(--on-surface-variant)' }}>{app.manifest.description ?? 'Declarative workspace App.'}</p>
     <div className="mt-3 text-[11px]" style={{ color: 'var(--outline)' }}>{app.manifest.modules.length} Module{app.manifest.modules.length === 1 ? '' : 's'} · Protocol v{app.manifest.compatibility.app_protocol} · {app.manifest.license}</div>
     {!connected && <div className="mt-auto flex items-center justify-between gap-3 pt-4"><span className="flex items-center gap-1 text-[11px]" style={{ color: 'var(--status-green)' }}><ShieldCheck size={13} /> No connected permissions</span>{canManage && app.state === 'staged' ? <button type="button" className="deft-pill min-h-11 text-white" style={{ background: 'var(--primary-container)' }} disabled={busy} onClick={onActivate}>{busy && <Loader2 size={13} className="animate-spin" />} Activate</button> : canManage && app.state === 'active' ? <button type="button" className="deft-pill min-h-11" disabled={busy} onClick={onDisable}>{busy ? <Loader2 size={13} className="animate-spin" /> : <Power size={13} />} Disable</button> : null}</div>}
-    {connected && <ConnectedAppManagement app={app} canManage={canManage} busy={busy} onDisable={onDisable} />}
+    {connected && <ConnectedAppManagement app={app} canManage={canManage} busy={busy} onDisable={onDisable} onChooseUpgrade={onChooseUpgrade} />}
   </article>;
 }
 

--- a/apps/web/src/components/apps/app-run-inspector.tsx
+++ b/apps/web/src/components/apps/app-run-inspector.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { AlertTriangle, CheckCircle2, Loader2, ReceiptText, ShieldCheck } from 'lucide-react';
+import { AppDialog } from '@/components/overlay-primitives';
+import { api } from '@/lib/api';
+import { appApiError, normalizeAppRunReceiptBundle, type AppRunReceiptBundle } from '@/lib/apps';
+
+export function AppRunInspector({ runId, onClose }: { runId: string | null; onClose: () => void }) {
+  const [bundle, setBundle] = useState<AppRunReceiptBundle | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!runId) {
+      setBundle(null);
+      setError(null);
+      setLoading(false);
+      return;
+    }
+    const controller = new AbortController();
+    setBundle(null);
+    setError(null);
+    setLoading(true);
+    void (async () => {
+      try {
+        const response = await api.fetch(`/api/app-runs/${encodeURIComponent(runId)}/receipts`, {
+          signal: controller.signal,
+        });
+        if (!response.ok) throw new Error(await appApiError(response, 'Unable to inspect this App Run.'));
+        if (!controller.signal.aborted) setBundle(normalizeAppRunReceiptBundle(await response.json()));
+      } catch (reason) {
+        if (!controller.signal.aborted) {
+          setError(reason instanceof Error ? reason.message : 'Unable to inspect this App Run.');
+        }
+      } finally {
+        if (!controller.signal.aborted) setLoading(false);
+      }
+    })();
+    return () => controller.abort();
+  }, [runId]);
+
+  return <AppDialog
+    open={runId !== null}
+    onClose={onClose}
+    title={bundle?.run.title ?? 'App Run receipts'}
+    description="Actor-authorized, tenant-scoped Run metadata and server-verified receipt proofs. Raw provider envelopes and output are not exposed here."
+    width={620}
+    footer={<div className="flex justify-end"><button type="button" className="deft-pill min-h-11" onClick={onClose}>Close</button></div>}
+  >
+    {loading && <div className="flex min-h-40 items-center justify-center"><Loader2 className="animate-spin" aria-label="Loading App Run receipts" /></div>}
+    {error && <div role="alert" className="flex items-start gap-2 rounded-xl p-3 text-xs" style={{ background: 'var(--danger-subtle)', color: 'var(--error)' }}><AlertTriangle size={15} className="mt-0.5 flex-shrink-0" /><span>{error}</span></div>}
+    {bundle && <div className="space-y-4">
+      <div className="flex items-start gap-2 rounded-xl p-3" style={{ background: bundle.run.state === 'succeeded' ? 'rgba(48,164,108,.10)' : 'var(--surface-container-high)' }}>
+        {bundle.run.state === 'succeeded' ? <CheckCircle2 size={16} className="mt-0.5 flex-shrink-0" style={{ color: 'var(--status-green)' }} /> : <ReceiptText size={16} className="mt-0.5 flex-shrink-0" />}
+        <div className="min-w-0"><h3 className="text-sm font-semibold">{bundle.run.state.replaceAll('_', ' ')}</h3><p className="mt-1 text-xs" style={{ color: 'var(--on-surface-variant)' }}>{bundle.run.outcome_summary ?? bundle.run.summary ?? 'No additional safe summary was retained.'}</p></div>
+      </div>
+      <dl className="grid gap-2 text-xs sm:grid-cols-2">
+        <Fact label="Operation" value={bundle.run.operation_name} />
+        <Fact label="Risk" value={bundle.run.risk_class.replaceAll('_', ' ')} />
+        <Fact label="Review" value={`${bundle.run.review_requirement.replaceAll('_', ' ')} · ${bundle.run.review_scope.replaceAll('_', ' ')}`} />
+        <Fact label="Retry" value={bundle.run.retry_class.replaceAll('_', ' ')} />
+        <Fact label="Retention" value={bundle.run.retention_class.replaceAll('_', ' ')} />
+        <Fact label="Result retention" value={bundle.run.result_purged_at ? `Purged ${formatTime(bundle.run.result_purged_at)}` : `Expires ${formatTime(bundle.run.result_expires_at)}`} />
+      </dl>
+      <div>
+        <h3 className="flex items-center gap-1.5 text-xs font-semibold"><ShieldCheck size={14} style={{ color: 'var(--status-green)' }} /> Verified receipts</h3>
+        {bundle.receipts.length === 0 ? <p className="mt-2 text-[11px]" style={{ color: 'var(--outline)' }}>No receipt has been emitted for this Run yet.</p> : <ul className="mt-2 space-y-2">{bundle.receipts.map((receipt) => <li key={receipt.receipt_id} className="rounded-lg p-3 text-[11px]" style={{ background: 'var(--surface-container-high)' }}>
+          <div className="flex items-center justify-between gap-3"><span className="font-semibold">{receipt.receipt_kind.replaceAll('_', ' ')}</span><span className="rounded-full px-2 py-0.5 text-[9px] font-semibold uppercase" style={{ color: 'var(--status-green)', background: 'var(--surface-container-low)' }}>Verified</span></div>
+          <p className="mt-1" style={{ color: 'var(--on-surface-variant)' }}>{receipt.run_state.replaceAll('_', ' ')} · {formatTime(receipt.occurred_at)} · key {receipt.signing_key_version}</p>
+          <p className="mt-1 break-all font-mono text-[9px]" style={{ color: 'var(--outline)' }}>{receipt.envelope_digest}</p>
+        </li>)}</ul>}
+      </div>
+    </div>}
+  </AppDialog>;
+}
+
+function Fact({ label, value }: { label: string; value: string }) {
+  return <div className="min-w-0 rounded-lg px-3 py-2" style={{ background: 'var(--surface-container-high)' }}><dt className="text-[10px] font-semibold uppercase" style={{ color: 'var(--outline)' }}>{label}</dt><dd className="mt-1 break-words">{value}</dd></div>;
+}
+
+function formatTime(value: string): string {
+  return new Date(value).toLocaleString();
+}

--- a/apps/web/src/components/apps/connected-app-management.tsx
+++ b/apps/web/src/components/apps/connected-app-management.tsx
@@ -2,7 +2,8 @@
 
 import { useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
-import { AlertTriangle, CheckCircle2, Loader2, RefreshCw, ShieldCheck } from 'lucide-react';
+import { AlertTriangle, CheckCircle2, FileUp, Loader2, RefreshCw, ShieldCheck } from 'lucide-react';
+import { AppRunInspector } from '@/components/apps/app-run-inspector';
 import { api } from '@/lib/api';
 import {
   appApiError,
@@ -20,11 +21,13 @@ export function ConnectedAppManagement({
   canManage,
   busy,
   onDisable,
+  onChooseUpgrade,
 }: {
   app: AppInstallation;
   canManage: boolean;
   busy: boolean;
   onDisable: () => void;
+  onChooseUpgrade: () => void;
 }) {
   const grantsState = useAppGrantManagement(app.id, canManage);
   const connectorState = useAppConnectors(canManage);
@@ -32,51 +35,55 @@ export function ConnectedAppManagement({
   const [review, setReview] = useState<ConnectedAppReview | null>(null);
   const [health, setHealth] = useState<ConnectedAppHealth | null>(null);
   const [acceptedPolicy, setAcceptedPolicy] = useState(false);
+  const [selectedRunId, setSelectedRunId] = useState<string | null>(null);
   const [working, setWorking] = useState<'review' | 'activate' | 'health' | null>(null);
   const [message, setMessage] = useState<{ tone: 'error' | 'success'; text: string } | null>(null);
   const grants = grantsState.grants;
-  const manifest = isConnectedAppManifest(app.manifest) ? app.manifest : null;
-  const version = grants?.versions.find((candidate) => candidate.id === app.version_id) ?? null;
-  const requested = grants?.snapshots.find((snapshot) => snapshot.id === version?.requested_grant_snapshot_id) ?? null;
+  const installedManifest = isConnectedAppManifest(app.manifest) ? app.manifest : null;
+  const target = grants?.review_target ?? null;
+  const manifest = target?.manifest ?? installedManifest;
   const effective = grants?.snapshots.find((snapshot) => snapshot.id === grants.installation.active_grant_snapshot_id) ?? null;
-  const activeConnectors = useMemo(
-    () => connectorState.connectors.filter((connector) => connector.is_active && !connector.connection_error),
-    [connectorState.connectors],
-  );
-
   useEffect(() => {
-    if (!manifest || activeConnectors.length === 0) return;
+    if (!target) return;
     setConnectorSelections((current) => {
-      const next = { ...current };
+      const next: Record<string, string> = {};
       let changed = false;
-      for (const requirement of manifest.connector_requirements) {
-        if (!next[requirement.key]) {
-          next[requirement.key] = activeConnectors[0].id;
-          changed = true;
-        }
+      for (const requirement of target.connector_requirements) {
+        const selected = current[requirement.key];
+        const currentCandidate = requirement.current_binding?.configured
+          ? requirement.current_binding.mcp_connection_id
+          : null;
+        const firstEligible = requirement.candidates.find((candidate) => candidate.eligible_for_review)?.id ?? '';
+        const nextSelection = requirement.candidates.some(
+          (candidate) => candidate.id === selected && candidate.eligible_for_review,
+        ) ? selected : currentCandidate ?? firstEligible;
+        next[requirement.key] = nextSelection;
+        if (nextSelection !== selected) changed = true;
       }
-      return changed ? next : current;
+      return changed || Object.keys(current).length !== Object.keys(next).length ? next : current;
     });
-  }, [activeConnectors, manifest]);
+    setReview(null);
+    setAcceptedPolicy(false);
+  }, [target?.app_version_id, target?.requested_snapshot_digest]);
 
   const reviewInput = useMemo(() => {
-    if (!manifest || !requested) return null;
-    const connectorSelectionsList = manifest.connector_requirements.map((requirement) => ({
+    if (!grants || !target) return null;
+    const connectorSelectionsList = target.connector_requirements.map((requirement) => ({
       connector_requirement_key: requirement.key,
       mcp_connection_id: connectorSelections[requirement.key] ?? '',
     }));
     if (connectorSelectionsList.some((selection) => !selection.mcp_connection_id)) return null;
     return {
-      app_version_id: app.version_id,
-      expected_package_digest: app.package_digest,
-      expected_requested_snapshot_digest: requested.snapshot_digest,
-      expected_lifecycle_epoch: app.lifecycle_epoch,
-      expected_grant_epoch: app.grant_epoch,
+      app_version_id: target.app_version_id,
+      expected_package_digest: target.package_digest,
+      expected_requested_snapshot_digest: target.requested_snapshot_digest,
+      expected_lifecycle_epoch: grants.installation.lifecycle_epoch,
+      expected_grant_epoch: grants.installation.grant_epoch,
       connector_selections: connectorSelectionsList,
     };
-  }, [app.grant_epoch, app.lifecycle_epoch, app.package_digest, app.version_id, connectorSelections, manifest, requested]);
+  }, [connectorSelections, grants, target]);
 
-  if (!manifest) return null;
+  if (!installedManifest) return null;
   if (!canManage) {
     return <p className="mt-4 border-t border-[var(--ghost-border)] pt-3 text-[11px]" style={{ color: 'var(--outline)' }}>An owner or admin can review connected permissions and health.</p>;
   }
@@ -106,7 +113,12 @@ export function ConnectedAppManagement({
       });
       if (!response.ok) throw new Error(await appApiError(response, 'Unable to activate this connected App.'));
       setReview(normalizeConnectedAppReview(await response.json()));
-      setMessage({ tone: 'success', text: 'Connected App activated with the reviewed authority.' });
+      const verb = target?.activation_kind === 'upgrade'
+        ? 'upgraded'
+        : target?.activation_kind === 'reenable'
+          ? 're-enabled'
+          : 'activated';
+      setMessage({ tone: 'success', text: `Connected App ${verb} with freshly reviewed authority.` });
       await Promise.all([refreshApps(), grantsState.mutate()]);
     } catch (error) {
       setMessage({ tone: 'error', text: error instanceof Error ? error.message : 'Unable to activate this connected App.' });
@@ -134,39 +146,61 @@ export function ConnectedAppManagement({
       {grantsState.isLoading ? <div className="flex min-h-16 items-center justify-center"><Loader2 size={16} className="animate-spin" aria-label="Loading connected App permissions" /></div>
         : grantsState.error || !grants ? <p role="alert" className="text-xs" style={{ color: 'var(--error)' }}>{grantsState.error instanceof Error ? grantsState.error.message : 'Connected App permissions did not load.'}</p>
           : <>
+            <div className="rounded-lg px-3 py-2.5 text-[11px]" style={{ background: 'var(--surface-container-high)' }}>
+              <h3 className="font-semibold">Supported local contract</h3>
+              <p className="mt-1" style={{ color: 'var(--on-surface-variant)' }}>
+                {grants.compatibility.app_kit.package} {grants.compatibility.app_kit.versions.join(', ')} · App Protocol v1 · {grants.compatibility.protocol_flows['1'].package_format} · {grants.compatibility.protocol_flows['1'].install_mode.replaceAll('_', ' ')}
+              </p>
+              <p className="mt-1" style={{ color: 'var(--outline)' }}>Local packages are unsigned. Source provenance is an unverified author claim, not a registry attestation.</p>
+            </div>
+
             <div className="grid gap-3 sm:grid-cols-2">
               <AuthorityCard
-                title="Requested authority"
-                body={`${requested?.resource_rights.length ?? 0} resource right${requested?.resource_rights.length === 1 ? '' : 's'} · ${manifest.actions.length} action${manifest.actions.length === 1 ? '' : 's'} · ${manifest.connector_requirements.length} connector${manifest.connector_requirements.length === 1 ? '' : 's'}`}
-                detail={requested ? shortDigest(requested.snapshot_digest) : 'Requested snapshot unavailable'}
+                title={target ? `${activationLabel(target.activation_kind)} authority` : 'Requested authority'}
+                body={target ? `${target.requested_authority.resource_rights.length} resource read${target.requested_authority.resource_rights.length === 1 ? '' : 's'} · ${target.manifest.actions.length} action${target.manifest.actions.length === 1 ? '' : 's'} · ${target.connector_requirements.length} connector${target.connector_requirements.length === 1 ? '' : 's'}` : 'No version is awaiting review'}
+                detail={target ? shortDigest(target.requested_snapshot_digest) : 'No pending requested snapshot'}
               />
               <AuthorityCard
                 title="Effective authority"
-                body={effective ? `${effective.resource_rights.length} resource right${effective.resource_rights.length === 1 ? '' : 's'} · ${grants.action_bindings.length} active binding${grants.action_bindings.length === 1 ? '' : 's'}` : 'No effective authority'}
-                detail={effective ? shortDigest(effective.snapshot_digest) : 'Activation is required'}
+                body={effective ? `${effective.resource_rights.length} resource read${effective.resource_rights.length === 1 ? '' : 's'} · ${grants.action_bindings.length} active binding${grants.action_bindings.length === 1 ? '' : 's'}` : 'No effective authority'}
+                detail={effective ? shortDigest(effective.snapshot_digest) : app.state === 'disabled' ? 'Revoked while disabled' : 'Activation is required'}
               />
             </div>
 
             <div>
-              <h3 className="text-xs font-semibold">Dependencies and provenance</h3>
+              <h3 className="text-xs font-semibold">Package provenance</h3>
               <p className="mt-1 break-all text-[11px]" style={{ color: 'var(--outline)' }}>
-                {manifest.provenance ? `${manifest.provenance.source_repository}@${manifest.provenance.source_commit}` : 'Local package without source provenance'}
+                Local unsigned · {manifest?.provenance ? `unverified source claim ${manifest.provenance.source_repository}@${manifest.provenance.source_commit}` : 'no source claim'}
               </p>
-              <ul className="mt-2 space-y-1.5 text-[11px]">
-                {(review?.dependencies ?? grants.dependencies).length === 0 ? <li style={{ color: 'var(--outline)' }}>No App dependencies.</li> : (review?.dependencies ?? grants.dependencies).map((dependency) => (
-                  <li key={`${dependency.dependency_key}:${dependency.dependency_version_id}`} className="rounded-lg px-2.5 py-2" style={{ background: 'var(--surface-container-high)' }}>
-                    <span className="font-medium">{dependency.dependency_key}</span> · {dependency.required_app_id}@{dependency.required_version}
-                    <span className="mt-0.5 block font-mono text-[9px]" style={{ color: 'var(--outline)' }}>{shortDigest(dependency.lock_digest)}</span>
-                  </li>
-                ))}
-              </ul>
             </div>
 
-            {app.state === 'staged' && <div className="space-y-3 rounded-xl p-3" style={{ background: 'var(--surface-container-high)' }}>
-              <div><h3 className="text-xs font-semibold">Connector bindings</h3><p className="mt-1 text-[11px]" style={{ color: 'var(--outline)' }}>Choose exact workspace connectors, then review the resulting authority before activation.</p></div>
-              {manifest.connector_requirements.map((requirement) => (
-                <label key={requirement.key} className="block text-[11px] font-medium">
-                  {requirement.key.replaceAll('_', ' ')}
+            {target && <div className="space-y-3">
+              <div>
+                <h3 className="text-xs font-semibold">Requested resource reads</h3>
+                <ul className="mt-2 space-y-1.5 text-[11px]">
+                  {target.requested_authority.resource_rights.map((right) => <li key={right.requirement_key} className="rounded-lg px-2.5 py-2" style={{ background: 'var(--surface-container-high)' }}><span className="font-medium">{right.requirement_key.replaceAll('_', ' ')}</span> · {right.resource_type}<span className="mt-0.5 block" style={{ color: 'var(--outline)' }}>{right.fields.join(', ')}</span></li>)}
+                </ul>
+              </div>
+              <div>
+                <h3 className="text-xs font-semibold">Dependency requirements</h3>
+                <ul className="mt-2 space-y-1.5 text-[11px]">
+                  {target.dependency_requirements.map((dependency) => <li key={dependency.key} className="flex items-start justify-between gap-3 rounded-lg px-2.5 py-2" style={{ background: 'var(--surface-container-high)' }}><span><span className="font-medium">{dependency.key}</span> · {dependency.app_id}@{dependency.version}{dependency.active_version && dependency.active_version !== dependency.version ? <span className="mt-0.5 block" style={{ color: 'var(--outline)' }}>Found {dependency.active_version}</span> : null}</span><RequirementState state={dependency.status} /></li>)}
+                </ul>
+              </div>
+              <div>
+                <h3 className="text-xs font-semibold">Capability requirements</h3>
+                <ul className="mt-2 space-y-1.5 text-[11px]">
+                  {target.manifest.capability_requirements.map((capability) => <li key={capability.key} className="rounded-lg px-2.5 py-2" style={{ background: 'var(--surface-container-high)' }}><span className="font-medium">{capability.key.replaceAll('_', ' ')}</span><span className="mt-0.5 block font-mono text-[9px]" style={{ color: 'var(--outline)' }}>{capability.interface.namespace}:{capability.interface.key}@{capability.interface.version}</span></li>)}
+                </ul>
+              </div>
+            </div>}
+
+            {target && <div className="space-y-3 rounded-xl p-3" style={{ background: 'var(--surface-container-high)' }}>
+              <div><h3 className="text-xs font-semibold">Connector bindings · {activationLabel(target.activation_kind)}</h3><p className="mt-1 text-[11px]" style={{ color: 'var(--outline)' }}>Choose exact configured connectors. Deft refreshes and verifies provider schemas only when you run the review.</p></div>
+              {target.connector_requirements.map((requirement) => {
+                const eligible = requirement.candidates.filter((candidate) => candidate.eligible_for_review);
+                return <label key={requirement.key} className="block text-[11px] font-medium">
+                  {requirement.key.replaceAll('_', ' ')} · MCP{requirement.required_operations.length > 0 ? ` · ${requirement.required_operations.join(', ')}` : ''}
                   <select
                     className="mt-1 min-h-11 w-full rounded-lg px-3 text-xs"
                     style={{ background: 'var(--surface-container-low)', border: '1px solid var(--outline-variant)' }}
@@ -176,29 +210,30 @@ export function ConnectedAppManagement({
                       setReview(null); setAcceptedPolicy(false);
                     }}
                   >
-                    <option value="">Select a healthy connector</option>
-                    {activeConnectors.map((connector) => <option key={connector.id} value={connector.id}>{connector.name}</option>)}
+                    <option value="">Select a configured connector</option>
+                    {requirement.candidates.map((candidate) => <option key={candidate.id} value={candidate.id} disabled={!candidate.eligible_for_review}>{candidate.name}{candidate.eligible_for_review ? '' : ` · ${candidate.status.replaceAll('_', ' ')}`}</option>)}
                   </select>
-                </label>
-              ))}
-              {manifest.connector_requirements.length > 0 && activeConnectors.length === 0 && <p role="alert" className="text-[11px]" style={{ color: 'var(--error)' }}>No active, healthy MCP connector is available. <Link href="/settings/integrations" className="underline">Configure one</Link>.</p>}
-              <button type="button" className="deft-pill min-h-11" disabled={!reviewInput || working !== null} onClick={() => void runReview()}>{working === 'review' && <Loader2 size={13} className="animate-spin" />} Review exact authority</button>
+                  {eligible.length === 0 && <span role="alert" className="mt-1 block" style={{ color: 'var(--error)' }}>No connector currently enables this operation. <Link href="/settings/integrations" className="underline">Configure one</Link>.</span>}
+                </label>;
+              })}
+              {target.missing_binding_keys.length > 0 && <p className="text-[11px]" style={{ color: 'var(--status-amber)' }}>{target.missing_binding_keys.length} requirement{target.missing_binding_keys.length === 1 ? '' : 's'} had no reusable current binding; select and review a connector above.</p>}
+              <button type="button" className="deft-pill min-h-11" disabled={!reviewInput || !target.readiness.dependencies_ready || !target.readiness.connector_candidates_ready || working !== null} onClick={() => void runReview()}>{working === 'review' && <Loader2 size={13} className="animate-spin" />} Review exact {target.activation_kind === 'reenable' ? 're-enable' : target.activation_kind} authority</button>
             </div>}
 
-            {review && <div className="space-y-3 rounded-xl p-3" style={{ background: review.permission_diff.kind === 'widening_or_incompatible' ? 'var(--danger-subtle)' : 'rgba(48,164,108,.10)', border: '1px solid var(--ghost-border)' }}>
-              <div className="flex items-start gap-2"><ShieldCheck size={16} className="mt-0.5 flex-shrink-0" /><div><h3 className="text-xs font-semibold">{permissionDiffLabel(review.permission_diff.kind)}</h3><p className="mt-1 text-[11px]" style={{ color: 'var(--on-surface-variant)' }}>{review.permission_diff.changed_atoms.length === 0 ? 'The reviewed authority matches the prior surface.' : `${review.permission_diff.changed_atoms.length} authority atom${review.permission_diff.changed_atoms.length === 1 ? '' : 's'} changed.`}</p></div></div>
-              {review.permission_diff.changed_atoms.length > 0 && <ul className="max-h-28 space-y-1 overflow-y-auto font-mono text-[9px]">{review.permission_diff.changed_atoms.map((atom) => <li key={atom} className="break-all">{atom}</li>)}</ul>}
+            {target && review && <div className="space-y-3 rounded-xl p-3" style={{ background: review.permission_diff.kind === 'widening_or_incompatible' ? 'var(--danger-subtle)' : 'rgba(48,164,108,.10)', border: '1px solid var(--ghost-border)' }}>
+              <div className="flex items-start gap-2"><ShieldCheck size={16} className="mt-0.5 flex-shrink-0" /><div><h3 className="text-xs font-semibold">{permissionDiffLabel(review.permission_diff.kind)}</h3><p className="mt-1 text-[11px]" style={{ color: 'var(--on-surface-variant)' }}>{review.permission_diff.changed_atoms.length === 0 ? 'The reviewed authority matches the prior surface.' : `${review.permission_diff.changed_atoms.length} authority area${review.permission_diff.changed_atoms.length === 1 ? '' : 's'} changed: ${review.permission_diff.changed_atoms.join(', ')}.`}</p></div></div>
               <div className="space-y-1.5 text-[11px]">
                 {review.action_bindings.map((binding) => <div key={binding.binding_digest} className="rounded-lg px-2.5 py-2" style={{ background: 'var(--surface-container-low)' }}><span className="font-medium">{binding.action_key.replaceAll('_', ' ')}</span><span className="block" style={{ color: 'var(--outline)' }}>{connectorName(binding.mcp_connection_id, connectorState.connectors)} · {binding.operation_name}</span></div>)}
               </div>
               <label className="flex min-h-11 items-start gap-2 rounded-lg px-2 py-2 text-[11px]" style={{ background: 'var(--surface-container-low)' }}><input type="checkbox" className="mt-0.5 h-4 w-4" checked={acceptedPolicy} onChange={(event) => setAcceptedPolicy(event.target.checked)} /><span>I accept Deft’s host-owned approval, retention, egress, and retry policy for these exact bindings.</span></label>
-              <button type="button" className="deft-pill min-h-11 text-white" style={{ background: 'var(--primary-container)' }} disabled={!acceptedPolicy || working !== null} onClick={() => void activate()}>{working === 'activate' && <Loader2 size={13} className="animate-spin" />} Activate reviewed App</button>
+              <button type="button" className="deft-pill min-h-11 text-white" style={{ background: 'var(--primary-container)' }} disabled={!acceptedPolicy || working !== null} onClick={() => void activate()}>{working === 'activate' && <Loader2 size={13} className="animate-spin" />} {activationAction(target.activation_kind)} reviewed App</button>
             </div>}
 
-            {grants.action_bindings.length > 0 && <div><h3 className="text-xs font-semibold">Effective action bindings</h3><ul className="mt-2 space-y-1.5">{grants.action_bindings.map((binding) => <li key={binding.id} className="rounded-lg px-2.5 py-2 text-[11px]" style={{ background: 'var(--surface-container-high)' }}><span className="font-medium">{binding.action_key.replaceAll('_', ' ')}</span><span className="block" style={{ color: 'var(--outline)' }}>{connectorName(binding.mcp_connection_id, connectorState.connectors)} · {binding.host_policy.review_requirement.replaceAll('_', ' ')} approval</span></li>)}</ul></div>}
+            {grants.action_bindings.length > 0 && <div><h3 className="text-xs font-semibold">{grants.installation.active_grant_snapshot_id ? 'Effective action bindings' : 'Prior reviewed bindings'}</h3>{!grants.installation.active_grant_snapshot_id && <p className="mt-1 text-[11px]" style={{ color: 'var(--outline)' }}>These bindings are revoked while the App is disabled and are shown only as inputs to a fresh review.</p>}<ul className="mt-2 space-y-1.5">{grants.action_bindings.map((binding) => <li key={binding.id} className="rounded-lg px-2.5 py-2 text-[11px]" style={{ background: 'var(--surface-container-high)' }}><span className="font-medium">{binding.action_key.replaceAll('_', ' ')}</span><span className="block" style={{ color: 'var(--outline)' }}>{connectorName(binding.mcp_connection_id, connectorState.connectors)} · {binding.host_policy.review_requirement.replaceAll('_', ' ')} approval</span></li>)}</ul></div>}
 
             <div className="flex flex-wrap gap-2">
-              <button type="button" className="deft-pill min-h-11" disabled={working !== null} onClick={() => void refreshHealth()}>{working === 'health' ? <Loader2 size={13} className="animate-spin" /> : <RefreshCw size={13} />} Refresh health</button>
+              {(app.state === 'active' || app.state === 'disabled') && target?.activation_kind !== 'upgrade' && <button type="button" className="deft-pill min-h-11" disabled={busy || working !== null} onClick={onChooseUpgrade}><FileUp size={13} /> Stage upgrade</button>}
+              {app.state === 'active' && <button type="button" className="deft-pill min-h-11" disabled={working !== null} onClick={() => void refreshHealth()}>{working === 'health' ? <Loader2 size={13} className="animate-spin" /> : <RefreshCw size={13} />} Refresh health</button>}
               {app.state === 'active' && <button type="button" className="deft-pill min-h-11" disabled={busy || working !== null} onClick={onDisable}>Disable</button>}
             </div>
             {health && <div role="status" className="rounded-lg px-3 py-2 text-[11px]" style={{ background: health.status === 'healthy' ? 'rgba(48,164,108,.10)' : 'var(--danger-subtle)', color: health.status === 'healthy' ? 'var(--status-green)' : 'var(--error)' }}>
@@ -206,8 +241,9 @@ export function ConnectedAppManagement({
               {health.issues.length > 0 && <ul className="mt-1 space-y-1">{health.issues.map((issue) => <li key={`${issue.code}:${issue.subject_id}`}>{issue.message}</li>)}</ul>}
             </div>}
 
-            <div><h3 className="text-xs font-semibold">Recent Runs</h3>{grants.recent_runs.length === 0 ? <p className="mt-1 text-[11px]" style={{ color: 'var(--outline)' }}>No App Runs yet.</p> : <ul className="mt-2 space-y-1.5">{grants.recent_runs.slice(0, 5).map((run) => <li key={run.id} className="flex items-start justify-between gap-3 rounded-lg px-2.5 py-2 text-[11px]" style={{ background: 'var(--surface-container-high)' }}><span className="min-w-0"><span className="block truncate font-medium">{run.title}</span><span className="block truncate" style={{ color: 'var(--outline)' }}>{run.outcome_summary ?? run.summary ?? new Date(run.created_at).toLocaleString()}</span></span><RunState state={run.state} /></li>)}</ul>}</div>
+            <div><h3 className="text-xs font-semibold">Recent Runs</h3>{grants.recent_runs.length === 0 ? <p className="mt-1 text-[11px]" style={{ color: 'var(--outline)' }}>No App Runs yet.</p> : <ul className="mt-2 space-y-1.5">{grants.recent_runs.slice(0, 5).map((run) => <li key={run.id}><button type="button" className="flex min-h-11 w-full items-start justify-between gap-3 rounded-lg px-2.5 py-2 text-left text-[11px]" style={{ background: 'var(--surface-container-high)' }} onClick={() => setSelectedRunId(run.id)}><span className="min-w-0"><span className="block truncate font-medium">{run.title}</span><span className="block truncate" style={{ color: 'var(--outline)' }}>{run.outcome_summary ?? run.summary ?? new Date(run.created_at).toLocaleString()}</span></span><RunState state={run.state} /></button></li>)}</ul>}</div>
           </>}
+      <AppRunInspector runId={selectedRunId} onClose={() => setSelectedRunId(null)} />
     </section>
   );
 }
@@ -233,4 +269,21 @@ function permissionDiffLabel(kind: ConnectedAppReview['permission_diff']['kind']
   if (kind === 'initial') return 'Initial connected authority';
   if (kind === 'unchanged') return 'Authority unchanged';
   return 'Authority widened or changed incompatibly';
+}
+
+function activationLabel(kind: 'initial' | 'upgrade' | 'reenable'): string {
+  if (kind === 'initial') return 'Initial';
+  if (kind === 'upgrade') return 'Upgrade';
+  return 'Re-enable';
+}
+
+function activationAction(kind: 'initial' | 'upgrade' | 'reenable'): string {
+  if (kind === 'initial') return 'Activate';
+  if (kind === 'upgrade') return 'Upgrade';
+  return 'Re-enable';
+}
+
+function RequirementState({ state }: { state: 'ready' | 'missing' | 'disabled' | 'version_mismatch' }) {
+  const color = state === 'ready' ? 'var(--status-green)' : 'var(--error)';
+  return <span className="flex-shrink-0 rounded-full px-2 py-0.5 text-[9px] font-semibold uppercase" style={{ color, background: 'var(--surface-container-low)' }}>{state.replaceAll('_', ' ')}</span>;
 }

--- a/apps/web/src/lib/apps.test.ts
+++ b/apps/web/src/lib/apps.test.ts
@@ -4,16 +4,97 @@ import {
   isConnectedAppManifest,
   normalizeAppGrantManagement,
   normalizeAppInstallation,
+  normalizeAppRunReceiptBundle,
   normalizeConnectedAppHealth,
   normalizeConnectedAppReview,
 } from './apps';
 
+const now = '2026-09-01T00:00:00.000Z';
+const provenance = {
+  source_repository: 'https://example.test/campaigns',
+  source_commit: 'abcdef0',
+};
 const moduleRef = {
   module_id: 'community.deft.campaigns',
   version: '1.0.0',
   manifest_path: 'modules/campaigns/deft.module.json',
   manifest_digest: 'sha256:module',
 };
+const compatibility = {
+  schema: 'deft.app_developer.compatibility.v1',
+  app_kit: { package: '@deft/app-kit', versions: ['0.1.0-alpha.1'] },
+  protocol_flows: {
+    '0': { package_format: 'deft.app.package.v0', install_mode: 'stage_and_activate' },
+    '1': { package_format: 'deft.app.package.v1', install_mode: 'stage_only' },
+  },
+};
+
+function connectedManifest(version = '1.0.0') {
+  return {
+    schema_version: '1',
+    id: 'community.deft.campaigns-app',
+    version,
+    name: 'Campaigns',
+    license: 'AGPL-3.0-only',
+    compatibility: { app_protocol: '1' },
+    provenance,
+    modules: [moduleRef],
+    navigation: [],
+    dependencies: [{ key: 'contacts', app_id: 'community.deft.contacts-app', version: '1.0.0' }],
+    resource_requirements: [
+      {
+        key: 'campaign',
+        source: { kind: 'included_module', module_id: moduleRef.module_id, version: moduleRef.version },
+        resource_type: 'campaigns',
+        fields: ['subject', 'body_text'],
+      },
+      {
+        key: 'contact',
+        source: {
+          kind: 'dependency_module',
+          dependency_key: 'contacts',
+          module_id: 'community.deft.contacts',
+          version: '1.0.0',
+        },
+        resource_type: 'contacts',
+        fields: ['email'],
+      },
+    ],
+    capability_requirements: [{
+      key: 'send_email',
+      interface: { kind: 'private', namespace: 'app_lineage', key: 'send_email', version: '1' },
+    }],
+    connector_requirements: [{ key: 'mail', provider_kind: 'mcp' }],
+    actions: [{
+      key: 'send',
+      label: 'Send',
+      capability_requirement_key: 'send_email',
+      connector_requirement_key: 'mail',
+      placement: { kind: 'resource_detail', resource_requirement_key: 'campaign' },
+      input_bindings: [
+        {
+          input_key: 'to',
+          source: {
+            kind: 'selected_relation_field',
+            source_resource_requirement_key: 'campaign',
+            relation_field_key: 'contacts',
+            target_resource_requirement_key: 'contact',
+            target_field_key: 'email',
+            selection: 'one',
+          },
+        },
+        {
+          input_key: 'subject',
+          source: { kind: 'resource_field', resource_requirement_key: 'campaign', field_key: 'subject' },
+        },
+        {
+          input_key: 'body_text',
+          source: { kind: 'resource_field', resource_requirement_key: 'campaign', field_key: 'body_text' },
+        },
+      ],
+    }],
+  };
+}
 
 function installation(protocol: '0' | '1') {
   return {
@@ -37,66 +118,242 @@ function installation(protocol: '0' | '1') {
       compatibility: { app_protocol: '0' },
       modules: [moduleRef],
       navigation: [],
-    } : {
-      schema_version: '1',
-      id: 'community.deft.campaigns-app',
-      version: '1.0.0',
-      name: 'Campaigns',
-      license: 'AGPL-3.0-only',
-      compatibility: { app_protocol: '1' },
-      modules: [moduleRef],
-      navigation: [],
-      dependencies: [{ key: 'contacts', app_id: 'community.deft.contacts-app', version: '1.0.0' }],
-      resource_requirements: [{ key: 'campaign', resource_type: 'campaigns', fields: ['subject'] }],
-      capability_requirements: [{ key: 'send_email' }],
-      connector_requirements: [{ key: 'mail', provider_kind: 'mcp' }],
-      actions: [{ key: 'send', label: 'Send', capability_requirement_key: 'send_email', connector_requirement_key: 'mail' }],
-    },
-    created_at: '2026-09-01T00:00:00.000Z',
-    updated_at: '2026-09-01T00:00:00.000Z',
+    } : connectedManifest(),
+    created_at: now,
+    updated_at: now,
   };
 }
 
-test('App installation normalization preserves v0 and discriminates connected v1 manifests', () => {
+test('App installation normalization preserves v0 and the expanded connected v1 manifest', () => {
   const v0 = normalizeAppInstallation(installation('0'));
   const v1 = normalizeAppInstallation(installation('1'));
   assert.equal(isConnectedAppManifest(v0.manifest), false);
   assert.equal(isConnectedAppManifest(v1.manifest), true);
-  if (isConnectedAppManifest(v1.manifest)) assert.equal(v1.manifest.actions[0].key, 'send');
+  if (isConnectedAppManifest(v1.manifest)) {
+    assert.deepEqual(v1.manifest.resource_requirements[1].source, {
+      kind: 'dependency_module',
+      dependency_key: 'contacts',
+      module_id: 'community.deft.contacts',
+      version: '1.0.0',
+    });
+    assert.deepEqual(v1.manifest.capability_requirements[0].interface, {
+      kind: 'private', namespace: 'app_lineage', key: 'send_email', version: '1',
+    });
+    assert.equal(v1.manifest.actions[0].placement.resource_requirement_key, 'campaign');
+    assert.equal(v1.manifest.actions[0].input_bindings[0].source.kind, 'selected_relation_field');
+  }
 });
 
-test('connected grant management projects requested, effective, binding, dependency, and recent Run data', () => {
+test('connected grant management projects staged review, active grants, compatibility, and recent Run data', () => {
   const grants = normalizeAppGrantManagement({ grants: {
     installation: {
       id: 'installation-1', app_id: 'community.deft.campaigns-app', state: 'active', active_version_id: 'version-1',
       active_grant_snapshot_id: 'effective-1', lifecycle_epoch: 1, grant_epoch: 1,
     },
-    versions: [{
-      id: 'version-1', version: '1.0.0', protocol_version: '1', state: 'active', package_digest: 'sha256:package',
-      manifest_digest: 'sha256:manifest', requested_grant_snapshot_id: 'requested-1', staged_at: '2026-09-01T00:00:00.000Z',
-      activated_at: '2026-09-01T00:01:00.000Z', superseded_at: null,
-    }],
+    compatibility,
+    versions: [
+      {
+        id: 'version-2', version: '1.1.0', protocol_version: '1', state: 'staged',
+        manifest: connectedManifest('1.1.0'), package_format: 'deft.app.package.v1', provenance,
+        provenance_trust: 'local_unsigned', package_digest: 'sha256:package-2', manifest_digest: 'sha256:manifest-2',
+        requested_grant_snapshot_id: 'requested-2', staged_at: '2026-09-01T00:03:00.000Z',
+        activated_at: null, superseded_at: null,
+      },
+      {
+        id: 'version-1', version: '1.0.0', protocol_version: '1', state: 'active',
+        manifest: connectedManifest(), package_format: 'deft.app.package.v1', provenance,
+        provenance_trust: 'local_unsigned', package_digest: 'sha256:package-1', manifest_digest: 'sha256:manifest-1',
+        requested_grant_snapshot_id: 'requested-1', staged_at: now,
+        activated_at: '2026-09-01T00:01:00.000Z', superseded_at: null,
+      },
+    ],
     snapshots: [
-      { id: 'requested-1', app_version_id: 'version-1', snapshot_kind: 'requested', requested_snapshot_id: null, supersedes_snapshot_id: null, resource_rights: [{}], classification: {}, snapshot_digest: 'sha256:requested', reviewed_at: null, created_at: '2026-09-01T00:00:00.000Z' },
+      { id: 'requested-2', app_version_id: 'version-2', snapshot_kind: 'requested', requested_snapshot_id: null, supersedes_snapshot_id: null, resource_rights: [{}], classification: {}, snapshot_digest: 'sha256:requested-2', reviewed_at: null, created_at: '2026-09-01T00:03:00.000Z' },
+      { id: 'requested-1', app_version_id: 'version-1', snapshot_kind: 'requested', requested_snapshot_id: null, supersedes_snapshot_id: null, resource_rights: [{}], classification: {}, snapshot_digest: 'sha256:requested-1', reviewed_at: null, created_at: now },
       { id: 'effective-1', app_version_id: 'version-1', snapshot_kind: 'effective', requested_snapshot_id: 'requested-1', supersedes_snapshot_id: null, resource_rights: [{}], classification: {}, snapshot_digest: 'sha256:effective', reviewed_at: '2026-09-01T00:01:00.000Z', created_at: '2026-09-01T00:01:00.000Z' },
     ],
-    dependencies: [{ id: 'dependency-1', dependency_key: 'contacts', required_app_id: 'community.deft.contacts-app', required_version: '1.0.0', dependency_installation_id: 'contacts-installation', dependency_version_id: 'contacts-version', dependency_lifecycle_epoch: 2, ownership: 'preexisting', lock_digest: 'sha256:lock' }],
-    action_bindings: [{
-      id: 'binding-1', action_key: 'send', capability_requirement_key: 'send_email', connector_requirement_key: 'mail',
-      interface_identity: 'private:app_lineage:send:1', provider_kind: 'mcp', mcp_connection_id: 'connection-1', operation_name: 'sandbox_send',
-      operation_schema_digest: 'sha256:schema', connector_authorization_version: 3, binding_digest: 'sha256:binding',
-      host_policy: { risk_class: 'external_write', review_requirement: 'per_invocation', review_scope: 'full', egress_class: 'external', retry_class: 'idempotent', retention_class: 'standard', automation_eligibility: 'denied', provider_idempotency_key_required: true },
+    review_target: {
+      activation_kind: 'upgrade',
+      app_version_id: 'version-2',
+      version: '1.1.0',
+      protocol_version: '1',
+      package_format: 'deft.app.package.v1',
+      package_digest: 'sha256:package-2',
+      manifest_digest: 'sha256:manifest-2',
+      manifest: connectedManifest('1.1.0'),
+      provenance,
+      provenance_trust: 'local_unsigned',
+      requested_snapshot_id: 'requested-2',
+      requested_snapshot_digest: 'sha256:requested-2',
+      requested_authority: {
+        resource_rights: [{
+          requirement_key: 'campaign',
+          source: { kind: 'included_module', module_id: moduleRef.module_id, version: moduleRef.version },
+          resource_type: 'campaigns',
+          fields: ['subject', 'body_text'],
+          right: 'read',
+        }],
+        classification: { review_required: true },
+      },
+      dependency_requirements: [{
+        key: 'contacts', app_id: 'community.deft.contacts-app', version: '1.0.0', status: 'ready',
+        installation_id: 'contacts-installation', active_version: '1.0.0', lifecycle_epoch: 2,
+      }],
+      connector_requirements: [{
+        key: 'mail',
+        provider_kind: 'mcp',
+        required_operations: ['send_email'],
+        current_binding: {
+          mcp_connection_id: 'connection-1', name: 'Sandbox mail', binding_digest: 'sha256:binding',
+          authorization_version: 3, configured: true,
+        },
+        candidates: [{
+          id: 'connection-1', name: 'Sandbox mail', status: 'configured', eligible_for_review: true,
+          authorization_version: 3, provider_schema_check: 'pending_review',
+        }],
+      }],
+      missing_binding_keys: [],
+      readiness: { dependencies_ready: true, connector_candidates_ready: true },
+    },
+    dependencies: [{
+      id: 'dependency-1', grant_snapshot_id: 'effective-1', dependency_key: 'contacts',
+      required_app_id: 'community.deft.contacts-app', required_version: '1.0.0',
+      dependency_installation_id: 'contacts-installation', dependency_version_id: 'contacts-version',
+      dependency_lifecycle_epoch: 2, ownership: 'preexisting', lock_digest: 'sha256:lock',
     }],
-    recent_runs: [{ id: 'run-1', state: 'pending_approval', safe_preview: { title: 'Send campaign', summary: 'One recipient' }, safe_outcome: null, created_at: '2026-09-01T00:02:00.000Z', updated_at: '2026-09-01T00:02:00.000Z' }],
+    action_bindings: [{
+      id: 'binding-1', grant_snapshot_id: 'effective-1', action_key: 'send',
+      capability_requirement_key: 'send_email', connector_requirement_key: 'mail',
+      interface_identity: 'private:app_lineage:send_email:1', provider_kind: 'mcp',
+      mcp_connection_id: 'connection-1', operation_name: 'send_email', operation_schema_digest: 'sha256:schema',
+      connector_authorization_version: 3, binding_digest: 'sha256:binding',
+      host_policy: {
+        risk_class: 'external_write', review_requirement: 'always', review_scope: 'full', egress_class: 'external',
+        retry_class: 'idempotent_with_key', retention_class: 'standard', automation_eligibility: 'denied',
+        provider_idempotency_key_required: true,
+      },
+    }],
+    recent_runs: [{
+      id: 'run-1', state: 'pending_approval', operation_name: 'send_email',
+      safe_preview: { title: 'Send campaign', summary: 'One recipient' }, safe_outcome: null,
+      risk_class: 'external_write', review_requirement: 'always',
+      result_expires_at: '2026-09-08T00:02:00.000Z', result_purged_at: null, terminal_at: null,
+      created_at: '2026-09-01T00:02:00.000Z', updated_at: '2026-09-01T00:02:00.000Z',
+    }],
   } });
 
+  assert.deepEqual(grants.compatibility, compatibility);
+  assert.deepEqual(grants.versions[0].provenance, provenance);
+  assert.equal(grants.versions[0].provenance_trust, 'local_unsigned');
+  assert.equal(grants.review_target?.activation_kind, 'upgrade');
+  assert.equal(grants.review_target?.dependency_requirements[0].status, 'ready');
+  assert.deepEqual(grants.review_target?.connector_requirements[0].required_operations, ['send_email']);
+  assert.deepEqual(grants.review_target?.missing_binding_keys, []);
   assert.equal(grants.snapshots.find((snapshot) => snapshot.snapshot_kind === 'effective')?.snapshot_digest, 'sha256:effective');
-  assert.equal(grants.action_bindings[0].mcp_connection_id, 'connection-1');
-  assert.equal(grants.dependencies[0].ownership, 'preexisting');
+  assert.equal(grants.action_bindings[0].grant_snapshot_id, 'effective-1');
+  assert.equal(grants.dependencies[0].grant_snapshot_id, 'effective-1');
   assert.deepEqual(grants.recent_runs[0], {
     id: 'run-1', state: 'pending_approval', title: 'Send campaign', summary: 'One recipient', outcome_summary: null,
+    operation_name: 'send_email', risk_class: 'external_write', review_requirement: 'always',
+    result_expires_at: '2026-09-08T00:02:00.000Z', result_purged_at: null, terminal_at: null,
     created_at: '2026-09-01T00:02:00.000Z', updated_at: '2026-09-01T00:02:00.000Z',
   });
+});
+
+test('App Run receipt normalization returns only the bounded verified projection', () => {
+  const raw = {
+    run: {
+      id: 'run-1',
+      state: 'succeeded',
+      operation_name: 'send_email',
+      safe_preview: { title: 'Send campaign', summary: 'One recipient' },
+      safe_outcome: { summary: 'Accepted by provider' },
+      risk_class: 'external_write',
+      review_requirement: 'always',
+      review_scope: 'full',
+      retry_class: 'idempotent_with_key',
+      retention_class: 'standard',
+      result_expires_at: '2026-09-08T00:02:00.000Z',
+      result_purged_at: null,
+      envelope: { secret: 'forbidden-run-envelope' },
+      signature: 'forbidden-run-signature',
+      signature_hmac: 'forbidden-run-hmac',
+      actor: { user_id: 'forbidden-run-actor' },
+      provider: { provider_instance_id: 'forbidden-run-provider' },
+    },
+    receipts: [{
+      receipt_id: 'receipt-1',
+      receipt_kind: 'attempt_terminal',
+      run_state: 'succeeded',
+      occurred_at: '2026-09-01T00:02:00.000Z',
+      envelope_digest: 'sha256:receipt',
+      signing_key_version: 'sig-v1',
+      signed_at: '2026-09-01T00:02:00.000Z',
+      verified: true,
+      envelope: { secret: 'forbidden-receipt-envelope' },
+      signature: 'forbidden-receipt-signature',
+      signature_hmac: 'forbidden-receipt-hmac',
+      actor: { user_id: 'forbidden-receipt-actor' },
+      provider: { provider_instance_id: 'forbidden-receipt-provider' },
+    }],
+    envelope: { secret: 'forbidden-bundle-envelope' },
+    signature: 'forbidden-bundle-signature',
+    actor: { user_id: 'forbidden-bundle-actor' },
+    provider: { provider_instance_id: 'forbidden-bundle-provider' },
+  };
+
+  const bundle = normalizeAppRunReceiptBundle(raw);
+  assert.deepEqual(bundle, {
+    run: {
+      id: 'run-1',
+      state: 'succeeded',
+      operation_name: 'send_email',
+      title: 'Send campaign',
+      summary: 'One recipient',
+      outcome_summary: 'Accepted by provider',
+      risk_class: 'external_write',
+      review_requirement: 'always',
+      review_scope: 'full',
+      retry_class: 'idempotent_with_key',
+      retention_class: 'standard',
+      result_expires_at: '2026-09-08T00:02:00.000Z',
+      result_purged_at: null,
+    },
+    receipts: [{
+      receipt_id: 'receipt-1',
+      receipt_kind: 'attempt_terminal',
+      run_state: 'succeeded',
+      occurred_at: '2026-09-01T00:02:00.000Z',
+      envelope_digest: 'sha256:receipt',
+      signing_key_version: 'sig-v1',
+      signed_at: '2026-09-01T00:02:00.000Z',
+      verified: true,
+    }],
+  });
+
+  const serialized = JSON.stringify(bundle);
+  for (const forbidden of [
+    'forbidden-run-envelope', 'forbidden-run-signature', 'forbidden-run-hmac', 'forbidden-run-actor',
+    'forbidden-run-provider', 'forbidden-receipt-envelope', 'forbidden-receipt-signature',
+    'forbidden-receipt-hmac', 'forbidden-receipt-actor', 'forbidden-receipt-provider',
+    'forbidden-bundle-envelope', 'forbidden-bundle-signature', 'forbidden-bundle-actor', 'forbidden-bundle-provider',
+  ]) assert.doesNotMatch(serialized, new RegExp(forbidden));
+});
+
+test('App Run receipt normalization rejects an unverified receipt', () => {
+  assert.throws(() => normalizeAppRunReceiptBundle({
+    run: {
+      id: 'run-1', state: 'succeeded', operation_name: 'send_email', safe_preview: {}, safe_outcome: null,
+      risk_class: 'external_write', review_requirement: 'always', review_scope: 'full',
+      retry_class: 'idempotent_with_key', retention_class: 'standard',
+      result_expires_at: '2026-09-08T00:02:00.000Z', result_purged_at: null,
+    },
+    receipts: [{
+      receipt_id: 'receipt-1', receipt_kind: 'attempt_terminal', run_state: 'succeeded',
+      occurred_at: now, envelope_digest: 'sha256:receipt', signing_key_version: 'sig-v1', signed_at: now,
+      verified: false,
+    }],
+  }), /not verified/);
 });
 
 test('review and health normalizers keep only safe management fields', () => {
@@ -106,7 +363,7 @@ test('review and health normalizers keep only safe management fields', () => {
     lifecycle_epoch: 0, grant_epoch: 0,
     permission_diff: { kind: 'initial', carry_forward_eligible: false, changed_atoms: ['action:send'], prior_authority_surface_digest: null, proposed_authority_surface_digest: 'sha256:surface' },
     classification: {}, resource_rights: [{}], dependencies: [],
-    action_bindings: [{ action_key: 'send', capability_requirement_key: 'send_email', connector_requirement_key: 'mail', interface_identity: 'private:send:1', provider_kind: 'mcp', mcp_connection_id: 'connection-1', operation_name: 'sandbox_send', operation_schema_digest: 'sha256:schema', connector_authorization_version: 1, binding_digest: 'sha256:binding' }],
+    action_bindings: [{ action_key: 'send', capability_requirement_key: 'send_email', connector_requirement_key: 'mail', interface_identity: 'private:app_lineage:send_email:1', provider_kind: 'mcp', mcp_connection_id: 'connection-1', operation_name: 'send_email', operation_schema_digest: 'sha256:schema', connector_authorization_version: 1, binding_digest: 'sha256:binding' }],
     authority_surface_digest: 'sha256:surface', review_digest: 'sha256:review',
   } });
   const health = normalizeConnectedAppHealth({ health: { status: 'unhealthy', installation_id: 'installation-1', active_grant_snapshot_id: null, lifecycle_epoch: 0, grant_epoch: 0, checked_provider_schemas: true, issues: [{ code: 'APP_NOT_ACTIVE', subject_id: 'installation-1', message: 'The App is not active' }] } });

--- a/apps/web/src/lib/apps.ts
+++ b/apps/web/src/lib/apps.ts
@@ -23,18 +23,44 @@ export type AppManifestV0 = AppManifestBase & {
   compatibility: { app_protocol: '0' };
 };
 
+export type AppResourceSource =
+  | { kind: 'included_module'; module_id: string; version: string }
+  | { kind: 'dependency_module'; dependency_key: string; module_id: string; version: string };
+
+export type AppActionInputSource =
+  | { kind: 'resource_field'; resource_requirement_key: string; field_key: string }
+  | {
+      kind: 'selected_relation_field';
+      source_resource_requirement_key: string;
+      relation_field_key: string;
+      target_resource_requirement_key: string;
+      target_field_key: string;
+      selection: 'one';
+    }
+  | { kind: 'user_input'; input_type: 'email' | 'text'; label: string; required: true };
+
 export type AppManifestV1 = AppManifestBase & {
   schema_version: '1';
   compatibility: { app_protocol: '1' };
   dependencies: Array<{ key: string; app_id: string; version: string }>;
-  resource_requirements: Array<{ key: string; resource_type: string; fields: string[] }>;
-  capability_requirements: Array<{ key: string }>;
+  resource_requirements: Array<{
+    key: string;
+    source: AppResourceSource;
+    resource_type: string;
+    fields: string[];
+  }>;
+  capability_requirements: Array<{
+    key: string;
+    interface: { kind: 'private'; namespace: 'app_lineage'; key: string; version: string };
+  }>;
   connector_requirements: Array<{ key: string; provider_kind: 'mcp' }>;
   actions: Array<{
     key: string;
     label: string;
     capability_requirement_key: string;
     connector_requirement_key: string;
+    placement: { kind: 'resource_detail'; resource_requirement_key: string };
+    input_bindings: Array<{ input_key: 'to' | 'subject' | 'body_text'; source: AppActionInputSource }>;
   }>;
 };
 
@@ -63,6 +89,7 @@ export type AppInstallation = {
 
 export type AppInspection = {
   manifest: AppManifest;
+  package_format: 'deft.app.package.v0' | 'deft.app.package.v1';
   manifest_digest: string;
   package_digest: string;
   canonical_package_json: string;
@@ -74,6 +101,10 @@ export type AppGrantVersion = {
   version: string;
   protocol_version: '0' | '1';
   state: string;
+  manifest: AppManifest;
+  package_format: 'deft.app.package.v0' | 'deft.app.package.v1';
+  provenance: AppManifestBase['provenance'] | null;
+  provenance_trust: 'local_unsigned';
   package_digest: string;
   manifest_digest: string;
   requested_grant_snapshot_id: string | null;
@@ -97,6 +128,7 @@ export type AppGrantSnapshot = {
 
 export type AppDependencyLock = {
   id: string;
+  grant_snapshot_id: string;
   dependency_key: string;
   required_app_id: string;
   required_version: string;
@@ -109,6 +141,7 @@ export type AppDependencyLock = {
 
 export type AppActionBinding = {
   id: string;
+  grant_snapshot_id: string;
   action_key: string;
   capability_requirement_key: string;
   connector_requirement_key: string;
@@ -137,8 +170,107 @@ export type AppRunSummary = {
   title: string;
   summary: string | null;
   outcome_summary: string | null;
+  operation_name: string;
+  risk_class: string;
+  review_requirement: string;
+  result_expires_at: string;
+  result_purged_at: string | null;
+  terminal_at: string | null;
   created_at: string;
   updated_at: string;
+};
+
+export type AppRunReceiptBundle = {
+  run: {
+    id: string;
+    state: AppRunSummary['state'];
+    operation_name: string;
+    title: string;
+    summary: string | null;
+    outcome_summary: string | null;
+    risk_class: string;
+    review_requirement: string;
+    review_scope: string;
+    retry_class: string;
+    retention_class: string;
+    result_expires_at: string;
+    result_purged_at: string | null;
+  };
+  receipts: Array<{
+    receipt_id: string;
+    receipt_kind: 'approval' | 'attempt_terminal' | 'reconciliation' | 'repair';
+    run_state: AppRunSummary['state'];
+    occurred_at: string;
+    envelope_digest: string;
+    signing_key_version: string;
+    signed_at: string;
+    verified: true;
+  }>;
+};
+
+export type AppHostCompatibility = {
+  schema: string;
+  app_kit: { package: string; versions: string[] };
+  protocol_flows: {
+    '0': { package_format: 'deft.app.package.v0'; install_mode: 'stage_and_activate' };
+    '1': { package_format: 'deft.app.package.v1'; install_mode: 'stage_only' };
+  };
+};
+
+export type ConnectedAppReviewTarget = {
+  activation_kind: 'initial' | 'upgrade' | 'reenable';
+  app_version_id: string;
+  version: string;
+  protocol_version: '1';
+  package_format: 'deft.app.package.v1';
+  package_digest: string;
+  manifest_digest: string;
+  manifest: AppManifestV1;
+  provenance: AppManifestBase['provenance'] | null;
+  provenance_trust: 'local_unsigned';
+  requested_snapshot_id: string;
+  requested_snapshot_digest: string;
+  requested_authority: {
+    resource_rights: Array<{
+      requirement_key: string;
+      source: AppResourceSource;
+      resource_type: string;
+      fields: string[];
+      right: 'read';
+    }>;
+    classification: Record<string, unknown>;
+  };
+  dependency_requirements: Array<{
+    key: string;
+    app_id: string;
+    version: string;
+    status: 'ready' | 'missing' | 'disabled' | 'version_mismatch';
+    installation_id: string | null;
+    active_version: string | null;
+    lifecycle_epoch: number | null;
+  }>;
+  connector_requirements: Array<{
+    key: string;
+    provider_kind: 'mcp';
+    required_operations: string[];
+    current_binding: {
+      mcp_connection_id: string;
+      name: string;
+      binding_digest: string;
+      authorization_version: number;
+      configured: boolean;
+    } | null;
+    candidates: Array<{
+      id: string;
+      name: string;
+      status: 'inactive' | 'unhealthy' | 'configured' | 'operation_disabled';
+      eligible_for_review: boolean;
+      authorization_version: number;
+      provider_schema_check: 'pending_review';
+    }>;
+  }>;
+  missing_binding_keys: string[];
+  readiness: { dependencies_ready: boolean; connector_candidates_ready: boolean };
 };
 
 export type AppGrantManagement = {
@@ -151,8 +283,10 @@ export type AppGrantManagement = {
     lifecycle_epoch: number;
     grant_epoch: number;
   };
+  compatibility: AppHostCompatibility;
   versions: AppGrantVersion[];
   snapshots: AppGrantSnapshot[];
+  review_target: ConnectedAppReviewTarget | null;
   dependencies: AppDependencyLock[];
   action_bindings: AppActionBinding[];
   recent_runs: AppRunSummary[];
@@ -231,6 +365,13 @@ function stringValue(value: unknown, label: string): string {
   return value;
 }
 
+function packageFormat(value: unknown): 'deft.app.package.v0' | 'deft.app.package.v1' {
+  if (value !== 'deft.app.package.v0' && value !== 'deft.app.package.v1') {
+    throw new Error('Invalid App package format.');
+  }
+  return value;
+}
+
 function nullableString(value: unknown, label: string): string | null {
   if (value === null || value === undefined) return null;
   return stringValue(value, label);
@@ -239,6 +380,11 @@ function nullableString(value: unknown, label: string): string | null {
 function integer(value: unknown, label: string): number {
   if (typeof value !== 'number' || !Number.isInteger(value) || value < 0) throw new Error(`Invalid ${label}.`);
   return value;
+}
+
+function nullableInteger(value: unknown, label: string): number | null {
+  if (value === null || value === undefined) return null;
+  return integer(value, label);
 }
 
 function stringArray(value: unknown, label: string): string[] {
@@ -259,6 +405,54 @@ function normalizeModuleReference(value: unknown): AppModuleReference {
     manifest_path: stringValue(row.manifest_path, 'App Module path'),
     manifest_digest: stringValue(row.manifest_digest, 'App Module digest'),
   };
+}
+
+function normalizeResourceSource(value: unknown): AppResourceSource {
+  const row = object(value, 'App resource source');
+  if (row.kind === 'included_module') return {
+    kind: 'included_module',
+    module_id: stringValue(row.module_id, 'App resource Module'),
+    version: stringValue(row.version, 'App resource Module version'),
+  };
+  if (row.kind === 'dependency_module') return {
+    kind: 'dependency_module',
+    dependency_key: stringValue(row.dependency_key, 'App resource dependency'),
+    module_id: stringValue(row.module_id, 'App resource Module'),
+    version: stringValue(row.version, 'App resource Module version'),
+  };
+  throw new Error('Invalid App resource source.');
+}
+
+function normalizeActionInputSource(value: unknown): AppActionInputSource {
+  const row = object(value, 'App action input source');
+  if (row.kind === 'resource_field') return {
+    kind: 'resource_field',
+    resource_requirement_key: stringValue(row.resource_requirement_key, 'App action resource requirement'),
+    field_key: stringValue(row.field_key, 'App action resource field'),
+  };
+  if (row.kind === 'selected_relation_field') {
+    if (row.selection !== 'one') throw new Error('Invalid App action relation selection.');
+    return {
+      kind: 'selected_relation_field',
+      source_resource_requirement_key: stringValue(row.source_resource_requirement_key, 'App action source resource'),
+      relation_field_key: stringValue(row.relation_field_key, 'App action relation field'),
+      target_resource_requirement_key: stringValue(row.target_resource_requirement_key, 'App action target resource'),
+      target_field_key: stringValue(row.target_field_key, 'App action target field'),
+      selection: 'one',
+    };
+  }
+  if (row.kind === 'user_input') {
+    if ((row.input_type !== 'email' && row.input_type !== 'text') || row.required !== true) {
+      throw new Error('Invalid App action user input.');
+    }
+    return {
+      kind: 'user_input',
+      input_type: row.input_type,
+      label: stringValue(row.label, 'App action input label'),
+      required: true,
+    };
+  }
+  throw new Error('Invalid App action input source.');
 }
 
 function normalizeManifest(value: unknown): AppManifest {
@@ -303,22 +497,52 @@ function normalizeManifest(value: unknown): AppManifest {
     })),
     resource_requirements: recordArray(row.resource_requirements ?? [], 'App resource requirements').map((entry) => ({
       key: stringValue(entry.key, 'App resource requirement key'),
+      source: normalizeResourceSource(entry.source),
       resource_type: stringValue(entry.resource_type, 'App resource type'),
       fields: stringArray(entry.fields ?? [], 'App resource fields'),
     })),
-    capability_requirements: recordArray(row.capability_requirements ?? [], 'App capability requirements').map((entry) => ({
-      key: stringValue(entry.key, 'App capability requirement key'),
-    })),
+    capability_requirements: recordArray(row.capability_requirements ?? [], 'App capability requirements').map((entry) => {
+      const descriptor = object(entry.interface, 'App capability interface');
+      if (descriptor.kind !== 'private' || descriptor.namespace !== 'app_lineage') {
+        throw new Error('Unsupported App capability interface.');
+      }
+      return {
+        key: stringValue(entry.key, 'App capability requirement key'),
+        interface: {
+          kind: 'private' as const,
+          namespace: 'app_lineage' as const,
+          key: stringValue(descriptor.key, 'App capability interface key'),
+          version: stringValue(descriptor.version, 'App capability interface version'),
+        },
+      };
+    }),
     connector_requirements: recordArray(row.connector_requirements ?? [], 'App connector requirements').map((entry) => {
       if (entry.provider_kind !== 'mcp') throw new Error('Unsupported App connector provider.');
       return { key: stringValue(entry.key, 'App connector requirement key'), provider_kind: 'mcp' as const };
     }),
-    actions: recordArray(row.actions ?? [], 'App actions').map((entry) => ({
-      key: stringValue(entry.key, 'App action key'),
-      label: stringValue(entry.label, 'App action label'),
-      capability_requirement_key: stringValue(entry.capability_requirement_key, 'App action capability'),
-      connector_requirement_key: stringValue(entry.connector_requirement_key, 'App action connector'),
-    })),
+    actions: recordArray(row.actions ?? [], 'App actions').map((entry) => {
+      const placement = object(entry.placement, 'App action placement');
+      if (placement.kind !== 'resource_detail') throw new Error('Unsupported App action placement.');
+      return {
+        key: stringValue(entry.key, 'App action key'),
+        label: stringValue(entry.label, 'App action label'),
+        capability_requirement_key: stringValue(entry.capability_requirement_key, 'App action capability'),
+        connector_requirement_key: stringValue(entry.connector_requirement_key, 'App action connector'),
+        placement: {
+          kind: 'resource_detail' as const,
+          resource_requirement_key: stringValue(
+            placement.resource_requirement_key,
+            'App action placement resource',
+          ),
+        },
+        input_bindings: recordArray(entry.input_bindings ?? [], 'App action input bindings').map((binding) => {
+          if (binding.input_key !== 'to' && binding.input_key !== 'subject' && binding.input_key !== 'body_text') {
+            throw new Error('Unsupported App action input key.');
+          }
+          return { input_key: binding.input_key, source: normalizeActionInputSource(binding.source) };
+        }),
+      };
+    }),
   };
 }
 
@@ -353,9 +577,11 @@ export function normalizeAppsResponse(value: unknown): AppInstallation[] {
 export function normalizeAppInspection(value: unknown): AppInspection {
   const body = object(value, 'App inspection response');
   const row = object(body.inspection ?? value, 'App inspection');
+  const packageValue = object(row.package, 'App package');
   if (!Array.isArray(row.permissions)) throw new Error('Invalid App inspection permissions.');
   return {
     manifest: normalizeManifest(row.manifest),
+    package_format: packageFormat(packageValue.package_format),
     manifest_digest: stringValue(row.manifest_digest, 'App manifest digest'),
     package_digest: stringValue(row.package_digest, 'App package digest'),
     canonical_package_json: stringValue(row.canonical_package_json, 'canonical App package'),
@@ -375,8 +601,189 @@ function normalizeRunSummary(value: unknown): AppRunSummary {
     title: typeof preview.title === 'string' && preview.title.trim() ? preview.title : 'App action',
     summary: typeof preview.summary === 'string' ? preview.summary : null,
     outcome_summary: typeof outcome.summary === 'string' ? outcome.summary : null,
+    operation_name: stringValue(row.operation_name, 'App Run operation'),
+    risk_class: stringValue(row.risk_class, 'App Run risk class'),
+    review_requirement: stringValue(row.review_requirement, 'App Run review requirement'),
+    result_expires_at: stringValue(row.result_expires_at, 'App Run result expiry'),
+    result_purged_at: nullableString(row.result_purged_at, 'App Run result purge time'),
+    terminal_at: nullableString(row.terminal_at, 'App Run terminal time'),
     created_at: stringValue(row.created_at, 'App Run created time'),
     updated_at: stringValue(row.updated_at, 'App Run updated time'),
+  };
+}
+
+export function normalizeAppRunReceiptBundle(value: unknown): AppRunReceiptBundle {
+  const body = object(value, 'App Run receipt response');
+  const run = object(body.run, 'App Run receipt metadata');
+  const state = run.state;
+  if (!['pending', 'pending_approval', 'running', 'waiting_external', 'succeeded', 'failed', 'cancelled', 'expired', 'unknown_outcome'].includes(String(state))) {
+    throw new Error('Invalid App Run receipt state.');
+  }
+  const preview = run.safe_preview ? object(run.safe_preview, 'App Run receipt preview') : {};
+  const outcome = run.safe_outcome ? object(run.safe_outcome, 'App Run receipt outcome') : {};
+  const receipts = recordArray(body.receipts ?? [], 'App Run receipts').map((receipt) => {
+    if (!['approval', 'attempt_terminal', 'reconciliation', 'repair'].includes(String(receipt.receipt_kind))) {
+      throw new Error('Invalid App Run receipt kind.');
+    }
+    if (!['pending', 'pending_approval', 'running', 'waiting_external', 'succeeded', 'failed', 'cancelled', 'expired', 'unknown_outcome'].includes(String(receipt.run_state))) {
+      throw new Error('Invalid App Run receipt state.');
+    }
+    if (receipt.verified !== true) throw new Error('App Run receipt is not verified.');
+    return {
+      receipt_id: stringValue(receipt.receipt_id, 'App Run receipt identity'),
+      receipt_kind: receipt.receipt_kind as AppRunReceiptBundle['receipts'][number]['receipt_kind'],
+      run_state: receipt.run_state as AppRunSummary['state'],
+      occurred_at: stringValue(receipt.occurred_at, 'App Run receipt time'),
+      envelope_digest: stringValue(receipt.envelope_digest, 'App Run receipt digest'),
+      signing_key_version: stringValue(receipt.signing_key_version, 'App Run receipt signing key'),
+      signed_at: stringValue(receipt.signed_at, 'App Run receipt signature time'),
+      verified: true as const,
+    };
+  });
+  return {
+    run: {
+      id: stringValue(run.id, 'App Run identity'),
+      state: state as AppRunSummary['state'],
+      operation_name: stringValue(run.operation_name, 'App Run operation'),
+      title: typeof preview.title === 'string' && preview.title.trim() ? preview.title : 'App action',
+      summary: typeof preview.summary === 'string' ? preview.summary : null,
+      outcome_summary: typeof outcome.summary === 'string' ? outcome.summary : null,
+      risk_class: stringValue(run.risk_class, 'App Run risk class'),
+      review_requirement: stringValue(run.review_requirement, 'App Run review requirement'),
+      review_scope: stringValue(run.review_scope, 'App Run review scope'),
+      retry_class: stringValue(run.retry_class, 'App Run retry class'),
+      retention_class: stringValue(run.retention_class, 'App Run retention class'),
+      result_expires_at: stringValue(run.result_expires_at, 'App Run result expiry'),
+      result_purged_at: nullableString(run.result_purged_at, 'App Run result purge time'),
+    },
+    receipts,
+  };
+}
+
+function normalizeHostCompatibility(value: unknown): AppHostCompatibility {
+  const row = object(value, 'App host compatibility');
+  const appKit = object(row.app_kit, 'App Kit compatibility');
+  const flows = object(row.protocol_flows, 'App protocol flows');
+  const v0 = object(flows['0'], 'App Protocol v0 flow');
+  const v1 = object(flows['1'], 'App Protocol v1 flow');
+  if (v0.install_mode !== 'stage_and_activate' || v1.install_mode !== 'stage_only') {
+    throw new Error('Invalid App install flow.');
+  }
+  const v0Format = packageFormat(v0.package_format);
+  const v1Format = packageFormat(v1.package_format);
+  if (v0Format !== 'deft.app.package.v0' || v1Format !== 'deft.app.package.v1') {
+    throw new Error('Invalid App protocol package format.');
+  }
+  return {
+    schema: stringValue(row.schema, 'App compatibility schema'),
+    app_kit: {
+      package: stringValue(appKit.package, 'App Kit package'),
+      versions: stringArray(appKit.versions, 'App Kit versions'),
+    },
+    protocol_flows: {
+      '0': { package_format: v0Format, install_mode: 'stage_and_activate' },
+      '1': { package_format: v1Format, install_mode: 'stage_only' },
+    },
+  };
+}
+
+function normalizeConnectedAppReviewTarget(value: unknown): ConnectedAppReviewTarget | null {
+  if (value === null || value === undefined) return null;
+  const row = object(value, 'connected App review target');
+  if (row.activation_kind !== 'initial' && row.activation_kind !== 'upgrade' && row.activation_kind !== 'reenable') {
+    throw new Error('Invalid connected App activation kind.');
+  }
+  if (row.protocol_version !== '1' || packageFormat(row.package_format) !== 'deft.app.package.v1') {
+    throw new Error('Invalid connected App review protocol.');
+  }
+  if (row.provenance_trust !== 'local_unsigned') throw new Error('Invalid App provenance trust.');
+  const manifest = normalizeManifest(row.manifest);
+  if (!isConnectedAppManifest(manifest)) throw new Error('Invalid connected App review manifest.');
+  const authority = object(row.requested_authority, 'requested App authority');
+  const dependencies = recordArray(row.dependency_requirements ?? [], 'App dependency requirements').map((entry) => {
+    if (!['ready', 'missing', 'disabled', 'version_mismatch'].includes(String(entry.status))) {
+      throw new Error('Invalid App dependency status.');
+    }
+    return {
+      key: stringValue(entry.key, 'App dependency key'),
+      app_id: stringValue(entry.app_id, 'App dependency identity'),
+      version: stringValue(entry.version, 'App dependency version'),
+      status: entry.status as ConnectedAppReviewTarget['dependency_requirements'][number]['status'],
+      installation_id: nullableString(entry.installation_id, 'App dependency installation'),
+      active_version: nullableString(entry.active_version, 'active dependency version'),
+      lifecycle_epoch: nullableInteger(entry.lifecycle_epoch, 'dependency lifecycle epoch'),
+    };
+  });
+  const connectors = recordArray(row.connector_requirements ?? [], 'App connector requirements').map((entry) => {
+    if (entry.provider_kind !== 'mcp') throw new Error('Invalid App connector provider.');
+    const currentValue = entry.current_binding;
+    const current = currentValue === null || currentValue === undefined ? null : (() => {
+      const binding = object(currentValue, 'current App connector binding');
+      return {
+        mcp_connection_id: stringValue(binding.mcp_connection_id, 'App connector identity'),
+        name: stringValue(binding.name, 'App connector name'),
+        binding_digest: stringValue(binding.binding_digest, 'App connector binding digest'),
+        authorization_version: integer(binding.authorization_version, 'App connector authorization version'),
+        configured: binding.configured === true,
+      };
+    })();
+    return {
+      key: stringValue(entry.key, 'App connector requirement key'),
+      provider_kind: 'mcp' as const,
+      required_operations: stringArray(entry.required_operations ?? [], 'App connector operations'),
+      current_binding: current,
+      candidates: recordArray(entry.candidates ?? [], 'App connector candidates').map((candidate) => {
+        if (!['inactive', 'unhealthy', 'configured', 'operation_disabled'].includes(String(candidate.status))) {
+          throw new Error('Invalid App connector candidate status.');
+        }
+        if (candidate.provider_schema_check !== 'pending_review') {
+          throw new Error('Invalid App provider schema check state.');
+        }
+        return {
+          id: stringValue(candidate.id, 'App connector candidate identity'),
+          name: stringValue(candidate.name, 'App connector candidate name'),
+          status: candidate.status as ConnectedAppReviewTarget['connector_requirements'][number]['candidates'][number]['status'],
+          eligible_for_review: candidate.eligible_for_review === true,
+          authorization_version: integer(candidate.authorization_version, 'App connector candidate authorization version'),
+          provider_schema_check: 'pending_review' as const,
+        };
+      }),
+    };
+  });
+  const readiness = object(row.readiness, 'App review readiness');
+  return {
+    activation_kind: row.activation_kind,
+    app_version_id: stringValue(row.app_version_id, 'App review version identity'),
+    version: stringValue(row.version, 'App review version'),
+    protocol_version: '1',
+    package_format: 'deft.app.package.v1',
+    package_digest: stringValue(row.package_digest, 'App review package digest'),
+    manifest_digest: stringValue(row.manifest_digest, 'App review manifest digest'),
+    manifest,
+    provenance: manifest.provenance ?? null,
+    provenance_trust: 'local_unsigned',
+    requested_snapshot_id: stringValue(row.requested_snapshot_id, 'requested App snapshot identity'),
+    requested_snapshot_digest: stringValue(row.requested_snapshot_digest, 'requested App snapshot digest'),
+    requested_authority: {
+      resource_rights: recordArray(authority.resource_rights ?? [], 'requested App resource rights').map((right) => {
+        if (right.right !== 'read') throw new Error('Invalid requested App resource right.');
+        return {
+          requirement_key: stringValue(right.requirement_key, 'App resource requirement key'),
+          source: normalizeResourceSource(right.source),
+          resource_type: stringValue(right.resource_type, 'App resource type'),
+          fields: stringArray(right.fields ?? [], 'App resource fields'),
+          right: 'read' as const,
+        };
+      }),
+      classification: object(authority.classification ?? {}, 'requested App classification'),
+    },
+    dependency_requirements: dependencies,
+    connector_requirements: connectors,
+    missing_binding_keys: stringArray(row.missing_binding_keys ?? [], 'missing App binding keys'),
+    readiness: {
+      dependencies_ready: readiness.dependencies_ready === true,
+      connector_candidates_ready: readiness.connector_candidates_ready === true,
+    },
   };
 }
 
@@ -396,13 +803,20 @@ export function normalizeAppGrantManagement(value: unknown): AppGrantManagement 
       lifecycle_epoch: integer(installation.lifecycle_epoch, 'App lifecycle epoch'),
       grant_epoch: integer(installation.grant_epoch, 'App grant epoch'),
     },
+    compatibility: normalizeHostCompatibility(root.compatibility),
     versions: recordArray(root.versions ?? [], 'App grant versions').map((row) => {
       if (row.protocol_version !== '0' && row.protocol_version !== '1') throw new Error('Invalid App protocol version.');
+      if (row.provenance_trust !== 'local_unsigned') throw new Error('Invalid App version provenance trust.');
+      const manifest = normalizeManifest(row.manifest);
       return {
         id: stringValue(row.id, 'App version identity'),
         version: stringValue(row.version, 'App version'),
         protocol_version: row.protocol_version,
         state: stringValue(row.state, 'App version state'),
+        manifest,
+        package_format: packageFormat(row.package_format),
+        provenance: manifest.provenance ?? null,
+        provenance_trust: 'local_unsigned' as const,
         package_digest: stringValue(row.package_digest, 'App package digest'),
         manifest_digest: stringValue(row.manifest_digest, 'App manifest digest'),
         requested_grant_snapshot_id: nullableString(row.requested_grant_snapshot_id, 'requested App grant identity'),
@@ -426,8 +840,10 @@ export function normalizeAppGrantManagement(value: unknown): AppGrantManagement 
         created_at: stringValue(row.created_at, 'App grant created time'),
       };
     }),
+    review_target: normalizeConnectedAppReviewTarget(root.review_target),
     dependencies: recordArray(root.dependencies ?? [], 'App dependency locks').map((row) => ({
       id: stringValue(row.id, 'App dependency lock identity'),
+      grant_snapshot_id: stringValue(row.grant_snapshot_id, 'App dependency grant identity'),
       dependency_key: stringValue(row.dependency_key, 'App dependency key'),
       required_app_id: stringValue(row.required_app_id, 'required App identity'),
       required_version: stringValue(row.required_version, 'required App version'),
@@ -451,6 +867,7 @@ function normalizeActionBinding(row: UnknownRecord): AppActionBinding {
   const host = object(row.host_policy, 'App action host policy');
   return {
     id: stringValue(row.id, 'App action binding identity'),
+    grant_snapshot_id: stringValue(row.grant_snapshot_id, 'App action grant identity'),
     action_key: stringValue(row.action_key, 'App action key'),
     capability_requirement_key: stringValue(row.capability_requirement_key, 'App capability key'),
     connector_requirement_key: stringValue(row.connector_requirement_key, 'App connector key'),

--- a/docs/connected-app-author-guide.md
+++ b/docs/connected-app-author-guide.md
@@ -1,9 +1,10 @@
 # Connected App author guide
 
-This guide covers the Phase 6 PR A proof: an independent author can create,
-check, build, verify host compatibility, and locally stage one App Protocol v1
-connected App using packed public artifacts. The handoff ends at a staged App
-with zero authority.
+This guide covers the Phase 6 connected-App journey through its native
+lifecycle: an independent author can create, check, build, verify host
+compatibility, and locally stage one App Protocol v1 connected App using packed
+public artifacts; an authorized workspace operator can then review, bind,
+activate, inspect, upgrade, disable, and freshly re-enable it in Deft.
 
 The current authoring artifact is `@deft/app-kit@0.1.0-alpha.1`. Use a packed
 tarball of that exact version; do not substitute a monorepo workspace link or
@@ -167,6 +168,11 @@ Wrong App Kit versions, missing protocol flows, and package-format mismatches
 also fail. `install-local` performs this same compatibility preflight before it
 reads or exchanges a pairing code.
 
+On success, `doctor` reports the exact App Kit package and version, App Protocol
+version, package format, install mode, and host URL. This is compatibility
+evidence only; it does not verify a registry, publisher identity, or package
+signature and does not establish trust.
+
 `doctor` checks App Kit/protocol/package compatibility only. It does not check
 connector health, simulate grants, activate an App, resolve relations, invoke a
 provider, or prove App Run readiness.
@@ -194,14 +200,46 @@ The result depends on the protocol:
 | v0 | Stage and activate the declarative App | No connected authority exists in v0 |
 | v1 | Leave the installation/version in `staged` | Zero effective grant, dependency lock, action binding, connector change, provider call, approval, or App Run |
 
-For v1, stop at the staged result. Hand the installable package, lockfile,
-requested-authority report, exact App Kit artifact identity, and proof-bundle
-identity to the owner/admin. Review, dependency selection, provider binding,
-effective-grant creation, and activation are host-owned operations; none can be
-encoded in the App package or requested-authority report. This PR A authoring
-slice does not promise a connected lifecycle UI for that handoff.
+For v1, the author stops at the staged result. Hand the installable package,
+lockfile, requested-authority report, exact App Kit artifact identity, and
+proof-bundle identity to the owner/admin. Review, dependency validation,
+provider binding, effective-grant creation, and activation are host-owned
+operations; none can be encoded in the App package or requested-authority
+report.
 
-## 6. Run the proof-only sandbox provider
+## 6. Complete the native operator lifecycle
+
+In **Settings → Apps**, an active owner or admin can inspect the exact staged
+version and package digest, requested resource reads, dependency status,
+lineage-private capability requirement, eligible connector candidates, and
+missing bindings. The screen labels local packages as unsigned and treats any
+declared source repository and commit as an unverified author claim.
+
+The operator selects exact connectors and runs review. Deft refreshes provider
+schemas at review time, computes the deterministic authority diff, and requires
+explicit acceptance of the host-owned approval, retention, egress, and retry
+policy before activation. Reloading the page does not lose the staged target;
+the host derives it from persisted installation and version state.
+
+An active or disabled connected App can stage a higher-version package through
+the same screen. The current version and effective authority remain unchanged
+until the upgrade receives its own exact review and atomic activation. When
+more than one higher version is staged, Deft selects the highest version as the
+only reviewable target; a client cannot activate an older staged package around
+that selection. Disable preserves data but clears active authority. The generic
+legacy enable path is intentionally unavailable for Protocol v1; **Re-enable**
+performs a new review
+against live membership, dependencies, connector authorization, provider
+schema, grant epochs, and bindings before restoring authority.
+
+Recent App Runs expose bounded safe status, policy, retention, and
+server-verified receipt metadata only to a caller already authorized to inspect
+that exact Run. The response omits raw provider envelopes, signatures,
+ciphertext, output payloads, and cross-actor metadata. A manager may therefore
+see a safe recent-Run summary but be denied its receipt detail when they were
+not an authorized Run actor.
+
+## 7. Run the proof-only sandbox provider
 
 The standalone
 [sandbox email provider](../examples/app-platform-sandbox-email-provider/README.md)
@@ -256,24 +294,21 @@ not allowlist a shell, PowerShell, `cmd`, `pnpm`, `npm`, `npx`, a package runner
 or a broad directory. Configuring this proof provider does not bind it to an
 App, grant provider access, or make a staged App executable.
 
-## PR A boundaries
+## Current boundaries
 
 - No self-grant: packages and reports request authority; only the host can
   create effective grants, bindings, and activation state.
-- No App-origin execution: PR A ends at zero-authority staging and makes no
-  provider call, approval, App Run, or receipt promise.
+- No author self-activation: author tooling ends at zero-authority staging;
+  reviewed App-origin execution remains host-owned and feature-gated.
 - No production email: the sandbox provider retains in-memory proof results and
   performs no network egress.
-- No connected lifecycle UI: the author path is CLI/API proof and adds no
-  review, bind, activate, or operating UI promise.
 - No automation: the v1 sandbox action is human-initiated, single-recipient,
   always reviewed by host policy, and forbidden in automation.
 - No external runtime promise: App Kit contains no MCP loader or hosted runtime,
   and the standalone provider is not a general runtime, SMTP adapter, sync
   engine, credential store, or public ingress service.
 
-Staging needs no App Run keyring because it creates no Run. Any later operator
-who separately enables reviewed App-origin execution must follow
+Staging needs no App Run keyring because it creates no Run. An operator who
+enables reviewed App-origin execution must follow
 [Governed App Run operations](app-run-operations.md), including matching
-database/keyring backup and restore; that later execution lifecycle is outside
-this PR A guide.
+database/keyring backup and restore.

--- a/docs/superpowers/plans/2026-09-01-app-platform-phase-6-and-track-a-loops.md
+++ b/docs/superpowers/plans/2026-09-01-app-platform-phase-6-and-track-a-loops.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |---|---|
-| Status | Loop 6.0 sealed from merged Phase 5 audit `c0da089d`; Phase 6 PR A implemented and locally validated, merge certification pending |
+| Status | Loop 6.0 sealed from merged Phase 5 audit `c0da089d`; Phase 6 PR A merged as #288 at `93856fd2`; PR B lifecycle/operator slice implemented and locally certified, PR CI/merge pending |
 | Architecture source | `docs/superpowers/plans/2026-08-29-full-surface-app-platform.md` |
 | Delivery source | `docs/superpowers/plans/2026-08-30-full-surface-app-platform-delivery-plan.md` |
 | Phase 6 outcome | An independent author can build, stage, install, operate, upgrade, disable, recover, and inspect a Tier 2 connected App using published contracts and tooling only |

--- a/packages/app-kit/README.md
+++ b/packages/app-kit/README.md
@@ -91,5 +91,5 @@ automation, runtimes, sync, custom UI, and public ingress are not part of this
 protocol.
 
 See the [connected App author guide](../../docs/connected-app-author-guide.md)
-for the packed-artifact workflow, compatibility handoff, sandbox-provider proof,
-and the Phase 6 PR A boundaries.
+for the packed-artifact workflow, native operator lifecycle,
+sandbox-provider proof, and current boundaries.

--- a/packages/app-kit/src/cli.ts
+++ b/packages/app-kit/src/cli.ts
@@ -7,6 +7,8 @@ import {
   buildDeftAppPackage,
   canonicalDeftAppRequestedAuthorityReportJson,
   checkDeftAppDeveloperContract,
+  DEFT_APP_KIT_PACKAGE_NAME,
+  DEFT_APP_KIT_VERSION,
   DEFT_APP_PACKAGE_FORMAT,
   DEFT_APP_REQUESTED_AUTHORITY_REPORT_PATH,
   parseDeftAppManifest,
@@ -339,7 +341,11 @@ async function doctor(): Promise<void> {
   const url = await hostUrl();
   const flow = await compatibleFlow(url, built);
   const protocol = built.package.manifest.compatibility.app_protocol;
-  console.log(`Compatible App Protocol v${protocol} ${flow.install_mode} host: ${url}`);
+  console.log(
+    `Compatible App Kit package ${DEFT_APP_KIT_PACKAGE_NAME} version ${DEFT_APP_KIT_VERSION}; `
+    + `App Protocol v${protocol}; package format ${flow.package_format}; `
+    + `install mode ${flow.install_mode}; host ${url}`,
+  );
 }
 
 async function readPairingCode(): Promise<string> {

--- a/packages/app-kit/test/cli.test.ts
+++ b/packages/app-kit/test/cli.test.ts
@@ -179,12 +179,22 @@ test('connected template emits a Module v2 dependency App and requested authorit
   const address = host.address();
   if (!address || typeof address === 'string') throw new Error('Expected a TCP test server');
   try {
+    const hostUrl = `http://127.0.0.1:${address.port}`;
+    const diagnosed = await runAsync(project, '', 'doctor', '--url', hostUrl);
+    assert.equal(diagnosed.status, 0, diagnosed.stderr);
+    assert.equal(
+      diagnosed.stdout.trim(),
+      `Compatible App Kit package @deft/app-kit version 0.1.0-alpha.1; App Protocol v1; `
+      + `package format deft.app.package.v1; install mode stage_only; host ${hostUrl}`,
+    );
+    assert.doesNotMatch(diagnosed.stdout, /registry|signature|signed|trusted|verified/i);
+
     const installed = await runAsync(
       project,
       'one-time-code\n',
       'install-local',
       '--url',
-      `http://127.0.0.1:${address.port}`,
+      hostUrl,
     );
     assert.equal(installed.status, 0, installed.stderr);
     assert.equal(installed.stdout.trim(), 'Staged Connected Campaigns (staged) for workspace review.');


### PR DESCRIPTION
## Summary
- complete the native manager lifecycle for Protocol v1 Apps: persisted server-selected initial/upgrade/re-enable targets, exact authority/dependency/connector review, staged upgrades, health/disable controls, and safe recent-Run inspection
- enforce the selected target and live manager authority before provider discovery and again at atomic activation
- verify receipt identity, digest, and HMAC before returning an actor-authorized redacted projection
- publish exact App Kit/host compatibility and unsigned provenance semantics in Settings, doctor output, and the author guide

## Evidence
- 29 focused API contract, route, receipt, and architecture tests
- 18 focused web contract tests
- 23 App Kit tests
- repository typecheck; final API typecheck/build; web lint; release-workflow tests
- one repository production build
- live desktop/mobile lifecycle proof for active upgrade and disabled re-enable: review, reload persistence, policy-gated native activation request, receipt inspection, 0 px overflow, no console/API errors, and no raw secret markers

## Deferred to PR CI
- The modified pgvector-backed connected-grants DB test was not run on the local Windows PostgreSQL installation because pgvector is unavailable there. The normal CI disposable `pgvector/pgvector:pg16` service will run the full API DB suite. No local `CREATE EXTENSION vector` retry was attempted.

## Boundary
This is Phase 6 PR B. It completes the native connected-App lifecycle/operator slice; the conformance, failure ceilings, independent-author trial, and immutable beta gate remain Phase 6 PR C.