### PR TITLE
fix(web): keep automation status visible on mobile

### DIFF
--- a/apps/web/src/components/apps/app-automation-management.tsx
+++ b/apps/web/src/components/apps/app-automation-management.tsx
@@ -24,7 +24,7 @@ export function AppAutomationManagement({ installationId }: { installationId: st
   };
 
   return <section className="space-y-3" aria-label="Scheduled App automations">
-    <div className="flex items-start justify-between gap-3">
+    <div className="flex flex-col items-start gap-3 sm:flex-row sm:justify-between">
       <div><h3 className="text-xs font-semibold">Scheduled automations</h3><p className="mt-1 text-[11px]" style={{ color: 'var(--outline)' }}>Host-governed daily runs with pinned resources, bounded retries, and receipts.</p></div>
       {management && <span className="rounded-full px-2 py-1 text-[10px] font-semibold uppercase" style={{ color: management.killSwitchEnabled ? 'var(--status-green)' : 'var(--status-amber)', background: 'var(--surface-container-high)' }}>{management.killSwitchEnabled ? 'Runner on' : 'Kill switch off'}</span>}
     </div>


### PR DESCRIPTION
The definitive Track A screenshot exposed the runner-state badge clipped at the 390px viewport edge even though document overflow remained zero. Stack the automation heading and status on small screens while preserving the existing desktop row. Web typecheck, focused ESLint, and diff checks pass. No contract, API, database, environment, or deployment change.