### PR TITLE
fix(apps): preserve UI authority for automation review

### DIFF
--- a/apps/api/src/lib/app-automation-management-service.ts
+++ b/apps/api/src/lib/app-automation-management-service.ts
@@ -47,6 +47,27 @@ function unavailable(message: string): never {
   throw new AppError(message, 'APP_STALE', 409);
 }
 
+function interactiveAutomationActionActor(
+  actor: ModuleActor,
+): Extract<ModuleActor, { kind: 'human' }> {
+  if (
+    actor.kind !== 'human'
+    || (actor.role !== 'owner' && actor.role !== 'admin')
+    || (actor.source !== 'ui' && actor.source !== 'rest')
+  ) {
+    throw new AppError(
+      'Only interactive workspace owners and admins can manage App automations',
+      'APP_ACCESS_DENIED',
+      403,
+    );
+  }
+  // The /api/apps management adapter authenticates an interactive browser
+  // through its REST route. App Action prepared authority records the caller
+  // surface, not the transport, so keep the original actor for approval/audit
+  // and use the established human:ui surface only for effect-free preparation.
+  return Object.freeze({ ...actor, source: 'ui' });
+}
+
 function refIdentity(ref: AppActionResourceEvidence['ref']): string {
   return `${ref.provider.provider_instance_id}\0${ref.resource_type}\0${ref.resource_id}`;
 }
@@ -88,7 +109,9 @@ async function resolveReviewInput(
       400,
     );
   }
-  const prepared = await appActionService.prepare({ actor }, {
+  const prepared = await appActionService.prepare({
+    actor: interactiveAutomationActionActor(actor),
+  }, {
     binding_id: input.binding_id,
     resource_ref: input.resource_ref,
     selections: input.selections,

--- a/apps/api/test/app-action-architecture.test.ts
+++ b/apps/api/test/app-action-architecture.test.ts
@@ -287,7 +287,13 @@ test('automation authoring and management stay generic and derive resource pins 
   const routes = await readFile(join(sourceRoot, 'routes/apps.ts'), 'utf8');
   assert.doesNotMatch(management, /campaign|contact|newsletter/i);
   assert.doesNotMatch(management, /capabilityService\.invoke|\.executeTool\s*\(/);
-  assert.match(management, /appActionService\.prepare/);
+  assert.match(
+    management,
+    /appActionService\.prepare\(\{\s*actor: interactiveAutomationActionActor\(actor\),?\s*\}/,
+    'managed review must adapt the interactive REST transport to established human:ui App Action authority',
+  );
+  assert.match(management, /keep the original actor for approval\/audit/);
+  assert.doesNotMatch(management, /source:\s*'rest'\s*\}\s*,\s*\{/);
   assert.match(management, /digestAppGrantValue\(record\.data\)/);
   assert.match(management, /prepareAppAutomationDefinitionReview/);
   assert.match(management, /createReviewedAppAutomationDefinition/);

--- a/scripts/ci/app-platform-phase6-browser-smoke.mjs
+++ b/scripts/ci/app-platform-phase6-browser-smoke.mjs
@@ -603,7 +603,16 @@ async function exerciseTrackAAutomation(
   }, { timeout: 20_000 });
   await dialog.getByRole('button', { name: 'Review schedule', exact: true }).click();
   const reviewResponse = await reviewResponsePromise;
-  requireCondition(reviewResponse.ok(), 'AUTOMATION_REVIEW_FAILED');
+  if (!reviewResponse.ok()) {
+    const failureBody = await reviewResponse.json().catch(() => null);
+    const responseCode = typeof failureBody?.code === 'string'
+      && /^[A-Z][A-Z0-9_]{0,63}$/.test(failureBody.code)
+      ? failureBody.code
+      : 'UNKNOWN';
+    throw new CertificationFailure(
+      `AUTOMATION_REVIEW_FAILED_${reviewResponse.status()}_${responseCode}`,
+    );
+  }
   const reviewBody = await reviewResponse.json().catch(() => null);
   const review = reviewBody?.review;
   requireCondition(


### PR DESCRIPTION
## Outcome\n- adapt the authenticated interactive App automation manager to the established human:ui App Action authority surface during effect-free review preparation\n- keep the original manager actor for resource pinning, approval, and audit\n- retain only bounded HTTP status/structured error codes in Track A browser certification failures\n\n## Trust boundary\nThis does not add human:rest to the sealed authority contract or broaden App execution authority. Non-human, non-manager, and MCP actors remain rejected.\n\n## Evidence\n- pnpm --filter @deft/api exec tsx --test test/app-action-architecture.test.ts\n- pnpm --filter @deft/api typecheck\n- git diff --check\n\nThe final immutable Track A certification will run after merge against the exact merged candidate SHA.