### PR TITLE
ci: preserve long predecessor probe values

### DIFF
--- a/scripts/app-platform-track-a-certification-workflow.test.mjs
+++ b/scripts/app-platform-track-a-certification-workflow.test.mjs
@@ -22,7 +22,7 @@ const executionSurface = [
   pnpmExecWrapper,
 ].join('\n');
 
-const CANDIDATE_COMMIT = 'ff5a3fae3e21b80fe51849e6cd8023d5228389d0';
+const CANDIDATE_COMMIT = '919f6b41e007d922478ded14d8554c00b24b7401';
 const PHASE6_BASELINE_COMMIT = '16875df2f6c9dc2bc3d850de6758b7dd56767a05';
 const PREDECESSOR_IMAGE =
   'ghcr.io/maneek21/deft@sha256:e565cc64ee22b5b9f6f99973e3762b639c27e026dc8824852145035acdacf788';
@@ -137,6 +137,11 @@ test('one shared orchestration pass owns image, upgrade, restore, predecessor, b
   assert.match(orchestrator, /cat "\$restore_log" >&2/);
   assert.match(orchestrator, /rm -f "\$restore_log"/);
   assert.match(orchestrator, /probe_row="\$\(/);
+  assert.equal(
+    occurrences(orchestrator, "replace(encode(convert_to(mr.data->>"),
+    2,
+    'predecessor probe values must remain single-line when PostgreSQL wraps Base64 output',
+  );
   assert.match(orchestrator, /DEFT_PROBE_NAME_BASE64="\$probe_name_base64"/);
   assert.match(orchestrator, /DEFT_PROBE_EMAIL_BASE64="\$probe_email_base64"/);
   assert.doesNotMatch(orchestrator, /mr\.data->>'name' = 'Ada Lovelace'/);

--- a/scripts/ci/certify-app-platform-phase5.sh
+++ b/scripts/ci/certify-app-platform-phase5.sh
@@ -263,8 +263,8 @@ rm -f "$restore_log"
 probe_row="$(
   docker exec "$restore_container" psql -U postgres -d "$database_name" -At -F ' ' -c "
     SELECT mr.org_id, ae.id, mr.id,
-           encode(convert_to(mr.data->>'name', 'UTF8'), 'base64'),
-           encode(convert_to(mr.data->>'email', 'UTF8'), 'base64')
+           replace(encode(convert_to(mr.data->>'name', 'UTF8'), 'base64'), E'\n', ''),
+           replace(encode(convert_to(mr.data->>'email', 'UTF8'), 'base64'), E'\n', '')
       FROM module_records mr
       JOIN module_installations mi ON mi.id = mr.installation_id AND mi.org_id = mr.org_id
       JOIN agent_employees ae ON ae.org_id = mr.org_id AND ae.is_active = true AND ae.is_deleted = false


### PR DESCRIPTION
Strips PostgreSQL Base64 line wrapping before passing predecessor probe values through the shell, locks the regression, and synchronizes the immutable candidate assertion. Root cause was proven by run 33551447752: a randomized email crossed PostgreSQL's 76-character Base64 wrap width and the shell consumed only the first line. Focused certification tests pass 12/12; Git Bash syntax and diff checks pass.