### PR TITLE
docs: publish preview.15 installation and release guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ env vars. Patch versions (`0.X.Y`) are non-breaking fixes only.
 
 ## [Unreleased]
 
-Planned for the v0.3.0-preview.15 core preview. Publication is pending release checks.
+## [0.3.0-preview.15] — 2026-09-08
 
 ### Added
 
@@ -46,8 +46,8 @@ Planned for the v0.3.0-preview.15 core preview. Publication is pending release c
 
 ### Release and upgrade notes
 
-- The next preview is a **core** release. Hermes is not certified or
-  distributed as a supported integration bundle for this candidate. Existing
+- This is a **core** release. Hermes is not certified or distributed as a
+  supported integration bundle for this release. Existing
   integration source and historical certification records are not new proof.
 - The schema advances to `0.3.0-preview.29`, including durable browser-session
   state and scoped native-create identities. Back up first and use the documented
@@ -443,7 +443,8 @@ The `0.1.0-alpha` tag was originally published under BSL 1.1. The current
 codebase has since been relicensed under [GNU AGPL v3.0 only](LICENSE); consult
 the license file present in the exact revision you use.
 
-[Unreleased]: https://github.com/Maneek21/Deft/compare/v0.3.0-preview.14...HEAD
+[Unreleased]: https://github.com/Maneek21/Deft/compare/v0.3.0-preview.15...HEAD
+[0.3.0-preview.15]: https://github.com/Maneek21/Deft/releases/tag/v0.3.0-preview.15
 [0.3.0-preview.14]: https://github.com/Maneek21/Deft/releases/tag/v0.3.0-preview.14
 [0.3.0-preview.13]: https://github.com/Maneek21/Deft/releases/tag/v0.3.0-preview.13
 [0.3.0-preview.12]: https://github.com/Maneek21/Deft/releases/tag/v0.3.0-preview.12

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1,6 +1,6 @@
 # Deft capability reference
 
-> Availability last reconciled on September 7, 2026. The latest published image is `v0.3.0-preview.14`; features present on `master` may belong to the unpublished `v0.3.0-preview.15` core candidate. See the [availability map](docs/product-status.md).
+> Availability last reconciled on September 8, 2026. The latest published image is `v0.3.0-preview.15`, a core release. Features present on `master` may be absent from that image. See the [availability map](docs/product-status.md).
 >
 > Deft is an alpha. This file describes the current product surface, not a compatibility guarantee. See [current limitations](docs/current-limitations.md) and the [roadmap](ROADMAP.md) before planning a production deployment.
 
@@ -113,7 +113,7 @@ Agent employees are separate workspace identities backed by a customer-controlle
 - Operate under trust level, scope, health, action-cap, audit, and approval rules
 - Expose supervision state, recent contact, failures, and bridge health to admins
 
-Deft does not require a specific agent framework. A compatible customer-operated runtime can use the streamable HTTP MCP endpoint. Hermes support is release-specific historical compatibility; it is excluded from the upcoming core preview and is not a new compatibility claim.
+Deft does not require a specific agent framework. A compatible customer-operated runtime can use the streamable HTTP MCP endpoint. Hermes support is release-specific historical compatibility; it is excluded from the preview.15 core release and is not a new compatibility claim.
 
 ## Personal AI app connections
 
@@ -180,7 +180,7 @@ Fresh installs use `pnpm db:push-full`. Supported release-to-release upgrades us
 
 - Modules define domain records, relationships, and Deft-rendered native views.
 - Declarative internal Apps package Modules for review and installation and are an opt-in alpha capability.
