### PR TITLE
docs: update Deft contact to maneek@deft.ing

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -25,7 +25,7 @@ The following will get a comment removed and, if repeated, a ban:
 
 ## Reporting
 
-If you see something that violates this, email **conduct@deft.ing**. We aim to reply within 3 business days. We'll keep your report confidential to the extent that resolving the situation allows. Maintainers are also subject to this code — feel free to report us too.
+If you see something that violates this, email **[maneek@deft.ing](mailto:maneek@deft.ing)**. We aim to reply within 3 business days. We'll keep your report confidential to the extent that resolving the situation allows. Maintainers are also subject to this code — feel free to report us too.
 
 ## Scope
 

--- a/README.md
+++ b/README.md
@@ -208,6 +208,10 @@ Contributions are welcome. Start with [CONTRIBUTING.md](CONTRIBUTING.md), run th
 
 If Deft is useful to you, starring the repository helps more teams find the project.
 
+## Contact
+
+Email [maneek@deft.ing](mailto:maneek@deft.ing) for questions, demos, or private support requests. See [SUPPORT.md](SUPPORT.md) for community support and [SECURITY.md](SECURITY.md) for private vulnerability reporting.
+
 ## License
 
 Deft is free software licensed under the [GNU Affero General Public License

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,7 +18,7 @@ Do not open a public GitHub issue for a suspected vulnerability.
 
 Preferred channel: [GitHub Security Advisories](https://github.com/Maneek21/Deft/security/advisories/new).
 
-Alternative: email `security@deft.ing`.
+Alternative: email [maneek@deft.ing](mailto:maneek@deft.ing).
 
 Include, when possible:
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -4,6 +4,7 @@ Deft is an alpha, open-source self-hosted project. Community support is best eff
 
 ## Where to ask
 
+- **Contact Deft:** email [maneek@deft.ing](mailto:maneek@deft.ing) for general questions, demos, or private support requests.
 - **Bug:** open a GitHub issue with reproduction steps.
 - **Feature or product proposal:** start a GitHub Discussion before a large implementation.
 - **Installation or usage question:** use GitHub Discussions.


### PR DESCRIPTION
Deft's public contact is now maneek@deft.ing. The README and support guide expose the address, and the security and conduct policies use the same verified mailbox.

Validation: git diff --check passed; reviewed all four documentation diffs and confirmed the linked local documents exist. No application code changed. Broad application tests were not run locally for this documentation-only change; required CI checks remain enabled.
