### PR TITLE
fix(apps): bootstrap Track A certification keyring

### DIFF
--- a/scripts/app-platform-certification-workflow.test.mjs
+++ b/scripts/app-platform-certification-workflow.test.mjs
@@ -89,8 +89,8 @@ test('certification uses real pgvector and proves matched backup, restore, and k
   assert.match(orchestrator, /restored-verification\.json/);
   assert.match(orchestrator, /host_uid="\$\(id -u\)"/);
   assert.match(orchestrator, /host_gid="\$\(id -g\)"/);
-  assert.equal(occurrences(orchestrator, "chown \"$HOST_UID:$HOST_GID\""), 4);
-  assert.equal(occurrences(orchestrator, 'certification-probe.ts keyring'), 2);
+  assert.equal(occurrences(orchestrator, "chown \"$HOST_UID:$HOST_GID\""), 5);
+  assert.equal(occurrences(orchestrator, 'certification-probe.ts keyring'), 3);
   const demoSeed = orchestrator.indexOf('pnpm --filter @deft/db seed:demo');
   const candidateUpgrade = orchestrator.indexOf('pnpm db:upgrade && pnpm module:verify');
   assert.notEqual(demoSeed, -1);

--- a/scripts/app-platform-phase6-certification-workflow.test.mjs
+++ b/scripts/app-platform-phase6-certification-workflow.test.mjs
@@ -138,7 +138,7 @@ test('shared gate receives the Phase 6 roots, hooks, and exact isolated resource
   assert.match(orchestrator, /git -C "\$candidate_root" rev-parse HEAD/);
   assert.match(orchestrator, /test\/app-origin-run-lifecycle-db\.test\.ts/);
   assert.match(orchestrator, /run_extension_hook "\$setup_hook" setup/);
-  assert.equal(occurrences(orchestrator, 'certification-probe.ts keyring'), 2);
+  assert.equal(occurrences(orchestrator, 'certification-probe.ts keyring'), 3);
   assert.match(
     orchestrator,
     /certification-probe\.ts keyring[\s\S]*run_extension_hook "\$setup_hook" setup[\s\S]*certification-probe\.ts keyring[\s\S]*app-run-keyring\.sha256/,

--- a/scripts/app-platform-track-a-certification-workflow.test.mjs
+++ b/scripts/app-platform-track-a-certification-workflow.test.mjs
@@ -154,11 +154,18 @@ test('automation is explicitly enabled in every candidate boot and the setup hoo
 test('candidate boots enable the rollout prerequisites before automation', () => {
   assert.match(
     orchestrator,
-    /run_candidate\(\) \{[\s\S]*?-e DEFT_APPS_ENABLED=true \\\r?\n\s+-e DEFT_APP_RUNS_ENABLED=true \\\r?\n\s+-e DEFT_APP_RUN_APP_ORIGIN_ENABLED=true \\\r?\n\s+-e DEFT_APP_AUTOMATIONS_ENABLED="\$app_automations_enabled"/,
+    /run_candidate\(\) \{[\s\S]*?-e DEFT_APPS_ENABLED=true \\\r?\n\s+-e DEFT_APP_RUNS_ENABLED=true \\\r?\n\s+-e DEFT_APP_RUN_APP_ORIGIN_ENABLED=true \\\r?\n\s+-e DEFT_APP_AUTOMATIONS_ENABLED="\$app_automations_enabled" \\\r?\n\s+-e DEFT_APP_RUN_KEYRINGS="\$\{keyring_json:-\}"/,
   );
   assert.match(
     orchestrator,
-    /-v "\$\{candidate_root\}\/examples:\/app\/examples:ro"[\s\S]*?-e DEFT_APPS_ENABLED=true \\\r?\n\s+-e DEFT_APP_RUNS_ENABLED=true \\\r?\n\s+-e DEFT_APP_RUN_APP_ORIGIN_ENABLED=true \\\r?\n\s+-e DEFT_APP_AUTOMATIONS_ENABLED="\$app_automations_enabled"/,
+    /-v "\$\{candidate_root\}\/examples:\/app\/examples:ro"[\s\S]*?-e DEFT_APPS_ENABLED=true \\\r?\n\s+-e DEFT_APP_RUNS_ENABLED=true \\\r?\n\s+-e DEFT_APP_RUN_APP_ORIGIN_ENABLED=true \\\r?\n\s+-e DEFT_APP_AUTOMATIONS_ENABLED="\$app_automations_enabled" \\\r?\n\s+-e DEFT_APP_RUN_KEYRINGS="\$keyring_json"/,
+  );
+});
+
+test('a disposable keyring exists before the first rollout-enabled candidate boot', () => {
+  assert.match(
+    orchestrator,
+    /candidate-image-revision\.txt"[\s\S]*?certification-probe\.ts keyring --output \/recovery\/app-run-keyrings\.json[\s\S]*?keyring_json="\$\(tr -d '\\n' < "\$keyring_path"\)"[\s\S]*?run_candidate "\$source_url_container" 'pnpm db:upgrade/,
   );
 });
 
@@ -192,7 +199,7 @@ test('the exact candidate database matrix includes grants and the automation lif
   assert.match(setupProbe, /appAutomationDefinitions/);
   assert.match(
     orchestrator,
-    /-e DEFT_APP_AUTOMATIONS_ENABLED="\$app_automations_enabled" \\\r?\n\s+--entrypoint sh "\$candidate_tag" \\\r?\n\s+-c '[^']*test\/app-origin-run-lifecycle-db\.test\.ts'/,
+    /-e DEFT_APP_AUTOMATIONS_ENABLED="\$app_automations_enabled" \\\r?\n\s+-e DEFT_APP_RUN_KEYRINGS="\$keyring_json" \\\r?\n\s+--entrypoint sh "\$candidate_tag" \\\r?\n\s+-c '[^']*test\/app-origin-run-lifecycle-db\.test\.ts'/,
   );
   assert.match(orchestrator, /run_extension_hook "\$setup_hook" setup/);
 });

--- a/scripts/ci/certify-app-platform-phase5.sh
+++ b/scripts/ci/certify-app-platform-phase5.sh
@@ -86,6 +86,7 @@ run_candidate() {
     -e DEFT_APP_RUNS_ENABLED=true \
     -e DEFT_APP_RUN_APP_ORIGIN_ENABLED=true \
     -e DEFT_APP_AUTOMATIONS_ENABLED="$app_automations_enabled" \
+    -e DEFT_APP_RUN_KEYRINGS="${keyring_json:-}" \
     --entrypoint sh "$candidate_tag" -c "$2"
 }
 
@@ -155,6 +156,16 @@ image_revision="$(docker image inspect "$candidate_tag" --format '{{index .Confi
 docker image inspect "$candidate_tag" > "$safe_dir/candidate-image-inspect.json"
 printf '%s\n' "$image_revision" > "$safe_dir/candidate-image-revision.txt"
 
+docker run --rm --network "$network" \
+  -v "${certifier_root}/scripts/ci/app-platform-phase5-certification-probe.ts:/app/scripts/ci/app-platform-phase5-certification-probe.ts:ro" \
+  -v "${recovery_dir}:/recovery" \
+  -e DATABASE_URL="$source_url_container" -e DEFT_TEST_DATABASE_URL="$source_url_container" \
+  -e HOST_UID="$host_uid" -e HOST_GID="$host_gid" \
+  --entrypoint sh "$candidate_tag" \
+  -c 'pnpm exec tsx scripts/ci/app-platform-phase5-certification-probe.ts keyring --output /recovery/app-run-keyrings.json && chown "$HOST_UID:$HOST_GID" /recovery/app-run-keyrings.json'
+chmod 600 "$keyring_path"
+keyring_json="$(tr -d '\n' < "$keyring_path")"
+
 run_candidate "$source_url_container" 'pnpm db:upgrade && pnpm module:verify'
 run_candidate "$source_url_container" 'pnpm --filter @deft/api exec tsx src/scripts/seed-platform-bundles.ts'
 docker run --rm --network "$network" \
@@ -168,6 +179,7 @@ docker run --rm --network "$network" \
   -e DEFT_APP_RUNS_ENABLED=true \
   -e DEFT_APP_RUN_APP_ORIGIN_ENABLED=true \
   -e DEFT_APP_AUTOMATIONS_ENABLED="$app_automations_enabled" \
+  -e DEFT_APP_RUN_KEYRINGS="$keyring_json" \
   --entrypoint sh "$candidate_tag" \
   -c 'pnpm --filter @deft/api exec tsx --test test/phase5-proof-package-determinism.test.ts test/phase5-sandbox-email-provider.test.ts test/app-origin-run-lifecycle-db.test.ts'
 


### PR DESCRIPTION
## Summary
- generate the existing disposable deterministic App Run keyring before the first rollout-enabled candidate boot
- pass it through early upgrade, seed, and database-test containers
- retain post-test and post-setup keyring regeneration and continuity proofs

## Evidence
- 
ode --test scripts/app-platform-track-a-certification-workflow.test.mjs scripts/app-platform-phase6-certification-workflow.test.mjs scripts/app-platform-certification-workflow.test.mjs (28/28)
- git diff --check`n- release-host run 33526810141 confirmed the prerequisite fix and isolated the next failure to the previously late keyring generation

## Scope
- certifier-only; pinned product candidate remains ff5a3fae3e21b80fe51849e6cd8023d5228389d0
- no product, schema, UI, deployment, or published artifact changes