-- Connected Apps and bounded daily actions are implemented on `master` for the upcoming core candidate. They are experimental, disabled by default, and require the flags and review flow in the [operator guide](docs/app-run-operations.md).
+- Connected Apps and bounded daily actions are included in preview.15. They are experimental, disabled by default, and require the flags and review flow in the [operator guide](docs/app-run-operations.md).
 - The current App protocols do not provide arbitrary custom UI, public portals, general external runtimes, or synchronization.
 
 ## Security posture

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [Website](https://deft.ing) | [Self-hosting guide](docs/self-hosting.md) | [Contributing](CONTRIBUTING.md)
 
-**Try Deft:** [install a workspace, connect your AI client, or build an internal App](docs/getting-started.md). The latest downloadable image is `v0.3.0-preview.14`; the `v0.3.0-preview.15` core candidate described on `master` has not been published. See the [current availability map](docs/product-status.md) before evaluating an unreleased feature.
+**Try Deft:** [install a workspace, connect your AI client, or build an internal App](docs/getting-started.md). The latest downloadable image is `v0.3.0-preview.15`. See the [current availability map](docs/product-status.md) before enabling an experimental feature.
 
 ![Where humans and agents work together.](docs/assets/repository/hero.png)
 
@@ -50,7 +50,7 @@ Deft still works as a normal workspace without an AI provider key. Chat, tasks, 
 
 ### An extensible workspace through Modules and Apps
 
-Modules add domain records, relationships, and native views. Apps package supported workspace extensions for operator review and installation. Declarative internal Apps are an opt-in alpha capability; connected Apps and bounded scheduled actions are implemented in the upcoming core candidate and remain disabled by default. Arbitrary custom UI and public portals are planned rather than part of the current contract.
+Modules add domain records, relationships, and native views. Apps package supported workspace extensions for operator review and installation. Declarative internal Apps, connected Apps, and bounded scheduled actions are opt-in alpha capabilities and remain disabled by default. Arbitrary custom UI and public portals are planned rather than part of the current contract.
 
 The bundled **Contacts** module is the first example of this model. The goal is not to turn Deft's core into every application a company might need, but to let new capabilities live on the same shared substrate instead of becoming another disconnected system.
 
@@ -139,7 +139,7 @@ BSL 1.1 license included in those revisions; relicensing this source tree does
 not retroactively change old tags or images.
 
 ```bash
-export DEFT_IMAGE=ghcr.io/maneek21/deft:0.3.0-preview.14
+export DEFT_IMAGE=ghcr.io/maneek21/deft:0.3.0-preview.15
 docker compose -f docker-compose.yml -f compose.prod.yml -f compose.release.yml pull
 docker compose -f docker-compose.yml -f compose.prod.yml -f compose.release.yml up -d postgres
 docker compose -f docker-compose.yml -f compose.prod.yml -f compose.release.yml run --rm init

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,12 +11,12 @@ This roadmap communicates direction, not delivery dates. Deft is an alpha and pr
 - Replace stale repository claims with current product proof
 - Keep permission, org isolation, and private-space tests mandatory
 
-## Upcoming core preview
+## Current core preview
 
-- Publish the prepared `v0.3.0-preview.15` core candidate after its release gates pass
-- Ship connected Apps and bounded scheduled actions as experimental, opt-in capabilities
-- Keep the release explicitly core-scoped; Hermes certification and its bundle are excluded
-- Publish operational release notes, checksums, provenance, SBOM, and the exact tested revision
+- `v0.3.0-preview.15` is published as a core release
+- Connected Apps and bounded scheduled actions ship as experimental, opt-in capabilities
+- Hermes certification and its bundle are excluded from this release
+- Release assets include operational notes, checksums, provenance, SBOM, and the exact revision
 
 ## Before stable v1
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,7 @@
 ## Operator and integration guides
 
 - [Connected App author guide](connected-app-author-guide.md)
-- [Historical Hermes compatibility guide](../integrations/hermes/deft-platform/README.md) (use only with a release that explicitly certifies it; excluded from the upcoming core preview)
+- [Historical Hermes compatibility guide](../integrations/hermes/deft-platform/README.md) (use only with a release that explicitly certifies it; excluded from the preview.15 core release)
 - [Legacy Hermes Agent Channel bridge rollback](hermes-agent-channel-service.md)
 - Public product capabilities: [FEATURES.md](../FEATURES.md)
 

--- a/docs/app-run-operations.md
+++ b/docs/app-run-operations.md
@@ -1,6 +1,6 @@
 # Governed App Run operations
 
-> **Upcoming core candidate:** these operations are implemented on `master` for the unpublished `v0.3.0-preview.15` core candidate. They are experimental and disabled by default. The latest published `v0.3.0-preview.14` image does not include this operating contract.
+> **Experimental in preview.15:** these operations are included in the published `v0.3.0-preview.15` core release. They are experimental and disabled by default.
 
 Governed App Runs are a disabled-by-default self-host opt-in with three controls.
 Exact `DEFT_APP_RUNS_ENABLED=true` enables key access, runtime composition, and

--- a/docs/connected-app-author-guide.md
+++ b/docs/connected-app-author-guide.md
@@ -1,6 +1,6 @@
 # Connected App author guide
 
-> **Upcoming core candidate:** this connected-App and bounded-automation flow is implemented on `master` for the unpublished `v0.3.0-preview.15` core candidate. It is experimental and disabled by default. It is not available in the latest published `v0.3.0-preview.14` image.
+> **Experimental in preview.15:** this connected-App and bounded-automation flow is included in the published `v0.3.0-preview.15` core release. It is experimental and disabled by default.
 
 This guide shows how to build a connected App, check that it matches the host,
 and submit it for workspace review. It supports App Protocol v1 connected Apps

--- a/docs/current-limitations.md
+++ b/docs/current-limitations.md
@@ -1,6 +1,6 @@
 # Current limitations
 
-Last reviewed September 7, 2026. The latest published preview is `v0.3.0-preview.14`; `master` also contains work for an unpublished `v0.3.0-preview.15` core candidate.
+Last reviewed September 8, 2026. The latest published preview is `v0.3.0-preview.15`, a core release.
 
 Deft is an alpha. It is suitable for technical evaluation, internal use, and controlled pilots where an operator can tolerate breaking changes and investigate failures.
 
@@ -43,7 +43,7 @@ Deft is an alpha. It is suitable for technical evaluation, internal use, and con
 ## Apps and Modules
 
 - Apps are disabled by default. The API requires `DEFT_APPS_ENABLED=true`, and the web build requires `NEXT_PUBLIC_FEATURE_APPS=true`.
-- Connected App execution and bounded automations add further flags and operator review. They are implemented on `master` for the upcoming core candidate, not available in the current preview.14 image.
+- Connected App execution and bounded automations add further flags and operator review. They are included in preview.15, experimental, and disabled by default.
 - App Protocol v0 provides declarative internal records and native views. Current protocols do not provide arbitrary custom UI, public portals, general external runtimes, or synchronization.
 - A package's requested permissions are review input. The host owns installation, grants, connector binding, activation, and execution authority.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,13 +1,13 @@
 # Getting started
 
-Choose the journey that matches what you want to evaluate. The latest downloadable image is `v0.3.0-preview.14`. Work described as part of the upcoming `v0.3.0-preview.15` core candidate is present in source but is not yet a published release.
+Choose the journey that matches what you want to evaluate. The latest downloadable image is `v0.3.0-preview.15`.
 
 ## Start a team workspace
 
-You need Docker Compose and `openssl`. Download the [preview.14 release assets](https://github.com/Maneek21/Deft/releases/tag/v0.3.0-preview.14) into an empty directory, copy `default.env.example` to `.env`, and use a separate `openssl rand -hex 32` value for each required secret: `POSTGRES_PASSWORD`, `JWT_SECRET`, `JWT_REFRESH_SECRET`, and `ENCRYPTION_KEY`.
+You need Docker Compose and `openssl`. Download the [preview.15 release assets](https://github.com/Maneek21/Deft/releases/tag/v0.3.0-preview.15) into an empty directory, copy `default.env.example` to `.env`, and use a separate `openssl rand -hex 32` value for each required secret: `POSTGRES_PASSWORD`, `JWT_SECRET`, `JWT_REFRESH_SECRET`, and `ENCRYPTION_KEY`.
 
 ```bash
-export DEFT_IMAGE=ghcr.io/maneek21/deft:0.3.0-preview.14
+export DEFT_IMAGE=ghcr.io/maneek21/deft:0.3.0-preview.15
 docker compose -f docker-compose.yml -f compose.prod.yml -f compose.release.yml pull
 docker compose -f docker-compose.yml -f compose.prod.yml -f compose.release.yml up -d postgres
 docker compose -f docker-compose.yml -f compose.prod.yml -f compose.release.yml run --rm init
@@ -29,7 +29,7 @@ Ask the client to list your tasks or search visible workspace knowledge. A succe
 This source/tarball path avoids assuming that `@deft/app-kit` is available from a public registry. Use a checkout matching the host release and Node.js 22.13+ with pnpm 11.10.0.
 
 ```bash
-git clone --branch v0.3.0-preview.14 --depth 1 https://github.com/Maneek21/Deft.git deft-app-source
+git clone --branch v0.3.0-preview.15 --depth 1 https://github.com/Maneek21/Deft.git deft-app-source
 cd deft-app-source
 pnpm install
 mkdir -p "$HOME/deft-artifacts"
@@ -37,7 +37,7 @@ pnpm --dir packages/app-kit pack --pack-destination "$HOME/deft-artifacts"
 mkdir -p "$HOME/deft-apps/hello-workspace"
 cd "$HOME/deft-apps/hello-workspace"
 pnpm init
-pnpm add --save-dev "$HOME/deft-artifacts/deft-app-kit-0.1.0-alpha.0.tgz"
+pnpm add --save-dev "$HOME/deft-artifacts/deft-app-kit-0.1.0-alpha.2.tgz"
 pnpm exec deft app init
 pnpm exec deft app check
 pnpm exec deft app build
@@ -45,8 +45,8 @@ pnpm exec deft app doctor --url http://localhost:3001
 pnpm exec deft app install-local --url http://localhost:3001
 ```
 
-These commands use the published preview.14 and its App Kit `0.1.0-alpha.0`. The upcoming core candidate uses `0.1.0-alpha.2`; use the guide from the same release as your host.
+These commands use the published preview.15 and its App Kit `0.1.0-alpha.2`. Use the guide from the same release as your host.
 
 The host API must have `DEFT_APPS_ENABLED=true` and `DEFT_APP_DEVELOPER_PAIRING_ENABLED=true`; the web build needs `NEXT_PUBLIC_FEATURE_APPS=true`. In **Settings → Apps**, an owner or admin creates the one-time developer pairing code; enter it when `install-local` prompts. For Protocol v0, a successful install stages and activates a Deft-rendered internal App. Open **Apps** and confirm its native navigation and Module view.
 
-Connected Apps and bounded daily actions are an experimental path in the upcoming core candidate. They require separate review, grants, bindings, activation, and additional operator flags. Follow the [connected App author guide](connected-app-author-guide.md) and [App Run operator guide](app-run-operations.md). Current protocols do not provide arbitrary custom UI or public portals.
+Connected Apps and bounded daily actions are an experimental path in preview.15. They require separate review, grants, bindings, activation, and additional operator flags. Follow the [connected App author guide](connected-app-author-guide.md) and [App Run operator guide](app-run-operations.md). Current protocols do not provide arbitrary custom UI or public portals.

--- a/docs/product-status.md
+++ b/docs/product-status.md
@@ -9,8 +9,7 @@ notes before upgrading, and keep a tested backup of your workspace.
 
 ## Choose a version
 
-The latest published preview is **v0.3.0-preview.14**. The **v0.3.0-preview.15
-core preview is being prepared**; it is not yet a downloadable release.
+The latest published preview is **v0.3.0-preview.15**, a **core** release.
 Development on `master` may include changes absent from the published image.
 
 | Capability | Availability | How to start |
@@ -19,8 +18,8 @@ Development on `master` may include changes absent from the published image.
 | Defty | Available when an operator configures a supported AI provider | [AI and agent limits](current-limitations.md#ai-and-agents) |
 | Personal MCP access | Available; authentication and client support vary | [Connect an AI client](getting-started.md#connect-an-ai-client) |
 | Declarative Modules and internal Apps | Available as an opt-in alpha capability; use a matching release's authoring guide | [Build an internal App](getting-started.md#build-an-internal-app) |
-| Connected Apps and bounded scheduled actions | Implemented on master and included in the upcoming core candidate; experimental and disabled by default | [Connected App author guide](connected-app-author-guide.md) |
-| Certified Hermes bundle | Release-specific historical support; excluded from the upcoming core preview | Read the chosen release's compatibility and certification notes |
+| Connected Apps and bounded scheduled actions | Included in the published preview; experimental and disabled by default | [Connected App author guide](connected-app-author-guide.md) |
+| Certified Hermes bundle | Release-specific historical support; excluded from preview.15 | Read the chosen release's compatibility and certification notes |
 | Arbitrary custom App UI, public portals, external runtimes and sync | Planned; not a general-purpose contract available today | [Roadmap](../ROADMAP.md) |
 | Hosted Deft service | Not currently offered | Self-host using the supported Docker Compose path |
 

--- a/docs/self-hosted-v1-contract.md
+++ b/docs/self-hosted-v1-contract.md
@@ -3,7 +3,7 @@
 This is the current promise for self-hosted Deft. Use this as the source of truth
 when updating README, docs, website copy, setup flows, and pilot reports.
 
-For version-specific availability, use [What you can use today](product-status.md). The latest published image is `v0.3.0-preview.14`; the upcoming `v0.3.0-preview.15` candidate is core-scoped and excludes Hermes certification and bundle artifacts.
+For version-specific availability, use [What you can use today](product-status.md). The latest published image is `v0.3.0-preview.15`; it is core-scoped and excludes Hermes certification and bundle artifacts.
 
 ## What self-hosted v1 promises
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -75,7 +75,7 @@ workflow and carry GitHub build provenance. Verify checksums and the image
 digest before deploying or installing the Hermes bundle:
 
 ```bash
-export TAG=v0.3.0-preview.14
+export TAG="$(jq -r .tag release-manifest.json)"
 export VERSION="${TAG#v}"
 export IMAGE=ghcr.io/maneek21/deft
 export DIGEST="$(docker buildx imagetools inspect "$IMAGE:$VERSION" --format '{{json .Manifest.Digest}}' | tr -d '"')"


### PR DESCRIPTION
Preview.15 is now published with a verified core release manifest, signed image, provenance, source archive, SBOM, and checksums. Public installation and authoring instructions can now point to that release and its matching App Kit alpha.2 package.

This updates the changelog and current availability guidance, preserves the explicit exclusion of Hermes certification, and makes the image verification example read its tag from the downloaded manifest.

Validation: reviewed the twelve documentation changes; `git diff --check` passes. Release artifact checksums and the published image signature were independently verified. No application code changes.

