### PR TITLE
Fix Track A lifecycle certification fixture

### DIFF
--- a/.github/workflows/app-platform-track-a-certification.yml
+++ b/.github/workflows/app-platform-track-a-certification.yml
@@ -19,7 +19,7 @@ env:
   APP_PLATFORM_RESOURCE_PREFIX: deft-track-a-cert-${{ github.run_id }}-${{ github.run_attempt }}
   APP_PLATFORM_CANDIDATE_TAG: deft:track-a-cert-${{ github.run_id }}-${{ github.run_attempt }}
   APP_PLATFORM_COMPOSE_PROJECT: deft-track-a-compose-${{ github.run_id }}-${{ github.run_attempt }}
-  APP_PLATFORM_DATABASE_NAME: deft_phase6_track_a_release_test
+  APP_PLATFORM_DATABASE_NAME: deft_phase5_phase6_track_a_release_test
   DEFT_APP_AUTOMATIONS_ENABLED: 'true'
 
 jobs:

--- a/scripts/app-platform-track-a-certification-workflow.test.mjs
+++ b/scripts/app-platform-track-a-certification-workflow.test.mjs
@@ -79,6 +79,13 @@ test('candidate, Phase 6 baseline, and supported predecessor are immutable and v
   assert.match(orchestrator, /\[\[ "\$predecessor_revision" == "\$predecessor_commit" \]\]/);
 });
 
+test('the disposable database activates inherited Phase 5 and Track A proofs', () => {
+  assert.match(
+    workflow,
+    /APP_PLATFORM_DATABASE_NAME:\s*deft_phase5_phase6_track_a_release_test/,
+  );
+});
+
 test('candidate receives one dependency install, typecheck, production build, and packed proof', () => {
   assert.equal(occurrences(workflow, 'pnpm install --frozen-lockfile'), 3);
   assert.equal(occurrences(workflow, 'run: pnpm typecheck'), 1);


### PR DESCRIPTION
## Summary
- preserve the exact Track A product candidate
- name the disposable certification database so inherited Phase 5 lifecycle tests execute instead of skipping
- add a static regression assertion for the database identity

## Evidence
- failed immutable run 33530622510 reached host certification, skipped the Phase 5 App-origin lifecycle test, and then failed its seeded proof-user assertion
- all 30 App-platform certification static tests pass locally
- git diff --check passes

## Scope
Certifier-only. No product, migration, deployment, token, or public contract changes.