### PR TITLE
feat(apps): certify connected App Platform beta

### DIFF
--- a/.github/workflows/app-platform-phase6-certification.yml
+++ b/.github/workflows/app-platform-phase6-certification.yml
@@ -1,0 +1,162 @@
+name: App Platform Phase 6 Certification
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: app-platform-phase6-certification
+  cancel-in-progress: false
+
+env:
+  APP_PLATFORM_CANDIDATE_SHA: 16875df2f6c9dc2bc3d850de6758b7dd56767a05
+  APP_PLATFORM_BASELINE_SHA: ec79592e669bdf915fad8a5d2480f0625d819a4c
+  PREDECESSOR_IMAGE: ghcr.io/maneek21/deft@sha256:e565cc64ee22b5b9f6f99973e3762b639c27e026dc8824852145035acdacf788
+  PREDECESSOR_COMMIT: 6d39e0e0413c82d36c9481849ae582fdf805d1a6
+  APP_PLATFORM_CERT_PHASE: phase6
+  APP_PLATFORM_RESOURCE_PREFIX: deft-p6-cert-${{ github.run_id }}-${{ github.run_attempt }}
+  APP_PLATFORM_CANDIDATE_TAG: deft:phase6-cert-${{ github.run_id }}-${{ github.run_attempt }}
+  APP_PLATFORM_COMPOSE_PROJECT: deft-p6-compose-${{ github.run_id }}-${{ github.run_attempt }}
+  APP_PLATFORM_DATABASE_NAME: deft_phase5_phase6_release_test
+
+jobs:
+  certify:
+    name: Immutable connected App Platform beta gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - name: Checkout certification orchestration
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Checkout exact Phase 6 product candidate
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ env.APP_PLATFORM_CANDIDATE_SHA }}
+          path: .cert/phase6-candidate
+          fetch-depth: 1
+
+      - name: Checkout exact Phase 4 baseline
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ env.APP_PLATFORM_BASELINE_SHA }}
+          path: .cert/phase4-baseline
+          fetch-depth: 1
+
+      - name: Verify immutable source identities
+        shell: bash
+        run: |
+          set -euo pipefail
+          certifier_sha="$(git rev-parse HEAD)"
+          candidate_sha="$(git -C .cert/phase6-candidate rev-parse HEAD)"
+          baseline_sha="$(git -C .cert/phase4-baseline rev-parse HEAD)"
+          [[ "$candidate_sha" == "$APP_PLATFORM_CANDIDATE_SHA" ]]
+          [[ "$baseline_sha" == "$APP_PLATFORM_BASELINE_SHA" ]]
+          {
+            echo "CERTIFIER_SHA=$certifier_sha"
+            echo "APP_PLATFORM_CANDIDATE_ROOT=$GITHUB_WORKSPACE/.cert/phase6-candidate"
+            echo "APP_PLATFORM_BASELINE_ROOT=$GITHUB_WORKSPACE/.cert/phase4-baseline"
+            echo "EVIDENCE_DIR=$RUNNER_TEMP/deft-phase6-evidence"
+          } >> "$GITHUB_ENV"
+
+      - uses: pnpm/action-setup@v6.0.10
+        with:
+          version: 11.10.0
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - uses: docker/setup-buildx-action@v4
+
+      - name: Install certifier dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install exact Phase 6 candidate dependencies
+        working-directory: .cert/phase6-candidate
+        run: pnpm install --frozen-lockfile
+
+      - name: Install exact Phase 4 baseline dependencies
+        working-directory: .cert/phase4-baseline
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Chromium for desktop and mobile evidence
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Typecheck exact Phase 6 candidate
+        working-directory: .cert/phase6-candidate
+        run: pnpm typecheck
+
+      - name: Build exact Phase 6 candidate once
+        working-directory: .cert/phase6-candidate
+        run: pnpm build
+
+      - name: Run immutable Phase 6 host certification
+        env:
+          CERTIFIER_ROOT: ${{ github.workspace }}
+          APP_PLATFORM_SETUP_HOOK: ${{ github.workspace }}/scripts/ci/app-platform-phase6-certification-setup.sh
+          APP_PLATFORM_OFFLINE_HOOK: ${{ github.workspace }}/scripts/ci/app-platform-phase6-certification-offline.sh
+          APP_PLATFORM_BROWSER_SCRIPT: ${{ github.workspace }}/scripts/ci/app-platform-phase6-browser-smoke.mjs
+        run: bash scripts/ci/certify-app-platform-phase5.sh
+
+      - name: Upload bounded safe certification evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-platform-phase6-safe-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ env.EVIDENCE_DIR }}/safe
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 90
+
+      - name: Upload exact candidate image archive
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-platform-phase6-image-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ env.EVIDENCE_DIR }}/candidate-image.tar.zst
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 90
+
+      - name: Remove and confirm isolated resources
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker info >/dev/null
+
+          docker rm -f \
+            "$APP_PLATFORM_RESOURCE_PREFIX-source" \
+            "$APP_PLATFORM_RESOURCE_PREFIX-restore" \
+            "$APP_PLATFORM_RESOURCE_PREFIX-app" >/dev/null 2>&1 || true
+          docker network rm "$APP_PLATFORM_RESOURCE_PREFIX-network" >/dev/null 2>&1 || true
+          docker volume rm \
+            "$APP_PLATFORM_RESOURCE_PREFIX-source-data" \
+            "$APP_PLATFORM_RESOURCE_PREFIX-restore-data" >/dev/null 2>&1 || true
+
+          mapfile -t compose_containers < <(
+            docker ps -aq --filter "label=com.docker.compose.project=$APP_PLATFORM_COMPOSE_PROJECT"
+          )
+          if ((${#compose_containers[@]})); then docker rm -f "${compose_containers[@]}" >/dev/null; fi
+          mapfile -t compose_networks < <(
+            docker network ls -q --filter "label=com.docker.compose.project=$APP_PLATFORM_COMPOSE_PROJECT"
+          )
+          if ((${#compose_networks[@]})); then docker network rm "${compose_networks[@]}" >/dev/null; fi
+          mapfile -t compose_volumes < <(
+            docker volume ls -q --filter "label=com.docker.compose.project=$APP_PLATFORM_COMPOSE_PROJECT"
+          )
+          if ((${#compose_volumes[@]})); then docker volume rm "${compose_volumes[@]}" >/dev/null; fi
+          docker image rm "$APP_PLATFORM_CANDIDATE_TAG" >/dev/null 2>&1 || true
+
+          [[ -z "$(docker ps -aq --filter "name=^/${APP_PLATFORM_RESOURCE_PREFIX}-(source|restore|app)$")" ]]
+          [[ -z "$(docker network ls -q --filter "name=^${APP_PLATFORM_RESOURCE_PREFIX}-network$")" ]]
+          [[ -z "$(docker volume ls -q --filter "name=^${APP_PLATFORM_RESOURCE_PREFIX}-(source|restore)-data$")" ]]
+          [[ -z "$(docker ps -aq --filter "label=com.docker.compose.project=$APP_PLATFORM_COMPOSE_PROJECT")" ]]
+          [[ -z "$(docker network ls -q --filter "label=com.docker.compose.project=$APP_PLATFORM_COMPOSE_PROJECT")" ]]
+          [[ -z "$(docker volume ls -q --filter "label=com.docker.compose.project=$APP_PLATFORM_COMPOSE_PROJECT")" ]]
+          if docker image inspect "$APP_PLATFORM_CANDIDATE_TAG" >/dev/null 2>&1; then exit 1; fi

--- a/apps/api/src/lib/app-action-service.ts
+++ b/apps/api/src/lib/app-action-service.ts
@@ -55,6 +55,7 @@ import {
   type AppRunAuthorizationCapture,
   type AppRunTokenScopeAuthorization,
 } from './app-run-live-authorization.js';
+import type { AppRunReadAuthorityRef } from './app-run-authorization.js';
 import type {
   AppRunPreparedInputCandidate,
   AppRunPreparedInputPayload,
@@ -236,7 +237,7 @@ export interface AppActionCapabilityPort {
 
 export interface AppActionLiveAuthorityPort {
   captureForPreparation(input: AppRunAuthorizationCapture): Promise<AppRunAuthorizationSnapshot>;
-  assertTokenScopes(input: AppRunTokenScopeAuthorization): Promise<void>;
+  assertTokenScopes(input: AppRunTokenScopeAuthorization): Promise<AppRunReadAuthorityRef>;
 }
 
 export interface AppActionPreparedInputPort {
@@ -277,8 +278,18 @@ export interface AppActionRunPort {
 }
 
 export interface AppActionRunReadPort {
-  inspect(orgId: string, runId: string, actor: AppRunActor): Promise<AppRunSafeView>;
-  result(orgId: string, runId: string, actor: AppRunActor): Promise<Readonly<{
+  inspect(
+    orgId: string,
+    runId: string,
+    actor: AppRunActor,
+    requiredAuthorityRef: AppRunReadAuthorityRef | null,
+  ): Promise<AppRunSafeView>;
+  result(
+    orgId: string,
+    runId: string,
+    actor: AppRunActor,
+    requiredAuthorityRef: AppRunReadAuthorityRef | null,
+  ): Promise<Readonly<{
     run: AppRunSafeView;
     value: unknown;
   }>>;
@@ -350,17 +361,19 @@ const lazyRunReads: AppActionRunReadPort = Object.freeze({
     orgId: Parameters<AppActionRunReadPort['inspect']>[0],
     runId: Parameters<AppActionRunReadPort['inspect']>[1],
     actor: Parameters<AppActionRunReadPort['inspect']>[2],
+    requiredAuthorityRef: Parameters<AppActionRunReadPort['inspect']>[3],
   ) {
     const { getAppRunRuntime } = await import('./app-run-runtime.js');
-    return (await getAppRunRuntime()).service.inspect(orgId, runId, actor);
+    return (await getAppRunRuntime()).service.inspect(orgId, runId, actor, requiredAuthorityRef);
   },
   async result(
     orgId: Parameters<AppActionRunReadPort['result']>[0],
     runId: Parameters<AppActionRunReadPort['result']>[1],
     actor: Parameters<AppActionRunReadPort['result']>[2],
+    requiredAuthorityRef: Parameters<AppActionRunReadPort['result']>[3],
   ) {
     const { getAppRunRuntime } = await import('./app-run-runtime.js');
-    return (await getAppRunRuntime()).service.result(orgId, runId, actor);
+    return (await getAppRunRuntime()).service.result(orgId, runId, actor, requiredAuthorityRef);
   },
 });
 
@@ -1163,8 +1176,13 @@ export class AppActionService {
 
   async inspectRun(callerValue: AppActionCaller, runId: string): Promise<AppRunSafeView> {
     const caller = callerContext(callerValue);
-    await this.#assertRunReadAuthority(caller);
-    return this.runReads.inspect(caller.actor.org_id, runId, caller.authenticated_subject);
+    const requiredAuthorityRef = await this.#assertRunReadAuthority(caller);
+    return this.runReads.inspect(
+      caller.actor.org_id,
+      runId,
+      caller.authenticated_subject,
+      requiredAuthorityRef,
+    );
   }
 
   async result(callerValue: AppActionCaller, runId: string): Promise<Readonly<{
@@ -1172,14 +1190,24 @@ export class AppActionService {
     value: unknown;
   }>> {
     const caller = callerContext(callerValue);
-    await this.#assertRunReadAuthority(caller);
-    return this.runReads.result(caller.actor.org_id, runId, caller.authenticated_subject);
+    const requiredAuthorityRef = await this.#assertRunReadAuthority(caller);
+    return this.runReads.result(
+      caller.actor.org_id,
+      runId,
+      caller.authenticated_subject,
+      requiredAuthorityRef,
+    );
   }
 
   async inspectReceipts(callerValue: AppActionCaller, runId: string): Promise<AppActionReceiptBundle> {
     const caller = callerContext(callerValue);
-    await this.#assertRunReadAuthority(caller);
-    const run = await this.runReads.inspect(caller.actor.org_id, runId, caller.authenticated_subject);
+    const requiredAuthorityRef = await this.#assertRunReadAuthority(caller);
+    const run = await this.runReads.inspect(
+      caller.actor.org_id,
+      runId,
+      caller.authenticated_subject,
+      requiredAuthorityRef,
+    );
     const receipts = await this.receiptReads.readVerified(caller.actor.org_id, runId);
     return Object.freeze({
       run: Object.freeze({
@@ -1200,10 +1228,10 @@ export class AppActionService {
     });
   }
 
-  async #assertRunReadAuthority(caller: CallerContext): Promise<void> {
-    if (!caller.surface.endsWith(':mcp')) return;
+  async #assertRunReadAuthority(caller: CallerContext): Promise<AppRunReadAuthorityRef | null> {
+    if (!caller.surface.endsWith(':mcp')) return null;
     try {
-      await this.liveAuthority.assertTokenScopes({
+      return await this.liveAuthority.assertTokenScopes({
         org_id: caller.actor.org_id,
         authenticated_subject: caller.authenticated_subject,
         required_token_scopes: APP_MCP_RUN_READ_SCOPES,

--- a/apps/api/src/lib/app-operations-service.ts
+++ b/apps/api/src/lib/app-operations-service.ts
@@ -1,0 +1,431 @@
+import {
+  appRunAttempts,
+  appRuns,
+  appRunSecretPayloads,
+} from '@deft/db/schema';
+import {
+  APP_RUN_DEFAULT_ATTEMPT_LIMIT,
+  APP_RUN_IDEMPOTENCY_RETENTION_MS,
+  APP_RUN_LIMITS,
+  APP_RUN_SECRET_RETENTION_MS,
+  type AppRunActor,
+  type AppRunAttemptState,
+  type AppRunState,
+} from '@deft/shared';
+import type { ModuleActor } from '@deft/shared/modules';
+import { and, asc, desc, eq, isNull, lte, or, sql } from 'drizzle-orm';
+import { db } from './db.js';
+import { APP_RUN_KEY_PURPOSES, type AppRunKeyPurpose } from './app-run-keyrings.js';
+import type {
+  AppRunOperationalMetric,
+  AppRunOperationsService,
+  AppRunRepairGap,
+} from './app-run-operations.js';
+import type { AppRunSafeView } from './app-run-repository.js';
+import { getAppRunRuntime } from './app-run-runtime.js';
+import { APP_RUN_ATTEMPT_JOB } from './app-run-scheduler.js';
+import { inspectConnectedAppHealth } from './app-review-service.js';
+import { listAppInstallations } from './app-service.js';
+import { ModuleError } from './module-errors.js';
+import { assertCurrentModuleManagerWithExecutor } from './module-service.js';
+import { getOrgQueueHealthSnapshot, type QueueHealthSnapshot } from './queue-health.js';
+import { getWorkerStatus } from '../workers/index.js';
+
+export const APP_OPERATIONS_BOUNDS = Object.freeze({
+  recent_runs: 25,
+  action_counts: 25,
+  audit_gaps: 100,
+  connected_apps: 25,
+  health_issue_codes: 25,
+});
+
+const ATTEMPT_STATES: readonly AppRunAttemptState[] = [
+  'pending',
+  'claimed',
+  'provider_call_started',
+  'succeeded',
+  'failed',
+  'cancelled',
+  'unknown_outcome',
+];
+
+type AppRunOperationsReadPort = Pick<AppRunOperationsService, 'metrics' | 'list' | 'auditGaps'>;
+
+export type AppOperationsAggregateSnapshot = Readonly<{
+  attempt_states: readonly Readonly<{
+    state: AppRunAttemptState;
+    count: number;
+    retry_attempts: number;
+    retryable_failed: number;
+  }>[];
+  action_counts: readonly Readonly<{ operation_name: string; count: number }>[];
+  retained_payload_count: number;
+  retained_payload_bytes: number;
+  cleanup_due_payload_count: number;
+  cleanup_due_payload_bytes: number;
+  overdue_run_cleanup_count: number;
+}>;
+
+type KeyReference = Readonly<{ purpose: AppRunKeyPurpose; key_id: string }>;
+
+export type ConnectedAppHealthSummary = Readonly<{
+  total: number;
+  checked: number;
+  truncated: boolean;
+  healthy: number;
+  unhealthy: number;
+  issue_counts: readonly Readonly<{ code: string; count: number }>[];
+}>;
+
+export type AppOperationsProjectionDependencies = Readonly<{
+  assertManager(actor: ModuleActor): Promise<void>;
+  runOperations: AppRunOperationsReadPort;
+  readAggregates(orgId: string, now: Date): Promise<AppOperationsAggregateSnapshot>;
+  readQueue(orgId: string, now: Date): Promise<QueueHealthSnapshot>;
+  readKeyReferences(orgId: string, now: Date): Promise<readonly KeyReference[]>;
+  configuredKeyIds(purpose: AppRunKeyPurpose): readonly string[];
+  readConnectedHealth(actor: ModuleActor, limit: number): Promise<ConnectedAppHealthSummary>;
+  now(): Date;
+}>;
+
+function count(value: unknown): number {
+  const parsed = Number(value ?? 0);
+  return Number.isFinite(parsed) ? Math.min(Number.MAX_SAFE_INTEGER, Math.max(0, Math.floor(parsed))) : 0;
+}
+
+function safeIdentifier(value: string, fallback: string): string {
+  return value.length <= 128 && /^[A-Za-z0-9][A-Za-z0-9_.:/-]*$/.test(value) ? value : fallback;
+}
+
+function humanRunActor(actor: ModuleActor): AppRunActor {
+  if (actor.kind !== 'human' || (actor.role !== 'owner' && actor.role !== 'admin')) {
+    throw new ModuleError(
+      'Only active workspace owners and admins can inspect App operations',
+      'MODULE_ACCESS_DENIED',
+      403,
+    );
+  }
+  return { actor_type: 'human', user_id: actor.actor_id };
+}
+
+function aggregateMetrics(metrics: readonly AppRunOperationalMetric[]) {
+  const byState = new Map<AppRunState, number>();
+  const byProvider = new Map<string, number>();
+  let total = 0;
+  for (const metric of metrics) {
+    const metricCount = count(metric.count);
+    total += metricCount;
+    byState.set(metric.state, count(byState.get(metric.state)) + metricCount);
+    byProvider.set(metric.provider_kind, count(byProvider.get(metric.provider_kind)) + metricCount);
+  }
+  return {
+    total: count(total),
+    by_state: [...byState].sort(([left], [right]) => left.localeCompare(right))
+      .map(([state, stateCount]) => ({ state, count: stateCount })),
+    by_provider: [...byProvider].sort(([left], [right]) => left.localeCompare(right))
+      .map(([provider_kind, providerCount]) => ({ provider_kind, count: providerCount })),
+  };
+}
+
+function aggregateGaps(gaps: readonly AppRunRepairGap[]) {
+  const byGap = new Map<AppRunRepairGap['gap'], number>();
+  for (const item of gaps.slice(0, APP_OPERATIONS_BOUNDS.audit_gaps)) {
+    byGap.set(item.gap, count(byGap.get(item.gap)) + 1);
+  }
+  return [...byGap].sort(([left], [right]) => left.localeCompare(right))
+    .map(([gap, gapCount]) => ({ gap, count: gapCount }));
+}
+
+function projectRecentRuns(orgId: string, runs: readonly AppRunSafeView[]) {
+  return runs.filter((run) => run.org_id === orgId)
+    .slice(0, APP_OPERATIONS_BOUNDS.recent_runs)
+    .map((run) => ({
+      run_id: safeIdentifier(run.id, 'unrecognized_run'),
+      state: run.state,
+      provider_kind: run.provider_kind,
+      operation_name: safeIdentifier(run.operation_name, 'unrecognized_operation'),
+      risk_class: run.risk_class,
+      review_requirement: run.review_requirement,
+      retry_class: run.retry_class,
+      retention_class: run.retention_class,
+      updated_at: run.updated_at.toISOString(),
+    }));
+}
+
+export class AppOperationsProjectionService {
+  constructor(private readonly dependencies: AppOperationsProjectionDependencies) {}
+
+  async read(actor: ModuleActor) {
+    const runActor = humanRunActor(actor);
+    await this.dependencies.assertManager(actor);
+    const now = this.dependencies.now();
+    const common = { org_id: actor.org_id, actor: runActor };
+    const [metrics, recentRows, gaps, aggregates, queue, keyReferences, connectedApps] = await Promise.all([
+      this.dependencies.runOperations.metrics(common),
+      this.dependencies.runOperations.list({
+        ...common,
+        limit: APP_OPERATIONS_BOUNDS.recent_runs,
+      }),
+      this.dependencies.runOperations.auditGaps({
+        ...common,
+        limit: APP_OPERATIONS_BOUNDS.audit_gaps,
+      }),
+      this.dependencies.readAggregates(actor.org_id, now),
+      this.dependencies.readQueue(actor.org_id, now),
+      this.dependencies.readKeyReferences(actor.org_id, now),
+      this.dependencies.readConnectedHealth(actor, APP_OPERATIONS_BOUNDS.connected_apps),
+    ]);
+
+    const runMetrics = aggregateMetrics(metrics);
+    const recent = projectRecentRuns(actor.org_id, recentRows);
+    const byGap = aggregateGaps(gaps);
+    const actionRows = aggregates.action_counts.slice(0, APP_OPERATIONS_BOUNDS.action_counts);
+    const keys = APP_RUN_KEY_PURPOSES.map((purpose) => {
+      const referenced = new Set(
+        keyReferences.filter((item) => item.purpose === purpose).map((item) => item.key_id),
+      );
+      const configured = new Set(this.dependencies.configuredKeyIds(purpose));
+      const missing = [...referenced].filter((keyId) => !configured.has(keyId)).length;
+      return {
+        purpose,
+        referenced_count: referenced.size,
+        configured_count: configured.size,
+        missing_referenced_count: missing,
+        all_referenced_available: missing === 0,
+      };
+    });
+    const attemptCounts = new Map<AppRunAttemptState, number>();
+    for (const row of aggregates.attempt_states) {
+      if (!ATTEMPT_STATES.includes(row.state)) continue;
+      attemptCounts.set(row.state, count(attemptCounts.get(row.state)) + count(row.count));
+    }
+    const attemptsByState = ATTEMPT_STATES
+      .filter((state) => attemptCounts.has(state))
+      .map((state) => ({ state, count: count(attemptCounts.get(state)) }));
+    const retryAttempts = aggregates.attempt_states.reduce(
+      (total, row) => total + count(row.retry_attempts),
+      0,
+    );
+    const retryableFailed = aggregates.attempt_states.reduce(
+      (total, row) => total + count(row.retryable_failed),
+      0,
+    );
+    const activeAttempts = aggregates.attempt_states
+      .filter((row) => ['pending', 'claimed', 'provider_call_started'].includes(row.state))
+      .reduce((total, row) => total + count(row.count), 0);
+    const reasons = [
+      ...(queue.status === 'degraded' ? ['queue'] : []),
+      ...(byGap.length > 0 ? ['integrity'] : []),
+      ...(count(aggregates.cleanup_due_payload_count) > 0
+        || count(aggregates.overdue_run_cleanup_count) > 0 ? ['payload_cleanup'] : []),
+      ...(connectedApps.unhealthy > 0 ? ['connected_apps'] : []),
+      ...(keys.some((item) => !item.all_referenced_available) ? ['key_availability'] : []),
+      ...(runMetrics.by_state.some((item) => item.state === 'unknown_outcome' && item.count > 0)
+        ? ['unknown_outcomes'] : []),
+    ];
+
+    return {
+      schema: 'deft.app_operations.v1' as const,
+      generated_at: now.toISOString(),
+      runs: {
+        total: runMetrics.total,
+        pending_approvals: runMetrics.by_state.find((item) => item.state === 'pending_approval')?.count ?? 0,
+        by_state: runMetrics.by_state,
+        recent,
+        recent_limit: APP_OPERATIONS_BOUNDS.recent_runs,
+        truncated: recentRows.length >= APP_OPERATIONS_BOUNDS.recent_runs,
+      },
+      queue: {
+        status: queue.status,
+        pending: count(queue.pending),
+        running: count(queue.running),
+        backlog: count(queue.pending),
+        completed: count(queue.completed),
+        failed: count(queue.failed),
+        oldest_ready_lag_seconds: count(queue.oldest_ready_lag_seconds),
+        expired_leases: count(queue.expired_leases),
+        recent_terminal_failures: count(queue.recent_terminal_failures),
+        worker_available: queue.worker.running && !queue.worker.heartbeat_stale,
+      },
+      attempts: {
+        total: attemptsByState.reduce((total, row) => total + row.count, 0),
+        retry_attempts: count(retryAttempts),
+        active: count(activeAttempts),
+        retryable_failed: count(retryableFailed),
+        by_state: attemptsByState,
+      },
+      payloads: {
+        retained_count: count(aggregates.retained_payload_count),
+        retained_bytes: count(aggregates.retained_payload_bytes),
+        cleanup_due_count: count(aggregates.cleanup_due_payload_count),
+        cleanup_due_bytes: count(aggregates.cleanup_due_payload_bytes),
+        overdue_run_cleanup_count: count(aggregates.overdue_run_cleanup_count),
+      },
+      integrity: {
+        sampled_gap_count: gaps.slice(0, APP_OPERATIONS_BOUNDS.audit_gaps).length,
+        sample_limit: APP_OPERATIONS_BOUNDS.audit_gaps,
+        truncated: gaps.length >= APP_OPERATIONS_BOUNDS.audit_gaps,
+        by_gap: byGap,
+      },
+      providers: runMetrics.by_provider,
+      actions: {
+        items: actionRows.map((row) => ({
+          operation_name: safeIdentifier(row.operation_name, 'unrecognized_operation'),
+          count: count(row.count),
+        })),
+        limit: APP_OPERATIONS_BOUNDS.action_counts,
+        truncated: aggregates.action_counts.length > APP_OPERATIONS_BOUNDS.action_counts,
+      },
+      connected_apps: {
+        total: count(connectedApps.total),
+        checked: count(connectedApps.checked),
+        limit: APP_OPERATIONS_BOUNDS.connected_apps,
+        truncated: connectedApps.truncated,
+        healthy: count(connectedApps.healthy),
+        unhealthy: count(connectedApps.unhealthy),
+        issue_counts: connectedApps.issue_counts
+          .slice(0, APP_OPERATIONS_BOUNDS.health_issue_codes)
+          .map((item) => ({
+            code: safeIdentifier(item.code, 'APP_HEALTH_ISSUE'),
+            count: count(item.count),
+          })),
+      },
+      policy: {
+        default_attempt_limit: APP_RUN_DEFAULT_ATTEMPT_LIMIT,
+        payload_limits_bytes: {
+          input: APP_RUN_LIMITS.input_bytes,
+          output: APP_RUN_LIMITS.output_bytes,
+          authorization_snapshot: APP_RUN_LIMITS.authorization_snapshot_bytes,
+          safe_preview: APP_RUN_LIMITS.safe_preview_bytes,
+          safe_event_payload: APP_RUN_LIMITS.safe_event_payload_bytes,
+          safe_receipt_envelope: APP_RUN_LIMITS.safe_receipt_envelope_bytes,
+        },
+        payload_retention_ms: APP_RUN_SECRET_RETENTION_MS,
+        idempotency_retention_ms: APP_RUN_IDEMPOTENCY_RETENTION_MS,
+      },
+      keys,
+      degraded: {
+        status: reasons.length === 0 ? 'ok' as const : 'degraded' as const,
+        reasons,
+      },
+    };
+  }
+}
+
+class PostgresAppOperationsAggregateReader {
+  async read(orgId: string, now: Date): Promise<AppOperationsAggregateSnapshot> {
+    const actionCount = sql<number>`count(*)::int`;
+    const [attemptStates, actionCounts, [payloads], [overdueCleanup]] = await Promise.all([
+      db.select({
+        state: appRunAttempts.state,
+        count: sql<number>`count(*)::int`,
+        retry_attempts: sql<number>`count(*) FILTER (WHERE ${appRunAttempts.attempt_number} > 1)::int`,
+        retryable_failed: sql<number>`count(*) FILTER (WHERE
+          ${appRunAttempts.state} = 'failed'
+          AND ${appRunAttempts.attempt_number} < ${appRuns.attempt_limit}
+          AND ${appRuns.retry_class} <> 'unsafe_or_unknown'
+        )::int`,
+      }).from(appRunAttempts).innerJoin(appRuns, and(
+        eq(appRuns.org_id, appRunAttempts.org_id),
+        eq(appRuns.id, appRunAttempts.run_id),
+      )).where(and(
+        eq(appRunAttempts.org_id, orgId),
+        eq(appRuns.org_id, orgId),
+      )).groupBy(appRunAttempts.state).orderBy(asc(appRunAttempts.state)),
+      db.select({
+        operation_name: appRuns.operation_name,
+        count: actionCount,
+      }).from(appRuns).where(eq(appRuns.org_id, orgId))
+        .groupBy(appRuns.operation_name)
+        .orderBy(desc(actionCount), asc(appRuns.operation_name))
+        .limit(APP_OPERATIONS_BOUNDS.action_counts + 1),
+      db.select({
+        retained_count: sql<number>`count(*) FILTER (WHERE ${appRunSecretPayloads.expires_at} > ${now})::int`,
+        retained_bytes: sql<number>`coalesce(sum(${appRunSecretPayloads.payload_bytes}) FILTER (
+          WHERE ${appRunSecretPayloads.expires_at} > ${now}
+        ), 0)::bigint`,
+        cleanup_due_count: sql<number>`count(*) FILTER (WHERE ${appRunSecretPayloads.expires_at} <= ${now})::int`,
+        cleanup_due_bytes: sql<number>`coalesce(sum(${appRunSecretPayloads.payload_bytes}) FILTER (
+          WHERE ${appRunSecretPayloads.expires_at} <= ${now}
+        ), 0)::bigint`,
+      }).from(appRunSecretPayloads).where(eq(appRunSecretPayloads.org_id, orgId)),
+      db.select({
+        count: sql<number>`count(*)::int`,
+      }).from(appRuns).where(and(
+        eq(appRuns.org_id, orgId),
+        or(
+          and(lte(appRuns.input_expires_at, now), isNull(appRuns.input_purged_at)),
+          and(lte(appRuns.result_expires_at, now), isNull(appRuns.result_purged_at)),
+        ),
+      )),
+    ]);
+
+    return {
+      attempt_states: attemptStates,
+      action_counts: actionCounts,
+      retained_payload_count: count(payloads?.retained_count),
+      retained_payload_bytes: count(payloads?.retained_bytes),
+      cleanup_due_payload_count: count(payloads?.cleanup_due_count),
+      cleanup_due_payload_bytes: count(payloads?.cleanup_due_bytes),
+      overdue_run_cleanup_count: count(overdueCleanup?.count),
+    };
+  }
+}
+
+async function readConnectedHealth(
+  actor: ModuleActor,
+  limit: number,
+): Promise<ConnectedAppHealthSummary> {
+  const connected = (await listAppInstallations(actor))
+    .filter((app) => app.manifest.compatibility.app_protocol === '1');
+  const selected = connected.slice(0, limit);
+  const health = await Promise.all(selected.map((app) => inspectConnectedAppHealth(
+    actor,
+    app.id,
+    { refresh_provider_schemas: false },
+  )));
+  const issueCounts = new Map<string, number>();
+  for (const item of health.flatMap((entry) => entry.issues)) {
+    const code = safeIdentifier(item.code, 'APP_HEALTH_ISSUE');
+    issueCounts.set(code, count(issueCounts.get(code)) + 1);
+  }
+  return {
+    total: connected.length,
+    checked: health.length,
+    truncated: connected.length > selected.length,
+    healthy: health.filter((item) => item.status === 'healthy').length,
+    unhealthy: health.filter((item) => item.status === 'unhealthy').length,
+    issue_counts: [...issueCounts].sort(([left], [right]) => left.localeCompare(right))
+      .slice(0, APP_OPERATIONS_BOUNDS.health_issue_codes)
+      .map(([code, issueCount]) => ({ code, count: issueCount })),
+  };
+}
+
+const postgresAggregates = new PostgresAppOperationsAggregateReader();
+
+export const appOperationsService = {
+  async read(actor: ModuleActor) {
+    await assertCurrentModuleManagerWithExecutor(db, actor);
+    const runtime = await getAppRunRuntime();
+    const projection = new AppOperationsProjectionService({
+      assertManager: async () => {},
+      runOperations: runtime.operations,
+      readAggregates: (orgId, now) => postgresAggregates.read(orgId, now),
+      readQueue: (orgId, now) => getOrgQueueHealthSnapshot(
+        orgId,
+        APP_RUN_ATTEMPT_JOB,
+        getWorkerStatus(),
+        now,
+      ),
+      readKeyReferences: async (orgId, now) => [
+        ...await runtime.repository.activeKeyReferences(now, orgId),
+        ...await runtime.secretRepository.retainedKeyReferences(now, orgId),
+        ...await runtime.secretRepository.receiptSigningKeyReferences(orgId),
+      ],
+      configuredKeyIds: (purpose) => runtime.keys.keyIds(purpose),
+      readConnectedHealth,
+      now: () => new Date(),
+    });
+    return projection.read(actor);
+  },
+};

--- a/apps/api/src/lib/app-run-authorization.ts
+++ b/apps/api/src/lib/app-run-authorization.ts
@@ -1,10 +1,16 @@
-import type { AppRunActor } from '@deft/shared';
-import { agentEmployees, orgMembers } from '@deft/db/schema';
+import { AppRunAuthorizationSnapshotSchema, type AppRunActor } from '@deft/shared';
+import { agentEmployees, appRuns, orgMembers } from '@deft/db/schema';
 import { and, eq } from 'drizzle-orm';
 import { db } from './db.js';
 import type { AppRunSafeView, AppRunTransaction } from './app-run-repository.js';
 
 export type AppRunAccessAction = 'inspect' | 'result' | 'cancel' | 'reconcile';
+
+export type AppRunReadAuthorityRef = Readonly<{
+  authority_kind: 'token_scope';
+  authority_id: string;
+  version: string;
+}>;
 
 export interface AppRunAuthorizer {
   authorize(input: Readonly<{
@@ -12,6 +18,7 @@ export interface AppRunAuthorizer {
     org_id: string;
     actor: AppRunActor;
     run: AppRunSafeView;
+    required_authority_ref: AppRunReadAuthorityRef | null;
   }>): Promise<boolean>;
 }
 
@@ -41,6 +48,25 @@ function actorMatchesRun(actor: AppRunActor, run: AppRunSafeView): boolean {
 export class PostgresAppRunAuthorizer implements AppRunAuthorizer {
   async authorize(input: Parameters<AppRunAuthorizer['authorize']>[0]): Promise<boolean> {
     if (input.org_id !== input.run.org_id || !actorMatchesRun(input.actor, input.run)) return false;
+    if (input.required_authority_ref) {
+      const required = input.required_authority_ref;
+      const [stored] = await db.select({
+        authorization_snapshot: appRuns.authorization_snapshot,
+      }).from(appRuns).where(and(
+        eq(appRuns.org_id, input.org_id),
+        eq(appRuns.id, input.run.id),
+      )).limit(1);
+      if (!stored) return false;
+      const snapshot = AppRunAuthorizationSnapshotSchema.safeParse(stored.authorization_snapshot);
+      if (
+        !snapshot.success
+        || !snapshot.data.authority_refs.some((ref) => (
+          ref.authority_kind === required.authority_kind
+          && ref.authority_id === required.authority_id
+          && ref.version === required.version
+        ))
+      ) return false;
+    }
     if (input.actor.actor_type === 'human') {
       const [membership] = await db.select({ id: orgMembers.id }).from(orgMembers).where(and(
         eq(orgMembers.org_id, input.org_id),

--- a/apps/api/src/lib/app-run-capability-bridge.ts
+++ b/apps/api/src/lib/app-run-capability-bridge.ts
@@ -315,7 +315,7 @@ export class PostgresGovernedCapabilityExecutor {
         }, 'MCP tool outcome is unknown', elapsedMs);
       }
       try {
-        const exact = await runtime.service.result(request.org_id, runId, actor);
+        const exact = await runtime.service.result(request.org_id, runId, actor, null);
         const retained = AppRunRetainedProviderResultSchema.parse(exact.value);
         providerSucceeded = retained.provider_succeeded;
         retainedOutput = retained.output;

--- a/apps/api/src/lib/app-run-live-authorization.ts
+++ b/apps/api/src/lib/app-run-live-authorization.ts
@@ -38,7 +38,10 @@ import {
 } from '@deft/db/schema';
 import { and, eq, inArray, isNull, sql } from 'drizzle-orm';
 import { db } from './db.js';
-import type { AppRunExecutionAuthorizer } from './app-run-authorization.js';
+import type {
+  AppRunExecutionAuthorizer,
+  AppRunReadAuthorityRef,
+} from './app-run-authorization.js';
 import type {
   AppRunSafeView,
   AppRunTransaction,
@@ -219,13 +222,11 @@ export class PostgresAppRunLiveAuthorization implements AppRunExecutionAuthorize
 
   /** Revalidate an exact MCP/OAuth token and its current scopes for actor-
    * scoped Run reads. This does not create or mutate Run authority. */
-  async assertTokenScopes(input: AppRunTokenScopeAuthorization): Promise<void> {
+  async assertTokenScopes(input: AppRunTokenScopeAuthorization): Promise<AppRunReadAuthorityRef> {
     if (input.token_authorities.length !== 1) {
       throw new Error('APP_RUN_AUTHORIZATION_STALE');
     }
-    await db.transaction(async (tx) => {
-      await this.#tokenAuthority(tx, input, input.token_authorities[0]!);
-    });
+    return db.transaction((tx) => this.#tokenAuthority(tx, input, input.token_authorities[0]!));
   }
 
   /** Trusted App submission verifier. The encrypted candidate supplies the
@@ -1068,7 +1069,7 @@ export class PostgresAppRunLiveAuthorization implements AppRunExecutionAuthorize
     tx: AppRunTransaction,
     input: TokenScopeCheckInput,
     token: AppRunTokenAuthority,
-  ): Promise<AuthorityRef> {
+  ): Promise<AppRunReadAuthorityRef> {
     if (token.token_kind === 'mcp') {
       const [row] = await tx.select().from(mcpTokens).where(and(
         eq(mcpTokens.org_id, input.org_id),

--- a/apps/api/src/lib/app-run-operations.ts
+++ b/apps/api/src/lib/app-run-operations.ts
@@ -5,6 +5,7 @@ import {
   appRunReceipts,
   appRuns,
   attentionItems,
+  orgMembers,
 } from '@deft/db/schema';
 import type { AppRunActor, AppRunState } from '@deft/shared';
 import { and, asc, desc, eq, inArray, or, sql } from 'drizzle-orm';
@@ -36,6 +37,26 @@ export interface AppRunOperationsAuthorizer {
 
 export const denyAllAppRunOperationsAuthorizer: AppRunOperationsAuthorizer = Object.freeze({
   async authorize() { return false; },
+});
+
+/** Read-only operational access is decided from the current org membership,
+ * never from a role cached in the request token. Repair remains separately
+ * dependency-injected and is intentionally denied by this runtime authorizer. */
+export const postgresAppRunReadOperationsAuthorizer: AppRunOperationsAuthorizer = Object.freeze({
+  async authorize(input: Parameters<AppRunOperationsAuthorizer['authorize']>[0]) {
+    if (input.action === 'repair' || input.actor.actor_type !== 'human') return false;
+    const [membership] = await db.select({
+      role: orgMembers.role,
+      is_active: orgMembers.is_active,
+    }).from(orgMembers).where(and(
+      eq(orgMembers.org_id, input.org_id),
+      eq(orgMembers.user_id, input.actor.user_id),
+    )).limit(1);
+    return Boolean(
+      membership?.is_active
+      && (membership.role === 'owner' || membership.role === 'admin'),
+    );
+  },
 });
 
 export type AppRunRepairGap = Readonly<{

--- a/apps/api/src/lib/app-run-repository.ts
+++ b/apps/api/src/lib/app-run-repository.ts
@@ -463,11 +463,17 @@ export class PostgresAppRunRepository {
     return updated;
   }
 
-  async activeKeyReferences(now: Date): Promise<readonly { purpose: 'fingerprint'; key_id: string }[]> {
+  async activeKeyReferences(
+    now: Date,
+    orgId?: string,
+  ): Promise<readonly { purpose: 'fingerprint'; key_id: string }[]> {
     const rows = await db.select({
       idempotency: appRuns.idempotency_key_version,
       input: appRuns.input_fingerprint_key_version,
-    }).from(appRuns).where(gt(appRuns.idempotency_expires_at, now));
+    }).from(appRuns).where(and(
+      gt(appRuns.idempotency_expires_at, now),
+      ...(orgId ? [eq(appRuns.org_id, orgId)] : []),
+    ));
     const ids = new Set(rows.flatMap((row) => [row.idempotency, row.input]));
     return [...ids].map((key_id) => ({ purpose: 'fingerprint' as const, key_id }));
   }

--- a/apps/api/src/lib/app-run-runtime.ts
+++ b/apps/api/src/lib/app-run-runtime.ts
@@ -5,7 +5,10 @@ import { PostgresAppRunAuthorizer } from './app-run-authorization.js';
 import { AppRunError } from './app-run-errors.js';
 import { parseEnvironmentAppRunKeyrings, type EnvironmentAppRunKeyProvider } from './app-run-keyrings.js';
 import { PostgresAppRunLiveAuthorization } from './app-run-live-authorization.js';
-import { AppRunOperationsService } from './app-run-operations.js';
+import {
+  AppRunOperationsService,
+  postgresAppRunReadOperationsAuthorizer,
+} from './app-run-operations.js';
 import { PinnedMcpAppRunProviderExecutor } from './app-run-provider-executor.js';
 import { PostgresAppRunReceiptReader, PostgresAppRunReceiptWriter } from './app-run-receipts.js';
 import { PostgresAppRunRepository } from './app-run-repository.js';
@@ -81,7 +84,7 @@ async function createAppRunRuntime(): Promise<AppRunRuntime> {
   );
   const operations = new AppRunOperationsService(
     repository,
-    undefined,
+    postgresAppRunReadOperationsAuthorizer,
     receipts,
     attention,
     clock,

--- a/apps/api/src/lib/app-run-secret-repository.ts
+++ b/apps/api/src/lib/app-run-secret-repository.ts
@@ -144,19 +144,26 @@ export class AppRunSecretRepository {
       : undefined;
   }
 
-  async retainedKeyReferences(now: Date): Promise<readonly { purpose: 'run_encryption'; key_id: string }[]> {
+  async retainedKeyReferences(
+    now: Date,
+    orgId?: string,
+  ): Promise<readonly { purpose: 'run_encryption'; key_id: string }[]> {
     const rows = await db.selectDistinct({ key_id: appRunSecretPayloads.key_version })
       .from(appRunSecretPayloads)
-      .where(sql`${appRunSecretPayloads.expires_at} > ${now}`);
+      .where(and(
+        sql`${appRunSecretPayloads.expires_at} > ${now}`,
+        ...(orgId ? [eq(appRunSecretPayloads.org_id, orgId)] : []),
+      ));
     return rows.map((row) => ({ purpose: 'run_encryption' as const, key_id: row.key_id }));
   }
 
-  async receiptSigningKeyReferences(): Promise<readonly {
+  async receiptSigningKeyReferences(orgId?: string): Promise<readonly {
     purpose: 'receipt_signing';
     key_id: string;
   }[]> {
     const rows = await db.selectDistinct({ key_id: appRunReceipts.signing_key_version })
-      .from(appRunReceipts);
+      .from(appRunReceipts)
+      .where(orgId ? eq(appRunReceipts.org_id, orgId) : undefined);
     return rows.map((row) => ({ purpose: 'receipt_signing' as const, key_id: row.key_id }));
   }
 

--- a/apps/api/src/lib/app-run-service.ts
+++ b/apps/api/src/lib/app-run-service.ts
@@ -29,6 +29,7 @@ import {
   denyAllAppRunAuthorizer,
   type AppRunAccessAction,
   type AppRunAuthorizer,
+  type AppRunReadAuthorityRef,
 } from './app-run-authorization.js';
 import { AppRunError, asAppRunError } from './app-run-errors.js';
 import {
@@ -494,9 +495,14 @@ export class AppRunService {
     return submitted;
   }
 
-  async inspect(orgId: string, runId: string, actor: AppRunActor): Promise<AppRunSafeView> {
+  async inspect(
+    orgId: string,
+    runId: string,
+    actor: AppRunActor,
+    requiredAuthorityRef: AppRunReadAuthorityRef | null,
+  ): Promise<AppRunSafeView> {
     const run = await this.requiredRun(orgId, runId);
-    await this.assertAuthorized('inspect', orgId, actor, run);
+    await this.assertAuthorized('inspect', orgId, actor, run, requiredAuthorityRef);
     return run;
   }
 
@@ -582,12 +588,17 @@ export class AppRunService {
     return reconciled;
   }
 
-  async result(orgId: string, runId: string, actor: AppRunActor): Promise<Readonly<{
+  async result(
+    orgId: string,
+    runId: string,
+    actor: AppRunActor,
+    requiredAuthorityRef: AppRunReadAuthorityRef | null,
+  ): Promise<Readonly<{
     run: AppRunSafeView;
     value: unknown;
   }>> {
     const run = await this.requiredRun(orgId, runId);
-    await this.assertAuthorized('result', orgId, actor, run);
+    await this.assertAuthorized('result', orgId, actor, run, requiredAuthorityRef);
     if (
       run.origin_kind === 'app'
       && (!this.appLiveAuthorization || !await this.appLiveAuthorization.authorizeDelivery({
@@ -629,8 +640,15 @@ export class AppRunService {
     orgId: string,
     actor: AppRunActor,
     run: AppRunSafeView,
+    requiredAuthorityRef: AppRunReadAuthorityRef | null = null,
   ): Promise<void> {
-    if (!await this.authorizer.authorize({ action, org_id: orgId, actor, run })) {
+    if (!await this.authorizer.authorize({
+      action,
+      org_id: orgId,
+      actor,
+      run,
+      required_authority_ref: requiredAuthorityRef,
+    })) {
       throw new AppRunError('APP_RUN_ACCESS_DENIED');
     }
   }

--- a/apps/api/src/lib/queue-health.ts
+++ b/apps/api/src/lib/queue-health.ts
@@ -1,4 +1,4 @@
-import { sql } from 'drizzle-orm';
+import { sql, type SQL } from 'drizzle-orm';
 import { db } from './db.js';
 
 export type QueueWorkerStatus = {
@@ -94,7 +94,8 @@ export function summarizeQueueHealth(
  * missing lease is treated as expired so legacy or partially-migrated rows are
  * visible instead of silently disappearing from health output.
  */
-export async function getQueueHealthSnapshot(
+async function queryQueueHealthSnapshot(
+  where: SQL,
   workerStatus: QueueWorkerStatus,
   now = new Date(),
 ): Promise<QueueHealthSnapshot> {
@@ -122,8 +123,31 @@ export async function getQueueHealthSnapshot(
           AND completed_at >= now() - interval '24 hours'
       )::int AS recent_terminal_failures
     FROM job_queue
+    WHERE ${where}
   `);
   const rows = (result as { rows?: QueueHealthRow[] }).rows
     ?? (result as unknown as QueueHealthRow[]);
   return summarizeQueueHealth(rows[0], workerStatus, now);
+}
+
+export async function getQueueHealthSnapshot(
+  workerStatus: QueueWorkerStatus,
+  now = new Date(),
+): Promise<QueueHealthSnapshot> {
+  return queryQueueHealthSnapshot(sql`true`, workerStatus, now);
+}
+
+/** Tenant-aware queue health for one bounded job family. Process heartbeat
+ * fields remain shared, while every persisted queue aggregate is scoped. */
+export async function getOrgQueueHealthSnapshot(
+  orgId: string,
+  jobName: string,
+  workerStatus: QueueWorkerStatus,
+  now = new Date(),
+): Promise<QueueHealthSnapshot> {
+  return queryQueueHealthSnapshot(
+    sql`org_id = ${orgId} AND name = ${jobName}`,
+    workerStatus,
+    now,
+  );
 }

--- a/apps/api/src/routes/apps.ts
+++ b/apps/api/src/routes/apps.ts
@@ -24,6 +24,9 @@ import {
 import { isAppError } from '../lib/app-errors.js';
 import { isModuleError } from '../lib/module-errors.js';
 import { createAppDeveloperPairing, revokeAppDeveloperPairing } from '../lib/app-developer-pairing.js';
+import { appOperationsService } from '../lib/app-operations-service.js';
+import { AppRunError } from '../lib/app-run-errors.js';
+import { appHttpFailure } from './app-http-errors.js';
 
 export const appRoutes = new Hono();
 
@@ -98,6 +101,15 @@ function failure(c: Context, error: unknown) {
       error: 'Only active workspace owners and admins can manage Apps',
       code: 'APP_ACCESS_DENIED',
     }, 403);
+  }
+  if (error instanceof AppRunError) {
+    if (error.code === 'APP_RUN_ACCESS_DENIED') {
+      return c.json({
+        error: 'Only active workspace owners and admins can inspect App operations',
+        code: 'APP_ACCESS_DENIED',
+      }, 403);
+    }
+    return appHttpFailure(c, error, 'App Run', 'app-runs');
   }
   if (error && typeof error === 'object' && 'appPayloadTooLarge' in error) {
     return c.json({ error: 'App package is too large', code: 'APP_INVALID_PACKAGE' }, 413);
@@ -227,6 +239,14 @@ appRoutes.get('/', async (c) => {
 appRoutes.get('/navigation', async (c) => {
   try {
     return c.json({ navigation: await listActiveAppNavigation(actorFromContext(c)) });
+  } catch (error) {
+    return failure(c, error);
+  }
+});
+
+appRoutes.get('/operations', async (c) => {
+  try {
+    return c.json({ operations: await appOperationsService.read(managerFromContext(c)) });
   } catch (error) {
     return failure(c, error);
   }

--- a/apps/api/test/app-action-service-db.test.ts
+++ b/apps/api/test/app-action-service-db.test.ts
@@ -389,14 +389,32 @@ test('App actions resolve and prepare one reviewed relation identically across f
       return { id: `loop5-run-${submittedRuns.length}` } as AppRunSafeView;
     },
   };
-  const runReadCalls: Array<Readonly<{ kind: 'inspect' | 'result'; org_id: string; run_id: string; actor: unknown }>> = [];
+  const runReadCalls: Array<Readonly<{
+    kind: 'inspect' | 'result';
+    org_id: string;
+    run_id: string;
+    actor: unknown;
+    required_authority_ref: unknown;
+  }>> = [];
   const runReads: AppActionRunReadPort = {
-    async inspect(readOrgId, runId, actor) {
-      runReadCalls.push({ kind: 'inspect', org_id: readOrgId, run_id: runId, actor });
+    async inspect(readOrgId, runId, actor, requiredAuthorityRef) {
+      runReadCalls.push({
+        kind: 'inspect',
+        org_id: readOrgId,
+        run_id: runId,
+        actor,
+        required_authority_ref: requiredAuthorityRef,
+      });
       return { id: runId } as AppRunSafeView;
     },
-    async result(readOrgId, runId, actor) {
-      runReadCalls.push({ kind: 'result', org_id: readOrgId, run_id: runId, actor });
+    async result(readOrgId, runId, actor, requiredAuthorityRef) {
+      runReadCalls.push({
+        kind: 'result',
+        org_id: readOrgId,
+        run_id: runId,
+        actor,
+        required_authority_ref: requiredAuthorityRef,
+      });
       return { run: { id: runId } as AppRunSafeView, value: { status: 'delivered' } };
     },
   };
@@ -460,6 +478,16 @@ test('App actions resolve and prepare one reviewed relation identically across f
     { kind: 'inspect', actor: { actor_type: 'human', user_id: ownerUserId } },
     { kind: 'result', actor: { actor_type: 'human', user_id: ownerUserId } },
   ]);
+  assert.equal(runReadCalls[0]?.required_authority_ref, null);
+  assert.deepEqual(runReadCalls[1]?.required_authority_ref, {
+    authority_kind: 'token_scope',
+    authority_id: mcpTokenId,
+    version: (runReadCalls[1]?.required_authority_ref as { version: string }).version,
+  });
+  assert.match(
+    (runReadCalls[1]?.required_authority_ref as { version: string }).version,
+    /^sha256:[a-f0-9]{64}$/,
+  );
 
   await db.update(mcpTokens).set({ scopes: ['read:modules', 'read:apps', 'invoke:apps'] }).where(and(
     eq(mcpTokens.org_id, orgId),

--- a/apps/api/test/app-operations.test.ts
+++ b/apps/api/test/app-operations.test.ts
@@ -1,0 +1,311 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { Hono } from 'hono';
+import type { AppRunSafeView } from '../src/lib/app-run-repository.js';
+import {
+  APP_OPERATIONS_BOUNDS,
+  AppOperationsProjectionService,
+  appOperationsService,
+  type AppOperationsProjectionDependencies,
+} from '../src/lib/app-operations-service.js';
+import { AppRunError } from '../src/lib/app-run-errors.js';
+import { ModuleError } from '../src/lib/module-errors.js';
+import { humanModuleActor } from '../src/lib/module-service.js';
+import { appRoutes } from '../src/routes/apps.js';
+
+const NOW = new Date('2026-09-01T10:00:00.000Z');
+const actor = humanModuleActor({
+  orgId: 'org-alpha',
+  userId: 'manager-alpha',
+  role: 'admin',
+  source: 'rest',
+});
+
+function run(id: string, orgId = actor.org_id): AppRunSafeView {
+  return {
+    id,
+    org_id: orgId,
+    state: 'succeeded',
+    provider_kind: 'mcp',
+    provider_instance_id: 'provider-instance-secret-marker',
+    provider_snapshot_id: 'provider-snapshot-secret-marker',
+    initiating_actor_id: 'initiating-actor-secret-marker',
+    execution_actor_id: 'execution-actor-secret-marker',
+    operation_name: `safe.operation.${id}`,
+    risk_class: 'external_write',
+    review_requirement: 'always',
+    retry_class: 'idempotent_with_key',
+    retention_class: 'standard',
+    updated_at: NOW,
+    safe_preview: { raw_payload: 'raw-payload-secret-marker' },
+    safe_outcome: { raw_result: 'raw-result-secret-marker' },
+  } as unknown as AppRunSafeView;
+}
+
+function dependencies(overrides: Partial<AppOperationsProjectionDependencies> = {}) {
+  const orgCalls: string[] = [];
+  const recentRows = [
+    run('foreign-run', 'org-beta'),
+    ...Array.from({ length: 30 }, (_, index) => run(`run-${index + 1}`)),
+  ];
+  const gaps = Array.from({ length: 120 }, (_, index) => ({
+    run_id: `gap-run-secret-marker-${index}`,
+    gap: index % 2 === 0 ? 'missing_receipt' as const : 'missing_terminal_event' as const,
+    artifact: 'run' as const,
+    attempt_id: `attempt-secret-marker-${index}`,
+    action_id: `action-secret-marker-${index}`,
+  }));
+  const base: AppOperationsProjectionDependencies = {
+    assertManager: async (value) => { orgCalls.push(`manager:${value.org_id}`); },
+    runOperations: {
+      async metrics(input) {
+        orgCalls.push(`metrics:${input.org_id}`);
+        return [
+          { state: 'pending_approval', risk_class: 'external_write', provider_kind: 'mcp', count: 2 },
+          { state: 'unknown_outcome', risk_class: 'external_write', provider_kind: 'mcp', count: 1 },
+          { state: 'succeeded', risk_class: 'read', provider_kind: 'mcp', count: 7 },
+        ];
+      },
+      async list(input) {
+        orgCalls.push(`list:${input.org_id}`);
+        return recentRows;
+      },
+      async auditGaps(input) {
+        orgCalls.push(`audit:${input.org_id}`);
+        return gaps;
+      },
+    },
+    async readAggregates(orgId) {
+      orgCalls.push(`aggregates:${orgId}`);
+      return {
+        attempt_states: [
+          { state: 'pending', count: 2, retry_attempts: 0, retryable_failed: 0 },
+          { state: 'failed', count: 3, retry_attempts: 2, retryable_failed: 1 },
+          { state: 'succeeded', count: 6, retry_attempts: 1, retryable_failed: 0 },
+        ],
+        action_counts: Array.from({ length: 30 }, (_, index) => ({
+          operation_name: `safe.action.${index + 1}`,
+          count: 30 - index,
+        })),
+        retained_payload_count: 8,
+        retained_payload_bytes: 2_048,
+        cleanup_due_payload_count: 2,
+        cleanup_due_payload_bytes: 512,
+        overdue_run_cleanup_count: 1,
+      };
+    },
+    async readQueue(orgId) {
+      orgCalls.push(`queue:${orgId}`);
+      return {
+        status: 'degraded',
+        pending: 4,
+        running: 1,
+        completed: 9,
+        failed: 2,
+        oldest_ready_lag_seconds: 12,
+        expired_leases: 1,
+        recent_terminal_failures: 2,
+        worker: {
+          running: true,
+          started_at: 'worker-start-secret-marker',
+          last_poll_at: 'worker-poll-secret-marker',
+          heartbeat_age_seconds: 1,
+          heartbeat_stale: false,
+          in_flight: 99,
+        },
+      };
+    },
+    async readKeyReferences(orgId) {
+      orgCalls.push(`keys:${orgId}`);
+      return [
+        { purpose: 'fingerprint', key_id: 'fingerprint-key-secret-marker-a' },
+        { purpose: 'fingerprint', key_id: 'fingerprint-key-secret-marker-b' },
+        { purpose: 'receipt_signing', key_id: 'receipt-key-secret-marker' },
+      ];
+    },
+    configuredKeyIds(purpose) {
+      return purpose === 'fingerprint'
+        ? ['fingerprint-key-secret-marker-a']
+        : purpose === 'receipt_signing'
+          ? ['receipt-key-secret-marker']
+          : ['encryption-key-secret-marker'];
+    },
+    async readConnectedHealth(value, limit) {
+      orgCalls.push(`health:${value.org_id}:${limit}`);
+      return {
+        total: 31,
+        checked: limit,
+        truncated: true,
+        healthy: 24,
+        unhealthy: 1,
+        issue_counts: [{ code: 'APP_CONNECTOR_DRIFT', count: 1 }],
+        provider_instance_id: 'health-provider-secret-marker',
+        active_grant_snapshot_id: 'grant-snapshot-secret-marker',
+      } as never;
+    },
+    now: () => NOW,
+  };
+  return { dependencies: { ...base, ...overrides }, orgCalls };
+}
+
+test('operations projection is bounded, tenant-scoped, and allowlist-redacted', async () => {
+  const setup = dependencies();
+  const projection = await new AppOperationsProjectionService(setup.dependencies).read(actor);
+
+  assert.equal(projection.schema, 'deft.app_operations.v1');
+  assert.equal(projection.runs.total, 10);
+  assert.equal(projection.runs.pending_approvals, 2);
+  assert.equal(projection.runs.recent.length, APP_OPERATIONS_BOUNDS.recent_runs);
+  assert.equal(projection.runs.recent.some((item) => item.run_id === 'foreign-run'), false);
+  assert.equal(projection.actions.items.length, APP_OPERATIONS_BOUNDS.action_counts);
+  assert.equal(projection.actions.truncated, true);
+  assert.equal(projection.integrity.sampled_gap_count, APP_OPERATIONS_BOUNDS.audit_gaps);
+  assert.equal(projection.integrity.truncated, true);
+  assert.equal(projection.connected_apps.checked, APP_OPERATIONS_BOUNDS.connected_apps);
+  assert.equal(projection.queue.worker_available, true);
+  assert.deepEqual(projection.degraded.reasons, [
+    'queue',
+    'integrity',
+    'payload_cleanup',
+    'connected_apps',
+    'key_availability',
+    'unknown_outcomes',
+  ]);
+  assert.deepEqual(
+    setup.orgCalls,
+    [
+      'manager:org-alpha',
+      'metrics:org-alpha',
+      'list:org-alpha',
+      'audit:org-alpha',
+      'aggregates:org-alpha',
+      'queue:org-alpha',
+      'keys:org-alpha',
+      `health:org-alpha:${APP_OPERATIONS_BOUNDS.connected_apps}`,
+    ],
+  );
+
+  const serialized = JSON.stringify(projection);
+  for (const marker of [
+    'org-beta',
+    'provider-instance-secret-marker',
+    'provider-snapshot-secret-marker',
+    'initiating-actor-secret-marker',
+    'execution-actor-secret-marker',
+    'raw-payload-secret-marker',
+    'raw-result-secret-marker',
+    'gap-run-secret-marker',
+    'attempt-secret-marker',
+    'action-secret-marker',
+    'worker-start-secret-marker',
+    'worker-poll-secret-marker',
+    'fingerprint-key-secret-marker',
+    'receipt-key-secret-marker',
+    'encryption-key-secret-marker',
+    'health-provider-secret-marker',
+    'grant-snapshot-secret-marker',
+  ]) {
+    assert.doesNotMatch(serialized, new RegExp(marker));
+  }
+  for (const forbiddenKey of [
+    'ciphertext_b64',
+    'signature_hmac',
+    'actor_id',
+    'provider_instance_id',
+    'provider_snapshot_id',
+    'active_grant_snapshot_id',
+    'key_id',
+    'raw_payload',
+    'raw_result',
+  ]) {
+    assert.equal(Object.prototype.hasOwnProperty.call(projection, forbiddenKey), false);
+    assert.doesNotMatch(serialized, new RegExp(`"${forbiddenKey}"`));
+  }
+});
+
+test('operations projection stops before reads when current membership was demoted', async () => {
+  let reads = 0;
+  const setup = dependencies({
+    assertManager: async () => {
+      throw new ModuleError('demoted', 'MODULE_ACCESS_DENIED', 403);
+    },
+    runOperations: {
+      async metrics() { reads += 1; return []; },
+      async list() { reads += 1; return []; },
+      async auditGaps() { reads += 1; return []; },
+    },
+  });
+  await assert.rejects(
+    () => new AppOperationsProjectionService(setup.dependencies).read(actor),
+    (error: unknown) => error instanceof ModuleError && error.code === 'MODULE_ACCESS_DENIED',
+  );
+  assert.equal(reads, 0);
+});
+
+function routeApp(user: Record<string, unknown>) {
+  const app = new Hono();
+  app.use('/api/apps/*', async (context, next) => {
+    context.set('user', user as never);
+    await next();
+  });
+  app.route('/api/apps', appRoutes);
+  return app;
+}
+
+test('GET /api/apps/operations is static, manager-only, and maps live demotion to 403', async (t) => {
+  const original = appOperationsService.read;
+  t.after(() => { appOperationsService.read = original; });
+  let calls = 0;
+  appOperationsService.read = async (value) => {
+    calls += 1;
+    assert.equal(value.org_id, 'org-alpha');
+    return { schema: 'deft.app_operations.v1', generated_at: NOW.toISOString() } as never;
+  };
+
+  const ownerResponse = await routeApp({
+    id: 'manager-alpha',
+    org_id: 'org-alpha',
+    email: 'manager@test.local',
+    role: 'owner',
+  }).request('/api/apps/operations');
+  assert.equal(ownerResponse.status, 200);
+  assert.equal((await ownerResponse.json() as { operations: { schema: string } }).operations.schema,
+    'deft.app_operations.v1');
+  assert.equal(calls, 1);
+
+  const memberResponse = await routeApp({
+    id: 'member-alpha',
+    org_id: 'org-alpha',
+    email: 'member@test.local',
+    role: 'member',
+  }).request('/api/apps/operations');
+  assert.equal(memberResponse.status, 403);
+  assert.equal(calls, 1);
+
+  appOperationsService.read = async () => {
+    throw new ModuleError('demoted', 'MODULE_ACCESS_DENIED', 403);
+  };
+  const demotedResponse = await routeApp({
+    id: 'manager-alpha',
+    org_id: 'org-alpha',
+    email: 'manager@test.local',
+    role: 'admin',
+  }).request('/api/apps/operations');
+  assert.equal(demotedResponse.status, 403);
+  assert.equal((await demotedResponse.json() as { code: string }).code, 'APP_ACCESS_DENIED');
+
+  appOperationsService.read = async () => {
+    throw new AppRunError('APP_RUNS_DISABLED');
+  };
+  const disabledResponse = await routeApp({
+    id: 'manager-alpha',
+    org_id: 'org-alpha',
+    email: 'manager@test.local',
+    role: 'owner',
+  }).request('/api/apps/operations');
+  assert.equal(disabledResponse.status, 503);
+  assert.deepEqual(await disabledResponse.json(), {
+    error: 'App Run execution is disabled',
+    code: 'APP_RUNS_DISABLED',
+  });
+});

--- a/apps/api/test/app-origin-run-lifecycle-db.test.ts
+++ b/apps/api/test/app-origin-run-lifecycle-db.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { createHash, randomUUID } from 'node:crypto';
 import test, { after } from 'node:test';
-import { and, count, eq, sql } from 'drizzle-orm';
+import { and, asc, count, eq, inArray, sql } from 'drizzle-orm';
 import { SANDBOX_EMAIL_SEND_PRIVATE_CONTRACT } from '@deft/app-kit';
 import {
   APP_RUN_CONTRACT_VERSIONS,
@@ -19,6 +19,7 @@ import {
   appGrantSnapshots,
   appInstallations,
   appRunAttempts,
+  appRunEvents,
   appRunReceipts,
   appRunSecretPayloads,
   appRuns,
@@ -39,13 +40,19 @@ import { AppRunError } from '../src/lib/app-run-errors.js';
 import { parseEnvironmentAppRunKeyrings } from '../src/lib/app-run-keyrings.js';
 import { PostgresAppRunLiveAuthorization } from '../src/lib/app-run-live-authorization.js';
 import { AppRunPreparedInputService } from '../src/lib/app-run-prepared-input.js';
-import { PinnedMcpAppRunProviderExecutor } from '../src/lib/app-run-provider-executor.js';
+import {
+  MCP_APP_RUN_RESULT_VERSION,
+  PinnedMcpAppRunProviderExecutor,
+} from '../src/lib/app-run-provider-executor.js';
 import { PostgresAppRunRepository, type AppRunTransaction } from '../src/lib/app-run-repository.js';
 import { AppRunSecretRepository } from '../src/lib/app-run-secret-repository.js';
 import { AppRunSecretService } from '../src/lib/app-run-secrets.js';
 import { AppRunService } from '../src/lib/app-run-service.js';
 import { noOpAppRunAttentionProjector } from '../src/lib/app-run-attention.js';
-import { PostgresAppRunReceiptWriter } from '../src/lib/app-run-receipts.js';
+import {
+  PostgresAppRunReceiptReader,
+  PostgresAppRunReceiptWriter,
+} from '../src/lib/app-run-receipts.js';
 import { CapabilityService, type CapabilityPinnedInvocationRequest } from '../src/lib/capability-service.js';
 import type {
   McpCapabilityDiscoveryRequest,
@@ -112,6 +119,9 @@ test('App actions create governed Runs once across every caller surface and fail
   const employeeUserId = randomUUID();
   const employeeId = randomUUID();
   const mcpTokenId = randomUUID();
+  const secondMcpTokenId = randomUUID();
+  const otherUserId = randomUUID();
+  const otherMcpTokenId = randomUUID();
   const connectionId = randomUUID();
   const connectionSlug = `loop5-mail-${suffix}`;
   const recipient = `loop5-recipient-${suffix}@example.test`;
@@ -133,6 +143,11 @@ test('App actions create governed Runs once across every caller surface and fail
       is_agent: true,
       agent_employee_id: employeeId,
     },
+    {
+      id: otherUserId,
+      email: `loop5-other-${suffix}@example.test`,
+      name: 'Loop 5 other member',
+    },
   ]);
   await db.insert(orgMembers).values([
     {
@@ -146,6 +161,13 @@ test('App actions create governed Runs once across every caller surface and fail
       id: randomUUID(),
       org_id: orgId,
       user_id: employeeUserId,
+      role: 'member',
+      is_active: true,
+    },
+    {
+      id: randomUUID(),
+      org_id: orgId,
+      user_id: otherUserId,
       role: 'member',
       is_active: true,
     },
@@ -220,6 +242,11 @@ test('App actions create governed Runs once across every caller surface and fail
   };
   const sandbox = new Phase4SandboxEmailProvider();
   const pinnedRequests: CapabilityPinnedInvocationRequest[] = [];
+  const forcedPinnedResults: McpPinnedExecutionResult[] = [];
+  let pinnedBlock: Readonly<{
+    entered: () => void;
+    wait: Promise<void>;
+  }> | null = null;
   const providerPort = {
     async discover(request: McpCapabilityDiscoveryRequest): Promise<McpCapabilityDiscoveryResult> {
       assert.equal(request.org_id, orgId);
@@ -231,6 +258,14 @@ test('App actions create governed Runs once across every caller surface and fail
     },
     async executePinned(request: CapabilityPinnedInvocationRequest): Promise<McpPinnedExecutionResult> {
       pinnedRequests.push(request);
+      const block = pinnedBlock;
+      if (block) {
+        pinnedBlock = null;
+        block.entered();
+        await block.wait;
+      }
+      const forced = forcedPinnedResults.shift();
+      if (forced) return forced;
       const effect = await sandbox.invoke({
         to: String(request.input.to),
         subject: String(request.input.subject),
@@ -318,18 +353,44 @@ test('App actions create governed Runs once across every caller surface and fail
     is_deleted: false,
     created_by: ownerUserId,
   });
-  await db.insert(mcpTokens).values({
-    id: mcpTokenId,
-    org_id: orgId,
-    user_id: ownerUserId,
-    agent_employee_id: null,
-    principal_kind: 'human',
-    name: 'Loop 5 human MCP token',
-    token_hash: `loop5-hash-${suffix}`,
-    token_prefix: `loop5-${suffix.slice(0, 8)}`,
-    scopes: ['read:modules', 'read:apps', 'invoke:apps', 'read:app-runs'],
-    created_by: ownerUserId,
-  });
+  await db.insert(mcpTokens).values([
+    {
+      id: mcpTokenId,
+      org_id: orgId,
+      user_id: ownerUserId,
+      agent_employee_id: null,
+      principal_kind: 'human',
+      name: 'Loop 5 human MCP token',
+      token_hash: `loop5-hash-${suffix}`,
+      token_prefix: `loop5-${suffix.slice(0, 8)}`,
+      scopes: ['read:modules', 'read:apps', 'invoke:apps', 'read:app-runs'],
+      created_by: ownerUserId,
+    },
+    {
+      id: secondMcpTokenId,
+      org_id: orgId,
+      user_id: ownerUserId,
+      agent_employee_id: null,
+      principal_kind: 'human',
+      name: 'Loop 5 second same-actor MCP token',
+      token_hash: `loop5-second-hash-${suffix}`,
+      token_prefix: `loop5-second-${suffix.slice(0, 8)}`,
+      scopes: ['read:modules', 'read:apps', 'invoke:apps', 'read:app-runs'],
+      created_by: ownerUserId,
+    },
+    {
+      id: otherMcpTokenId,
+      org_id: orgId,
+      user_id: otherUserId,
+      agent_employee_id: null,
+      principal_kind: 'human',
+      name: 'Loop 5 other-actor MCP token',
+      token_hash: `loop5-other-hash-${suffix}`,
+      token_prefix: `loop5-other-${suffix.slice(0, 8)}`,
+      scopes: ['read:modules', 'read:apps', 'invoke:apps', 'read:app-runs'],
+      created_by: ownerUserId,
+    },
+  ]);
 
   const [fingerprintRows, encryptionRows, signingRows] = await Promise.all([
     db.select({
@@ -358,6 +419,7 @@ test('App actions create governed Runs once across every caller surface and fail
     const secretRepository = new AppRunSecretRepository(secrets);
     const liveAuthorization = new PostgresAppRunLiveAuthorization();
     const receipts = new PostgresAppRunReceiptWriter(secrets, secretRepository);
+    const receiptReader = new PostgresAppRunReceiptReader(secrets);
     const pinnedExecutor = new PinnedMcpAppRunProviderExecutor({
       executePinned: (request) => capabilities.invokePinned(request),
     });
@@ -402,9 +464,14 @@ test('App actions create governed Runs once across every caller surface and fail
       { read: readModuleRecordScalarFields },
       { submitPreparedApp: (context, candidate) => runService.submitPreparedApp(context, candidate) },
       {
-        inspect: (readOrgId, runId, actor) => runService.inspect(readOrgId, runId, actor),
-        result: (readOrgId, runId, actor) => runService.result(readOrgId, runId, actor),
+        inspect: (readOrgId, runId, actor, requiredAuthorityRef) => (
+          runService.inspect(readOrgId, runId, actor, requiredAuthorityRef)
+        ),
+        result: (readOrgId, runId, actor, requiredAuthorityRef) => (
+          runService.result(readOrgId, runId, actor, requiredAuthorityRef)
+        ),
       },
+      receiptReader,
     );
     const callers: ReadonlyArray<Readonly<{
       name: 'ui' | 'defty' | 'employee' | 'human_mcp';
@@ -660,10 +727,131 @@ test('App actions create governed Runs once across every caller surface and fail
       assert.ok(runReceipts.every((receipt) => receipt.run_id === positive.run.id));
 
     }
+    const successfulRunIds = distinctPositiveRuns.map((positive) => positive.run.id);
+    const successfulEvents = await db.select({
+      run_id: appRunEvents.run_id,
+      sequence: appRunEvents.sequence,
+      event_type: appRunEvents.event_type,
+      payload: appRunEvents.payload,
+    }).from(appRunEvents).where(and(
+      eq(appRunEvents.org_id, orgId),
+      inArray(appRunEvents.run_id, successfulRunIds),
+    )).orderBy(asc(appRunEvents.run_id), asc(appRunEvents.sequence));
+    const successParity: unknown[] = [];
     for (const positive of surfaceRuns) {
       const retained = await actions.result(positive.surface.caller, positive.run.id);
       assert.equal(retained.run.state, 'succeeded');
-      assert.equal((retained.value as { provider_succeeded?: boolean }).provider_succeeded, true);
+      const result = retained.value as Readonly<{
+        schema_version?: string;
+        provider_succeeded?: boolean;
+        output?: Readonly<{
+          schema_version?: string;
+          legacy_output?: Readonly<{ status?: string }>;
+        }>;
+      }>;
+      assert.equal(result.provider_succeeded, true);
+      const receiptBundle = await actions.inspectReceipts(positive.surface.caller, positive.run.id);
+      const persisted = persistedRuns.find((run) => run.id === positive.run.id);
+      if (!persisted) throw new Error(`${positive.surface.name} persisted Run is missing`);
+      const normalizedEvents = successfulEvents
+        .filter((event) => event.run_id === positive.run.id)
+        .map((event) => {
+          const payload = event.payload as Record<string, unknown>;
+          return {
+            event_type: event.event_type,
+            ...(typeof payload.from_state === 'string' ? { from_state: payload.from_state } : {}),
+            ...(typeof payload.to_state === 'string' ? { to_state: payload.to_state } : {}),
+          };
+        });
+      successParity.push({
+        binding: {
+          origin_kind: persisted.origin_kind,
+          binding_key: persisted.origin_app_binding_key,
+          operation_name: retained.run.operation_name,
+        },
+        policy: {
+          risk_class: retained.run.risk_class,
+          review_requirement: retained.run.review_requirement,
+          review_scope: retained.run.review_scope,
+          retry_class: retained.run.retry_class,
+          retention_class: retained.run.retention_class,
+        },
+        state: retained.run.state,
+        safe_preview: retained.run.safe_preview,
+        safe_outcome: retained.run.safe_outcome,
+        result: {
+          schema_version: result.schema_version,
+          provider_succeeded: result.provider_succeeded,
+          output_schema_version: result.output?.schema_version,
+          legacy_status: result.output?.legacy_output?.status,
+        },
+        transitions: normalizedEvents,
+        receipts: receiptBundle.receipts.map((receipt) => ({
+          receipt_kind: receipt.receipt_kind,
+          run_state: receipt.run_state,
+          verified: receipt.verified,
+        })),
+      });
+    }
+    const successBaseline = successParity[0];
+    assert.ok(successBaseline);
+    assert.ok((successBaseline as { transitions: Array<{ to_state?: string }> }).transitions
+      .some((event) => event.to_state === 'succeeded'));
+    for (const normalized of successParity.slice(1)) assert.deepEqual(normalized, successBaseline);
+    assert.equal(
+      (await actions.inspectRun(humanMcpRun.surface.caller, humanMcpRun.run.id)).id,
+      humanMcpRun.run.id,
+      'the original live token must inspect its Run',
+    );
+    assert.equal(
+      (await actions.inspectReceipts(humanMcpRun.surface.caller, humanMcpRun.run.id)).receipts.length,
+      2,
+      'the original live token must inspect verified receipts',
+    );
+
+    const alternateTokenCallers: ReadonlyArray<Readonly<{
+      label: string;
+      caller: AppActionCaller;
+    }>> = [
+      {
+        label: 'second token for the same actor',
+        caller: {
+          actor: humanModuleActor({
+            orgId,
+            userId: ownerUserId,
+            role: 'owner',
+            source: 'mcp',
+            scopes: ['read:modules', 'read:apps', 'invoke:apps', 'read:app-runs'],
+          }),
+          token_authorities: [{ token_kind: 'mcp', token_id: secondMcpTokenId }],
+        },
+      },
+      {
+        label: 'different actor and token',
+        caller: {
+          actor: humanModuleActor({
+            orgId,
+            userId: otherUserId,
+            role: 'member',
+            source: 'mcp',
+            scopes: ['read:modules', 'read:apps', 'invoke:apps', 'read:app-runs'],
+          }),
+          token_authorities: [{ token_kind: 'mcp', token_id: otherMcpTokenId }],
+        },
+      },
+    ];
+    for (const alternate of alternateTokenCallers) {
+      for (const read of [
+        () => actions.inspectRun(alternate.caller, humanMcpRun.run.id),
+        () => actions.result(alternate.caller, humanMcpRun.run.id),
+        () => actions.inspectReceipts(alternate.caller, humanMcpRun.run.id),
+      ]) {
+        await assert.rejects(
+          read,
+          (error: unknown) => error instanceof AppRunError && error.code === 'APP_RUN_ACCESS_DENIED',
+          `${alternate.label} read another token's Run`,
+        );
+      }
     }
     assert.equal(sandbox.callCount, distinctPositiveRuns.length, 'each caller-authority Run must produce one provider effect');
     assert.equal(pinnedRequests.length, distinctPositiveRuns.length);
@@ -674,6 +862,319 @@ test('App actions create governed Runs once across every caller surface and fail
       assert.deepEqual(request.dispatch_pin, dispatchPin);
       assert.equal(Object.hasOwn(request, 'connection_slug'), false);
     }
+
+    const approvedRun = async (label: string) => {
+      const input = actionInput(`loop7-${label}-${suffix}`);
+      const prepared = await actions.prepare(callers[0]!.caller, input);
+      const run = await actions.invoke(callers[0]!.caller, {
+        ...input,
+        input_candidate: prepared.input_candidate,
+      });
+      const [approval] = await db.select().from(agentActions).where(and(
+        eq(agentActions.org_id, orgId),
+        eq(agentActions.source, 'app_run'),
+        eq(agentActions.app_run_id, run.id),
+      ));
+      if (!approval) throw new Error(`${label} App-origin approval is missing`);
+      assert.equal((await approvalResolver.approve(approval.id, ownerUserId)).status, 'approved');
+      const [attempt] = await db.select().from(appRunAttempts).where(and(
+        eq(appRunAttempts.org_id, orgId),
+        eq(appRunAttempts.run_id, run.id),
+        eq(appRunAttempts.attempt_number, 1),
+      ));
+      if (!attempt) throw new Error(`${label} App-origin attempt is missing`);
+      return { run, attempt };
+    };
+    const verifiedReceiptKinds = async (runId: string) => {
+      const bundle = await actions.inspectReceipts(callers[0]!.caller, runId);
+      assert.equal(bundle.receipts.every((receipt) => receipt.verified), true);
+      return bundle.receipts.map((receipt) => receipt.receipt_kind).sort();
+    };
+
+    const retryCase = await approvedRun('indeterminate-retry');
+
+    const retryRequestStart = pinnedRequests.length;
+    forcedPinnedResults.push({ status: 'indeterminate' });
+    const ambiguous = await attemptRunner.runImmediate(
+      orgId,
+      retryCase.run.id,
+      retryCase.attempt.id,
+      'loop7-indeterminate-worker',
+    );
+    assert.equal(ambiguous.run.state, 'running');
+    assert.deepEqual(ambiguous.provider_result, { status: 'indeterminate' });
+    const retryAttempts = await db.select().from(appRunAttempts).where(and(
+      eq(appRunAttempts.org_id, orgId),
+      eq(appRunAttempts.run_id, retryCase.run.id),
+    )).orderBy(asc(appRunAttempts.attempt_number));
+    assert.equal(retryAttempts.length, 2);
+    assert.equal(retryAttempts[0]?.state, 'unknown_outcome');
+    assert.equal(retryAttempts[1]?.state, 'pending');
+    assert.equal(retryAttempts[1]?.retry_of_attempt_id, retryAttempts[0]?.id);
+
+    const recovered = await attemptRunner.runImmediate(
+      orgId,
+      retryCase.run.id,
+      retryAttempts[1]!.id,
+      'loop7-retry-worker',
+    );
+    assert.equal(recovered.run.state, 'succeeded');
+    const retryRequests = pinnedRequests.slice(retryRequestStart);
+    assert.equal(retryRequests.length, 2);
+    assert.equal(
+      retryRequests[0]?.input.idempotency_key,
+      retryRequests[1]?.input.idempotency_key,
+      'App-origin ambiguity retry must preserve the provider idempotency key',
+    );
+    assert.equal(typeof retryRequests[0]?.input.idempotency_key, 'string');
+    const retryResult = await actions.result(callers[0]!.caller, retryCase.run.id);
+    assert.equal(retryResult.run.state, 'succeeded');
+    assert.equal((retryResult.value as { provider_succeeded?: boolean }).provider_succeeded, true);
+    const retryReceiptBundle = await actions.inspectReceipts(callers[0]!.caller, retryCase.run.id);
+    assert.deepEqual(
+      retryReceiptBundle.receipts.map((receipt) => receipt.receipt_kind),
+      ['approval', 'attempt_terminal', 'attempt_terminal'],
+    );
+    assert.equal(retryReceiptBundle.receipts.every((receipt) => receipt.verified), true);
+    assert.equal(
+      (retryResult.value as { output?: { schema_version?: string } }).output?.schema_version,
+      MCP_APP_RUN_RESULT_VERSION,
+    );
+    assert.equal(sandbox.callCount, distinctPositiveRuns.length + 1);
+
+    const failureCase = await approvedRun('provider-declared-failure');
+    const failureEffectsBefore = sandbox.callCount;
+    forcedPinnedResults.push({
+      status: 'returned',
+      provider_succeeded: false,
+      output: { code: 'recipient_rejected' },
+      error: 'recipient rejected',
+      duration_ms: 1,
+    });
+    const providerFailure = await attemptRunner.runImmediate(
+      orgId,
+      failureCase.run.id,
+      failureCase.attempt.id,
+      'loop7-provider-failure-worker',
+    );
+    assert.equal(providerFailure.run.state, 'failed');
+    assert.deepEqual(providerFailure.run.safe_outcome, {
+      success: false,
+      provider_call_attempted: true,
+      result_status: 'retained',
+      error_code: 'APP_RUN_PROVIDER_ERROR',
+    });
+    assert.equal(sandbox.callCount, failureEffectsBefore);
+    const failureResult = await actions.result(callers[0]!.caller, failureCase.run.id);
+    assert.equal(
+      (failureResult.value as { provider_succeeded?: boolean }).provider_succeeded,
+      false,
+    );
+    assert.deepEqual(
+      await verifiedReceiptKinds(failureCase.run.id),
+      ['approval', 'attempt_terminal'],
+    );
+
+    const timeoutCase = await approvedRun('pre-aborted-timeout');
+    const timeoutRequestsBefore = pinnedRequests.length;
+    const timeoutController = new AbortController();
+    timeoutController.abort();
+    const timedOut = await attemptRunner.runImmediate(
+      orgId,
+      timeoutCase.run.id,
+      timeoutCase.attempt.id,
+      'loop7-timeout-worker',
+      timeoutController.signal,
+    );
+    assert.equal(timedOut.run.state, 'failed');
+    assert.deepEqual(timedOut.provider_result, {
+      status: 'not_attempted',
+      error_code: 'APP_RUN_PROVIDER_TIMEOUT',
+    });
+    assert.deepEqual(timedOut.run.safe_outcome, {
+      success: false,
+      provider_call_attempted: false,
+      result_status: 'unavailable',
+      error_code: 'APP_RUN_PROVIDER_TIMEOUT',
+    });
+    assert.equal(pinnedRequests.length, timeoutRequestsBefore);
+    await assert.rejects(
+      actions.result(callers[0]!.caller, timeoutCase.run.id),
+      (error: unknown) => error instanceof AppRunError && error.code === 'APP_RUN_RESULT_EXPIRED',
+    );
+    assert.deepEqual(
+      await verifiedReceiptKinds(timeoutCase.run.id),
+      ['approval', 'attempt_terminal'],
+    );
+
+    const claimedCase = await approvedRun('stale-claimed-recovery');
+    const claimedAt = new Date(Date.now() - 2_000);
+    const [staleClaim] = await db.update(appRunAttempts).set({
+      state: 'claimed',
+      claim_owner: 'loop7-stale-claimed-worker',
+      claim_token: randomUUID(),
+      claimed_at: claimedAt,
+      lease_expires_at: new Date(claimedAt.getTime() + 1_000),
+      updated_at: claimedAt,
+    }).where(and(
+      eq(appRunAttempts.org_id, orgId),
+      eq(appRunAttempts.id, claimedCase.attempt.id),
+    )).returning();
+    assert.ok(staleClaim);
+    const claimedRequestsBefore = pinnedRequests.length;
+    const claimedEffectsBefore = sandbox.callCount;
+    assert.equal(await attemptRunner.recoverRun(orgId, claimedCase.run.id), 1);
+    const claimedAttempts = await db.select().from(appRunAttempts).where(and(
+      eq(appRunAttempts.org_id, orgId),
+      eq(appRunAttempts.run_id, claimedCase.run.id),
+    )).orderBy(asc(appRunAttempts.attempt_number));
+    assert.equal(claimedAttempts.length, 2);
+    assert.equal(claimedAttempts[0]?.state, 'failed');
+    assert.equal(claimedAttempts[0]?.error_code, 'APP_RUN_PROVIDER_UNAVAILABLE');
+    assert.equal(claimedAttempts[1]?.retry_of_attempt_id, claimedAttempts[0]?.id);
+    assert.equal(pinnedRequests.length, claimedRequestsBefore);
+    assert.equal((await attemptRunner.runImmediate(
+      orgId,
+      claimedCase.run.id,
+      claimedAttempts[1]!.id,
+      'loop7-stale-claimed-retry-worker',
+    )).run.state, 'succeeded');
+    assert.equal(pinnedRequests.length, claimedRequestsBefore + 1);
+    assert.equal(sandbox.callCount, claimedEffectsBefore + 1);
+    assert.deepEqual(
+      await verifiedReceiptKinds(claimedCase.run.id),
+      ['approval', 'attempt_terminal', 'attempt_terminal'],
+    );
+
+    const startedCase = await approvedRun('stale-provider-call-started-recovery');
+    let releasePinned!: () => void;
+    const pinnedWait = new Promise<void>((resolve) => { releasePinned = resolve; });
+    let markPinnedEntered!: () => void;
+    const pinnedEntered = new Promise<void>((resolve) => { markPinnedEntered = resolve; });
+    pinnedBlock = { entered: markPinnedEntered, wait: pinnedWait };
+    let recoveryNow = new Date();
+    const recoveryRunner = new AppRunAttemptRunner(
+      repository,
+      secretRepository,
+      secrets,
+      pinnedExecutor,
+      liveAuthorization,
+      () => recoveryNow,
+      1_000,
+      60_000,
+      receipts,
+    );
+    const startedRequestsBefore = pinnedRequests.length;
+    const startedEffectsBefore = sandbox.callCount;
+    const lateProvider = recoveryRunner.runImmediate(
+      orgId,
+      startedCase.run.id,
+      startedCase.attempt.id,
+      'loop7-stale-provider-call-worker',
+    );
+    await pinnedEntered;
+    recoveryNow = new Date(recoveryNow.getTime() + 2_000);
+    let startedRecoveryCount = 0;
+    try {
+      startedRecoveryCount = await recoveryRunner.recoverRun(orgId, startedCase.run.id);
+    } finally {
+      releasePinned();
+    }
+    await lateProvider;
+    assert.equal(startedRecoveryCount, 1);
+    const startedAttempts = await db.select().from(appRunAttempts).where(and(
+      eq(appRunAttempts.org_id, orgId),
+      eq(appRunAttempts.run_id, startedCase.run.id),
+    )).orderBy(asc(appRunAttempts.attempt_number));
+    assert.equal(startedAttempts.length, 2);
+    assert.equal(startedAttempts[0]?.state, 'unknown_outcome');
+    assert.equal(startedAttempts[1]?.retry_of_attempt_id, startedAttempts[0]?.id);
+    assert.equal((await recoveryRunner.runImmediate(
+      orgId,
+      startedCase.run.id,
+      startedAttempts[1]!.id,
+      'loop7-provider-call-retry-worker',
+    )).run.state, 'succeeded');
+    const startedRequests = pinnedRequests.slice(startedRequestsBefore);
+    assert.equal(startedRequests.length, 2);
+    assert.equal(
+      startedRequests[0]?.input.idempotency_key,
+      startedRequests[1]?.input.idempotency_key,
+    );
+    assert.equal(typeof startedRequests[0]?.input.idempotency_key, 'string');
+    assert.equal(sandbox.callCount, startedEffectsBefore + 1);
+    assert.deepEqual(
+      await verifiedReceiptKinds(startedCase.run.id),
+      ['approval', 'attempt_terminal', 'attempt_terminal'],
+    );
+
+    const repairCase = await approvedRun('post-result-finalization-repair');
+    const repairRequestsBefore = pinnedRequests.length;
+    const repairEffectsBefore = sandbox.callCount;
+    const originalTransition = repository.transition.bind(repository);
+    let injectFinalizationFailure = true;
+    repository.transition = async (tx, input) => {
+      if (
+        injectFinalizationFailure
+        && input.run.id === repairCase.run.id
+        && input.state === 'succeeded'
+      ) {
+        injectFinalizationFailure = false;
+        throw new Error('injected App-origin finalization failure');
+      }
+      return originalTransition(tx, input);
+    };
+    try {
+      await assert.rejects(
+        attemptRunner.runImmediate(
+          orgId,
+          repairCase.run.id,
+          repairCase.attempt.id,
+          'loop7-finalization-failure-worker',
+        ),
+        /injected App-origin finalization failure/,
+      );
+    } finally {
+      repository.transition = originalTransition;
+    }
+    const [knownResultAttempt] = await db.select().from(appRunAttempts).where(and(
+      eq(appRunAttempts.org_id, orgId),
+      eq(appRunAttempts.id, repairCase.attempt.id),
+    ));
+    assert.equal(knownResultAttempt?.state, 'provider_call_started');
+    assert.ok(knownResultAttempt?.provider_call_finished_at);
+    assert.ok(knownResultAttempt?.safe_outcome);
+    const repairNow = new Date(Date.now() + 2 * 60_000);
+    const repairRunner = new AppRunAttemptRunner(
+      repository,
+      secretRepository,
+      secrets,
+      pinnedExecutor,
+      liveAuthorization,
+      () => repairNow,
+      60_000,
+      20_000,
+      receipts,
+    );
+    assert.equal(await repairRunner.recoverRun(orgId, repairCase.run.id), 1);
+    assert.equal(pinnedRequests.length, repairRequestsBefore + 1);
+    assert.equal(sandbox.callCount, repairEffectsBefore + 1);
+    const repairedResult = await actions.result(callers[0]!.caller, repairCase.run.id);
+    assert.equal(repairedResult.run.state, 'succeeded');
+    assert.equal((repairedResult.value as { provider_succeeded?: boolean }).provider_succeeded, true);
+    assert.deepEqual(
+      await verifiedReceiptKinds(repairCase.run.id),
+      ['approval', 'attempt_terminal'],
+    );
+    assert.ok(await runService.purgeExpiredSecrets(
+      new Date(repairedResult.run.result_expires_at.getTime() + 1),
+      1_000,
+    ));
+    await assert.rejects(
+      actions.result(callers[0]!.caller, repairCase.run.id),
+      (error: unknown) => error instanceof AppRunError && error.code === 'APP_RUN_RESULT_EXPIRED',
+    );
+    assert.equal(sandbox.callCount, distinctPositiveRuns.length + 4);
 
     const pendingRun = async (surface: typeof callers[number], label: string): Promise<AppRunSafeView> => {
       const input = actionInput(`loop7-stale-${label}-${suffix}`);
@@ -851,7 +1352,7 @@ test('App actions create governed Runs once across every caller surface and fail
       (error: unknown) => error instanceof AppRunError && error.code === 'APP_RUN_AUTHORIZATION_STALE',
     );
     await attemptRunner.runImmediate(orgId, connectorRun.id, connectorAttempt.id, 'loop7-revoked-worker');
-    assert.equal(sandbox.callCount, distinctPositiveRuns.length, 'revoked connector reached the provider');
+    assert.equal(sandbox.callCount, distinctPositiveRuns.length + 4, 'revoked connector reached the provider');
 
     const [[runCount], [approvalCount]] = await Promise.all([
       db.select({ value: count() }).from(appRuns).where(eq(appRuns.org_id, orgId)),
@@ -860,8 +1361,8 @@ test('App actions create governed Runs once across every caller surface and fail
         eq(agentActions.source, 'app_run'),
       )),
     ]);
-    assert.equal(runCount?.value, distinctPositiveRuns.length + 4);
-    assert.equal(approvalCount?.value, distinctPositiveRuns.length + 4);
+    assert.equal(runCount?.value, distinctPositiveRuns.length + 10);
+    assert.equal(approvalCount?.value, distinctPositiveRuns.length + 10);
   } finally {
     keys.destroy();
   }

--- a/apps/api/test/app-run-engine-db.test.ts
+++ b/apps/api/test/app-run-engine-db.test.ts
@@ -841,9 +841,9 @@ test('concurrent runners call once, commit the call boundary, and replay retaine
   release();
   await firstExecution;
 
-  const finished = await setup.service.inspect(ORG_ID, created.id, trusted.initiating_actor);
+  const finished = await setup.service.inspect(ORG_ID, created.id, trusted.initiating_actor, null);
   assert.equal(finished.state, 'succeeded');
-  assert.deepEqual((await setup.service.result(ORG_ID, created.id, trusted.initiating_actor)).value, {
+  assert.deepEqual((await setup.service.result(ORG_ID, created.id, trusted.initiating_actor, null)).value, {
     schema_version: APP_RUN_CONTRACT_VERSIONS.provider_result,
     provider_succeeded: true,
     output: { message_id: 'message-1' },
@@ -863,7 +863,7 @@ test('concurrent runners call once, commit the call boundary, and replay retaine
     throw new Error('secret read should not happen');
   };
   await assert.rejects(
-    denied.service.result(ORG_ID, created.id, trusted.initiating_actor),
+    denied.service.result(ORG_ID, created.id, trusted.initiating_actor, null),
     (error: any) => error?.code === 'APP_RUN_ACCESS_DENIED',
   );
   assert.equal(touchedSecret, false);
@@ -894,7 +894,7 @@ test('provider-reported failures retain an authorized exact response without rec
     error_code: 'APP_RUN_PROVIDER_ERROR',
   });
   assert.deepEqual((await setup.service.result(
-    ORG_ID, created.id, trusted.initiating_actor,
+    ORG_ID, created.id, trusted.initiating_actor, null,
   )).value, {
     schema_version: APP_RUN_CONTRACT_VERSIONS.provider_result,
     provider_succeeded: false,
@@ -933,7 +933,7 @@ test('a provider call known not to have started fails without an indeterminate o
   await runner.run(ORG_ID, created.id, attemptId, 'not-attempted-duplicate');
   assert.equal(executor.calls.length, 1);
   await assert.rejects(
-    setup.service.result(ORG_ID, created.id, trusted.initiating_actor),
+    setup.service.result(ORG_ID, created.id, trusted.initiating_actor, null),
     (error: any) => error?.code === 'APP_RUN_RESULT_EXPIRED',
   );
 });
@@ -1168,7 +1168,7 @@ test('oversized post-effect output remains known success without exact result or
   await runner.run(ORG_ID, created.id, attemptId, 'oversized-worker-2');
   assert.equal(executor.calls.length, 1);
   await assert.rejects(
-    setup.service.result(ORG_ID, created.id, trusted.initiating_actor),
+    setup.service.result(ORG_ID, created.id, trusted.initiating_actor, null),
     (error: any) => error?.code === 'APP_RUN_RESULT_EXPIRED',
   );
 });

--- a/apps/api/test/app-run-receipt-inspection.test.ts
+++ b/apps/api/test/app-run-receipt-inspection.test.ts
@@ -6,6 +6,8 @@ import { APP_RUN_CONTRACT_VERSIONS, canonicalCapabilityJson } from '@deft/shared
 
 import {
   AppActionService,
+  type AppActionCaller,
+  type AppActionLiveAuthorityPort,
   type AppActionRunReadPort,
 } from '../src/lib/app-action-service.js';
 import { closeDb } from '../src/lib/db.js';
@@ -16,6 +18,7 @@ import {
   type AppRunReceiptReader,
   type AppRunStoredReceiptRow,
 } from '../src/lib/app-run-receipts.js';
+import type { AppRunSafeView } from '../src/lib/app-run-repository.js';
 import { AppRunSecretService } from '../src/lib/app-run-secrets.js';
 import { humanModuleActor } from '../src/lib/module-service.js';
 
@@ -163,11 +166,12 @@ test('AppActionService authorizes through Run inspection before reading receipts
   const forbiddenActor = 'forbidden-actor-id';
   const forbiddenProvider = 'forbidden-provider-instance';
   const runReads: AppActionRunReadPort = {
-    async inspect(orgId, runId, actor) {
+    async inspect(orgId, runId, actor, requiredAuthorityRef) {
       order.push('inspect');
       assert.equal(orgId, ORG_ID);
       assert.equal(runId, RUN_ID);
       assert.deepEqual(actor, { actor_type: 'human', user_id: 'receipt-reader-user' });
+      assert.equal(requiredAuthorityRef, null);
       return {
         id: RUN_ID,
         org_id: forbiddenOrg,
@@ -290,4 +294,114 @@ test('AppActionService authorizes through Run inspection before reading receipts
     (error: unknown) => error instanceof AppRunError && error.code === 'APP_RUN_ACCESS_DENIED',
   );
   assert.equal(receiptReadsAfterDenial, 0);
+});
+
+test('AppActionService binds MCP inspect, result, and receipt reads to the exact live token', async () => {
+  const actorId = 'exact-token-reader';
+  const originalTokenId = 'exact-token-original';
+  const originalAuthority = {
+    authority_kind: 'token_scope' as const,
+    authority_id: originalTokenId,
+    version: `sha256:${'1'.repeat(64)}`,
+  };
+  const liveAuthority: AppActionLiveAuthorityPort = {
+    async captureForPreparation() {
+      throw new Error('not used');
+    },
+    async assertTokenScopes(input) {
+      const tokenId = input.token_authorities[0]?.token_id;
+      if (!tokenId) throw new Error('missing token');
+      return {
+        authority_kind: 'token_scope',
+        authority_id: tokenId,
+        version: tokenId === originalTokenId
+          ? originalAuthority.version
+          : `sha256:${'2'.repeat(64)}`,
+      };
+    },
+  };
+  const run = {
+    id: RUN_ID,
+    state: 'succeeded',
+    operation_name: 'send_email',
+    safe_preview: { title: 'Safe preview' },
+    safe_outcome: { success: true, provider_call_attempted: true, result_status: 'retained' },
+    risk_class: 'external_write',
+    review_requirement: 'always',
+    review_scope: 'per_invocation',
+    retry_class: 'idempotent_with_key',
+    retention_class: 'standard',
+    result_expires_at: new Date('2026-09-03T12:00:00.000Z'),
+    result_purged_at: null,
+  } as AppRunSafeView;
+  const authorizeRead = (
+    actor: Parameters<AppActionRunReadPort['inspect']>[2],
+    authority: Parameters<AppActionRunReadPort['inspect']>[3],
+  ) => {
+    if (
+      actor.actor_type !== 'human'
+      || actor.user_id !== actorId
+      || authority?.authority_kind !== originalAuthority.authority_kind
+      || authority.authority_id !== originalAuthority.authority_id
+      || authority.version !== originalAuthority.version
+    ) throw new AppRunError('APP_RUN_ACCESS_DENIED');
+  };
+  const runReads: AppActionRunReadPort = {
+    async inspect(_orgId, _runId, actor, requiredAuthorityRef) {
+      authorizeRead(actor, requiredAuthorityRef);
+      return run;
+    },
+    async result(_orgId, _runId, actor, requiredAuthorityRef) {
+      authorizeRead(actor, requiredAuthorityRef);
+      return { run, value: { status: 'delivered' } };
+    },
+  };
+  let receiptReads = 0;
+  const service = new AppActionService(
+    undefined,
+    liveAuthority,
+    undefined,
+    undefined,
+    undefined,
+    runReads,
+    {
+      async readVerified() {
+        receiptReads += 1;
+        return [];
+      },
+    },
+  );
+  const caller = (userId: string, tokenId: string): AppActionCaller => ({
+    actor: humanModuleActor({
+      orgId: ORG_ID,
+      userId,
+      role: 'member',
+      source: 'mcp',
+      scopes: ['read:app-runs'],
+    }),
+    token_authorities: [{ token_kind: 'mcp', token_id: tokenId }],
+  });
+  const originalCaller = caller(actorId, originalTokenId);
+
+  assert.equal((await service.inspectRun(originalCaller, RUN_ID)).id, RUN_ID);
+  assert.deepEqual((await service.result(originalCaller, RUN_ID)).value, { status: 'delivered' });
+  assert.equal((await service.inspectReceipts(originalCaller, RUN_ID)).run.id, RUN_ID);
+  assert.equal(receiptReads, 1);
+
+  for (const alternate of [
+    caller(actorId, 'exact-token-second'),
+    caller('different-reader', 'exact-token-other-actor'),
+  ]) {
+    for (const read of [
+      () => service.inspectRun(alternate, RUN_ID),
+      () => service.result(alternate, RUN_ID),
+      () => service.inspectReceipts(alternate, RUN_ID),
+    ]) {
+      await assert.rejects(
+        read,
+        (error: unknown) => error instanceof AppRunError && error.code === 'APP_RUN_ACCESS_DENIED',
+      );
+    }
+  }
+  assert.equal(receiptReads, 1, 'denied receipt reads must stop before receipt storage');
 });

--- a/docs/app-run-operations.md
+++ b/docs/app-run-operations.md
@@ -101,6 +101,21 @@ Encryption-key loss prevents retained input/result recovery; signing-key loss
 prevents receipt verification; fingerprint-key loss prevents safe replay
 matching. None can be reconstructed from database contents.
 
+## Inspect bounded App operations
+
+An authenticated workspace owner or admin can read `GET /api/apps/operations`.
+The endpoint rechecks current organization membership and returns the
+`deft.app_operations.v1` projection: bounded Run and attempt counts, queue
+health, approval and cleanup pressure, connected-App health, retention and
+payload ceilings, and whether every referenced key version is configured.
+
+This is a read-only health surface, not a repair API. It omits provider and
+actor identities, grant snapshots, raw input and result payloads, ciphertext,
+receipt signatures, key IDs, and key material. A member, a demoted manager, an
+agent, or a request while the Run engine is disabled cannot use it. Resolve the
+reported degraded reason through the existing App lifecycle or recovery
+runbook; do not infer permission to replay an unknown provider outcome.
+
 ## Disable and rollback
 
 The normal entrance rollback is to set the affected intake flag false while

--- a/docs/superpowers/plans/2026-09-01-app-platform-phase-6-and-track-a-loops.md
+++ b/docs/superpowers/plans/2026-09-01-app-platform-phase-6-and-track-a-loops.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |---|---|
-| Status | Loop 6.0 sealed from merged Phase 5 audit `c0da089d`; Phase 6 PR A merged as #288 at `93856fd2`; PR B lifecycle/operator slice implemented and locally certified, PR CI/merge pending |
+| Status | Loop 6.0 sealed from merged Phase 5 audit `c0da089d`; Phase 6 PR A merged as #288 at `93856fd2`; PR B merged as #289 at `21ca39b1`; PR C product candidate frozen at `16875df2`, immutable beta certification pending |
 | Architecture source | `docs/superpowers/plans/2026-08-29-full-surface-app-platform.md` |
 | Delivery source | `docs/superpowers/plans/2026-08-30-full-surface-app-platform-delivery-plan.md` |
 | Phase 6 outcome | An independent author can build, stage, install, operate, upgrade, disable, recover, and inspect a Tier 2 connected App using published contracts and tooling only |

--- a/scripts/app-platform-certification-workflow.test.mjs
+++ b/scripts/app-platform-certification-workflow.test.mjs
@@ -60,10 +60,10 @@ test('certification checks the exact candidate revision and builds without publi
   assert.match(workflow, /baseline_sha="\$\(git -C \.cert\/phase4-baseline rev-parse HEAD\)"/);
   assert.match(workflow, /\[\[ "\$baseline_sha" == "\$PHASE4_BASELINE_SHA" \]\]/);
   assert.match(workflow, /bash scripts\/ci\/certify-app-platform-phase5\.sh/);
-  assert.match(orchestrator, /git -C "\$phase5_root" rev-parse HEAD/);
+  assert.match(orchestrator, /git -C "\$candidate_root" rev-parse HEAD/);
   assert.match(orchestrator, /docker buildx build --load/);
   assert.match(orchestrator, /org\.opencontainers\.image\.revision/);
-  assert.match(orchestrator, /\[\[ "\$image_revision" == "\$phase5_sha" \]\]/);
+  assert.match(orchestrator, /\[\[ "\$image_revision" == "\$candidate_sha" \]\]/);
   for (const forbidden of [
     /docker\s+push\b/,
     /push:\s*true\b/,

--- a/scripts/app-platform-phase6-certification-workflow.test.mjs
+++ b/scripts/app-platform-phase6-certification-workflow.test.mjs
@@ -1,0 +1,184 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const workflow = readFileSync(
+  new URL('../.github/workflows/app-platform-phase6-certification.yml', import.meta.url),
+  'utf8',
+);
+const orchestrator = readFileSync(
+  new URL('./ci/certify-app-platform-phase5.sh', import.meta.url),
+  'utf8',
+);
+const setupHook = readFileSync(
+  new URL('./ci/app-platform-phase6-certification-setup.sh', import.meta.url),
+  'utf8',
+);
+const offlineHook = readFileSync(
+  new URL('./ci/app-platform-phase6-certification-offline.sh', import.meta.url),
+  'utf8',
+);
+const executionSurface = `${workflow}\n${orchestrator}\n${setupHook}\n${offlineHook}`;
+
+const CANDIDATE_COMMIT = '16875df2f6c9dc2bc3d850de6758b7dd56767a05';
+const CANDIDATE_PLACEHOLDER = '__PRODUCT_CANDIDATE_SHA__';
+const PHASE4_BASELINE_COMMIT = 'ec79592e669bdf915fad8a5d2480f0625d819a4c';
+const PREDECESSOR_IMAGE =
+  'ghcr.io/maneek21/deft@sha256:e565cc64ee22b5b9f6f99973e3762b639c27e026dc8824852145035acdacf788';
+const PREDECESSOR_COMMIT = '6d39e0e0413c82d36c9481849ae582fdf805d1a6';
+
+function occurrences(source, value) {
+  return source.split(value).length - 1;
+}
+
+function uploadSteps(source) {
+  return source.match(
+    /^ {6}- name: Upload[^\r\n]*(?:\r?\n(?! {6}- name:)[^\r\n]*)*/gm,
+  ) ?? [];
+}
+
+test('Phase 6 certification is manual, read-only, bounded, and non-concurrent', () => {
+  assert.match(workflow, /^on:\s*\r?\n\s+workflow_dispatch:/m);
+  assert.doesNotMatch(
+    workflow,
+    /^\s{2}(?:push|pull_request|pull_request_target|schedule|release):/m,
+  );
+  assert.match(workflow, /permissions:\s*\r?\n\s+contents:\s*read\b/);
+  assert.match(workflow, /concurrency:\s*\r?\n\s+group:\s*app-platform-phase6-certification/);
+  assert.match(workflow, /cancel-in-progress:\s*false/);
+  assert.match(workflow, /timeout-minutes:\s*120/);
+  for (const forbidden of [
+    /contents:\s*write/,
+    /packages:\s*write/,
+    /id-token:\s*write/,
+    /attestations:\s*write/,
+    /actions:\s*write/,
+  ]) assert.doesNotMatch(workflow, forbidden);
+});
+
+test('candidate, baseline, and predecessor identities are immutable and verified', () => {
+  assert.equal(occurrences(workflow, CANDIDATE_COMMIT), 1);
+  assert.equal(occurrences(workflow, CANDIDATE_PLACEHOLDER), 0);
+  assert.equal(occurrences(workflow, PHASE4_BASELINE_COMMIT), 1);
+  assert.equal(occurrences(workflow, PREDECESSOR_IMAGE), 1);
+  assert.equal(occurrences(workflow, PREDECESSOR_COMMIT), 1);
+  assert.match(workflow, /path:\s*\.cert\/phase6-candidate/);
+  assert.match(workflow, /path:\s*\.cert\/phase4-baseline/);
+  assert.match(workflow, /ref:\s*\$\{\{\s*env\.APP_PLATFORM_CANDIDATE_SHA\s*\}\}/);
+  assert.match(workflow, /ref:\s*\$\{\{\s*env\.APP_PLATFORM_BASELINE_SHA\s*\}\}/);
+  assert.match(
+    workflow,
+    /candidate_sha="\$\(git -C \.cert\/phase6-candidate rev-parse HEAD\)"/,
+  );
+  assert.match(workflow, /\[\[ "\$candidate_sha" == "\$APP_PLATFORM_CANDIDATE_SHA" \]\]/);
+  assert.match(
+    workflow,
+    /baseline_sha="\$\(git -C \.cert\/phase4-baseline rev-parse HEAD\)"/,
+  );
+  assert.match(workflow, /\[\[ "\$baseline_sha" == "\$APP_PLATFORM_BASELINE_SHA" \]\]/);
+});
+
+test('three dependency roots are installed before one candidate typecheck and production build', () => {
+  assert.equal(occurrences(workflow, 'pnpm install --frozen-lockfile'), 3);
+  assert.match(workflow, /Install certifier dependencies/);
+  assert.match(
+    workflow,
+    /Install exact Phase 6 candidate dependencies[\s\S]*?working-directory: \.cert\/phase6-candidate/,
+  );
+  assert.match(
+    workflow,
+    /Install exact Phase 4 baseline dependencies[\s\S]*?working-directory: \.cert\/phase4-baseline/,
+  );
+  assert.match(workflow, /docker\/setup-buildx-action@v4/);
+  assert.match(workflow, /playwright install --with-deps chromium/);
+  assert.equal(occurrences(workflow, 'run: pnpm typecheck'), 1);
+  assert.equal(occurrences(workflow, 'run: pnpm build'), 1);
+  assert.ok(
+    workflow.indexOf('run: pnpm typecheck') < workflow.indexOf('run: pnpm build'),
+    'candidate typecheck must precede its single production build',
+  );
+});
+
+test('shared gate receives the Phase 6 roots, hooks, and exact isolated resources', () => {
+  assert.match(workflow, /APP_PLATFORM_CERT_PHASE:\s*phase6/);
+  assert.match(workflow, /APP_PLATFORM_CANDIDATE_ROOT=\$GITHUB_WORKSPACE\/\.cert\/phase6-candidate/);
+  assert.match(workflow, /APP_PLATFORM_BASELINE_ROOT=\$GITHUB_WORKSPACE\/\.cert\/phase4-baseline/);
+  assert.match(workflow, /APP_PLATFORM_RESOURCE_PREFIX:\s*deft-p6-cert-\$\{\{ github\.run_id \}\}-\$\{\{ github\.run_attempt \}\}/);
+  assert.match(workflow, /APP_PLATFORM_DATABASE_NAME:\s*deft_phase5_phase6_release_test/);
+  assert.match(
+    workflow,
+    /APP_PLATFORM_SETUP_HOOK:[^\n]*app-platform-phase6-certification-setup\.sh/,
+  );
+  assert.match(
+    workflow,
+    /APP_PLATFORM_OFFLINE_HOOK:[^\n]*app-platform-phase6-certification-offline\.sh/,
+  );
+  assert.match(
+    workflow,
+    /APP_PLATFORM_BROWSER_SCRIPT:[^\n]*app-platform-phase6-browser-smoke\.mjs/,
+  );
+  assert.match(workflow, /run:\s*bash scripts\/ci\/certify-app-platform-phase5\.sh/);
+  assert.match(orchestrator, /git -C "\$candidate_root" rev-parse HEAD/);
+  assert.match(orchestrator, /run_extension_hook "\$setup_hook" setup/);
+  assert.match(orchestrator, /node "\$browser_script"/);
+  assert.match(orchestrator, /run_extension_hook "\$offline_hook" offline/);
+  assert.match(setupHook, /SELECT count\(\*\) FROM mcp_connections WHERE slug LIKE 'loop5-mail-%'/);
+  assert.match(setupHook, /is_active = true/);
+  assert.match(
+    setupHook,
+    /app_run_authorization_version = app_run_authorization_version \+ 1/,
+  );
+  assert.match(offlineHook, /\[\[ "\$after_total" == "\$before_total" \]\]/);
+  assert.match(offlineHook, /invocation_failed_without_creating_a_run/);
+});
+
+test('only bounded safe evidence and the exact candidate image are retained', () => {
+  const uploads = uploadSteps(workflow);
+  assert.equal(uploads.length, 2);
+  assert.match(uploads[0], /if:\s*always\(\)/);
+  assert.match(uploads[0], /path:\s*\$\{\{ env\.EVIDENCE_DIR \}\}\/safe\s*$/m);
+  assert.match(uploads[1], /if:\s*success\(\)/);
+  assert.match(
+    uploads[1],
+    /path:\s*\$\{\{ env\.EVIDENCE_DIR \}\}\/candidate-image\.tar\.zst\s*$/m,
+  );
+  for (const upload of uploads) {
+    assert.match(upload, /retention-days:\s*90/);
+    assert.doesNotMatch(upload, /(?:recovery|keyring|database\.dump|\.env|\.cert|\*\*)/i);
+  }
+});
+
+test('cleanup targets only the exact Phase 6 prefix and Compose project', () => {
+  assert.match(workflow, /if:\s*always\(\)[\s\S]*?Remove and confirm isolated resources/);
+  assert.match(workflow, /\$APP_PLATFORM_RESOURCE_PREFIX-source/);
+  assert.match(workflow, /\$APP_PLATFORM_RESOURCE_PREFIX-restore/);
+  assert.match(workflow, /\$APP_PLATFORM_RESOURCE_PREFIX-app/);
+  assert.match(workflow, /\$APP_PLATFORM_RESOURCE_PREFIX-network/);
+  assert.match(workflow, /\$APP_PLATFORM_RESOURCE_PREFIX-source-data/);
+  assert.match(workflow, /\$APP_PLATFORM_RESOURCE_PREFIX-restore-data/);
+  assert.match(
+    workflow,
+    /label=com\.docker\.compose\.project=\$APP_PLATFORM_COMPOSE_PROJECT/,
+  );
+  assert.match(workflow, /docker image rm "\$APP_PLATFORM_CANDIDATE_TAG"/);
+  assert.match(workflow, /docker image inspect "\$APP_PLATFORM_CANDIDATE_TAG"/);
+  for (const forbidden of [
+    /docker\s+system\s+prune/,
+    /docker\s+(?:container|image|network|volume)\s+prune/,
+    /docker\s+rm\s+-f\s+\$\(/,
+    /docker\s+volume\s+rm\s+\$\(/,
+    /docker\s+network\s+rm\s+\$\(/,
+  ]) assert.doesNotMatch(workflow, forbidden);
+});
+
+test('the complete certification surface cannot publish repository or image state', () => {
+  for (const forbidden of [
+    /docker\s+push\b/,
+    /push:\s*true\b/,
+    /git\s+push\b/,
+    /gh\s+(?:pr|release)\s+(?:create|merge|upload)\b/,
+    /(?:oras|cosign)\s+(?:push|sign)\b/,
+    /softprops\/action-gh-release/,
+    /actions\/create-release/,
+  ]) assert.doesNotMatch(executionSurface, forbidden);
+});

--- a/scripts/ci/app-platform-phase6-browser-smoke.mjs
+++ b/scripts/ci/app-platform-phase6-browser-smoke.mjs
@@ -1,0 +1,632 @@
+import { spawn } from 'node:child_process';
+import { mkdtemp, mkdir, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { chromium } from 'playwright';
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+const webUrl = (process.env.DEFT_WEB_URL || 'http://127.0.0.1:3000').replace(/\/$/, '');
+const email = process.env.DEFT_TEST_EMAIL || 'diego@testers-tomatoes.com';
+const password = process.env.DEFT_TEST_PASSWORD || 'tomato123';
+const evidenceDirectory = resolve(
+  process.env.DEFT_APP_PLATFORM_EVIDENCE_DIR || 'dist/app-platform-phase6-certification',
+);
+const evidencePath = resolve(
+  process.env.DEFT_APP_PLATFORM_PHASE6_BROWSER_EVIDENCE
+    || process.env.DEFT_APP_PLATFORM_BROWSER_EVIDENCE
+    || `${evidenceDirectory}/apps-phase6-browser-smoke.json`,
+);
+const upgradePackageInput = process.env.DEFT_APP_PLATFORM_UPGRADE_PACKAGE;
+const phase5Script = resolve(scriptDirectory, 'app-platform-phase5-browser-smoke.mjs');
+const appKitPackageJsonPath = resolve(scriptDirectory, '../../packages/app-kit/package.json');
+const packageByteLimit = 1024 * 1024;
+const desktopViewport = Object.freeze({ width: 1440, height: 900 });
+const mobileViewport = Object.freeze({ width: 390, height: 844 });
+const receiptDescription = 'Actor-authorized, tenant-scoped Run metadata and server-verified receipt proofs. Raw provider envelopes and output are not exposed here.';
+const policyAcceptance = 'I accept Deft’s host-owned approval, retention, egress, and retry policy for these exact bindings.';
+
+class CertificationFailure extends Error {
+  constructor(code) {
+    super(code);
+    this.name = 'CertificationFailure';
+    this.code = code;
+  }
+}
+
+function requireCondition(condition, code) {
+  if (!condition) throw new CertificationFailure(code);
+}
+
+function errorCode(error) {
+  return error instanceof CertificationFailure ? error.code : 'UNEXPECTED_BROWSER_FAILURE';
+}
+
+function safeOrigin(value) {
+  try {
+    const parsed = new URL(value);
+    requireCondition(['http:', 'https:'].includes(parsed.protocol), 'WEB_URL_PROTOCOL_INVALID');
+    requireCondition(!parsed.username && !parsed.password, 'WEB_URL_CREDENTIALS_FORBIDDEN');
+    requireCondition(parsed.host.length <= 255, 'WEB_URL_HOST_INVALID');
+    return `${parsed.protocol}//${parsed.host}`;
+  } catch (error) {
+    if (error instanceof CertificationFailure) throw error;
+    throw new CertificationFailure('WEB_URL_INVALID');
+  }
+}
+
+function collectStrings(value, output) {
+  if (typeof value === 'string') {
+    if (value.length >= 8) output.add(value);
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) collectStrings(item, output);
+    return;
+  }
+  if (value && typeof value === 'object') {
+    for (const item of Object.values(value)) collectStrings(item, output);
+  }
+}
+
+function secretMarkers() {
+  const markers = new Set();
+  for (const name of [
+    'DEFT_TEST_PASSWORD',
+    'DEFT_APP_RUN_KEYRINGS',
+    'JWT_SECRET',
+    'JWT_REFRESH_SECRET',
+    'ENCRYPTION_KEY',
+  ]) {
+    const value = process.env[name];
+    if (!value) continue;
+    if (name === 'DEFT_APP_RUN_KEYRINGS') {
+      try {
+        collectStrings(JSON.parse(value), markers);
+      } catch {
+        // The API validates keyrings. Keep the raw value only as an in-memory
+        // marker so this certification never prints it.
+      }
+    }
+    if (value.length >= 8) markers.add(value);
+  }
+  if (!process.env.DEFT_TEST_PASSWORD && password.length >= 8) markers.add(password);
+
+  const extra = process.env.DEFT_APP_PLATFORM_SECRET_MARKERS;
+  if (extra) {
+    let parsed;
+    try {
+      parsed = JSON.parse(extra);
+    } catch {
+      throw new CertificationFailure('SECRET_MARKERS_INVALID');
+    }
+    requireCondition(
+      Array.isArray(parsed) && parsed.every((item) => typeof item === 'string'),
+      'SECRET_MARKERS_INVALID',
+    );
+    collectStrings(parsed, markers);
+  }
+  return [...markers];
+}
+
+async function readUpgradePackage() {
+  requireCondition(Boolean(upgradePackageInput), 'UPGRADE_PACKAGE_REQUIRED');
+  const packagePath = resolve(upgradePackageInput);
+  let packageStat;
+  try {
+    packageStat = await stat(packagePath);
+  } catch {
+    throw new CertificationFailure('UPGRADE_PACKAGE_UNREADABLE');
+  }
+  requireCondition(packageStat.isFile(), 'UPGRADE_PACKAGE_NOT_FILE');
+  requireCondition(packageStat.size <= packageByteLimit, 'UPGRADE_PACKAGE_TOO_LARGE');
+
+  let raw;
+  let parsed;
+  try {
+    raw = await readFile(packagePath, 'utf8');
+    requireCondition(Buffer.byteLength(raw, 'utf8') <= packageByteLimit, 'UPGRADE_PACKAGE_TOO_LARGE');
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    if (error instanceof CertificationFailure) throw error;
+    throw new CertificationFailure('UPGRADE_PACKAGE_INVALID_JSON');
+  }
+  const manifest = parsed && typeof parsed === 'object' ? parsed.manifest : null;
+  requireCondition(parsed?.package_format === 'deft.app.package.v1', 'UPGRADE_PACKAGE_FORMAT_INVALID');
+  requireCondition(manifest?.schema_version === '1', 'UPGRADE_MANIFEST_SCHEMA_INVALID');
+  requireCondition(manifest?.compatibility?.app_protocol === '1', 'UPGRADE_PROTOCOL_INVALID');
+  requireCondition(
+    typeof manifest.id === 'string' && manifest.id.length > 0 && manifest.id.length <= 255,
+    'UPGRADE_APP_ID_INVALID',
+  );
+  requireCondition(
+    typeof manifest.name === 'string' && manifest.name.length > 0 && manifest.name.length <= 128,
+    'UPGRADE_APP_NAME_INVALID',
+  );
+  requireCondition(
+    typeof manifest.version === 'string'
+      && manifest.version.length <= 64
+      && /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(manifest.version),
+    'UPGRADE_APP_VERSION_INVALID',
+  );
+  return { packagePath, manifest };
+}
+
+async function readAppKitContract() {
+  try {
+    const parsed = JSON.parse(await readFile(appKitPackageJsonPath, 'utf8'));
+    requireCondition(parsed.name === '@deft/app-kit', 'APP_KIT_PACKAGE_INVALID');
+    requireCondition(typeof parsed.version === 'string' && parsed.version.length <= 64, 'APP_KIT_VERSION_INVALID');
+    return { packageName: parsed.name, version: parsed.version };
+  } catch (error) {
+    if (error instanceof CertificationFailure) throw error;
+    throw new CertificationFailure('APP_KIT_PACKAGE_UNREADABLE');
+  }
+}
+
+async function runPhase5Baseline() {
+  const temporaryDirectory = await mkdtemp(join(tmpdir(), 'deft-phase6-browser-'));
+  const baselineEvidencePath = resolve(temporaryDirectory, 'apps-browser-smoke.json');
+  try {
+    await new Promise((resolveRun, rejectRun) => {
+      const child = spawn(process.execPath, [phase5Script], {
+        cwd: process.cwd(),
+        env: {
+          ...process.env,
+          DEFT_APP_PLATFORM_REQUIRE_CONNECTED: 'true',
+          DEFT_APP_PLATFORM_EVIDENCE_DIR: temporaryDirectory,
+          DEFT_APP_PLATFORM_BROWSER_EVIDENCE: baselineEvidencePath,
+        },
+        stdio: 'ignore',
+      });
+      child.once('error', () => rejectRun(new CertificationFailure('PHASE5_BASELINE_LAUNCH_FAILED')));
+      child.once('close', (code) => {
+        if (code === 0) resolveRun();
+        else rejectRun(new CertificationFailure('PHASE5_BASELINE_FAILED'));
+      });
+    });
+    let baseline;
+    try {
+      baseline = JSON.parse(await readFile(baselineEvidencePath, 'utf8'));
+    } catch {
+      throw new CertificationFailure('PHASE5_BASELINE_EVIDENCE_INVALID');
+    }
+    requireCondition(
+      baseline.schema === 'deft.app_platform.phase5.browser_smoke.v1' && baseline.result === 'passed',
+      'PHASE5_BASELINE_EVIDENCE_INVALID',
+    );
+  } finally {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  }
+}
+
+async function login(page) {
+  await page.goto(`${webUrl}/login`, { waitUntil: 'domcontentloaded' });
+  await page.locator('#login-email').waitFor({ state: 'visible', timeout: 20_000 });
+  await page.locator('#login-email').fill(email);
+  await page.locator('#login-password').fill(password);
+  const loginResponse = page.waitForResponse(
+    (response) => response.request().method() === 'POST'
+      && new URL(response.url()).pathname === '/api/auth/login',
+    { timeout: 20_000 },
+  );
+  await page.getByRole('button', { name: 'Sign in', exact: true }).click();
+  const response = await loginResponse;
+  requireCondition(response.ok(), 'LOGIN_FAILED');
+  await page.waitForURL((url) => !url.pathname.startsWith('/login'), { timeout: 20_000 });
+}
+
+async function openApps(page, viewport) {
+  await page.setViewportSize(viewport);
+  await page.goto(`${webUrl}/settings/apps`, { waitUntil: 'domcontentloaded' });
+  requireCondition(!new URL(page.url()).pathname.startsWith('/login'), 'APPS_REDIRECTED_TO_LOGIN');
+  const title = viewport.width < 768
+    ? page.getByText('Settings · Apps', { exact: true })
+    : page.getByRole('heading', { name: 'Apps', exact: true });
+  await title.first().waitFor({ state: 'visible', timeout: 20_000 });
+}
+
+function appCard(page, appId) {
+  return page.locator('article').filter({ hasText: `${appId}@` }).first();
+}
+
+async function waitForApp(page, appId, state, version) {
+  const card = appCard(page, appId);
+  await card.waitFor({ state: 'visible', timeout: 20_000 });
+  await card.getByText(state, { exact: true }).waitFor({ state: 'visible', timeout: 20_000 });
+  if (version) {
+    await card.getByText(`${appId}@${version}`, { exact: true }).waitFor({ state: 'visible', timeout: 20_000 });
+  }
+  return card;
+}
+
+async function assertSafeRenderedSurface(page, markers, codePrefix) {
+  const [text, html] = await Promise.all([
+    page.locator('body').innerText(),
+    page.content(),
+  ]);
+  for (const marker of markers) {
+    requireCondition(!text.includes(marker) && !html.includes(marker), `${codePrefix}_SECRET_VISIBLE`);
+  }
+  const rendered = `${text}\n${html}`;
+  requireCondition(!/deft_app_dev_[A-Za-z0-9_-]{16,}/.test(rendered), `${codePrefix}_TOKEN_VISIBLE`);
+  requireCondition(!/hmac-sha256:[a-f0-9]{64}/i.test(rendered), `${codePrefix}_SIGNATURE_VISIBLE`);
+}
+
+async function assertConnectedContract(card, appKit) {
+  await card.getByRole('heading', { name: 'Supported local contract', exact: true })
+    .waitFor({ state: 'visible', timeout: 20_000 });
+  const text = await card.innerText();
+  requireCondition(text.includes(`${appKit.packageName} ${appKit.version}`), 'APP_KIT_COMPATIBILITY_MISSING');
+  requireCondition(text.includes('App Protocol v1'), 'APP_PROTOCOL_COMPATIBILITY_MISSING');
+  requireCondition(text.includes('deft.app.package.v1'), 'PACKAGE_FORMAT_COMPATIBILITY_MISSING');
+  requireCondition(text.includes('stage only'), 'STAGE_ONLY_COMPATIBILITY_MISSING');
+  requireCondition(
+    text.includes('Local packages are unsigned. Source provenance is an unverified author claim, not a registry attestation.'),
+    'UNSIGNED_PROVENANCE_WARNING_MISSING',
+  );
+  requireCondition(text.includes('Package provenance') && text.includes('Local unsigned'), 'PACKAGE_PROVENANCE_MISSING');
+}
+
+async function openAndVerifyReceipt(
+  page,
+  card,
+  markers,
+  screenshotPath,
+  codePrefix,
+  expectedState = null,
+  expectedReceiptKind = null,
+) {
+  const recentRuns = card.getByRole('heading', { name: 'Recent Runs', exact: true });
+  await recentRuns.waitFor({ state: 'visible', timeout: 20_000 });
+  const list = recentRuns.locator('xpath=following-sibling::ul[1]');
+  requireCondition(await list.count() === 1, `${codePrefix}_RECENT_RUN_MISSING`);
+  const runButton = list.getByRole('button').first();
+  await runButton.waitFor({ state: 'visible', timeout: 20_000 });
+  await runButton.click();
+
+  const dialog = page.getByRole('dialog');
+  await dialog.waitFor({ state: 'visible', timeout: 20_000 });
+  await dialog.getByText(receiptDescription, { exact: true }).waitFor({ state: 'visible', timeout: 20_000 });
+  await dialog.getByRole('heading', { name: 'Verified receipts', exact: true })
+    .waitFor({ state: 'visible', timeout: 20_000 });
+  if (expectedState) {
+    await dialog.getByRole('heading', { name: expectedState, exact: true })
+      .waitFor({ state: 'visible', timeout: 20_000 });
+  }
+  if (expectedReceiptKind) {
+    await dialog.getByText(expectedReceiptKind, { exact: true })
+      .waitFor({ state: 'visible', timeout: 20_000 });
+  }
+  for (const label of ['Operation', 'Risk', 'Review', 'Retry', 'Retention', 'Result retention']) {
+    await dialog.getByText(label, { exact: true }).waitFor({ state: 'visible', timeout: 20_000 });
+  }
+  await dialog.getByText('Verified', { exact: true }).first().waitFor({ state: 'visible', timeout: 20_000 });
+  await assertSafeRenderedSurface(page, markers, codePrefix);
+  await page.screenshot({ path: screenshotPath, fullPage: true });
+  await dialog.getByRole('button', { name: 'Close', exact: true }).click();
+  await dialog.waitFor({ state: 'hidden', timeout: 20_000 });
+}
+
+async function stageUpgrade(page, card, manifest, packagePath) {
+  const chooserPromise = page.waitForEvent('filechooser', { timeout: 20_000 });
+  await card.getByRole('button', { name: 'Stage upgrade', exact: true }).click();
+  const chooser = await chooserPromise;
+  await chooser.setFiles(packagePath);
+
+  await page.getByRole('heading', { name: `Review ${manifest.name} upgrade`, exact: true })
+    .waitFor({ state: 'visible', timeout: 20_000 });
+  const inspection = page.getByRole('heading', { name: `Review ${manifest.name} upgrade`, exact: true })
+    .locator('xpath=ancestor::section[1]');
+  const inspectionText = await inspection.innerText();
+  requireCondition(inspectionText.includes('App v1'), 'UPGRADE_INSPECTION_PROTOCOL_MISSING');
+  requireCondition(inspectionText.includes('deft.app.package.v1'), 'UPGRADE_INSPECTION_FORMAT_MISSING');
+  requireCondition(inspectionText.includes('Unsigned local'), 'UPGRADE_INSPECTION_PROVENANCE_MISSING');
+  requireCondition(inspectionText.includes('Staging grants no authority.'), 'UPGRADE_INSPECTION_AUTHORITY_WARNING_MISSING');
+  await inspection.getByRole('button', { name: 'Stage upgrade for review', exact: true }).click();
+  await page.getByRole('status')
+    .filter({ hasText: `${manifest.name} ${manifest.version} staged for explicit upgrade review.` })
+    .waitFor({ state: 'visible', timeout: 20_000 });
+}
+
+async function reviewAndActivate(page, card, activationKind) {
+  const labels = activationKind === 'upgrade'
+    ? {
+        review: 'Review exact upgrade authority',
+        activate: 'Upgrade reviewed App',
+        success: 'Connected App upgraded with freshly reviewed authority.',
+      }
+    : {
+        review: 'Review exact re-enable authority',
+        activate: 'Re-enable reviewed App',
+        success: 'Connected App re-enabled with freshly reviewed authority.',
+      };
+  const reviewButton = card.getByRole('button', { name: labels.review, exact: true });
+  await reviewButton.waitFor({ state: 'visible', timeout: 20_000 });
+  requireCondition(await reviewButton.isEnabled(), `${activationKind.toUpperCase()}_REVIEW_NOT_READY`);
+  await reviewButton.click();
+
+  await card.getByRole('heading', {
+    name: /^(Initial connected authority|Authority unchanged|Authority widened or changed incompatibly)$/,
+  }).waitFor({ state: 'visible', timeout: 20_000 });
+  const acceptance = card.getByRole('checkbox', { name: policyAcceptance, exact: true });
+  await acceptance.waitFor({ state: 'visible', timeout: 20_000 });
+  await acceptance.check();
+  requireCondition(await acceptance.isChecked(), `${activationKind.toUpperCase()}_POLICY_NOT_ACCEPTED`);
+
+  const activateButton = card.getByRole('button', { name: labels.activate, exact: true });
+  requireCondition(await activateButton.isEnabled(), `${activationKind.toUpperCase()}_ACTIVATE_NOT_READY`);
+  await activateButton.click();
+  await page.getByRole('status').filter({ hasText: labels.success })
+    .waitFor({ state: 'visible', timeout: 20_000 });
+}
+
+async function invokePackedProviderThroughUi(page, manifest, markers, receiptScreenshotPath) {
+  await page.goto(`${webUrl}/modules/resource-campaigns/campaigns`, { waitUntil: 'domcontentloaded' });
+  const campaignLinks = page.getByRole('link', { name: 'Connected campaign', exact: true });
+  await campaignLinks.first().waitFor({ state: 'visible', timeout: 20_000 });
+  const campaignHrefs = await campaignLinks.evaluateAll((links) => [
+    ...new Set(links.map((link) => link.getAttribute('href')).filter(Boolean)),
+  ]);
+  requireCondition(campaignHrefs.length === 1, 'CONNECTED_CAMPAIGN_NOT_UNIQUE');
+  await campaignLinks.first().click();
+  await page.getByRole('heading', { name: 'Connected campaign', exact: true, level: 1 })
+    .waitFor({ state: 'visible', timeout: 20_000 });
+
+  const actions = page.locator('section[aria-label="App actions"]');
+  await actions.waitFor({ state: 'visible', timeout: 20_000 });
+  await actions.getByRole('button', { name: 'Send campaign email', exact: true }).click();
+  const actionDialog = page.getByRole('dialog');
+  await actionDialog.getByRole('heading', { name: 'Send campaign email', exact: true })
+    .waitFor({ state: 'visible', timeout: 20_000 });
+  await actionDialog.getByRole('button', { name: 'Review action', exact: true }).click();
+  await actionDialog.getByRole('button', { name: 'Confirm and run', exact: true })
+    .waitFor({ state: 'visible', timeout: 20_000 });
+  await actionDialog.getByRole('button', { name: 'Confirm and run', exact: true }).click();
+  const inboxLink = actionDialog.getByRole('link', { name: 'Review approval in Inbox', exact: true });
+  await inboxLink.waitFor({ state: 'visible', timeout: 20_000 });
+  await assertSafeRenderedSurface(page, markers, 'PACKED_PROVIDER_ACTION');
+  await inboxLink.click();
+
+  await page.getByRole('heading', { name: 'Inbox', exact: true, level: 1 })
+    .waitFor({ state: 'visible', timeout: 20_000 });
+  const campaignLabel = page.getByText('Connected campaign', { exact: true }).first();
+  await campaignLabel.waitFor({ state: 'visible', timeout: 20_000 });
+  const approvalCard = campaignLabel.locator(
+    'xpath=ancestor::div[.//button[normalize-space(.)="Approve App action"]][1]',
+  );
+  await approvalCard.getByText('Send campaign email', { exact: true })
+    .waitFor({ state: 'visible', timeout: 20_000 });
+  const approveButton = approvalCard.getByRole('button', { name: 'Approve App action', exact: true });
+  const approvalResponse = page.waitForResponse((response) => {
+    const pathname = new URL(response.url()).pathname;
+    return response.request().method() === 'POST'
+      && /^\/api\/agent\/actions\/[^/]+\/approve$/.test(pathname);
+  }, { timeout: 20_000 });
+  await approveButton.click();
+  requireCondition((await approvalResponse).ok(), 'PACKED_PROVIDER_APPROVAL_FAILED');
+
+  await openApps(page, desktopViewport);
+  const card = await waitForApp(page, manifest.id, 'active', manifest.version);
+  const recentRuns = card.getByRole('heading', { name: 'Recent Runs', exact: true });
+  await recentRuns.waitFor({ state: 'visible', timeout: 20_000 });
+  const newestRun = recentRuns.locator('xpath=following-sibling::ul[1]').getByRole('button').first();
+  await newestRun.getByText('Send campaign email', { exact: true })
+    .waitFor({ state: 'visible', timeout: 20_000 });
+  try {
+    await newestRun.getByText('succeeded', { exact: true })
+      .waitFor({ state: 'visible', timeout: 60_000 });
+  } catch {
+    throw new CertificationFailure('PACKED_PROVIDER_RUN_NOT_SUCCEEDED');
+  }
+  await openAndVerifyReceipt(
+    page,
+    card,
+    markers,
+    receiptScreenshotPath,
+    'PACKED_PROVIDER_RECEIPT',
+    'succeeded',
+    'attempt terminal',
+  );
+}
+
+function installFailureTracking(page) {
+  const counts = {
+    desktop: { console: 0, page: 0, api: 0 },
+    mobile: { console: 0, page: 0, api: 0 },
+  };
+  let phase = 'desktop';
+  page.on('console', (message) => {
+    if (message.type() === 'error') counts[phase].console += 1;
+  });
+  page.on('pageerror', () => {
+    counts[phase].page += 1;
+  });
+  page.on('response', (response) => {
+    let pathname;
+    try {
+      pathname = new URL(response.url()).pathname;
+    } catch {
+      return;
+    }
+    if (response.status() >= 400
+      && (pathname === '/api/apps'
+        || pathname.startsWith('/api/apps/')
+        || pathname.startsWith('/api/app-runs/')
+        || pathname.startsWith('/api/app-actions/')
+        || pathname.startsWith('/api/agent/actions/')
+        || pathname.startsWith('/api/attention')
+        || pathname.startsWith('/api/modules')
+        || pathname === '/api/mcp-connections'
+        || pathname.startsWith('/api/mcp-connections/'))) {
+      counts[phase].api += 1;
+    }
+  });
+  return {
+    counts,
+    setPhase(nextPhase) {
+      phase = nextPhase;
+    },
+  };
+}
+
+function relativeEvidencePath(path) {
+  return relative(evidenceDirectory, path).replaceAll('\\', '/');
+}
+
+function serializedSafeEvidence(evidence, markers) {
+  const serialized = `${JSON.stringify(evidence, null, 2)}\n`;
+  const unsafe = markers.some((marker) => serialized.includes(marker))
+    || /deft_app_dev_[A-Za-z0-9_-]{16,}/.test(serialized)
+    || /hmac-sha256:[a-f0-9]{64}/i.test(serialized);
+  if (!unsafe) return serialized;
+  return `${JSON.stringify({
+    schema: evidence.schema,
+    result: 'failed',
+    route: '/settings/apps',
+    completed_at: evidence.completed_at,
+    error_code: 'UNSAFE_EVIDENCE_BLOCKED',
+  }, null, 2)}\n`;
+}
+
+async function main() {
+  await mkdir(evidenceDirectory, { recursive: true });
+  await mkdir(dirname(evidencePath), { recursive: true });
+  let markers = [];
+  let failureTracking = null;
+  const evidence = {
+    schema: 'deft.app_platform.phase6.browser_smoke.v1',
+    result: 'failed',
+    target_origin: null,
+    route: '/settings/apps',
+    completed_at: null,
+    baseline: { phase5_browser_smoke: false },
+    upgrade: {
+      source: 'DEFT_APP_PLATFORM_UPGRADE_PACKAGE',
+      package_format: 'deft.app.package.v1',
+      protocol_version: '1',
+      expected_version: null,
+    },
+    checks: {
+      authenticated_login: false,
+      compatible_unsigned_contract_visible: false,
+      desktop_safe_receipt_visible: false,
+      upgrade_staged_through_file_ui: false,
+      upgrade_exact_review_accepted_and_activated: false,
+      disabled_then_freshly_reviewed_and_reenabled: false,
+      packed_provider_invoked_through_ui: false,
+      mobile_active_upgrade_visible: false,
+      mobile_safe_receipt_visible: false,
+      no_horizontal_overflow: false,
+      no_console_page_or_api_failures: false,
+      no_secret_or_signature_markers: false,
+    },
+    screenshots: {},
+    observed_failures: {
+      desktop: { console: 0, page: 0, api: 0 },
+      mobile: { console: 0, page: 0, api: 0 },
+    },
+  };
+  let browser;
+  try {
+    markers = secretMarkers();
+    evidence.target_origin = safeOrigin(webUrl);
+    const [{ packagePath, manifest }, appKit] = await Promise.all([
+      readUpgradePackage(),
+      readAppKitContract(),
+    ]);
+    evidence.upgrade.expected_version = manifest.version;
+
+    await runPhase5Baseline();
+    evidence.baseline.phase5_browser_smoke = true;
+
+    browser = await chromium.launch({ headless: true });
+    const context = await browser.newContext({ viewport: desktopViewport });
+    const page = await context.newPage();
+    failureTracking = installFailureTracking(page);
+
+    await login(page);
+    evidence.checks.authenticated_login = true;
+    await openApps(page, desktopViewport);
+    let card = await waitForApp(page, manifest.id, 'active');
+    await assertConnectedContract(card, appKit);
+    evidence.checks.compatible_unsigned_contract_visible = true;
+
+    const desktopReceiptPath = resolve(evidenceDirectory, 'phase6-desktop-receipt.png');
+    await openAndVerifyReceipt(page, card, markers, desktopReceiptPath, 'DESKTOP_RECEIPT');
+    evidence.checks.desktop_safe_receipt_visible = true;
+    evidence.screenshots.desktop_receipt = relativeEvidencePath(desktopReceiptPath);
+
+    await stageUpgrade(page, card, manifest, packagePath);
+    evidence.checks.upgrade_staged_through_file_ui = true;
+    card = await waitForApp(page, manifest.id, 'active');
+    await reviewAndActivate(page, card, 'upgrade');
+    card = await waitForApp(page, manifest.id, 'active', manifest.version);
+    evidence.checks.upgrade_exact_review_accepted_and_activated = true;
+    const desktopUpgradePath = resolve(evidenceDirectory, 'phase6-desktop-upgraded.png');
+    await assertSafeRenderedSurface(page, markers, 'DESKTOP_UPGRADE');
+    await page.screenshot({ path: desktopUpgradePath, fullPage: true });
+    evidence.screenshots.desktop_upgraded = relativeEvidencePath(desktopUpgradePath);
+
+    await card.getByRole('button', { name: 'Disable', exact: true }).click();
+    await page.getByRole('status')
+      .filter({ hasText: `${manifest.name} is disabled. Its data is preserved.` })
+      .waitFor({ state: 'visible', timeout: 20_000 });
+    await waitForApp(page, manifest.id, 'disabled', manifest.version);
+    await openApps(page, desktopViewport);
+    card = await waitForApp(page, manifest.id, 'disabled', manifest.version);
+    await reviewAndActivate(page, card, 'reenable');
+    card = await waitForApp(page, manifest.id, 'active', manifest.version);
+    evidence.checks.disabled_then_freshly_reviewed_and_reenabled = true;
+    const desktopReenabledPath = resolve(evidenceDirectory, 'phase6-desktop-reenabled.png');
+    await assertSafeRenderedSurface(page, markers, 'DESKTOP_REENABLED');
+    await page.screenshot({ path: desktopReenabledPath, fullPage: true });
+    evidence.screenshots.desktop_reenabled = relativeEvidencePath(desktopReenabledPath);
+
+    await invokePackedProviderThroughUi(page, manifest, markers, desktopReceiptPath);
+    evidence.checks.packed_provider_invoked_through_ui = true;
+
+    failureTracking.setPhase('mobile');
+    await openApps(page, mobileViewport);
+    card = await waitForApp(page, manifest.id, 'active', manifest.version);
+    evidence.checks.mobile_active_upgrade_visible = true;
+    const mobileReceiptPath = resolve(evidenceDirectory, 'phase6-mobile-receipt.png');
+    await openAndVerifyReceipt(page, card, markers, mobileReceiptPath, 'MOBILE_RECEIPT');
+    evidence.checks.mobile_safe_receipt_visible = true;
+    evidence.screenshots.mobile_receipt = relativeEvidencePath(mobileReceiptPath);
+
+    const overflow = await page.evaluate(() => document.documentElement.scrollWidth - window.innerWidth);
+    requireCondition(overflow <= 2, 'MOBILE_HORIZONTAL_OVERFLOW');
+    evidence.checks.no_horizontal_overflow = true;
+    const mobileFinalPath = resolve(evidenceDirectory, 'phase6-mobile-final.png');
+    await assertSafeRenderedSurface(page, markers, 'MOBILE_FINAL');
+    await page.screenshot({ path: mobileFinalPath, fullPage: true });
+    evidence.screenshots.mobile_final = relativeEvidencePath(mobileFinalPath);
+
+    evidence.observed_failures = failureTracking.counts;
+    for (const phase of ['desktop', 'mobile']) {
+      requireCondition(failureTracking.counts[phase].console === 0, `${phase.toUpperCase()}_CONSOLE_FAILURE`);
+      requireCondition(failureTracking.counts[phase].page === 0, `${phase.toUpperCase()}_PAGE_FAILURE`);
+      requireCondition(failureTracking.counts[phase].api === 0, `${phase.toUpperCase()}_API_FAILURE`);
+    }
+    evidence.checks.no_console_page_or_api_failures = true;
+    evidence.checks.no_secret_or_signature_markers = true;
+    evidence.result = 'passed';
+    evidence.completed_at = new Date().toISOString();
+    console.log('APP_PLATFORM_PHASE6_BROWSER_SMOKE_PASSED');
+    console.log('Evidence written to the configured path.');
+  } catch (error) {
+    evidence.completed_at = new Date().toISOString();
+    evidence.error_code = errorCode(error);
+    throw error;
+  } finally {
+    if (failureTracking) evidence.observed_failures = failureTracking.counts;
+    await writeFile(evidencePath, serializedSafeEvidence(evidence, markers), 'utf8');
+    if (browser) await browser.close();
+  }
+}
+
+main().catch((error) => {
+  console.error(`[FAIL] App Platform Phase 6 browser smoke: ${errorCode(error)}`);
+  process.exitCode = 1;
+});

--- a/scripts/ci/app-platform-phase6-certification-offline.sh
+++ b/scripts/ci/app-platform-phase6-certification-offline.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+[[ "${CERTIFICATION_STAGE:?CERTIFICATION_STAGE is required}" == "offline" ]]
+app_container="${APP_CONTAINER:?APP_CONTAINER is required}"
+candidate_tag="${CANDIDATE_TAG:?CANDIDATE_TAG is required}"
+network="${CERT_NETWORK:?CERT_NETWORK is required}"
+restore_container="${RESTORE_CONTAINER:?RESTORE_CONTAINER is required}"
+restore_database_url="${RESTORE_DATABASE_URL:?RESTORE_DATABASE_URL is required}"
+database_name="${DATABASE_NAME:?DATABASE_NAME is required}"
+safe_dir="${SAFE_EVIDENCE_DIR:?SAFE_EVIDENCE_DIR is required}"
+certifier_root="${CERTIFIER_ROOT:?CERTIFIER_ROOT is required}"
+keyring_json="${DEFT_APP_RUN_KEYRINGS:?DEFT_APP_RUN_KEYRINGS is required}"
+proof_email="${DEFT_TEST_EMAIL:?DEFT_TEST_EMAIL is required}"
+
+read -r proof_org before_total before_succeeded before_failed < <(
+  docker exec "$restore_container" psql -U postgres -d "$database_name" -qAt -F ' ' \
+    -v proof_email="$proof_email" -c "
+      SELECT om.org_id,
+             count(ar.id),
+             count(ar.id) FILTER (WHERE ar.state = 'succeeded'),
+             count(ar.id) FILTER (WHERE ar.state = 'failed')
+        FROM users u
+        JOIN org_members om ON om.user_id = u.id AND om.is_active = true
+        LEFT JOIN app_runs ar ON ar.org_id = om.org_id AND ar.origin_kind = 'app'
+       WHERE u.email = :'proof_email'
+       GROUP BY om.org_id"
+)
+[[ "$proof_org" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]]
+[[ "$before_total" =~ ^[0-9]+$ && "$before_succeeded" =~ ^[0-9]+$ && "$before_failed" =~ ^[0-9]+$ ]]
+
+docker rm -f "$app_container" >/dev/null
+docker run -d --name "$app_container" --network "$network" -p 3000:3000 -p 3001:3001 \
+  -e DATABASE_URL="$restore_database_url" \
+  -e JWT_SECRET=phase5-cert-jwt-not-for-prod \
+  -e JWT_REFRESH_SECRET=phase5-cert-refresh-not-for-prod \
+  -e ENCRYPTION_KEY=phase5-cert-envelope-key-32bytes \
+  -e DEFT_APPS_ENABLED=true \
+  -e DEFT_APP_RUNS_ENABLED=true \
+  -e DEFT_APP_RUN_APP_ORIGIN_ENABLED=true \
+  -e DEFT_APP_RUN_LEGACY_MCP_CUTOVER_ENABLED=false \
+  -e DEFT_APP_RUN_KEYRINGS="$keyring_json" \
+  -e DEFT_SELF_HOSTED=true \
+  -e DEFT_MCP_ENABLE_UNSAFE_STDIO=true \
+  -e MCP_STDIO_ALLOWED_COMMANDS=/usr/local/bin/node \
+  -e NEXT_PUBLIC_APP_URL=http://127.0.0.1:3000 \
+  -e NEXT_PUBLIC_API_URL=http://127.0.0.1:3001 \
+  -e NEXT_PUBLIC_WS_URL=http://127.0.0.1:3001 \
+  -e NEXT_PUBLIC_FEATURE_APPS=true \
+  "$candidate_tag" >/dev/null
+
+for attempt in $(seq 1 45); do
+  if curl --fail --silent http://127.0.0.1:3001/health >/dev/null \
+    && curl --fail --silent http://127.0.0.1:3000/login >/dev/null; then break; fi
+  if [[ "$attempt" == 45 ]]; then docker logs "$app_container"; exit 1; fi
+  sleep 2
+done
+
+DEFT_WEB_URL=http://127.0.0.1:3000 \
+DEFT_TEST_EMAIL="$proof_email" \
+DEFT_TEST_PASSWORD=tomato123 \
+DEFT_APP_RUN_KEYRINGS="$keyring_json" \
+JWT_SECRET=phase5-cert-jwt-not-for-prod \
+JWT_REFRESH_SECRET=phase5-cert-refresh-not-for-prod \
+ENCRYPTION_KEY=phase5-cert-envelope-key-32bytes \
+DEFT_APP_PLATFORM_EVIDENCE_DIR="$safe_dir" \
+DEFT_APP_PLATFORM_OFFLINE_EVIDENCE="$safe_dir/offline-evidence.json" \
+node "$certifier_root/scripts/ci/app-platform-phase6-offline-smoke.mjs"
+
+read -r after_total after_succeeded after_failed < <(
+  docker exec "$restore_container" psql -U postgres -d "$database_name" -qAt -F ' ' -c "
+    SELECT count(*),
+           count(*) FILTER (WHERE state = 'succeeded'),
+           count(*) FILTER (WHERE state = 'failed')
+      FROM app_runs
+     WHERE org_id = '$proof_org' AND origin_kind = 'app'"
+)
+[[ "$after_total" == "$before_total" ]]
+[[ "$after_succeeded" == "$before_succeeded" ]]
+[[ "$after_failed" == "$before_failed" ]]
+
+cat > "$safe_dir/phase6-offline-summary.json" <<'JSON'
+{
+  "schema": "deft.app_platform.phase6.offline.v1",
+  "result": "passed",
+  "candidate_booted_without_provider_mount": true,
+  "local_resource_opened": true,
+  "connector_reported_unhealthy": true,
+  "invocation_failed_without_creating_a_run": true
+}
+JSON

--- a/scripts/ci/app-platform-phase6-certification-setup.sh
+++ b/scripts/ci/app-platform-phase6-certification-setup.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+[[ "${CERTIFICATION_STAGE:?CERTIFICATION_STAGE is required}" == "setup" ]]
+candidate_root="${CANDIDATE_ROOT:?CANDIDATE_ROOT is required}"
+certifier_root="${CERTIFIER_ROOT:?CERTIFIER_ROOT is required}"
+candidate_tag="${CANDIDATE_TAG:?CANDIDATE_TAG is required}"
+network="${CERT_NETWORK:?CERT_NETWORK is required}"
+source_container="${SOURCE_CONTAINER:?SOURCE_CONTAINER is required}"
+source_database_url="${SOURCE_DATABASE_URL:?SOURCE_DATABASE_URL is required}"
+safe_dir="${SAFE_EVIDENCE_DIR:?SAFE_EVIDENCE_DIR is required}"
+recovery_dir="${RECOVERY_DIR:?RECOVERY_DIR is required}"
+app_docker_args_file="${APP_DOCKER_ARGS_FILE:?APP_DOCKER_ARGS_FILE is required}"
+upgrade_package_path="${UPGRADE_PACKAGE_PATH:?UPGRADE_PACKAGE_PATH is required}"
+keyring_json="${DEFT_APP_RUN_KEYRINGS:?DEFT_APP_RUN_KEYRINGS is required}"
+run_id="${GITHUB_RUN_ID:?GITHUB_RUN_ID is required}"
+run_attempt="${GITHUB_RUN_ATTEMPT:?GITHUB_RUN_ATTEMPT is required}"
+
+compose_project="deft-p6-compose-${run_id}-${run_attempt}"
+compose_env="${recovery_dir}/phase6-compose.env"
+compose_files=(
+  -f "${candidate_root}/docker-compose.yml"
+  -f "${candidate_root}/compose.prod.yml"
+  -f "${certifier_root}/scripts/ci/app-platform-phase6-compose.yml"
+)
+
+compose() {
+  DEFT_CERT_CANDIDATE_IMAGE="$candidate_tag" DEFT_CERT_ENV_FILE="$compose_env" \
+    docker compose --project-name "$compose_project" --env-file "$compose_env" \
+    "${compose_files[@]}" "$@"
+}
+
+compose_down() {
+  set +e
+  compose down --volumes --remove-orphans >/dev/null 2>&1
+}
+trap compose_down EXIT
+
+umask 077
+{
+  printf 'POSTGRES_PASSWORD=%s\n' 'phase6-compose-postgres'
+  printf 'JWT_SECRET=%s\n' 'phase6-compose-jwt-not-for-prod'
+  printf 'JWT_REFRESH_SECRET=%s\n' 'phase6-compose-refresh-not-for-prod'
+  printf 'ENCRYPTION_KEY=%s\n' 'phase6-compose-envelope-key-32bytes'
+  printf 'NEXT_PUBLIC_APP_URL=%s\n' 'http://127.0.0.1:3100'
+  printf 'NEXT_PUBLIC_API_URL=%s\n' 'http://127.0.0.1:3101'
+  printf 'NEXT_PUBLIC_WS_URL=%s\n' 'http://127.0.0.1:3101'
+  printf 'NEXT_PUBLIC_FEATURE_APPS=%s\n' 'true'
+  printf 'DEFT_WEB_PORT=%s\n' '3100'
+  printf 'DEFT_API_PORT=%s\n' '3101'
+  printf 'DEFT_APPS_ENABLED=%s\n' 'true'
+  printf 'DEFT_APP_RUNS_ENABLED=%s\n' 'true'
+  printf 'DEFT_APP_RUN_APP_ORIGIN_ENABLED=%s\n' 'true'
+  printf 'DEFT_APP_RUN_LEGACY_MCP_CUTOVER_ENABLED=%s\n' 'false'
+  printf 'DEFT_APP_RUN_KEYRINGS=%s\n' "$keyring_json"
+} > "$compose_env"
+
+compose up -d postgres
+compose --profile tools run --rm init
+compose up -d deft
+compose --profile tools run --rm doctor
+compose --profile tools run --rm smoke
+compose images --format json > "$safe_dir/phase6-compose-images.json"
+compose_down
+trap - EXIT
+
+provider_pack_dir="${recovery_dir}/provider-pack"
+provider_runtime="${recovery_dir}/provider-runtime"
+mkdir -p "$provider_pack_dir" "$provider_runtime"
+(
+  cd "${candidate_root}/examples/app-platform-sandbox-email-provider"
+  pnpm pack --pack-destination "$provider_pack_dir"
+)
+provider_tarball="$(find "$provider_pack_dir" -maxdepth 1 -type f -name '*.tgz' -print -quit)"
+[[ -n "$provider_tarball" && -f "$provider_tarball" ]]
+tar -xzf "$provider_tarball" -C "$provider_runtime" --strip-components=1
+[[ -f "$provider_runtime/server.mjs" && -f "$provider_runtime/package.json" ]]
+sha256sum "$provider_tarball" | cut -d ' ' -f 1 > "$safe_dir/phase6-provider-package.sha256"
+
+upgrade_source="${recovery_dir}/connected-resource-campaigns-upgrade"
+cp -R "${candidate_root}/examples/connected-resource-campaigns-app" "$upgrade_source"
+node --input-type=module - "$upgrade_source/deft.app.json" <<'NODE'
+import { readFileSync, writeFileSync } from 'node:fs';
+const path = process.argv[2];
+const manifest = JSON.parse(readFileSync(path, 'utf8'));
+const [major, minor, patch] = manifest.version.split('.').map(Number);
+if (![major, minor, patch].every(Number.isInteger)) throw new Error('Expected a semver App version');
+manifest.version = `${major}.${minor}.${patch + 1}`;
+writeFileSync(path, `${JSON.stringify(manifest, null, 2)}\n`);
+NODE
+(
+  cd "$upgrade_source"
+  node "${candidate_root}/packages/app-kit/dist/cli.js" app check
+  node "${candidate_root}/packages/app-kit/dist/cli.js" app build
+)
+cp "$upgrade_source/.deft/app.deftapp.json" "$upgrade_package_path"
+sha256sum "$upgrade_package_path" | cut -d ' ' -f 1 > "$safe_dir/phase6-upgrade-package.sha256"
+sha256sum "$upgrade_source/.deft/requested-authority.json" | cut -d ' ' -f 1 \
+  > "$safe_dir/phase6-upgrade-requested-authority.sha256"
+
+connector_count="$(docker exec "$source_container" psql -U postgres -d "${DATABASE_NAME:?DATABASE_NAME is required}" -qAtc \
+  "SELECT count(*) FROM mcp_connections WHERE slug LIKE 'loop5-mail-%'")"
+[[ "$connector_count" == "1" ]]
+docker exec "$source_container" psql -U postgres -d "$DATABASE_NAME" -v ON_ERROR_STOP=1 -q \
+  -c "UPDATE mcp_connections
+         SET server_url = NULL,
+             transport = 'stdio',
+             stdio_command = '/usr/local/bin/node',
+             stdio_args = '[\"/deft-provider/server.mjs\"]'::jsonb,
+             tools_cache = NULL,
+             tools_cached_at = NULL,
+             is_active = true,
+             app_run_authorization_version = app_run_authorization_version + 1,
+             updated_at = now()
+       WHERE slug LIKE 'loop5-mail-%'" >/dev/null
+
+{
+  printf '%s\n' '-v'
+  printf '%s\n' "${provider_runtime}:/deft-provider:ro"
+  printf '%s\n' '-e' 'DEFT_SELF_HOSTED=true'
+  printf '%s\n' '-e' 'DEFT_MCP_ENABLE_UNSAFE_STDIO=true'
+  printf '%s\n' '-e' 'MCP_STDIO_ALLOWED_COMMANDS=/usr/local/bin/node'
+} > "$app_docker_args_file"
+
+docker run --rm --network "$network" \
+  -v "${candidate_root}/examples:/app/examples:ro" \
+  -e DATABASE_URL="$source_database_url" \
+  -e DEFT_TEST_DATABASE_URL="$source_database_url" \
+  -e JWT_SECRET=phase6-cert-jwt-not-for-prod \
+  -e JWT_REFRESH_SECRET=phase6-cert-refresh-not-for-prod \
+  -e ENCRYPTION_KEY=phase6-cert-envelope-key-32bytes \
+  -e DEFT_APPS_ENABLED=true \
+  -e DEFT_APP_RUNS_ENABLED=true \
+  -e DEFT_APP_RUN_APP_ORIGIN_ENABLED=true \
+  -e DEFT_APP_RUN_LEGACY_MCP_CUTOVER_ENABLED=false \
+  -e DEFT_APP_RUN_KEYRINGS="$keyring_json" \
+  --entrypoint sh "$candidate_tag" -c '
+    pnpm --filter @deft/shared exec tsx --test test/capabilities.test.ts test/app-runs.test.ts &&
+    pnpm --filter @deft/app-kit test &&
+    pnpm --filter @deft/api exec tsx --test \
+      test/capability-service.test.ts \
+      test/capability-immediate-execution-db.test.ts \
+      test/app-action-service-db.test.ts \
+      test/app-origin-run-cutover-db.test.ts \
+      test/app-origin-run-lifecycle-db.test.ts \
+      test/apps-connected-grants-db.test.ts \
+      test/app-run-engine-db.test.ts \
+      test/app-run-receipt-inspection.test.ts \
+      test/app-run-secrets.test.ts \
+      test/app-operations.test.ts \
+      test/queue-health.test.ts \
+      test/app-action-architecture.test.ts \
+      test/app-run-architecture.test.ts \
+      test/capability-architecture.test.ts \
+      test/mcp-connector-safety.test.ts
+  '
+
+cat > "$safe_dir/phase6-setup-summary.json" <<'JSON'
+{
+  "schema": "deft.app_platform.phase6.setup.v1",
+  "result": "passed",
+  "self_host_compose": "exact_candidate",
+  "provider": "separately_packed_stdio_sandbox",
+  "upgrade": "public_app_kit_exact_package",
+  "connector_authority": "invalidated_for_fresh_review",
+  "conformance": "focused_phase4_to_phase6_matrix"
+}
+JSON

--- a/scripts/ci/app-platform-phase6-compose.yml
+++ b/scripts/ci/app-platform-phase6-compose.yml
@@ -1,0 +1,21 @@
+x-phase6-candidate: &phase6-candidate
+  image: ${DEFT_CERT_CANDIDATE_IMAGE:?DEFT_CERT_CANDIDATE_IMAGE is required}
+  pull_policy: never
+  build: !reset null
+  env_file: !override ${DEFT_CERT_ENV_FILE:?DEFT_CERT_ENV_FILE is required}
+
+services:
+  deft:
+    <<: *phase6-candidate
+
+  init:
+    <<: *phase6-candidate
+
+  upgrade:
+    <<: *phase6-candidate
+
+  doctor:
+    <<: *phase6-candidate
+
+  smoke:
+    <<: *phase6-candidate

--- a/scripts/ci/app-platform-phase6-offline-smoke.mjs
+++ b/scripts/ci/app-platform-phase6-offline-smoke.mjs
@@ -1,0 +1,118 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname, relative, resolve } from 'node:path';
+import { chromium } from 'playwright';
+
+const webUrl = (process.env.DEFT_WEB_URL || 'http://127.0.0.1:3000').replace(/\/$/, '');
+const email = process.env.DEFT_TEST_EMAIL || 'diego@testers-tomatoes.com';
+const password = process.env.DEFT_TEST_PASSWORD || 'tomato123';
+const evidenceDirectory = resolve(
+  process.env.DEFT_APP_PLATFORM_EVIDENCE_DIR || 'dist/app-platform-phase6-certification',
+);
+const evidencePath = resolve(
+  process.env.DEFT_APP_PLATFORM_OFFLINE_EVIDENCE || `${evidenceDirectory}/offline-evidence.json`,
+);
+const screenshotPath = resolve(evidenceDirectory, 'phase6-offline-denied-action.png');
+const appId = 'org.deft.reference.resource-campaigns-app';
+
+function requireCondition(condition, code) {
+  if (!condition) throw new Error(code);
+}
+
+async function login(page) {
+  await page.goto(`${webUrl}/login`, { waitUntil: 'domcontentloaded' });
+  await page.locator('#login-email').fill(email);
+  await page.locator('#login-password').fill(password);
+  const response = page.waitForResponse((candidate) => (
+    candidate.request().method() === 'POST'
+    && new URL(candidate.url()).pathname === '/api/auth/login'
+  ));
+  await page.getByRole('button', { name: 'Sign in', exact: true }).click();
+  requireCondition((await response).ok(), 'OFFLINE_LOGIN_FAILED');
+  await page.waitForURL((url) => !url.pathname.startsWith('/login'), { timeout: 20_000 });
+}
+
+function appCard(page) {
+  return page.locator('article').filter({ hasText: `${appId}@` }).first();
+}
+
+async function openLocalCampaign(page) {
+  await page.goto(`${webUrl}/modules/resource-campaigns/campaigns`, { waitUntil: 'domcontentloaded' });
+  const link = page.getByRole('link', { name: 'Connected campaign', exact: true }).first();
+  await link.waitFor({ state: 'visible', timeout: 20_000 });
+  await link.click();
+  await page.getByRole('region', { name: 'App actions', exact: true })
+    .waitFor({ state: 'visible', timeout: 20_000 });
+}
+
+async function assertInvocationFailsClosed(page) {
+  await page.getByRole('button', { name: 'Send campaign email', exact: true }).click();
+  const dialog = page.getByRole('dialog');
+  await dialog.waitFor({ state: 'visible', timeout: 20_000 });
+  const alert = dialog.getByRole('alert');
+  await alert.waitFor({ state: 'visible', timeout: 20_000 });
+  requireCondition(
+    /provider discovery failed/i.test(await alert.innerText()),
+    'OFFLINE_PROVIDER_FAILURE_NOT_EXPLICIT',
+  );
+  requireCondition(
+    await dialog.getByRole('button', { name: 'Review action', exact: true }).count() === 0,
+    'OFFLINE_ACTION_REVIEW_AVAILABLE',
+  );
+  requireCondition(
+    await dialog.getByRole('button', { name: 'Confirm and run', exact: true }).count() === 0,
+    'OFFLINE_ACTION_INVOKE_AVAILABLE',
+  );
+  requireCondition(
+    await dialog.getByRole('link', { name: 'Review approval in Inbox', exact: true }).count() === 0,
+    'OFFLINE_APPROVAL_AVAILABLE',
+  );
+  await page.screenshot({ path: screenshotPath, fullPage: true });
+  await dialog.getByRole('button', { name: 'Cancel', exact: true })
+    .waitFor({ state: 'visible', timeout: 20_000 });
+  await dialog.getByRole('button', { name: 'Cancel', exact: true }).click();
+}
+
+async function main() {
+  await mkdir(evidenceDirectory, { recursive: true });
+  await mkdir(dirname(evidencePath), { recursive: true });
+  const evidence = {
+    schema: 'deft.app_platform.phase6.offline_browser.v1',
+    result: 'failed',
+    checks: {
+      local_resource_opened: false,
+      connector_reported_unhealthy: false,
+      invocation_failed_safely: false,
+    },
+    screenshot: relative(evidenceDirectory, screenshotPath).replaceAll('\\', '/'),
+  };
+  let browser;
+  try {
+    browser = await chromium.launch({ headless: true });
+    const page = await browser.newPage({ viewport: { width: 1440, height: 900 } });
+    await login(page);
+    await openLocalCampaign(page);
+    evidence.checks.local_resource_opened = true;
+
+    await page.goto(`${webUrl}/settings/apps`, { waitUntil: 'domcontentloaded' });
+    const card = appCard(page);
+    await card.waitFor({ state: 'visible', timeout: 20_000 });
+    await card.getByRole('button', { name: 'Refresh health', exact: true }).click();
+    const health = card.getByRole('status').filter({ hasText: /health issue/ });
+    await health.waitFor({ state: 'visible', timeout: 20_000 });
+    requireCondition(!/^Healthy$/m.test(await health.innerText()), 'OFFLINE_CONNECTOR_REPORTED_HEALTHY');
+    evidence.checks.connector_reported_unhealthy = true;
+
+    await openLocalCampaign(page);
+    await assertInvocationFailsClosed(page);
+    evidence.checks.invocation_failed_safely = true;
+    evidence.result = 'passed';
+  } finally {
+    await writeFile(evidencePath, `${JSON.stringify(evidence, null, 2)}\n`, 'utf8');
+    if (browser) await browser.close();
+  }
+}
+
+main().catch((error) => {
+  console.error(`[FAIL] App Platform Phase 6 offline smoke: ${error instanceof Error ? error.message : 'UNKNOWN'}`);
+  process.exitCode = 1;
+});

--- a/scripts/ci/certify-app-platform-phase5.sh
+++ b/scripts/ci/certify-app-platform-phase5.sh
@@ -1,39 +1,51 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-phase5_sha="${PHASE5_CANDIDATE_SHA:?PHASE5_CANDIDATE_SHA is required}"
-phase4_sha="${PHASE4_BASELINE_SHA:?PHASE4_BASELINE_SHA is required}"
+cert_phase="${APP_PLATFORM_CERT_PHASE:-phase5}"
+candidate_sha="${APP_PLATFORM_CANDIDATE_SHA:-${PHASE5_CANDIDATE_SHA:?PHASE5_CANDIDATE_SHA or APP_PLATFORM_CANDIDATE_SHA is required}}"
+baseline_sha="${APP_PLATFORM_BASELINE_SHA:-${PHASE4_BASELINE_SHA:?PHASE4_BASELINE_SHA or APP_PLATFORM_BASELINE_SHA is required}}"
 predecessor_image="${PREDECESSOR_IMAGE:?PREDECESSOR_IMAGE is required}"
 predecessor_commit="${PREDECESSOR_COMMIT:?PREDECESSOR_COMMIT is required}"
 certifier_root="${CERTIFIER_ROOT:?CERTIFIER_ROOT is required}"
-phase5_root="${PHASE5_ROOT:?PHASE5_ROOT is required}"
-phase4_root="${PHASE4_ROOT:?PHASE4_ROOT is required}"
+candidate_root="${APP_PLATFORM_CANDIDATE_ROOT:-${PHASE5_ROOT:?PHASE5_ROOT or APP_PLATFORM_CANDIDATE_ROOT is required}}"
+baseline_root="${APP_PLATFORM_BASELINE_ROOT:-${PHASE4_ROOT:?PHASE4_ROOT or APP_PLATFORM_BASELINE_ROOT is required}}"
 evidence_root="${EVIDENCE_DIR:?EVIDENCE_DIR is required}"
+browser_script="${APP_PLATFORM_BROWSER_SCRIPT:-${certifier_root}/scripts/ci/app-platform-phase5-browser-smoke.mjs}"
+setup_hook="${APP_PLATFORM_SETUP_HOOK:-}"
+offline_hook="${APP_PLATFORM_OFFLINE_HOOK:-}"
 
 run_id="${GITHUB_RUN_ID:?GITHUB_RUN_ID is required}"
 run_attempt="${GITHUB_RUN_ATTEMPT:?GITHUB_RUN_ATTEMPT is required}"
-prefix="deft-p5-cert-${run_id}-${run_attempt}"
+prefix="${APP_PLATFORM_RESOURCE_PREFIX:-deft-p5-cert-${run_id}-${run_attempt}}"
 network="${prefix}-network"
 source_container="${prefix}-source"
 restore_container="${prefix}-restore"
 app_container="${prefix}-app"
 source_volume="${prefix}-source-data"
 restore_volume="${prefix}-restore-data"
-candidate_tag="deft:phase5-cert-${run_id}-${run_attempt}"
-database_name="deft_phase4_phase5_release_test"
-postgres_password="phase5-cert-postgres"
+candidate_tag="${APP_PLATFORM_CANDIDATE_TAG:-deft:${cert_phase}-cert-${run_id}-${run_attempt}}"
+database_name="${APP_PLATFORM_DATABASE_NAME:-deft_phase4_phase5_release_test}"
+postgres_password="${APP_PLATFORM_POSTGRES_PASSWORD:-phase5-cert-postgres}"
 host_port=55432
 source_url_host="postgres://postgres:${postgres_password}@127.0.0.1:${host_port}/${database_name}"
 source_url_container="postgres://postgres:${postgres_password}@${source_container}:5432/${database_name}"
 restore_url_container="postgres://postgres:${postgres_password}@${restore_container}:5432/${database_name}"
 safe_dir="${evidence_root}/safe"
-recovery_dir="${RUNNER_TEMP:?RUNNER_TEMP is required}/deft-phase5-recovery-${run_id}-${run_attempt}"
+recovery_dir="${RUNNER_TEMP:?RUNNER_TEMP is required}/deft-${cert_phase}-recovery-${run_id}-${run_attempt}"
 keyring_path="${recovery_dir}/app-run-keyrings.json"
 restored_keyring_path="${recovery_dir}/restored-app-run-keyrings.json"
 dump_path="${recovery_dir}/database.dump"
 candidate_archive="${evidence_root}/candidate-image.tar.zst"
+app_docker_args_file="${recovery_dir}/app-docker-args.txt"
+upgrade_package_path="${recovery_dir}/phase6-upgrade.deftapp.json"
 host_uid="$(id -u)"
 host_gid="$(id -g)"
+
+[[ "$cert_phase" =~ ^[a-z0-9][a-z0-9_-]{0,31}$ ]]
+[[ "$run_id" =~ ^[0-9]+$ && "$run_attempt" =~ ^[0-9]+$ ]]
+[[ "$prefix" =~ ^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$ ]]
+[[ "$candidate_tag" =~ ^[A-Za-z0-9][A-Za-z0-9_.:/-]{0,127}$ ]]
+[[ "$database_name" =~ ^[A-Za-z_][A-Za-z0-9_]{0,62}$ ]]
 
 mkdir -p "$safe_dir" "$recovery_dir"
 chmod 700 "$recovery_dir"
@@ -43,8 +55,9 @@ cleanup() {
   docker rm -f "$app_container" "$restore_container" "$source_container" >/dev/null 2>&1
   docker network rm "$network" >/dev/null 2>&1
   docker volume rm "$restore_volume" "$source_volume" >/dev/null 2>&1
-  rm -f "$keyring_path" "$restored_keyring_path" "$dump_path"
-  rmdir "$recovery_dir" >/dev/null 2>&1
+  if [[ "$recovery_dir" == "${RUNNER_TEMP}/deft-${cert_phase}-recovery-${run_id}-${run_attempt}" ]]; then
+    rm -rf -- "$recovery_dir"
+  fi
 }
 trap cleanup EXIT
 
@@ -70,8 +83,28 @@ run_candidate() {
     --entrypoint sh "$candidate_tag" -c "$2"
 }
 
-[[ "$(git -C "$phase5_root" rev-parse HEAD)" == "$phase5_sha" ]]
-[[ "$(git -C "$phase4_root" rev-parse HEAD)" == "$phase4_sha" ]]
+run_extension_hook() {
+  local hook="$1"
+  local stage="$2"
+  if [[ -z "$hook" ]]; then return 0; fi
+  [[ -f "$hook" ]]
+  CERTIFICATION_STAGE="$stage" CERT_PHASE="$cert_phase" \
+  CERTIFIER_ROOT="$certifier_root" CANDIDATE_ROOT="$candidate_root" \
+  CANDIDATE_SHA="$candidate_sha" BASELINE_ROOT="$baseline_root" \
+  BASELINE_SHA="$baseline_sha" CANDIDATE_TAG="$candidate_tag" \
+  CERT_NETWORK="$network" SOURCE_CONTAINER="$source_container" \
+  RESTORE_CONTAINER="$restore_container" APP_CONTAINER="$app_container" \
+  SOURCE_DATABASE_URL="$source_url_container" RESTORE_DATABASE_URL="$restore_url_container" \
+  DATABASE_NAME="$database_name" POSTGRES_PASSWORD="$postgres_password" \
+  SAFE_EVIDENCE_DIR="$safe_dir" RECOVERY_DIR="$recovery_dir" \
+  APP_DOCKER_ARGS_FILE="$app_docker_args_file" UPGRADE_PACKAGE_PATH="$upgrade_package_path" \
+  DEFT_APP_RUN_KEYRINGS="${restored_keyring_json:-${keyring_json:-}}" \
+  DEFT_TEST_EMAIL="${proof_email:-}" \
+  bash "$hook"
+}
+
+[[ "$(git -C "$candidate_root" rev-parse HEAD)" == "$candidate_sha" ]]
+[[ "$(git -C "$baseline_root" rev-parse HEAD)" == "$baseline_sha" ]]
 
 docker network create "$network" >/dev/null
 docker volume create "$source_volume" >/dev/null
@@ -87,7 +120,7 @@ docker exec "$source_container" psql -U postgres -d "$database_name" -Atc \
   "SELECT extversion FROM pg_extension WHERE extname = 'vector'" > "$safe_dir/pgvector-version.txt"
 
 (
-  cd "$phase4_root"
+  cd "$baseline_root"
   pnpm --filter @deft/app-kit build
   DATABASE_URL="$source_url_host" pnpm db:push-full
   DATABASE_URL="$source_url_host" pnpm --filter @deft/db seed:demo
@@ -102,23 +135,23 @@ docker buildx build --load \
   --tag "$candidate_tag" \
   --iidfile "$safe_dir/candidate-buildkit-iid.txt" \
   --metadata-file "$safe_dir/candidate-buildkit-metadata.json" \
-  --build-arg "VCS_REF=$phase5_sha" \
+  --build-arg "VCS_REF=$candidate_sha" \
   --build-arg NEXT_PUBLIC_APP_URL=http://127.0.0.1:3000 \
   --build-arg NEXT_PUBLIC_API_URL=http://127.0.0.1:3001 \
   --build-arg NEXT_PUBLIC_WS_URL=http://127.0.0.1:3001 \
   --build-arg NEXT_PUBLIC_FEATURE_HUDDLES=true \
   --build-arg NEXT_PUBLIC_FEATURE_APPS=true \
-  "$phase5_root"
+  "$candidate_root"
 
 image_revision="$(docker image inspect "$candidate_tag" --format '{{index .Config.Labels "org.opencontainers.image.revision"}}')"
-[[ "$image_revision" == "$phase5_sha" ]]
+[[ "$image_revision" == "$candidate_sha" ]]
 docker image inspect "$candidate_tag" > "$safe_dir/candidate-image-inspect.json"
 printf '%s\n' "$image_revision" > "$safe_dir/candidate-image-revision.txt"
 
 run_candidate "$source_url_container" 'pnpm db:upgrade && pnpm module:verify'
 run_candidate "$source_url_container" 'pnpm --filter @deft/api exec tsx src/scripts/seed-platform-bundles.ts'
 docker run --rm --network "$network" \
-  -v "${phase5_root}/examples:/app/examples:ro" \
+  -v "${candidate_root}/examples:/app/examples:ro" \
   -e DATABASE_URL="$source_url_container" \
   -e DEFT_TEST_DATABASE_URL="$source_url_container" \
   -e JWT_SECRET=phase5-cert-jwt-not-for-prod \
@@ -156,6 +189,7 @@ keyring_hash="$(sha256sum "$keyring_path" | cut -d ' ' -f 1)"
 printf '%s\n' "$keyring_hash" > "$safe_dir/app-run-keyring.sha256"
 
 keyring_json="$(tr -d '\n' < "$keyring_path")"
+run_extension_hook "$setup_hook" setup
 docker run --rm --network "$network" \
   -v "${certifier_root}/scripts/ci/app-platform-phase5-certification-probe.ts:/app/scripts/ci/app-platform-phase5-certification-probe.ts:ro" \
   -v "${safe_dir}:/evidence" \
@@ -244,6 +278,8 @@ docker run --rm --network "$network" \
   --entrypoint sh "$candidate_tag" \
   -c 'pnpm exec tsx scripts/ci/app-platform-phase5-certification-probe.ts verify --expected-snapshot /evidence/source-snapshot.json --output /evidence/restored-verification.json && chown "$HOST_UID:$HOST_GID" /evidence/restored-verification.json'
 
+app_docker_args=()
+if [[ -s "$app_docker_args_file" ]]; then mapfile -t app_docker_args < "$app_docker_args_file"; fi
 docker run -d --name "$app_container" --network "$network" -p 3000:3000 -p 3001:3001 \
   -e DATABASE_URL="$restore_url_container" \
   -e JWT_SECRET=phase5-cert-jwt-not-for-prod \
@@ -258,6 +294,7 @@ docker run -d --name "$app_container" --network "$network" -p 3000:3000 -p 3001:
   -e NEXT_PUBLIC_API_URL=http://127.0.0.1:3001 \
   -e NEXT_PUBLIC_WS_URL=http://127.0.0.1:3001 \
   -e NEXT_PUBLIC_FEATURE_APPS=true \
+  "${app_docker_args[@]}" \
   "$candidate_tag" >/dev/null
 for attempt in $(seq 1 45); do
   if curl --fail --silent http://127.0.0.1:3001/health >/dev/null \
@@ -276,7 +313,10 @@ JWT_REFRESH_SECRET=phase5-cert-refresh-not-for-prod \
 ENCRYPTION_KEY=phase5-cert-envelope-key-32bytes \
 DEFT_APP_PLATFORM_EVIDENCE_DIR="$safe_dir" \
 DEFT_APP_PLATFORM_BROWSER_EVIDENCE="$safe_dir/browser-evidence.json" \
-node "$certifier_root/scripts/ci/app-platform-phase5-browser-smoke.mjs"
+DEFT_APP_PLATFORM_UPGRADE_PACKAGE="$upgrade_package_path" \
+node "$browser_script"
+
+run_extension_hook "$offline_hook" offline
 
 docker save "$candidate_tag" | zstd -T0 -10 -o "$candidate_archive"
 sha256sum "$candidate_archive" | cut -d ' ' -f 1 > "$safe_dir/candidate-image-archive.sha256"
@@ -285,21 +325,21 @@ docker exec "$restore_container" psql -U postgres -d "$database_name" -Atc \
   > "$safe_dir/migration-ledger.txt"
 
 CERTIFIER_SHA="${CERTIFIER_SHA:?CERTIFIER_SHA is required}" \
-PHASE5_CANDIDATE_SHA="$phase5_sha" PHASE4_BASELINE_SHA="$phase4_sha" \
+CERT_PHASE="$cert_phase" CANDIDATE_SHA="$candidate_sha" BASELINE_SHA="$baseline_sha" \
 PREDECESSOR_IMAGE="$predecessor_image" IMAGE_REVISION="$image_revision" \
 node --input-type=module - "$safe_dir/certification-summary.json" <<'NODE'
 import { writeFileSync } from 'node:fs';
 const output = process.argv[2];
 writeFileSync(output, `${JSON.stringify({
-  schema: 'deft.app_platform.phase5.release_host.v1',
+  schema: `deft.app_platform.${process.env.CERT_PHASE}.release_host.v1`,
   result: 'passed',
   certifier_sha: process.env.CERTIFIER_SHA,
-  candidate_sha: process.env.PHASE5_CANDIDATE_SHA,
-  baseline_sha: process.env.PHASE4_BASELINE_SHA,
+  candidate_sha: process.env.CANDIDATE_SHA,
+  baseline_sha: process.env.BASELINE_SHA,
   candidate_revision: process.env.IMAGE_REVISION,
   predecessor_image: process.env.PREDECESSOR_IMAGE,
   published: false,
 }, null, 2)}\n`, { mode: 0o644 });
 NODE
 
-echo 'Phase 5 immutable non-publishing certification passed.'
+echo "${cert_phase} immutable non-publishing certification passed."


### PR DESCRIPTION
## Summary
- close Phase 6 App-origin lifecycle and exact-token read isolation gaps
- add one bounded, live-manager App operations projection without exposing repair or sensitive payloads
- certify the immutable product candidate `16875df2f6c9dc2bc3d850de6758b7dd56767a05` through packed external authoring, real stdio provider execution, lifecycle upgrade/disable/re-enable, offline fail-closed behavior, Compose/self-host, pgvector, backup/restore, predecessor-read, and cleanup evidence
- keep the release claim bounded to **Connected App Platform beta**

## Local evidence
- `pnpm --filter @deft/api typecheck`
- focused API/architecture/receipt/operations tests: 51 passed; the sole local DB assertion is blocked by the documented stale local schema missing `job_queue.org_id`
- `pnpm --filter @deft/app-kit test`: 23 passed, including clean packed external installation
- Phase 5 + Phase 6 certification workflow contracts: 14 passed
- shell syntax, Node syntax, YAML parse, and `git diff --check` passed

## Release evidence
The new manual, read-only workflow pins the exact product candidate above. It publishes nothing. After merge it must pass before the Phase 6 audit/claim is sealed.