### PR TITLE
fix(certification): restore into disposable database

### DIFF
--- a/scripts/app-platform-track-a-certification-workflow.test.mjs
+++ b/scripts/app-platform-track-a-certification-workflow.test.mjs
@@ -132,6 +132,10 @@ test('one shared orchestration pass owns image, upgrade, restore, predecessor, b
   assert.equal(occurrences(orchestrator, "'pnpm db:upgrade && pnpm module:verify'"), 1);
   assert.equal(occurrences(orchestrator, 'pg_dump -U postgres'), 1);
   assert.equal(occurrences(orchestrator, 'pg_restore -U postgres'), 1);
+  assert.match(orchestrator, /pg_restore -U postgres[^\n]+\\\s*\n\s*--exit-on-error/);
+  assert.doesNotMatch(orchestrator, /pg_restore[^\n]+--clean/);
+  assert.match(orchestrator, /cat "\$restore_log" >&2/);
+  assert.match(orchestrator, /rm -f "\$restore_log"/);
   assert.equal(occurrences(orchestrator, 'docker pull "$predecessor_image"'), 1);
   assert.equal(occurrences(orchestrator, 'node "$browser_script"'), 1);
   assert.equal(occurrences(orchestrator, 'run_extension_hook "$offline_hook" offline'), 1);

--- a/scripts/ci/certify-app-platform-phase5.sh
+++ b/scripts/ci/certify-app-platform-phase5.sh
@@ -252,7 +252,13 @@ docker run -d --name "$restore_container" --network "$network" \
 wait_for_postgres "$restore_container"
 docker exec "$restore_container" psql -U postgres -d "$database_name" -v ON_ERROR_STOP=1 \
   -c 'CREATE EXTENSION IF NOT EXISTS vector;'
-docker exec -i "$restore_container" pg_restore -U postgres -d "$database_name" --clean --if-exists < "$dump_path"
+restore_log="$safe_dir/database-restore.log"
+if ! docker exec -i "$restore_container" pg_restore -U postgres -d "$database_name" \
+  --exit-on-error < "$dump_path" > "$restore_log" 2>&1; then
+  cat "$restore_log" >&2
+  exit 1
+fi
+rm -f "$restore_log"
 
 read -r probe_org probe_employee probe_record < <(
   docker exec "$restore_container" psql -U postgres -d "$database_name" -At -F ' ' -c "


### PR DESCRIPTION
## Summary
- restore the immutable App Platform snapshot into the already-fresh disposable database without a redundant clean pass
- stop on the first real restore error and retain a bounded diagnostic log only on failure
- lock the behavior with the Track A orchestration test

## Verification
- 36 focused certification orchestration/probe tests pass
- Git Bash syntax check passes
- git diff --check passes