### PR TITLE
Certify Track A migration and automation continuity

### DIFF
--- a/.github/workflows/app-platform-track-a-certification.yml
+++ b/.github/workflows/app-platform-track-a-certification.yml
@@ -20,6 +20,8 @@ env:
   APP_PLATFORM_CANDIDATE_TAG: deft:track-a-cert-${{ github.run_id }}-${{ github.run_attempt }}
   APP_PLATFORM_COMPOSE_PROJECT: deft-track-a-compose-${{ github.run_id }}-${{ github.run_attempt }}
   APP_PLATFORM_DATABASE_NAME: deft_phase5_phase6_track_a_release_test
+  APP_PLATFORM_EXPECTED_LATEST_MIGRATION: 0.3.0-preview.26
+  APP_PLATFORM_INCLUDE_TRACK_A_CONTINUITY: 'true'
   DEFT_APP_AUTOMATIONS_ENABLED: 'true'
 
 jobs:

--- a/scripts/app-platform-track-a-certification-workflow.test.mjs
+++ b/scripts/app-platform-track-a-certification-workflow.test.mjs
@@ -84,6 +84,27 @@ test('the disposable database activates inherited Phase 5 and Track A proofs', (
     workflow,
     /APP_PLATFORM_DATABASE_NAME:\s*deft_phase5_phase6_track_a_release_test/,
   );
+  assert.match(
+    workflow,
+    /APP_PLATFORM_EXPECTED_LATEST_MIGRATION:\s*0\.3\.0-preview\.26/,
+  );
+  assert.match(workflow, /APP_PLATFORM_INCLUDE_TRACK_A_CONTINUITY:\s*'true'/);
+  assert.equal(
+    occurrences(
+      orchestrator,
+      '-e APP_PLATFORM_EXPECTED_LATEST_MIGRATION="$expected_latest_migration"',
+    ),
+    2,
+  );
+  assert.equal(
+    occurrences(
+      orchestrator,
+      '-e APP_PLATFORM_INCLUDE_TRACK_A_CONTINUITY="$include_track_a_continuity"',
+    ),
+    2,
+  );
+  assert.match(setupProbe, /appAutomationDefinitions/);
+  assert.match(orchestrator, /include_track_a_continuity=.*false/);
 });
 
 test('candidate receives one dependency install, typecheck, production build, and packed proof', () => {

--- a/scripts/ci/app-platform-phase5-certification-probe.test.ts
+++ b/scripts/ci/app-platform-phase5-certification-probe.test.ts
@@ -7,6 +7,7 @@ import { digestSupportedModuleManifest } from '../../packages/shared/src/index.j
 import {
   __test,
   assembleContinuitySnapshot,
+  certificationContinuityTables,
   classifySucceededPayloadEvidence,
   deterministicCertificationKeyring,
   parseCliArgs,
@@ -93,10 +94,34 @@ test('continuity hash is deterministic, metadata-bound, and contains no row valu
 
   const changed = assembleContinuitySnapshot({ ...input, pgvectorVersion: '0.8.2' });
   assert.notEqual(changed.continuity_sha256, first.continuity_sha256);
+  assert.equal(
+    assembleContinuitySnapshot({
+      ...input,
+      migrations: [{ version: '0.3.0-preview.26', checksum: 'sha256:track-a-migration' }],
+    }, '0.3.0-preview.26').latest_migration,
+    '0.3.0-preview.26',
+  );
+  assert.throws(
+    () => assembleContinuitySnapshot(input, '0.3.0-preview.26'),
+    /PHASE5_MIGRATION_NOT_CURRENT/,
+  );
   assert.deepEqual(__test.parseContinuitySnapshot(first), first);
   assert.throws(
     () => __test.parseContinuitySnapshot({ ...first, continuity_sha256: `sha256:${'0'.repeat(64)}` }),
     /EXPECTED_SNAPSHOT_HASH_INVALID/,
+  );
+});
+
+test('Track A continuity adds only automation authority and fire state', () => {
+  assert.deepEqual(certificationContinuityTables('false'), __test.CONTINUITY_TABLES);
+  assert.deepEqual(certificationContinuityTables('true'), [
+    ...__test.CONTINUITY_TABLES,
+    'app_automation_definitions',
+    'app_automation_fires',
+  ]);
+  assert.throws(
+    () => certificationContinuityTables('app_automation_definitions'),
+    /TRACK_A_CONTINUITY_MODE_INVALID/,
   );
 });
 

--- a/scripts/ci/app-platform-phase5-certification-probe.ts
+++ b/scripts/ci/app-platform-phase5-certification-probe.ts
@@ -35,6 +35,10 @@ const CONTINUITY_TABLES = Object.freeze([
   'resource_relation_receipts',
   'resource_relation_sets',
 ] as const);
+const TRACK_A_CONTINUITY_TABLES = Object.freeze([
+  'app_automation_definitions',
+  'app_automation_fires',
+] as const);
 
 const EXPECTED_APP_PACKAGE_DIGESTS = Object.freeze([
   'sha256:1471f0b94da9f6851bd978c315bc22a2dd0343b61a87477e4293b144c54248d8',
@@ -46,7 +50,8 @@ const EXPECTED_APP_PACKAGE_DIGESTS = Object.freeze([
 // package-artifact digest is already pinned by the exact App package digest.
 const EXPECTED_MODULE_MANIFEST_DIGEST =
   'sha256:70a2c14dffc15b7e8aa1e056a53b5933fa351e305d86e13ebf467bf8159287f2';
-const EXPECTED_LATEST_MIGRATION = '0.3.0-preview.25';
+const EXPECTED_LATEST_MIGRATION =
+  process.env.APP_PLATFORM_EXPECTED_LATEST_MIGRATION?.trim() || '0.3.0-preview.25';
 
 type CliOptions = Readonly<{
   mode: 'keyring' | 'snapshot' | 'verify';
@@ -262,7 +267,7 @@ export function assembleContinuitySnapshot(input: Readonly<{
   pgvectorVersion: string;
   migrations: readonly unknown[];
   tables: readonly ContinuityTableSnapshot[];
-}>): ContinuitySnapshot {
+}>, expectedLatestMigration = EXPECTED_LATEST_MIGRATION): ContinuitySnapshot {
   if (input.migrations.length === 0) {
     throw new CertificationProbeError('MIGRATION_LEDGER_EMPTY');
   }
@@ -274,7 +279,7 @@ export function assembleContinuitySnapshot(input: Readonly<{
   if (typeof latestMigration !== 'string' || !latestMigration) {
     throw new CertificationProbeError('MIGRATION_LEDGER_INVALID');
   }
-  if (latestMigration !== EXPECTED_LATEST_MIGRATION) {
+  if (latestMigration !== expectedLatestMigration) {
     throw new CertificationProbeError('PHASE5_MIGRATION_NOT_CURRENT');
   }
   const partial = {
@@ -292,9 +297,20 @@ export function assembleContinuitySnapshot(input: Readonly<{
   });
 }
 
+export function certificationContinuityTables(
+  includeTrackA = process.env.APP_PLATFORM_INCLUDE_TRACK_A_CONTINUITY,
+): readonly string[] {
+  if (includeTrackA !== undefined && includeTrackA !== 'true' && includeTrackA !== 'false') {
+    throw new CertificationProbeError('TRACK_A_CONTINUITY_MODE_INVALID');
+  }
+  return includeTrackA === 'true'
+    ? Object.freeze([...CONTINUITY_TABLES, ...TRACK_A_CONTINUITY_TABLES])
+    : CONTINUITY_TABLES;
+}
+
 async function createContinuitySnapshot(client: PgClient): Promise<ContinuitySnapshot> {
   const tables: ContinuityTableSnapshot[] = [];
-  for (const table of CONTINUITY_TABLES) {
+  for (const table of certificationContinuityTables()) {
     const result = await client.query<{ value: unknown }>(
       `SELECT to_jsonb(certification_row) AS value
          FROM (SELECT * FROM "${table}" ORDER BY id) AS certification_row`,
@@ -683,6 +699,7 @@ if (invokedPath && fileURLToPath(import.meta.url) === invokedPath) {
 export const __test = Object.freeze({
   SNAPSHOT_SCHEMA,
   CONTINUITY_TABLES,
+  TRACK_A_CONTINUITY_TABLES,
   EXPECTED_APP_PACKAGE_DIGESTS,
   EXPECTED_MODULE_MANIFEST_DIGEST,
   EXPECTED_LATEST_MIGRATION,

--- a/scripts/ci/certify-app-platform-phase5.sh
+++ b/scripts/ci/certify-app-platform-phase5.sh
@@ -14,6 +14,8 @@ browser_script="${APP_PLATFORM_BROWSER_SCRIPT:-${certifier_root}/scripts/ci/app-
 setup_hook="${APP_PLATFORM_SETUP_HOOK:-}"
 offline_hook="${APP_PLATFORM_OFFLINE_HOOK:-}"
 app_automations_enabled="${DEFT_APP_AUTOMATIONS_ENABLED:-false}"
+expected_latest_migration="${APP_PLATFORM_EXPECTED_LATEST_MIGRATION:-0.3.0-preview.25}"
+include_track_a_continuity="${APP_PLATFORM_INCLUDE_TRACK_A_CONTINUITY:-false}"
 
 run_id="${GITHUB_RUN_ID:?GITHUB_RUN_ID is required}"
 run_attempt="${GITHUB_RUN_ATTEMPT:?GITHUB_RUN_ATTEMPT is required}"
@@ -48,6 +50,8 @@ host_gid="$(id -g)"
 [[ "$candidate_tag" =~ ^[A-Za-z0-9][A-Za-z0-9_.:/-]{0,127}$ ]]
 [[ "$database_name" =~ ^[A-Za-z_][A-Za-z0-9_]{0,62}$ ]]
 [[ "$app_automations_enabled" == "true" || "$app_automations_enabled" == "false" ]]
+[[ "$expected_latest_migration" =~ ^[0-9]+\.[0-9]+\.[0-9]+-preview\.[0-9]+$ ]]
+[[ "$include_track_a_continuity" == "true" || "$include_track_a_continuity" == "false" ]]
 
 mkdir -p "$safe_dir" "$recovery_dir"
 chmod 700 "$recovery_dir"
@@ -227,6 +231,8 @@ docker run --rm --network "$network" \
   -v "${safe_dir}:/evidence" \
   -e DATABASE_URL="$source_url_container" -e DEFT_TEST_DATABASE_URL="$source_url_container" \
   -e DEFT_APP_RUN_KEYRINGS="$keyring_json" \
+  -e APP_PLATFORM_EXPECTED_LATEST_MIGRATION="$expected_latest_migration" \
+  -e APP_PLATFORM_INCLUDE_TRACK_A_CONTINUITY="$include_track_a_continuity" \
   -e HOST_UID="$host_uid" -e HOST_GID="$host_gid" \
   --entrypoint sh "$candidate_tag" \
   -c 'pnpm exec tsx scripts/ci/app-platform-phase5-certification-probe.ts snapshot --output /evidence/source-snapshot.json && chown "$HOST_UID:$HOST_GID" /evidence/source-snapshot.json'
@@ -307,6 +313,8 @@ docker run --rm --network "$network" \
   -e DEFT_APP_RUN_LEGACY_MCP_CUTOVER_ENABLED=false \
   -e DEFT_APP_AUTOMATIONS_ENABLED="$app_automations_enabled" \
   -e DEFT_APP_RUN_KEYRINGS="$restored_keyring_json" \
+  -e APP_PLATFORM_EXPECTED_LATEST_MIGRATION="$expected_latest_migration" \
+  -e APP_PLATFORM_INCLUDE_TRACK_A_CONTINUITY="$include_track_a_continuity" \
   -e HOST_UID="$host_uid" -e HOST_GID="$host_gid" \
   --entrypoint sh "$candidate_tag" \
   -c 'pnpm exec tsx scripts/ci/app-platform-phase5-certification-probe.ts verify --expected-snapshot /evidence/source-snapshot.json --output /evidence/restored-verification.json && chown "$HOST_UID:$HOST_GID" /evidence/restored-verification.json'


### PR DESCRIPTION
## Summary
- preserve the exact Track A product candidate
- make the inherited continuity probe accept an explicit certifier-owned latest migration while retaining Phase 5's .25 default
- include pp_automation_definitions and pp_automation_fires in Track A backup/restore hashes only
- reject invalid continuity modes and lock both paths with focused tests

## Evidence
- immutable master run 33534407707 passed 117 host tests and Track A package setup, then failed at the inherited .25 migration assertion against the correct .26 candidate
- bounded follow-up audit found no other stale Track A gate; it identified the two omitted automation state tables as a release-evidence gap
- 30 orchestration tests pass
- 7 continuity-probe tests pass
- API typecheck passes
- certifier shell syntax and git diff --check pass

## Scope
Certifier-only. Phase 5/6 defaults remain unchanged. No product behavior, migration, deployment, token, or public contract changes.