### PR TITLE
fix(apps): validate automation create through review seam

### DIFF
--- a/apps/api/src/lib/app-automation-management-service.ts
+++ b/apps/api/src/lib/app-automation-management-service.ts
@@ -168,11 +168,16 @@ export async function createManagedAppAutomation(
   rawInput: z.input<typeof AppAutomationCreateRequestSchema>,
 ) {
   const input = AppAutomationCreateRequestSchema.parse(rawInput);
-  const reviewInput = await resolveReviewInput(actor, appInstallationId, input);
+  const {
+    expected_review_digest: expectedReviewDigest,
+    accept_code_owned_policy: acceptCodeOwnedPolicy,
+    ...reviewRequest
+  } = input;
+  const reviewInput = await resolveReviewInput(actor, appInstallationId, reviewRequest);
   return createReviewedAppAutomationDefinition(actor, {
     ...reviewInput,
-    expected_review_digest: input.expected_review_digest as `sha256:${string}`,
-    accept_code_owned_policy: input.accept_code_owned_policy,
+    expected_review_digest: expectedReviewDigest as `sha256:${string}`,
+    accept_code_owned_policy: acceptCodeOwnedPolicy,
   });
 }
 

--- a/apps/api/test/app-action-architecture.test.ts
+++ b/apps/api/test/app-action-architecture.test.ts
@@ -294,6 +294,11 @@ test('automation authoring and management stay generic and derive resource pins 
   );
   assert.match(management, /keep the original actor for approval\/audit/);
   assert.doesNotMatch(management, /source:\s*'rest'\s*\}\s*,\s*\{/);
+  assert.match(
+    management,
+    /expected_review_digest:\s*expectedReviewDigest[\s\S]*?accept_code_owned_policy:\s*acceptCodeOwnedPolicy[\s\S]*?\.\.\.reviewRequest[\s\S]*?resolveReviewInput\(actor, appInstallationId, reviewRequest\)/,
+    'create-only proof fields must be removed before strict review-request validation',
+  );
   assert.match(management, /digestAppGrantValue\(record\.data\)/);
   assert.match(management, /prepareAppAutomationDefinitionReview/);
   assert.match(management, /createReviewedAppAutomationDefinition/);

--- a/scripts/ci/app-platform-phase6-browser-smoke.mjs
+++ b/scripts/ci/app-platform-phase6-browser-smoke.mjs
@@ -42,6 +42,15 @@ function requireCondition(condition, code) {
   if (!condition) throw new CertificationFailure(code);
 }
 
+async function throwSafeResponseFailure(response, prefix) {
+  const failureBody = await response.json().catch(() => null);
+  const responseCode = typeof failureBody?.code === 'string'
+    && /^[A-Z][A-Z0-9_]{0,63}$/.test(failureBody.code)
+    ? failureBody.code
+    : 'UNKNOWN';
+  throw new CertificationFailure(`${prefix}_${response.status()}_${responseCode}`);
+}
+
 function errorCode(error) {
   return error instanceof CertificationFailure ? error.code : 'UNEXPECTED_BROWSER_FAILURE';
 }
@@ -604,14 +613,7 @@ async function exerciseTrackAAutomation(
   await dialog.getByRole('button', { name: 'Review schedule', exact: true }).click();
   const reviewResponse = await reviewResponsePromise;
   if (!reviewResponse.ok()) {
-    const failureBody = await reviewResponse.json().catch(() => null);
-    const responseCode = typeof failureBody?.code === 'string'
-      && /^[A-Z][A-Z0-9_]{0,63}$/.test(failureBody.code)
-      ? failureBody.code
-      : 'UNKNOWN';
-    throw new CertificationFailure(
-      `AUTOMATION_REVIEW_FAILED_${reviewResponse.status()}_${responseCode}`,
-    );
+    await throwSafeResponseFailure(reviewResponse, 'AUTOMATION_REVIEW_FAILED');
   }
   const reviewBody = await reviewResponse.json().catch(() => null);
   const review = reviewBody?.review;
@@ -651,7 +653,9 @@ async function exerciseTrackAAutomation(
   }, { timeout: 20_000 });
   await dialog.getByRole('button', { name: 'Approve and create', exact: true }).click();
   const createResponse = await createResponsePromise;
-  requireCondition(createResponse.status() === 201, 'AUTOMATION_CREATE_FAILED');
+  if (createResponse.status() !== 201) {
+    await throwSafeResponseFailure(createResponse, 'AUTOMATION_CREATE_FAILED');
+  }
   await dialog.getByRole('heading', { name: 'Automation created', exact: true })
     .waitFor({ state: 'visible', timeout: 20_000 });
   await dialog.getByRole('button', { name: 'Done', exact: true }).click();


### PR DESCRIPTION
## Outcome\n- strip create-only review digest/policy acceptance fields before the strict shared review-request parser\n- retain those exact validated fields for final create authorization\n- preserve bounded safe HTTP status/error codes in Track A browser certification\n\n## Scope\nNo schema, migration, environment, UI, deployment, or authority-contract widening.\n\n## Evidence\n- exact browser failure reproduced at create after successful review\n- strict schema composition traced to the two unrecognized create-only fields\n- pnpm --filter @deft/api exec tsx --test test/app-action-architecture.test.ts\n- pnpm --filter @deft/api typecheck\n- 
ode --check scripts/ci/app-platform-phase6-browser-smoke.mjs\n- git diff --check\n\nThe immutable Track A gate will be rerun against the exact merge SHA.