### PR TITLE
fix(apps): boot Track A certifier with prerequisites

### DIFF
--- a/scripts/app-platform-track-a-certification-workflow.test.mjs
+++ b/scripts/app-platform-track-a-certification-workflow.test.mjs
@@ -151,6 +151,17 @@ test('automation is explicitly enabled in every candidate boot and the setup hoo
   assert.match(setupHook, /DEFT_APP_AUTOMATIONS_ENABLED[^\n]*true|true[^\n]*DEFT_APP_AUTOMATIONS_ENABLED/);
 });
 
+test('candidate boots enable the rollout prerequisites before automation', () => {
+  assert.match(
+    orchestrator,
+    /run_candidate\(\) \{[\s\S]*?-e DEFT_APPS_ENABLED=true \\\r?\n\s+-e DEFT_APP_RUNS_ENABLED=true \\\r?\n\s+-e DEFT_APP_RUN_APP_ORIGIN_ENABLED=true \\\r?\n\s+-e DEFT_APP_AUTOMATIONS_ENABLED="\$app_automations_enabled"/,
+  );
+  assert.match(
+    orchestrator,
+    /-v "\$\{candidate_root\}\/examples:\/app\/examples:ro"[\s\S]*?-e DEFT_APPS_ENABLED=true \\\r?\n\s+-e DEFT_APP_RUNS_ENABLED=true \\\r?\n\s+-e DEFT_APP_RUN_APP_ORIGIN_ENABLED=true \\\r?\n\s+-e DEFT_APP_AUTOMATIONS_ENABLED="\$app_automations_enabled"/,
+  );
+});
+
 test('the exact browser fixture is mandatory, so the Phase 6 legacy path cannot pass', () => {
   assert.match(
     workflow,

--- a/scripts/ci/certify-app-platform-phase5.sh
+++ b/scripts/ci/certify-app-platform-phase5.sh
@@ -82,6 +82,9 @@ run_candidate() {
     -e JWT_SECRET=phase5-cert-jwt-not-for-prod \
     -e JWT_REFRESH_SECRET=phase5-cert-refresh-not-for-prod \
     -e ENCRYPTION_KEY=phase5-cert-envelope-key-32bytes \
+    -e DEFT_APPS_ENABLED=true \
+    -e DEFT_APP_RUNS_ENABLED=true \
+    -e DEFT_APP_RUN_APP_ORIGIN_ENABLED=true \
     -e DEFT_APP_AUTOMATIONS_ENABLED="$app_automations_enabled" \
     --entrypoint sh "$candidate_tag" -c "$2"
 }
@@ -161,6 +164,9 @@ docker run --rm --network "$network" \
   -e JWT_SECRET=phase5-cert-jwt-not-for-prod \
   -e JWT_REFRESH_SECRET=phase5-cert-refresh-not-for-prod \
   -e ENCRYPTION_KEY=phase5-cert-envelope-key-32bytes \
+  -e DEFT_APPS_ENABLED=true \
+  -e DEFT_APP_RUNS_ENABLED=true \
+  -e DEFT_APP_RUN_APP_ORIGIN_ENABLED=true \
   -e DEFT_APP_AUTOMATIONS_ENABLED="$app_automations_enabled" \
   --entrypoint sh "$candidate_tag" \
   -c 'pnpm --filter @deft/api exec tsx --test test/phase5-proof-package-determinism.test.ts test/phase5-sandbox-email-provider.test.ts test/app-origin-run-lifecycle-db.test.ts'


### PR DESCRIPTION
## Summary
- pass the required Apps and App Run rollout flags into early Track A candidate containers
- lock the dependency ordering with a certification contract test

## Evidence
- 
ode --test scripts/app-platform-track-a-certification-workflow.test.mjs scripts/app-platform-phase6-certification-workflow.test.mjs scripts/app-platform-certification-workflow.test.mjs (27/27)
- git diff --check`n- first immutable gate run 33525034566 isolated the failure to missing prerequisite env; cleanup and safe evidence upload passed

## Scope
- certifier-only; the pinned product candidate remains ff5a3fae3e21b80fe51849e6cd8023d5228389d0
- no product, schema, UI, deployment, or published artifact changes