### PR TITLE
ci: scope Track A app state assertion

### DIFF
--- a/scripts/app-platform-track-a-certification-workflow.test.mjs
+++ b/scripts/app-platform-track-a-certification-workflow.test.mjs
@@ -227,6 +227,11 @@ test('the exact browser fixture is mandatory, so the Phase 6 legacy path cannot 
   );
   assert.match(browserSmoke, /APP_PLATFORM_TRACK_A_BROWSER_SMOKE_PASSED/);
   assert.match(browserSmoke, /APP_PLATFORM_PHASE6_BROWSER_SMOKE_PASSED/);
+  assert.match(
+    browserSmoke,
+    /identity\.locator\('\.\.'\)\.getByText\(state, \{ exact: true \}\)/,
+  );
+  assert.doesNotMatch(browserSmoke, /card\.getByText\(state, \{ exact: true \}\)/);
 });
 
 test('the exact candidate database matrix includes grants and the automation lifecycle', () => {

--- a/scripts/ci/app-platform-phase6-browser-smoke.mjs
+++ b/scripts/ci/app-platform-phase6-browser-smoke.mjs
@@ -287,10 +287,11 @@ function appCard(page, appId) {
 async function waitForApp(page, appId, state, version) {
   const card = appCard(page, appId);
   await card.waitFor({ state: 'visible', timeout: 20_000 });
-  await card.getByText(state, { exact: true }).waitFor({ state: 'visible', timeout: 20_000 });
-  if (version) {
-    await card.getByText(`${appId}@${version}`, { exact: true }).waitFor({ state: 'visible', timeout: 20_000 });
-  }
+  const identity = version
+    ? card.getByText(`${appId}@${version}`, { exact: true })
+    : card.locator('p').filter({ hasText: `${appId}@` }).first();
+  await identity.waitFor({ state: 'visible', timeout: 20_000 });
+  await identity.locator('..').getByText(state, { exact: true }).waitFor({ state: 'visible', timeout: 20_000 });
   return card;
 }
 


### PR DESCRIPTION
## Summary
- anchor App lifecycle assertions to the visible App identity header
- avoid collisions with automation definition state labels inside the same card
- lock the scoped locator in the Track A certifier contract test

## Validation
- node --check scripts/ci/app-platform-phase6-browser-smoke.mjs
- node --test scripts/app-platform-track-a-certification-workflow.test.mjs
- git diff --check