### PR TITLE
Fix Track A package-format certification assertion

### DIFF
--- a/apps/api/src/scripts/app-platform-track-a-certification-setup.ts
+++ b/apps/api/src/scripts/app-platform-track-a-certification-setup.ts
@@ -58,7 +58,7 @@ async function main(): Promise<void> {
     package_format?: string;
     manifest?: { id?: string; version?: string; schema_version?: string; compatibility?: { app_protocol?: string } };
   };
-  assert.equal(packed.package_format, 'deft.app.package.v1');
+  assert.equal(packed.package_format, 'deft.app.package.v2');
   assert.equal(packed.manifest?.id, CAMPAIGN_APP_ID);
   assert.equal(packed.manifest?.version, '4.0.0');
   assert.equal(packed.manifest?.schema_version, '2');

--- a/scripts/app-platform-track-a-certification-setup.test.mjs
+++ b/scripts/app-platform-track-a-certification-setup.test.mjs
@@ -29,6 +29,7 @@ test('Track A setup delegates Phase 6 and adds only the frozen automation prereq
   assert.match(setupProbe, /stageAppUpgrade/);
   assert.match(setupProbe, /prepareConnectedAppReview/);
   assert.match(setupProbe, /activateConnectedAppInstallation/);
+  assert.match(setupProbe, /assert\.equal\(packed\.package_format, 'deft\.app\.package\.v2'\)/);
   assert.match(setupProbe, /appAutomationDefinitions/);
   assert.match(setupProbe, /assert\.equal\(definitionsAfter\.length, 0\)/);
   assert.match(setupProbe, /assert\.equal\(campaignRecords\.length, 1\)/);


### PR DESCRIPTION
## Summary
- preserve the exact Track A product candidate
- update the Track A setup probe to expect its actual App Protocol v2 package format
- add a static regression assertion

## Evidence
- immutable master run 33532473358 passed 117 host tests, built deft.app.package.v2, then failed only because this certifier asserted v1
- all 30 App-platform certification static tests pass locally
- API typecheck passes
- git diff --check passes

## Scope
Certifier-only. No product behavior, migration, deployment, token, or public contract changes.