### PR TITLE
test(apps): run image conformance without rebuilding

### DIFF
--- a/scripts/app-platform-phase6-certification-workflow.test.mjs
+++ b/scripts/app-platform-phase6-certification-workflow.test.mjs
@@ -128,6 +128,11 @@ test('shared gate receives the Phase 6 roots, hooks, and exact isolated resource
     setupHook,
     /app_run_authorization_version = app_run_authorization_version \+ 1/,
   );
+  assert.match(
+    setupHook,
+    /pnpm --filter @deft\/app-kit exec tsx --test test\/\*\.test\.ts/,
+  );
+  assert.doesNotMatch(setupHook, /pnpm --filter @deft\/app-kit test/);
   assert.match(offlineHook, /\[\[ "\$after_total" == "\$before_total" \]\]/);
   assert.match(offlineHook, /invocation_failed_without_creating_a_run/);
 });

--- a/scripts/ci/app-platform-phase6-certification-setup.sh
+++ b/scripts/ci/app-platform-phase6-certification-setup.sh
@@ -136,7 +136,7 @@ docker run --rm --network "$network" \
   -e DEFT_APP_RUN_KEYRINGS="$keyring_json" \
   --entrypoint sh "$candidate_tag" -c '
     pnpm --filter @deft/shared exec tsx --test test/capabilities.test.ts test/app-runs.test.ts &&
-    pnpm --filter @deft/app-kit test &&
+    pnpm --filter @deft/app-kit exec tsx --test test/*.test.ts &&
     pnpm --filter @deft/api exec tsx --test \
       test/capability-service.test.ts \
       test/capability-immediate-execution-db.test.ts \


### PR DESCRIPTION
## Outcome

Repairs the immutable Phase 6 certification harness after run 33486588658 failed inside the exact production image.

## Change

- run App Kit conformance tests directly with the candidate image's existing tsx runtime and built artifacts
- guard the workflow contract against invoking the package test script, whose pretest rebuild requires the intentionally absent root tsconfig
- leave the pinned product candidate SHA and all certification requirements unchanged

## Evidence

- Git Bash syntax check for the setup hook
- Phase 5 + Phase 6 workflow contract tests: 14/14 passed
- git diff --check